### PR TITLE
Matrix exponential performance

### DIFF
--- a/chemex/experiments/cest/profiles/coupled.py
+++ b/chemex/experiments/cest/profiles/coupled.py
@@ -22,6 +22,7 @@ from scipy import linalg
 
 from chemex import constants
 from chemex.experiments.cest import cest_profile, util
+from chemex.util import expmm
 
 
 class Profile(cest_profile.CESTProfile):
@@ -118,7 +119,7 @@ class Profile(cest_profile.CESTProfile):
 
                     else:
                         propagators = [
-                            linalg.expm(liouvillian * self.time_t1) for liouvillian in liouvillians
+                            expmm(liouvillian, self.time_t1) for liouvillian in liouvillians
                         ]
                         propagator = np.average(propagators, weights=self.b1_weights, axis=0)[mesh]
 

--- a/chemex/experiments/cest/profiles/cw_dec.py
+++ b/chemex/experiments/cest/profiles/cw_dec.py
@@ -17,6 +17,7 @@ J Phys Chem B (2012), 116, 14311-7
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex.experiments import base_profile
 from chemex.experiments.cest import cest_profile
 
@@ -142,7 +143,7 @@ class Profile(cest_profile.CESTProfile):
 
                 else:
                     propagators = [
-                        linalg.expm(liouvillian * self.time_t1) for liouvillian in liouvillians
+                        expmm(liouvillian, self.time_t1) for liouvillian in liouvillians
                     ]
                     propagator = np.average(propagators, weights=self.b1_weights, axis=0)[mesh]
 

--- a/chemex/experiments/cest/profiles/hn_ap.py
+++ b/chemex/experiments/cest/profiles/hn_ap.py
@@ -11,6 +11,7 @@ Analyzes chemical exchange during the CEST block. This is calculated using the
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex import parameters
 from chemex.experiments.cest import cest_profile
 
@@ -141,7 +142,7 @@ class Profile(cest_profile.CESTProfile):
 
                 else:
                     propagators = [
-                        linalg.expm(liouvillian * self.time_t1) for liouvillian in liouvillians
+                        expmm(liouvillian, self.time_t1) for liouvillian in liouvillians
                     ]
                     propagator = np.average(propagators, weights=self.b1_weights, axis=0)[mesh]
 

--- a/chemex/experiments/cest/profiles/ip.py
+++ b/chemex/experiments/cest/profiles/ip.py
@@ -18,6 +18,7 @@ J Am Chem Soc (2012), 134, 8148-8161
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex.experiments.cest import cest_profile
 
 
@@ -114,7 +115,7 @@ class Profile(cest_profile.CESTProfile):
 
                 else:
                     propagators = [
-                        linalg.expm(liouvillian * self.time_t1) for liouvillian in liouvillians
+                        expmm(liouvillian, self.time_t1) for liouvillian in liouvillians
                     ]
                     propagator = np.average(propagators, weights=self.b1_weights, axis=0)[mesh]
 

--- a/chemex/experiments/cpmg/profiles/ch3_h2c.py
+++ b/chemex/experiments/cpmg/profiles/ch3_h2c.py
@@ -21,6 +21,7 @@ import functools
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex.bases import util
 from chemex.experiments import base_profile
 from chemex.experiments.cpmg import cpmg_profile
@@ -110,8 +111,8 @@ class Profile(cpmg_profile.CPMGProfile):
         l_pw1y = l_free + self.base.compute_liouvillian(omega1y_i=+self.omega1_i)
 
         # Propagators
-        p_90px = linalg.expm(l_pw1x * self.pw)
-        p_90py = linalg.expm(l_pw1y * self.pw)
+        p_90px = expmm(l_pw1x, self.pw)
+        p_90py = expmm(l_pw1y, self.pw)
         p_180px = np.linalg.matrix_power(p_90px, 2)
         p_180py = np.linalg.matrix_power(p_90py, 2)
         p_180x_s = self.base.p_180x_s

--- a/chemex/experiments/cpmg/profiles/chd2_h1sq.py
+++ b/chemex/experiments/cpmg/profiles/chd2_h1sq.py
@@ -23,6 +23,7 @@ import functools
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex import parameters
 from chemex.bases import util
 from chemex.experiments import base_profile
@@ -134,10 +135,10 @@ class Profile(cpmg_profile.CPMGProfile):
         l_mw1x = l_free + self.base.compute_liouvillian(omega1x_i=-self.omega1_i)
 
         # Propagators
-        p_90px = linalg.expm(l_pw1x * self.pw)
+        p_90px = expmm(l_pw1x, self.pw)
         p_180px = np.linalg.matrix_power(p_90px, 2)
-        p_180py = linalg.expm(l_pw1y * 2.0 * self.pw)
-        p_180mx = linalg.expm(l_mw1x * 2.0 * self.pw)
+        p_180py = expmm(l_pw1y, 2.0 * self.pw)
+        p_180mx = expmm(l_mw1x, 2.0 * self.pw)
         p_180pmx = 0.5 * (p_180px + p_180mx)  # +/- phase cycling
 
         p_free_list = util.compute_propagators_from_time_series(l_free, self.time_series)

--- a/chemex/experiments/cpmg/profiles/co_ap.py
+++ b/chemex/experiments/cpmg/profiles/co_ap.py
@@ -26,6 +26,7 @@ import functools
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex import parameters
 from chemex.bases import util
 from chemex.experiments import base_profile
@@ -141,8 +142,8 @@ class Profile(cpmg_profile.CPMGProfile):
         l_mw1y = l_free + self.base.compute_liouvillian(omega1y_i=-self.omega1_i)
 
         # Propagators
-        p_90py = linalg.expm(l_pw1y * self.pw)
-        p_90my = linalg.expm(l_mw1y * self.pw)
+        p_90py = expmm(l_pw1y * self.pw)
+        p_90my = expmm(l_mw1y * self.pw)
         p_180py = np.linalg.matrix_power(p_90py, 2)
         p_180my = np.linalg.matrix_power(p_90my, 2)
         p_180pmy = 0.5 * (p_180py + p_180my)

--- a/chemex/experiments/cpmg/profiles/cw.py
+++ b/chemex/experiments/cpmg/profiles/cw.py
@@ -22,6 +22,7 @@ import functools
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex.bases import util
 from chemex.experiments import base_profile
 from chemex.experiments.cpmg import cpmg_profile
@@ -103,10 +104,10 @@ class Profile(cpmg_profile.CPMGProfile):
         l_mw1x = l_free + self.base.compute_liouvillian(omega1x_i=-self.omega1_i)
 
         # Calculation of all the needed propagators
-        p_90px = linalg.expm(l_pw1x * self.pw)
+        p_90px = expmm(l_pw1x, self.pw)
         p_180px = np.linalg.matrix_power(p_90px, 2)
-        p_180py = linalg.expm(l_pw1y * 2.0 * self.pw)
-        p_180mx = linalg.expm(l_mw1x * 2.0 * self.pw)
+        p_180py = expmm(l_pw1y, 2.0 * self.pw)
+        p_180mx = expmm(l_mw1x, 2.0 * self.pw)
         p_180pmx = 0.5 * (p_180px + p_180mx)  # +/- phase cycling
 
         p_free_list = util.compute_propagators_from_time_series(l_free, self.time_series)

--- a/chemex/experiments/cpmg/profiles/hn_ap.py
+++ b/chemex/experiments/cpmg/profiles/hn_ap.py
@@ -25,6 +25,7 @@ import functools
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex import parameters
 from chemex.bases import util
 from chemex.experiments import base_profile
@@ -137,10 +138,10 @@ class Profile(cpmg_profile.CPMGProfile):
         l_mw1x = l_free + self.base.compute_liouvillian(omega1x_i=-self.omega1_i)
 
         # Propagators
-        p_90px = linalg.expm(l_pw1x * self.pw)
+        p_90px = expmm(l_pw1x, self.pw)
         p_180px = np.linalg.matrix_power(p_90px, 2)
-        p_180py = linalg.expm(l_pw1y * 2.0 * self.pw)
-        p_180mx = linalg.expm(l_mw1x * 2.0 * self.pw)
+        p_180py = expmm(l_pw1y, 2.0 * self.pw)
+        p_180mx = expmm(l_mw1x, 2.0 * self.pw)
         p_180pmx = 0.5 * (p_180px + p_180mx)  # +/- phase cycling
 
         p_free_list = util.compute_propagators_from_time_series(l_free, self.time_series)

--- a/chemex/experiments/cpmg/profiles/n_atrosy.py
+++ b/chemex/experiments/cpmg/profiles/n_atrosy.py
@@ -21,6 +21,7 @@ import functools
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex.bases import util
 from chemex.experiments import base_profile
 from chemex.experiments.cpmg import cpmg_profile
@@ -112,10 +113,10 @@ class Profile(cpmg_profile.CPMGProfile):
         l_mw1y = l_free + self.base.compute_liouvillian(omega1y_i=-self.omega1_i)
 
         # Propagators
-        p_90px = linalg.expm(l_pw1x * self.pw)
-        p_90py = linalg.expm(l_pw1y * self.pw)
-        p_90mx = linalg.expm(l_mw1x * self.pw)
-        p_90my = linalg.expm(l_mw1y * self.pw)
+        p_90px = expmm(l_pw1x, self.pw)
+        p_90py = expmm(l_pw1y, self.pw)
+        p_90mx = expmm(l_mw1x, self.pw)
+        p_90my = expmm(l_mw1y, self.pw)
         p_180px = np.linalg.matrix_power(p_90px, 2)
         p_180py = np.linalg.matrix_power(p_90py, 2)
         p_180x_s = self.base.p_180x_s

--- a/chemex/experiments/cpmg/profiles/n_trosy.py
+++ b/chemex/experiments/cpmg/profiles/n_trosy.py
@@ -19,6 +19,7 @@ import functools
 import numpy as np
 from scipy import linalg
 
+from chemex.util import expmm
 from chemex.bases import util
 from chemex.experiments import base_profile
 from chemex.experiments.cpmg import cpmg_profile
@@ -110,10 +111,10 @@ class Profile(cpmg_profile.CPMGProfile):
         l_mw1y = l_free + self.base.compute_liouvillian(omega1y_i=-self.omega1_i)
 
         # Propagators
-        p_90px = linalg.expm(l_pw1x * self.pw)
-        p_90py = linalg.expm(l_pw1y * self.pw)
-        p_90mx = linalg.expm(l_mw1x * self.pw)
-        p_90my = linalg.expm(l_mw1y * self.pw)
+        p_90px = expmm(l_pw1x, self.pw)
+        p_90py = expmm(l_pw1y, self.pw)
+        p_90mx = expmm(l_mw1x, self.pw)
+        p_90my = expmm(l_mw1y, self.pw)
         p_180px = np.linalg.matrix_power(p_90px, 2)
         p_180py = np.linalg.matrix_power(p_90py, 2)
         p_180x_s = self.base.p_180x_s

--- a/chemex/fitting.py
+++ b/chemex/fitting.py
@@ -36,7 +36,7 @@ def run_fit(fit_filename, params, data):
             minimizer = lmfit.Minimizer(func, c_params)
 
             try:
-                result = minimizer.minimize(params=c_params)
+                result = minimizer.minimize(params=c_params, xtol=1e-5, ftol=1e-5)
 
             except KeyboardInterrupt:
                 result = minimizer.result

--- a/chemex/util.py
+++ b/chemex/util.py
@@ -3,7 +3,8 @@
 import configparser
 import os
 import sys
-
+import numpy as np
+from scipy import linalg
 
 def make_dir(path=None):
     """Ensure existence of the directory."""
@@ -78,3 +79,17 @@ def header1(string):
 def header2(string):
     """Print a formatted subheading."""
     print(("\n".join(["", string, "-" * len(string), ""])))
+
+
+def expmm(A, t):
+    """Calculate exp(A*t) by eigendecomposition.
+
+    For performance, the input matrix is assumed to be square and double precision.
+    """
+    s, vr = linalg.eig(A)
+    # propagators are negative semi-definite, i.e. no propagator should have a positive eigenvalue
+    s = np.minimum(s, 0)
+    vri = linalg.inv(vr)
+    r = np.real(np.dot(np.dot(vr, np.diag(np.exp(s*t))), vri))
+
+    return r


### PR DESCRIPTION
* Large speed-up can be obtained by replacing scipy matrix exponentiation with direct calculation by eigendecomposition.
* Helper function created for this calculation, particularly to avoid additional matrix operations when doing calculations of the form exp(A*t)
* Convergence criteria for LM slightly relaxed, giving much shorter run times
* No effect on accuracy from tests of my own data and example data
