### PR TITLE
Fixes when using positional argument "info" 

### DIFF
--- a/chemex/chemex.py
+++ b/chemex/chemex.py
@@ -31,7 +31,7 @@ def print_logo():
         "*   Version: {:<15s}                    *\n"
         "*                                               *\n"
         "* * * * * * * * * * * * * * * * * * * * * * * * *\n"
-            .format(version.__version__)
+        .format(version.__version__)
     ))
 
 
@@ -139,8 +139,7 @@ def main():
     args = parsing.arg_parse()
 
     if args.commands == 'info':
-        parsing.format_experiment_help(args.experiments)
-
+        parsing.format_experiment_help(args.types, args.experiments)
 
     elif args.commands == 'fit':
 

--- a/chemex/parsing.py
+++ b/chemex/parsing.py
@@ -66,11 +66,12 @@ def arg_parse():
 
         for exp in exps:
 
-            name_exp = exp.replace('chemex.experiments.', '')
-
             package_exp = importlib.import_module(exp)
 
             if hasattr(package_exp, 'Profile'):
+                name_exp = exp.replace('chemex.experiments.' + name_exp_type +
+                                       '.', '').replace('profiles.', '')
+
                 subparsers_info_type.add_parser(
                     name_exp,
                     help=package_exp.__doc__.split('\n')[0],
@@ -175,12 +176,18 @@ def arg_parse():
     return args
 
 
-def format_experiment_help(name_experiment=None):
+def format_experiment_help(exp_type, exp_name):
     headline1 = "Experimental parameters"
     headline2 = "Fitted parameters (by default)"
     headline3 = "Fixed parameters (by default)"
 
-    module_exp = importlib.import_module('.'.join(['chemex.experiments', name_experiment]))
+    if exp_type in ['cest', 'cpmg']:
+        module_exp = importlib.import_module('.'.join(['chemex.experiments',
+                                                       exp_type, 'profiles',
+                                                       exp_name]))
+    else:
+        module_exp = importlib.import_module('.'.join(['chemex.experiments',
+                                                       exp_type, exp_name]))
 
     title = module_exp.__doc__.split('\n')[0]
     description = '\n'.join(module_exp.__doc__.split('\n')[1:]).strip('\n')


### PR DESCRIPTION
This PR allows for the use of short positional arguments when specifying experiments (e.g., "coupled" instead of "cest.profiles.coupled" for cest experiment). 

However, the function "format_experiment_help" in parsing.py throws errors because there are not "attributes_exp" and "params_exp" given anymore for the experimental parameters and fitted/fixed fitting parameters. I guess the easiest thing to do is just to include this information directly in the experiment file (e.g., ip.py). Alternatively, one could probably get this information from the files in "bases" but that would require a bit more coding. I would be happy to implement this in either way - what would you suggest?

Also, it looks like the description of "hn_aph.py" isn't completely correct?