### PR TITLE
CEST fixes

### DIFF
--- a/chemex/experiments/cest/cest_profile.py
+++ b/chemex/experiments/cest/cest_profile.py
@@ -20,7 +20,7 @@ class CESTProfile(base_profile.BaseProfile):
         self.val = measurements['intensities']
         self.err = measurements['intensities_err']
 
-        self.reference = (self.b1_offsets <= -1.0e+04)
+        self.reference = (self.b1_offsets <= -1.0e+04) | (self.b1_offsets >= 1.0e+04)
 
         self.on_resonance_filter = base_profile.check_par(
             exp_details, 'on_resonance_filter', float, default=0.0)

--- a/chemex/experiments/cest/plotting.py
+++ b/chemex/experiments/cest/plotting.py
@@ -65,8 +65,12 @@ def compute_profiles(data_grouped, params):
 
         cs = params[profile.map_names['cs_i_a']].value
         dw = params[profile.map_names['dw_i_ab']].value
+        if '3st' in profile.model:
+            dw2 = params[profile.map_names['dw_i_ac']].value
+        else:
+            dw2 = None
 
-        profiles[peak] = b1_ppm_exp, mag_cal, mag_exp, mag_err, b1_ppm_fit, mag_fit, cs, dw
+        profiles[peak] = b1_ppm_exp, mag_cal, mag_exp, mag_err, b1_ppm_fit, mag_fit, cs, dw, dw2
 
     return profiles
 
@@ -131,28 +135,41 @@ def plot_data(data, params, output_dir='./'):
 
                 ax1.axvline(
                     cs,
-                    color=plotting.palette['Black']['Dividers'],
+                    color=plotting.palette['Blue']['100'],
                     linestyle='-',
                     linewidth=1.0,
                     zorder=-100)
                 ax2.axvline(
                     cs,
-                    color=plotting.palette['Black']['Dividers'],
+                    color=plotting.palette['Blue']['100'],
                     linestyle='-',
                     linewidth=1.0,
                     zorder=-100)
                 ax1.axvline(
                     cs + dw,
-                    color=plotting.palette['Black']['Dividers'],
+                    color=plotting.palette['Red']['100'],
                     linestyle='-',
                     linewidth=1.0,
                     zorder=-100)
                 ax2.axvline(
                     cs + dw,
-                    color=plotting.palette['Black']['Dividers'],
+                    color=plotting.palette['Red']['100'],
                     linestyle='-',
                     linewidth=1.0,
                     zorder=-100)
+                if dw2 is not None:
+                    ax1.axvline(
+                        cs + dw2,
+                        color=plotting.palette['Orange']['100'],
+                        linestyle='-',
+                        linewidth=1.0,
+                        zorder=-100)
+                    ax2.axvline(
+                        cs + dw2,
+                        color=plotting.palette['Orange']['100'],
+                        linestyle='-',
+                        linewidth=1.0,
+                        zorder=-100)
 
                 ax1.axhline(0, color=plotting.palette['Black']['Text'], linewidth=0.5)
                 ax2.axhline(0, color=plotting.palette['Black']['Text'], linewidth=0.5)

--- a/chemex/experiments/cest/plotting.py
+++ b/chemex/experiments/cest/plotting.py
@@ -47,7 +47,7 @@ def compute_profiles(data_grouped, params):
     profiles = {}
 
     for peak, profile in data_grouped.items():
-        mask = profile.b1_offsets > -10000.0
+        mask = (profile.b1_offsets > -10000.0) & (profile.b1_offsets < 10000.0)
         mask_ref = np.logical_not(mask)
 
         val_ref = np.mean(profile.val[mask_ref])

--- a/chemex/experiments/cest/plotting.py
+++ b/chemex/experiments/cest/plotting.py
@@ -122,7 +122,7 @@ def plot_data(data, params, output_dir='./'):
                 name_exp, 'w') as file_exp:
 
             for peak in sorted(profiles):
-                b1_ppm, mag_cal, mag_exp, mag_err, b1_ppm_fit, mag_fit, cs, dw = profiles[peak]
+                b1_ppm, mag_cal, mag_exp, mag_err, b1_ppm_fit, mag_fit, cs, dw, dw2 = profiles[peak]
 
                 write_profile_fit(peak.assignment, b1_ppm_fit, mag_fit, file_txt)
                 write_profile_exp(peak.assignment, b1_ppm, mag_exp, mag_err, mag_cal, file_exp)


### PR DESCRIPTION
A couple of small fixes I've found when analysing some CEST experiments:
* large positive and negative frequencies can both be accepted for defining CEST reference points (>1e4 and <-1e4 Hz) - for compatibility with previous chemex version
* chemical shifts of all states are marked on CEST output plots for three-state models, with a colour scheme introduced to distinguish states (blue/red/[orange])