### PR TITLE
Make all parameters and parameter constraints explicit

### DIFF
--- a/chemex/bases/three_state/exchange_model.py
+++ b/chemex/bases/three_state/exchange_model.py
@@ -1,17 +1,146 @@
 """Module exchange_model contains code for setting up different three-site
 exchange models."""
 
+import lmfit
+from scipy import constants as cst
 
-def update_params(params=None,
-                  map_names=None,
-                  model=None,
-                  temperature=None,
-                  p_total=None,
-                  l_total=None):
+from chemex import parameters
+
+
+def create_exchange_params(model=None, temperature=None, p_total=None, l_total=None):
     """Update the experimental and fitting parameters depending on the
     model."""
 
-    if model not in {'pb_kex'}:
-        print("Warning: The \'model\' option should be either \'3st.pb_kex\'.")
+    map_names = {}
+    params = lmfit.Parameters()
+
+    if model not in {'3st.pb_kex', '3st.eyring'}:
+
+        print("Warning: The \'model\' option should be either \'3st.pb_kex\'")
+        print(", \'3st.eyring\'.")
         print("\nSet it to the default model: \'3st.pb_kex\'.")
-        model = 'pb_kex'
+
+        model = '3st.pb_kex'
+
+    kws = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
+
+    map_names.update({
+        'kab': parameters.ParameterName('kab', **kws).to_full_name(),
+        'kba': parameters.ParameterName('kba', **kws).to_full_name(),
+        'kac': parameters.ParameterName('kac', **kws).to_full_name(),
+        'kca': parameters.ParameterName('kca', **kws).to_full_name(),
+        'kbc': parameters.ParameterName('kbc', **kws).to_full_name(),
+        'kcb': parameters.ParameterName('kcb', **kws).to_full_name(),
+        'pa': parameters.ParameterName('pa', **kws).to_full_name(),
+        'pb': parameters.ParameterName('pb', **kws).to_full_name(),
+        'pc': parameters.ParameterName('pc', **kws).to_full_name(),
+        'kex_ab': parameters.ParameterName('kex_ab', **kws).to_full_name(),
+        'kex_ac': parameters.ParameterName('kex_ac', **kws).to_full_name(),
+        'kex_bc': parameters.ParameterName('kex_bc', **kws).to_full_name(),
+    })
+
+    if model == '3st.pb_kex':
+
+        params.add_many(
+            (map_names['pb'], 0.05, True, 0.0, 1.0, None),
+            (map_names['pc'], 0.05, True, 0.0, 1.0, None),
+            (map_names['kex_ab'], 200.0, True, 0.0, None, None),
+            (map_names['kex_ac'], 0.0, False, 0.0, None, None),
+            (map_names['kex_bc'], 200.0, True, 0.0, None, None), )
+
+        pa = '1.0 - {pb} - {pc}'.format(**map_names)
+
+        params.add_many((map_names['pa'], 0.95, True, 0.0, 1.0, pa), )
+
+        kab = '{kex_ab} * {pb} / ({pa} + {pb}) if {pa} + {pb} else 0.0'.format(**map_names)
+        kba = '{kex_ab} * {pa} / ({pa} + {pb}) if {pa} + {pb} else 0.0'.format(**map_names)
+        kac = '{kex_ac} * {pc} / ({pa} + {pc}) if {pa} + {pc} else 0.0'.format(**map_names)
+        kca = '{kex_ac} * {pa} / ({pa} + {pc}) if {pa} + {pc} else 0.0'.format(**map_names)
+        kbc = '{kex_bc} * {pc} / ({pb} + {pc}) if {pb} + {pc} else 0.0'.format(**map_names)
+        kcb = '{kex_bc} * {pb} / ({pb} + {pc}) if {pb} + {pc} else 0.0'.format(**map_names)
+
+        params.add_many(
+            (map_names['kab'], 10.0, True, 0.0, None, kab),
+            (map_names['kba'], 190.0, True, 0.0, None, kba),
+            (map_names['kac'], 0.0, True, 0.0, None, kac),
+            (map_names['kca'], 0.0, True, 0.0, None, kca),
+            (map_names['kbc'], 0.0, True, 0.0, None, kbc),
+            (map_names['kcb'], 0.0, True, 0.0, None, kcb), )
+
+    elif model == '3st.eyring':
+
+        map_names.update({
+            'dh_b': parameters.ParameterName('dh_b').to_full_name(),
+            'ds_b': parameters.ParameterName('ds_b').to_full_name(),
+            'dh_c': parameters.ParameterName('dh_c').to_full_name(),
+            'ds_c': parameters.ParameterName('ds_c').to_full_name(),
+            'dh_ab': parameters.ParameterName('dh_ab').to_full_name(),
+            'ds_ab': parameters.ParameterName('ds_ab').to_full_name(),
+            'dh_ac': parameters.ParameterName('dh_ac').to_full_name(),
+            'ds_ac': parameters.ParameterName('ds_ac').to_full_name(),
+            'dh_bc': parameters.ParameterName('dh_bc').to_full_name(),
+            'ds_bc': parameters.ParameterName('ds_bc').to_full_name(),
+        })
+
+        params.add_many(
+            (map_names['dh_b'], 6.5e+03, True, None, None, None),
+            (map_names['ds_b'], 0.0, False, None, None, None),
+            (map_names['dh_c'], 6.5e+03, True, None, None, None),
+            (map_names['ds_c'], 0.0, False, None, None, None),
+            (map_names['dh_ab'], 6.5e+04, True, None, None, None),
+            (map_names['ds_ab'], 0.0, False, None, None, None),
+            (map_names['dh_ac'], 6.5e+09, False, None, None, None),
+            (map_names['ds_ac'], 0.0, False, None, None, None),
+            (map_names['dh_bc'], 6.5e+04, True, None, None, None),
+            (map_names['ds_bc'], 0.0, False, None, None, None), )
+
+        t_kelvin = temperature + 273.15
+        kbt_h = cst.k * t_kelvin / cst.h
+        rt = cst.R * t_kelvin
+
+        kab = ('{kbt_h} * exp(-({dh_ab} - {t_kelvin} * {ds_ab}) / {rt})'.format(
+            kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
+
+        kba = (
+            '{kbt_h} * exp(-(({dh_ab} - {dh_b}) - {t_kelvin} * ({ds_ab} - {ds_b})) / {rt})'.format(
+                kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
+
+        kac = ('{kbt_h} * exp(-({dh_ac} - {t_kelvin} * {ds_ac}) / {rt})'.format(
+            kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
+
+        kca = (
+            '{kbt_h} * exp(-(({dh_ac} - {dh_c}) - {t_kelvin} * ({ds_ac} - {ds_c})) / {rt})'.format(
+                kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
+
+        kbc = (
+            '{kbt_h} * exp(-(({dh_bc} - {dh_b}) - {t_kelvin} * ({ds_bc} - {ds_b})) / {rt})'.format(
+                kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
+
+        kcb = (
+            '{kbt_h} * exp(-(({dh_bc} - {dh_c}) - {t_kelvin} * ({ds_bc} - {ds_c})) / {rt})'.format(
+                kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
+
+        params.add_many(
+            (map_names['kab'], 10.0, True, 0.0, None, kab),
+            (map_names['kba'], 190.0, True, 0.0, None, kba),
+            (map_names['kac'], 0.0, True, 0.0, None, kac),
+            (map_names['kca'], 0.0, True, 0.0, None, kca),
+            (map_names['kbc'], 0.0, True, 0.0, None, kbc),
+            (map_names['kcb'], 0.0, True, 0.0, None, kcb), )
+
+        pa = '{kba} * {kca} / ({kba} * {kca} + {kab} * {kca} + {kac} * {kba})'.format(**map_names)
+        pb = '{kab} * {kcb} / ({kab} * {kcb} + {kba} * {kcb} + {kbc} * {kab})'.format(**map_names)
+        pc = '{kbc} * {kac} / ({kbc} * {kac} + {kcb} * {kab} + {kca} * {kbc})'.format(**map_names)
+        kex_ab = '{kab} + {kba}'.format(**map_names)
+        kex_ac = '{kac} + {kca}'.format(**map_names)
+        kex_bc = '{kbc} + {kcb}'.format(**map_names)
+
+        params.add_many(
+            (map_names['pa'], 0.0, None, 0.0, 1.0, pa),
+            (map_names['pb'], 0.0, None, 0.0, 1.0, pb),
+            (map_names['pc'], 0.0, None, 0.0, 1.0, pc),
+            (map_names['kex_ab'], 0.0, None, 0.0, None, kex_ab),
+            (map_names['kex_ac'], 0.0, None, 0.0, None, kex_ac),
+            (map_names['kex_bc'], 0.0, None, 0.0, None, kex_bc), )
+
+    return map_names, params

--- a/chemex/bases/three_state/ixy.py
+++ b/chemex/bases/three_state/ixy.py
@@ -42,21 +42,11 @@ p_180y_i = np.diag([-1.0, 1.0,
 
 
 def compute_liouvillian(
-        pb=0.0, pc=0.0, kex_ab=0.0, kex_bc=0.0, kex_ac=0.0,
+        kab=0.0, kba=0.0, kac=0.0, kca=0.0, kbc=0.0, kcb=0.0,
         r2_i_a=0.0, omega_i_a=0.0,
         r2_i_b=0.0, omega_i_b=0.0,
         r2_i_c=0.0, omega_i_c=0.0):
     """Compute the Liouvillian."""
-    pa = 1.0 - pb - pc
-
-    kab = kba = kbc = kcb = kac = kca = 0.0
-
-    if pa + pb:
-        kab, kba = kex_ab / (pa + pb) * np.array([pb, pa])
-    if pb + pc:
-        kbc, kcb = kex_bc / (pb + pc) * np.array([pc, pb])
-    if pa + pc:
-        kac, kca = kex_ac / (pa + pc) * np.array([pc, pa])
 
     liouvillian = (
         mat_r2_i_a * r2_i_a +
@@ -79,9 +69,9 @@ def compute_liouvillian(
 # yapf: enable
 
 
-def compute_equilibrium_x(pb=0.0, pc=0.0, **kwargs):
+def compute_equilibrium_x(pa=0.0, pb=0.0, pc=0.0, **kwargs):
     """Compute the equilibrium magnetization."""
-    return np.array([[1.0 - pb - pc, 0.0, pb, 0.0, pc, 0.0]]).T
+    return np.array([[pa, 0.0, pb, 0.0, pc, 0.0]]).T
 
 
 def create_default_params(model=None,
@@ -91,49 +81,43 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs2 = {'temperature': temperature, 'nuclei': nuclei}
-    kwargs3 = {'temperature': temperature, 'nuclei': nuclei, 'h_larmor_frq': h_larmor_frq}
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'pc': parameters.ParameterName('pc', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'kex_ac': parameters.ParameterName('kex_ac', **kwargs1).to_full_name(),
-        'kex_bc': parameters.ParameterName('kex_bc', **kwargs1).to_full_name(),
-        'dw_i_ab': parameters.ParameterName('dw_ab', **kwargs2).to_full_name(),
-        'dw_i_ac': parameters.ParameterName('dw_ac', **kwargs2).to_full_name(),
-        'cs_i_a': parameters.ParameterName('cs_a', **kwargs2).to_full_name(),
-        'r2_i_a': parameters.ParameterName('r2_a', **kwargs3).to_full_name(),
-        'cs_i_b': parameters.ParameterName('cs_b', **kwargs2).to_full_name(),
-        'r2_i_b': parameters.ParameterName('r2_b', **kwargs3).to_full_name(),
-        'cs_i_c': parameters.ParameterName('cs_c', **kwargs2).to_full_name(),
-        'r2_i_c': parameters.ParameterName('r2_c', **kwargs3).to_full_name(),
-    }
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
+    resonance_i, resonance_s = nuclei.resonances
+
+    kw1 = {'temperature': temperature, 'nuclei': resonance_i['name']}
+
+    map_names.update({
+        'dw_i_ab': parameters.ParameterName('dw_ab', **kw1).to_full_name(),
+        'dw_i_ac': parameters.ParameterName('dw_ac', **kw1).to_full_name(),
+        'cs_i_a': parameters.ParameterName('cs_a', **kw1).to_full_name(),
+        'cs_i_b': parameters.ParameterName('cs_b', **kw1).to_full_name(),
+        'cs_i_c': parameters.ParameterName('cs_c', **kw1).to_full_name(),
+    })
+
+    kw2 = {'temperature': temperature, 'nuclei': resonance_i['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_i_a': parameters.ParameterName('r2_a', **kw2).to_full_name(),
+        'r2_i_b': parameters.ParameterName('r2_b', **kw2).to_full_name(),
+        'r2_i_c': parameters.ParameterName('r2_c', **kw2).to_full_name(),
+    })
+
+    params.add_many(
+        (map_names['dw_i_ab'], 0.0, True, None, None, None),
+        (map_names['dw_i_ac'], 0.0, False, None, None, None),
+        (map_names['cs_i_a'], 0.0, False, None, None, None),
+        (map_names['r2_i_a'], 10.0, True, 0.0, None, None), )
 
     cs_i_b = '{cs_i_a} + {dw_i_ab}'.format(**map_names)
     cs_i_c = '{cs_i_a} + {dw_i_ac}'.format(**map_names)
-    r2_i_b = r2_i_c = map_names['r2_i_a']
-
-    params = lmfit.Parameters()
+    r2_i_c = r2_i_b = map_names['r2_i_a']
 
     params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.025, True, 0.0, 1.0, None),
-        (map_names['pc'], 0.025, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['kex_ac'], 0.0, False, 0.0, None, None),
-        (map_names['kex_bc'], 200.0, True, 0.0, None, None),
-        (map_names['dw_i_ab'], 0.0, True, None, None, None),
-        (map_names['dw_i_ac'], 0.0, True, None, None, None),
-        (map_names['cs_i_a'], 0.0, False, None, None, None),
-        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
-        (map_names['cs_i_b'], 0.0, True, None, None, cs_i_b),
+        (map_names['cs_i_b'], 0.0, None, None, None, cs_i_b),
         (map_names['r2_i_b'], 10.0, None, 0.0, None, r2_i_b),
-        (map_names['cs_i_c'], 0.0, True, None, None, cs_i_c),
+        (map_names['cs_i_c'], 0.0, None, None, None, cs_i_c),
         (map_names['r2_i_c'], 10.0, None, 0.0, None, r2_i_c), )
-
-    map_names, params = exchange_model.update_params(params, map_names, model, temperature, p_total,
-                                                     l_total)
 
     return map_names, params

--- a/chemex/bases/three_state/ixyz.py
+++ b/chemex/bases/three_state/ixyz.py
@@ -1,10 +1,10 @@
 """TODO: module docstring."""
 
-import lmfit
 import numpy as np
 
 from chemex import parameters
 from chemex.bases import ref
+from chemex.bases.three_state import exchange_model
 
 # yapf: disable
 indexes = [0, 1, 2,
@@ -39,23 +39,13 @@ index_iz_a = [2]
 
 
 def compute_liouvillian(
-        pb=0.0, pc=0.0, kex_ab=0.0, kex_bc=0.0, kex_ac=0.0,
+        kab=0.0, kba=0.0, kac=0.0, kca=0.0, kbc=0.0, kcb=0.0,
         r2_i_a=0.0, r1_i_a=0.0, omega_i_a=0.0,
         r2_i_b=0.0, r1_i_b=0.0, omega_i_b=0.0,
         r2_i_c=0.0, r1_i_c=0.0, omega_i_c=0.0,
         omega1x_i=0.0, omega1y_i=0.0,
         **kwargs):
     """Compute the Liouvillian."""
-    pa = 1.0 - pb - pc
-
-    kab = kba = kbc = kcb = kac = kca = 0.0
-
-    if pa + pb:
-        kab, kba = kex_ab / (pa + pb) * np.array([pb, pa])
-    if pb + pc:
-        kbc, kcb = kex_bc / (pb + pc) * np.array([pc, pb])
-    if pa + pc:
-        kac, kca = kex_ac / (pa + pc) * np.array([pc, pa])
 
     liouvillian = (
         mat_r2_i_a * r2_i_a +
@@ -85,9 +75,9 @@ def compute_liouvillian(
 # yapf: enable
 
 
-def compute_equilibrium(pb=0.0, pc=0.0, **kwargs):
+def compute_equilibrium(pa=0.0, pb=0.0, pc=0.0, **kwargs):
     """Compute the equilibrium magnetization."""
-    return np.array([[0.0, 0.0, 1.0 - pb - pc, 0.0, 0.0, pb, 0.0, 0.0, pc]]).T
+    return np.array([[0.0, 0.0, pa, 0.0, 0.0, pb, 0.0, 0.0, pc]]).T
 
 
 def create_default_params(model=None,
@@ -97,52 +87,50 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs2 = {'temperature': temperature, 'nuclei': nuclei}
-    kwargs3 = {'temperature': temperature, 'nuclei': nuclei, 'h_larmor_frq': h_larmor_frq}
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'pc': parameters.ParameterName('pc', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'kex_ac': parameters.ParameterName('kex_ac', **kwargs1).to_full_name(),
-        'kex_bc': parameters.ParameterName('kex_bc', **kwargs1).to_full_name(),
-        'dw_i_ab': parameters.ParameterName('dw_ab', **kwargs2).to_full_name(),
-        'dw_i_ac': parameters.ParameterName('dw_ac', **kwargs2).to_full_name(),
-        'cs_i_a': parameters.ParameterName('cs_a', **kwargs2).to_full_name(),
-        'r2_i_a': parameters.ParameterName('r2_a', **kwargs3).to_full_name(),
-        'r1_i_a': parameters.ParameterName('r1_a', **kwargs3).to_full_name(),
-        'cs_i_b': parameters.ParameterName('cs_b', **kwargs2).to_full_name(),
-        'r2_i_b': parameters.ParameterName('r2_b', **kwargs3).to_full_name(),
-        'r1_i_b': parameters.ParameterName('r1_b', **kwargs3).to_full_name(),
-        'cs_i_c': parameters.ParameterName('cs_c', **kwargs2).to_full_name(),
-        'r2_i_c': parameters.ParameterName('r2_c', **kwargs3).to_full_name(),
-        'r1_i_c': parameters.ParameterName('r1_c', **kwargs3).to_full_name(),
-    }
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
+    resonance_i, resonance_s = nuclei.resonances
+
+    kw1 = {'temperature': temperature, 'nuclei': resonance_i['name']}
+
+    map_names.update({
+        'dw_i_ab': parameters.ParameterName('dw_ab', **kw1).to_full_name(),
+        'dw_i_ac': parameters.ParameterName('dw_ac', **kw1).to_full_name(),
+        'cs_i_a': parameters.ParameterName('cs_a', **kw1).to_full_name(),
+        'cs_i_b': parameters.ParameterName('cs_b', **kw1).to_full_name(),
+        'cs_i_c': parameters.ParameterName('cs_c', **kw1).to_full_name(),
+    })
+
+    kw2 = {'temperature': temperature, 'nuclei': resonance_i['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_i_a': parameters.ParameterName('r2_a', **kw2).to_full_name(),
+        'r1_i_a': parameters.ParameterName('r1_a', **kw2).to_full_name(),
+        'r2_i_b': parameters.ParameterName('r2_b', **kw2).to_full_name(),
+        'r1_i_b': parameters.ParameterName('r1_b', **kw2).to_full_name(),
+        'r2_i_c': parameters.ParameterName('r2_c', **kw2).to_full_name(),
+        'r1_i_c': parameters.ParameterName('r1_c', **kw2).to_full_name(),
+    })
+
+    params.add_many(
+        (map_names['dw_i_ab'], 0.0, True, None, None, None),
+        (map_names['dw_i_ac'], 0.0, False, None, None, None),
+        (map_names['cs_i_a'], 0.0, False, None, None, None),
+        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
+        (map_names['r1_i_a'], 1.0, True, 0.0, None, None), )
 
     cs_i_b = '{cs_i_a} + {dw_i_ab}'.format(**map_names)
     cs_i_c = '{cs_i_a} + {dw_i_ac}'.format(**map_names)
-    r1_i_b = r1_i_c = map_names['r1_i_a']
-
-    params = lmfit.Parameters()
+    r1_i_c = r1_i_b = map_names['r1_i_a']
+    r2_i_c = r2_i_b = map_names['r2_i_a']
 
     params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.025, True, 0.0, 1.0, None),
-        (map_names['pc'], 0.025, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['kex_ac'], 0.0, False, 0.0, None, None),
-        (map_names['kex_bc'], 200.0, True, 0.0, None, None),
-        (map_names['dw_i_ab'], 0.0, True, None, None, None),
-        (map_names['dw_i_ac'], 0.0, True, None, None, None),
-        (map_names['cs_i_a'], 0.0, False, None, None, None),
-        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
-        (map_names['r1_i_a'], 1.0, True, 0.0, None, None),
-        (map_names['cs_i_b'], 0.0, True, None, None, cs_i_b),
-        (map_names['r2_i_b'], 10.0, True, 0.0, None, None),
-        (map_names['r1_i_b'], 1.0, True, 0.0, None, r1_i_b),
-        (map_names['cs_i_c'], 0.0, True, None, None, cs_i_c),
-        (map_names['r2_i_c'], 10.0, True, 0.0, None, None),
-        (map_names['r1_i_c'], 1.0, True, 0.0, None, r1_i_c), )
+        (map_names['cs_i_b'], 0.0, None, None, None, cs_i_b),
+        (map_names['r2_i_b'], 10.0, None, 0.0, None, r2_i_b),
+        (map_names['r1_i_b'], 1.0, None, 0.0, None, r1_i_b),
+        (map_names['cs_i_c'], 0.0, None, None, None, cs_i_c),
+        (map_names['r2_i_c'], 10.0, None, 0.0, None, r2_i_c),
+        (map_names['r1_i_c'], 1.0, None, 0.0, None, r1_i_c), )
 
     return map_names, params

--- a/chemex/bases/three_state/ixyzsxyz.py
+++ b/chemex/bases/three_state/ixyzsxyz.py
@@ -84,7 +84,7 @@ index_iz_a = [2]
 
 # yapf: disable
 def compute_liouvillian(
-        pb=0.0, pc=0.0, kex_ab=0.0, kex_ac=0.0, kex_bc=0.0,
+        kab=0.0, kba=0.0, kac=0.0, kca=0.0, kbc=0.0, kcb=0.0,
         r2_i_a=0.0, r1_i_a=0.0, r2a_i_a=0.0, etaxy_i_a=0.0, etaz_i_a=0.0, omega_i_a=0.0,
         r2_i_b=0.0, r1_i_b=0.0, r2a_i_b=0.0, etaxy_i_b=0.0, etaz_i_b=0.0, omega_i_b=0.0,
         r2_i_c=0.0, r1_i_c=0.0, r2a_i_c=0.0, etaxy_i_c=0.0, etaz_i_c=0.0, omega_i_c=0.0,
@@ -97,16 +97,6 @@ def compute_liouvillian(
         omega1x_i=0.0, omega1y_i=0.0, omega1x_s=0.0, omega1y_s=0.0,
         **kwargs):
     """Compute the Liouvillian."""
-    pa = 1.0 - pb - pc
-
-    kab = kba = kbc = kcb = kac = kca = 0.0
-
-    if pa + pb:
-        kab, kba = kex_ab / (pa + pb) * np.array([pb, pa])
-    if pb + pc:
-        kbc, kcb = kex_bc / (pb + pc) * np.array([pc, pb])
-    if pa + pc:
-        kac, kca = kex_ac / (pa + pc) * np.array([pc, pa])
 
     liouvillian = (
         mat_r2_i_a * r2_i_a +
@@ -194,10 +184,10 @@ def compute_liouvillian(
 # yapf: enable
 
 
-def compute_equilibrium(pb=0.0, pc=0.0, **kwargs):
+def compute_equilibrium(pa=0.0, pb=0.0, pc=0.0, **kwargs):
     """Compute the equilibrium magnetization."""
     mag0 = np.zeros((45, 1))
-    mag0[index_iz] = [[1.0 - pb - pc], [pb], [pc]]
+    mag0[index_iz] = [[pa], [pb], [pc]]
 
     return mag0
 
@@ -209,119 +199,97 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
+
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
     resonance_i, resonance_s = nuclei.resonances
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs2 = {'temperature': temperature, 'nuclei': resonance_i['name']}
-    kwargs3 = {
-        'temperature': temperature,
-        'nuclei': resonance_i['name'],
-        'h_larmor_frq': h_larmor_frq
-    }
-    kwargs4 = {'temperature': temperature, 'nuclei': resonance_s['name']}
-    kwargs5 = {
-        'temperature': temperature,
-        'nuclei': resonance_s['name'],
-        'h_larmor_frq': h_larmor_frq
-    }
-    kwargs6 = {'temperature': temperature, 'nuclei': nuclei.assignment}
-    kwargs7 = {
-        'temperature': temperature,
-        'nuclei': nuclei.assignment,
-        'h_larmor_frq': h_larmor_frq
-    }
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'pc': parameters.ParameterName('pc', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'kex_bc': parameters.ParameterName('kex_bc', **kwargs1).to_full_name(),
-        'kex_ac': parameters.ParameterName('kex_ac', **kwargs1).to_full_name(),
-        'dw_i_ab': parameters.ParameterName('dw_ab', **kwargs2).to_full_name(),
-        'dw_i_ac': parameters.ParameterName('dw_ac', **kwargs2).to_full_name(),
-        'dw_s_ab': parameters.ParameterName('dw_ab', **kwargs4).to_full_name(),
-        'dw_s_ac': parameters.ParameterName('dw_ac', **kwargs4).to_full_name(),
-        'cs_i_a': parameters.ParameterName('cs_a', **kwargs2).to_full_name(),
-        'r2_i_a': parameters.ParameterName('r2_a', **kwargs3).to_full_name(),
-        'r1_i_a': parameters.ParameterName('r1_a', **kwargs3).to_full_name(),
-        'r2a_i_a': parameters.ParameterName('r2a_a', **kwargs3).to_full_name(),
-        'etaxy_i_a': parameters.ParameterName('etaxy_a', **kwargs3).to_full_name(),
-        'etaz_i_a': parameters.ParameterName('etaz_a', **kwargs3).to_full_name(),
-        'cs_s_a': parameters.ParameterName('cs_a', **kwargs4).to_full_name(),
-        'r2_s_a': parameters.ParameterName('r2_a', **kwargs5).to_full_name(),
-        'r1_s_a': parameters.ParameterName('r1_a', **kwargs5).to_full_name(),
-        'r2a_s_a': parameters.ParameterName('r2a_a', **kwargs5).to_full_name(),
-        'etaxy_s_a': parameters.ParameterName('etaxy_a', **kwargs5).to_full_name(),
-        'etaz_s_a': parameters.ParameterName('etaz_a', **kwargs5).to_full_name(),
-        'r1a_a': parameters.ParameterName('r1a_a', **kwargs7).to_full_name(),
-        'r2_mq_a': parameters.ParameterName('r2_mq_a', **kwargs7).to_full_name(),
-        'mu_mq_a': parameters.ParameterName('mu_mq_a', **kwargs7).to_full_name(),
-        'sigma_a': parameters.ParameterName('sigma_a', **kwargs7).to_full_name(),
-        'j_a': parameters.ParameterName('j_a', **kwargs6).to_full_name(),
-        'cs_i_b': parameters.ParameterName('cs_b', **kwargs2).to_full_name(),
-        'r2_i_b': parameters.ParameterName('r2_b', **kwargs3).to_full_name(),
-        'r1_i_b': parameters.ParameterName('r1_b', **kwargs3).to_full_name(),
-        'r2a_i_b': parameters.ParameterName('r2a_b', **kwargs3).to_full_name(),
-        'etaxy_i_b': parameters.ParameterName('etaxy_b', **kwargs3).to_full_name(),
-        'etaz_i_b': parameters.ParameterName('etaz_b', **kwargs3).to_full_name(),
-        'cs_s_b': parameters.ParameterName('cs_b', **kwargs4).to_full_name(),
-        'r2_s_b': parameters.ParameterName('r2_b', **kwargs5).to_full_name(),
-        'r1_s_b': parameters.ParameterName('r1_b', **kwargs5).to_full_name(),
-        'r2a_s_b': parameters.ParameterName('r2a_b', **kwargs5).to_full_name(),
-        'etaxy_s_b': parameters.ParameterName('etaxy_b', **kwargs5).to_full_name(),
-        'etaz_s_b': parameters.ParameterName('etaz_b', **kwargs5).to_full_name(),
-        'r1a_b': parameters.ParameterName('r1a_b', **kwargs7).to_full_name(),
-        'r2_mq_b': parameters.ParameterName('r2_mq_b', **kwargs7).to_full_name(),
-        'mu_mq_b': parameters.ParameterName('mu_mq_b', **kwargs7).to_full_name(),
-        'sigma_b': parameters.ParameterName('sigma_b', **kwargs7).to_full_name(),
-        'j_b': parameters.ParameterName('j_b', **kwargs6).to_full_name(),
-        'cs_i_c': parameters.ParameterName('cs_c', **kwargs2).to_full_name(),
-        'r2_i_c': parameters.ParameterName('r2_c', **kwargs3).to_full_name(),
-        'r1_i_c': parameters.ParameterName('r1_c', **kwargs3).to_full_name(),
-        'r2a_i_c': parameters.ParameterName('r2a_c', **kwargs3).to_full_name(),
-        'etaxy_i_c': parameters.ParameterName('etaxy_c', **kwargs3).to_full_name(),
-        'etaz_i_c': parameters.ParameterName('etaz_c', **kwargs3).to_full_name(),
-        'cs_s_c': parameters.ParameterName('cs_c', **kwargs4).to_full_name(),
-        'r2_s_c': parameters.ParameterName('r2_c', **kwargs5).to_full_name(),
-        'r1_s_c': parameters.ParameterName('r1_c', **kwargs5).to_full_name(),
-        'r2a_s_c': parameters.ParameterName('r2a_c', **kwargs5).to_full_name(),
-        'etaxy_s_c': parameters.ParameterName('etaxy_c', **kwargs5).to_full_name(),
-        'etaz_s_c': parameters.ParameterName('etaz_c', **kwargs5).to_full_name(),
-        'r1a_c': parameters.ParameterName('r1a_c', **kwargs7).to_full_name(),
-        'r2_mq_c': parameters.ParameterName('r2_mq_c', **kwargs7).to_full_name(),
-        'mu_mq_c': parameters.ParameterName('mu_mq_c', **kwargs7).to_full_name(),
-        'sigma_c': parameters.ParameterName('sigma_c', **kwargs7).to_full_name(),
-        'j_c': parameters.ParameterName('j_c', **kwargs6).to_full_name(),
-    }
+    kw1 = {'temperature': temperature, 'nuclei': resonance_i['name']}
 
-    cs_i_b = '{cs_i_a} + {dw_i_ab}'.format(**map_names)
-    cs_i_c = '{cs_i_a} + {dw_i_ac}'.format(**map_names)
-    cs_s_b = '{cs_s_a} + {dw_s_ab}'.format(**map_names)
-    cs_s_c = '{cs_s_a} + {dw_s_ac}'.format(**map_names)
-    r1_i_c = r1_i_b = map_names['r1_i_a']
-    r2_i_c = r2_i_b = map_names['r2_i_a']
-    r1_s_c = r1_s_b = map_names['r1_s_a']
-    r2_s_c = r2_s_b = map_names['r2_s_a']
-    r1a_c = r1a_b = map_names['r1a_a']
-    r2a_i_c = r2a_i_b = map_names['r2a_i_a']
-    r2a_s_c = r2a_s_b = map_names['r2a_s_a']
-    etaxy_i_c = etaxy_i_b = map_names['etaxy_i_a']
-    etaz_i_c = etaz_i_b = map_names['etaz_i_a']
-    etaxy_s_c = etaxy_s_b = map_names['etaxy_s_a']
-    etaz_s_c = etaz_s_b = map_names['etaz_s_a']
-    sigma_c = sigma_b = map_names['sigma_a']
-    mu_mq_c = mu_mq_b = map_names['mu_mq_a']
-    r2_mq_c = r2_mq_b = map_names['r2_mq_a']
-    j_c = j_b = map_names['j_a']
+    map_names.update({
+        'dw_i_ab': parameters.ParameterName('dw_ab', **kw1).to_full_name(),
+        'dw_i_ac': parameters.ParameterName('dw_ac', **kw1).to_full_name(),
+        'cs_i_a': parameters.ParameterName('cs_a', **kw1).to_full_name(),
+        'cs_i_b': parameters.ParameterName('cs_b', **kw1).to_full_name(),
+        'cs_i_c': parameters.ParameterName('cs_c', **kw1).to_full_name(),
+    })
 
-    params = lmfit.Parameters()
+    kw2 = {'temperature': temperature, 'nuclei': resonance_i['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_i_a': parameters.ParameterName('r2_a', **kw2).to_full_name(),
+        'r1_i_a': parameters.ParameterName('r1_a', **kw2).to_full_name(),
+        'r2a_i_a': parameters.ParameterName('r2a_a', **kw2).to_full_name(),
+        'etaxy_i_a': parameters.ParameterName('etaxy_a', **kw2).to_full_name(),
+        'etaz_i_a': parameters.ParameterName('etaz_a', **kw2).to_full_name(),
+        'r2_i_b': parameters.ParameterName('r2_b', **kw2).to_full_name(),
+        'r1_i_b': parameters.ParameterName('r1_b', **kw2).to_full_name(),
+        'r2a_i_b': parameters.ParameterName('r2a_b', **kw2).to_full_name(),
+        'etaxy_i_b': parameters.ParameterName('etaxy_b', **kw2).to_full_name(),
+        'etaz_i_b': parameters.ParameterName('etaz_b', **kw2).to_full_name(),
+        'r2_i_c': parameters.ParameterName('r2_c', **kw2).to_full_name(),
+        'r1_i_c': parameters.ParameterName('r1_c', **kw2).to_full_name(),
+        'r2a_i_c': parameters.ParameterName('r2a_c', **kw2).to_full_name(),
+        'etaxy_i_c': parameters.ParameterName('etaxy_c', **kw2).to_full_name(),
+        'etaz_i_c': parameters.ParameterName('etaz_c', **kw2).to_full_name(),
+    })
+
+    kw3 = {'temperature': temperature, 'nuclei': resonance_s['name']}
+
+    map_names.update({
+        'dw_s_ab': parameters.ParameterName('dw_ab', **kw3).to_full_name(),
+        'dw_s_ac': parameters.ParameterName('dw_ac', **kw3).to_full_name(),
+        'cs_s_a': parameters.ParameterName('cs_a', **kw3).to_full_name(),
+        'cs_s_b': parameters.ParameterName('cs_b', **kw3).to_full_name(),
+        'cs_s_c': parameters.ParameterName('cs_c', **kw3).to_full_name(),
+    })
+
+    kw4 = {'temperature': temperature, 'nuclei': resonance_s['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_s_a': parameters.ParameterName('r2_a', **kw4).to_full_name(),
+        'r1_s_a': parameters.ParameterName('r1_a', **kw4).to_full_name(),
+        'r2a_s_a': parameters.ParameterName('r2a_a', **kw4).to_full_name(),
+        'etaxy_s_a': parameters.ParameterName('etaxy_a', **kw4).to_full_name(),
+        'etaz_s_a': parameters.ParameterName('etaz_a', **kw4).to_full_name(),
+        'r2_s_b': parameters.ParameterName('r2_b', **kw4).to_full_name(),
+        'r1_s_b': parameters.ParameterName('r1_b', **kw4).to_full_name(),
+        'r2a_s_b': parameters.ParameterName('r2a_b', **kw4).to_full_name(),
+        'etaxy_s_b': parameters.ParameterName('etaxy_b', **kw4).to_full_name(),
+        'etaz_s_b': parameters.ParameterName('etaz_b', **kw4).to_full_name(),
+        'r2_s_c': parameters.ParameterName('r2_c', **kw4).to_full_name(),
+        'r1_s_c': parameters.ParameterName('r1_c', **kw4).to_full_name(),
+        'r2a_s_c': parameters.ParameterName('r2a_c', **kw4).to_full_name(),
+        'etaxy_s_c': parameters.ParameterName('etaxy_c', **kw4).to_full_name(),
+        'etaz_s_c': parameters.ParameterName('etaz_c', **kw4).to_full_name(),
+    })
+
+    kw5 = {'temperature': temperature, 'nuclei': nuclei.assignment}
+
+    map_names.update({
+        'j_a': parameters.ParameterName('j_a', **kw5).to_full_name(),
+        'j_b': parameters.ParameterName('j_b', **kw5).to_full_name(),
+        'j_c': parameters.ParameterName('j_c', **kw5).to_full_name(),
+    })
+
+    kw6 = {'temperature': temperature, 'nuclei': nuclei.assignment, 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r1a_a': parameters.ParameterName('r1a_a', **kw6).to_full_name(),
+        'r2_mq_a': parameters.ParameterName('r2_mq_a', **kw6).to_full_name(),
+        'mu_mq_a': parameters.ParameterName('mu_mq_a', **kw6).to_full_name(),
+        'sigma_a': parameters.ParameterName('sigma_a', **kw6).to_full_name(),
+        'r1a_b': parameters.ParameterName('r1a_b', **kw6).to_full_name(),
+        'r2_mq_b': parameters.ParameterName('r2_mq_b', **kw6).to_full_name(),
+        'mu_mq_b': parameters.ParameterName('mu_mq_b', **kw6).to_full_name(),
+        'sigma_b': parameters.ParameterName('sigma_b', **kw6).to_full_name(),
+        'r1a_c': parameters.ParameterName('r1a_c', **kw6).to_full_name(),
+        'r2_mq_c': parameters.ParameterName('r2_mq_c', **kw6).to_full_name(),
+        'mu_mq_c': parameters.ParameterName('mu_mq_c', **kw6).to_full_name(),
+        'sigma_c': parameters.ParameterName('sigma_c', **kw6).to_full_name(),
+    })
 
     params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.025, True, 0.0, 1.0, None),
-        (map_names['pc'], 0.025, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['kex_bc'], 200.0, True, 0.0, None, None),
-        (map_names['kex_ac'], 0.0, False, 0.0, None, None),
         (map_names['dw_i_ab'], 0.0, True, None, None, None),
         (map_names['dw_i_ac'], 0.0, True, None, None, None),
         (map_names['dw_s_ab'], 0.0, False, None, None, None),
@@ -342,7 +310,29 @@ def create_default_params(model=None,
         (map_names['sigma_a'], 0.0, False, None, None, None),
         (map_names['r2_mq_a'], 10.0, False, 0.0, None, None),
         (map_names['r1a_a'], 2.0, False, 0.0, None, None),
-        (map_names['j_a'], -93.0, False, None, None, None),
+        (map_names['j_a'], -93.0, False, None, None, None), )
+
+    cs_i_b = '{cs_i_a} + {dw_i_ab}'.format(**map_names)
+    cs_s_b = '{cs_s_a} + {dw_s_ab}'.format(**map_names)
+    cs_i_c = '{cs_i_a} + {dw_i_ac}'.format(**map_names)
+    cs_s_c = '{cs_s_a} + {dw_s_ac}'.format(**map_names)
+    r1_i_c = r1_i_b = map_names['r1_i_a']
+    r2_i_c = r2_i_b = map_names['r2_i_a']
+    r1_s_c = r1_s_b = map_names['r1_s_a']
+    r2_s_c = r2_s_b = map_names['r2_s_a']
+    r1a_c = r1a_b = map_names['r1a_a']
+    r2a_i_c = r2a_i_b = map_names['r2a_i_a']
+    r2a_s_c = r2a_s_b = map_names['r2a_s_a']
+    etaxy_i_c = etaxy_i_b = map_names['etaxy_i_a']
+    etaz_i_c = etaz_i_b = map_names['etaz_i_a']
+    etaxy_s_c = etaxy_s_b = map_names['etaxy_s_a']
+    etaz_s_c = etaz_s_b = map_names['etaz_s_a']
+    sigma_c = sigma_b = map_names['sigma_a']
+    mu_mq_c = mu_mq_b = map_names['mu_mq_a']
+    r2_mq_c = r2_mq_b = map_names['r2_mq_a']
+    j_c = j_b = map_names['j_a']
+
+    params.add_many(
         (map_names['cs_i_b'], 0.0, None, None, None, cs_i_b),
         (map_names['r2_i_b'], 10.0, None, 0.0, None, r2_i_b),
         (map_names['r1_i_b'], 1.0, None, 0.0, None, r1_i_b),
@@ -377,8 +367,5 @@ def create_default_params(model=None,
         (map_names['r2_mq_c'], 10.0, None, 0.0, None, r2_mq_c),
         (map_names['r1a_c'], 2.0, None, 0.0, None, r1a_c),
         (map_names['j_c'], -93.0, None, None, None, j_c), )
-
-    map_names, params = exchange_model.update_params(params, map_names, model, temperature, p_total,
-                                                     l_total)
 
     return map_names, params

--- a/chemex/bases/three_state/ixyzsz.py
+++ b/chemex/bases/three_state/ixyzsz.py
@@ -4,7 +4,6 @@
 
 """
 
-import lmfit
 import numpy as np
 
 from chemex import parameters
@@ -71,7 +70,7 @@ p_180x_i_perfect = np.diag([1.0, -1.0, -1.0, 1.0, -1.0, -1.0,
 
 
 def compute_liouvillian(
-        pb=0.0, pc=0.0, kex_ab=0.0, kex_bc=0.0, kex_ac=0.0,
+        kab=0.0, kba=0.0, kac=0.0, kca=0.0, kbc=0.0, kcb=0.0,
         r2_i_a=0.0, r1_i_a=0.0, r2a_i_a=0.0, etaxy_i_a=0.0, etaz_i_a=0.0, omega_i_a=0.0,
         r2_i_b=0.0, r1_i_b=0.0, r2a_i_b=0.0, etaxy_i_b=0.0, etaz_i_b=0.0, omega_i_b=0.0,
         r2_i_c=0.0, r1_i_c=0.0, r2a_i_c=0.0, etaxy_i_c=0.0, etaz_i_c=0.0, omega_i_c=0.0,
@@ -81,16 +80,6 @@ def compute_liouvillian(
         omega1x_i=0.0, omega1y_i=0.0,
         **kwargs):
     """Compute the Liouvillian."""
-    pa = 1.0 - pb - pc
-
-    kab = kba = kbc = kcb = kac = kca = 0.0
-
-    if pa + pb:
-        kab, kba = kex_ab / (pa + pb) * np.array([pb, pa])
-    if pb + pc:
-        kbc, kcb = kex_bc / (pb + pc) * np.array([pc, pb])
-    if pa + pc:
-        kac, kca = kex_ac / (pa + pc) * np.array([pc, pa])
 
     liouvillian = (
         mat_r2_i_a * r2_i_a +
@@ -140,18 +129,18 @@ def compute_liouvillian(
 # yapf: enable
 
 
-def compute_equilibrium_2izsz(pb=0.0, pc=0.0, **kwargs):
+def compute_equilibrium_2izsz(pa=0.0, pb=0.0, pc=0.0, **kwargs):
     """Compute the equilibrium magnetization."""
     mag0 = np.zeros((18, 1))
-    mag0[index_2izsz] = [[1.0 - pb - pc], [pb], [pc]]
+    mag0[index_2izsz] = [[pa], [pb], [pc]]
 
     return mag0
 
 
-def compute_2izsz_a(pb=0.0, pc=0.0, **kwargs):
+def compute_2izsz_a(pa=0.0, **kwargs):
     """Compute the equilibrium magnetization for anti-TROSY."""
     mag0 = np.zeros((18, 1))
-    mag0[index_2izsz] = [[1.0 - pb - pc], [0.0], [0.0]]
+    mag0[index_2izsz] = [[pa], [0.0], [0.0]]
 
     return mag0
 
@@ -163,102 +152,95 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
-    resonance_i, resonance_s = nuclei.resonances
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs2 = {'temperature': temperature, 'nuclei': resonance_i['name']}
-    kwargs3 = {
-        'temperature': temperature,
-        'nuclei': resonance_i['name'],
-        'h_larmor_frq': h_larmor_frq
-    }
-    kwargs4 = {'temperature': temperature, 'nuclei': nuclei.assignment}
-    kwargs5 = {
-        'temperature': temperature,
-        'nuclei': nuclei.assignment,
-        'h_larmor_frq': h_larmor_frq
-    }
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'pc': parameters.ParameterName('pc', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'kex_bc': parameters.ParameterName('kex_bc', **kwargs1).to_full_name(),
-        'kex_ac': parameters.ParameterName('kex_ac', **kwargs1).to_full_name(),
-        'dw_i_ab': parameters.ParameterName('dw_ab', **kwargs2).to_full_name(),
-        'dw_i_ac': parameters.ParameterName('dw_ac', **kwargs2).to_full_name(),
-        'cs_i_a': parameters.ParameterName('cs_a', **kwargs2).to_full_name(),
-        'r2_i_a': parameters.ParameterName('r2_a', **kwargs3).to_full_name(),
-        'r2a_i_a': parameters.ParameterName('r2a_a', **kwargs3).to_full_name(),
-        'r1_i_a': parameters.ParameterName('r1_a', **kwargs3).to_full_name(),
-        'r1a_a': parameters.ParameterName('r1a_a', **kwargs5).to_full_name(),
-        'etaxy_i_a': parameters.ParameterName('etaxy_a', **kwargs3).to_full_name(),
-        'etaz_i_a': parameters.ParameterName('etaz_a', **kwargs3).to_full_name(),
-        'j_a': parameters.ParameterName('j_a', **kwargs4).to_full_name(),
-        'cs_i_b': parameters.ParameterName('cs_b', **kwargs2).to_full_name(),
-        'r2_i_b': parameters.ParameterName('r2_b', **kwargs3).to_full_name(),
-        'r2a_i_b': parameters.ParameterName('r2a_b', **kwargs3).to_full_name(),
-        'r1_i_b': parameters.ParameterName('r1_b', **kwargs3).to_full_name(),
-        'r1a_b': parameters.ParameterName('r1a_b', **kwargs5).to_full_name(),
-        'etaxy_i_b': parameters.ParameterName('etaxy_b', **kwargs3).to_full_name(),
-        'etaz_i_b': parameters.ParameterName('etaz_b', **kwargs3).to_full_name(),
-        'j_b': parameters.ParameterName('j_b', **kwargs4).to_full_name(),
-        'cs_i_c': parameters.ParameterName('cs_c', **kwargs2).to_full_name(),
-        'r2_i_c': parameters.ParameterName('r2_c', **kwargs3).to_full_name(),
-        'r2a_i_c': parameters.ParameterName('r2a_c', **kwargs3).to_full_name(),
-        'r1_i_c': parameters.ParameterName('r1_c', **kwargs3).to_full_name(),
-        'r1a_c': parameters.ParameterName('r1a_c', **kwargs5).to_full_name(),
-        'etaxy_i_c': parameters.ParameterName('etaxy_c', **kwargs3).to_full_name(),
-        'etaz_i_c': parameters.ParameterName('etaz_c', **kwargs3).to_full_name(),
-        'j_c': parameters.ParameterName('j_c', **kwargs4).to_full_name(),
-    }
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
+    resonance_i, resonance_s = nuclei.resonances
+
+    kw1 = {'temperature': temperature, 'nuclei': resonance_i['name']}
+
+    map_names.update({
+        'dw_i_ab': parameters.ParameterName('dw_ab', **kw1).to_full_name(),
+        'dw_i_ac': parameters.ParameterName('dw_ac', **kw1).to_full_name(),
+        'cs_i_a': parameters.ParameterName('cs_a', **kw1).to_full_name(),
+        'cs_i_b': parameters.ParameterName('cs_b', **kw1).to_full_name(),
+        'cs_i_c': parameters.ParameterName('cs_c', **kw1).to_full_name(),
+    })
+
+    kw2 = {'temperature': temperature, 'nuclei': resonance_i['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_i_a': parameters.ParameterName('r2_a', **kw2).to_full_name(),
+        'r1_i_a': parameters.ParameterName('r1_a', **kw2).to_full_name(),
+        'r2a_i_a': parameters.ParameterName('r2a_a', **kw2).to_full_name(),
+        'etaxy_i_a': parameters.ParameterName('etaxy_a', **kw2).to_full_name(),
+        'etaz_i_a': parameters.ParameterName('etaz_a', **kw2).to_full_name(),
+        'r2_i_b': parameters.ParameterName('r2_b', **kw2).to_full_name(),
+        'r1_i_b': parameters.ParameterName('r1_b', **kw2).to_full_name(),
+        'r2a_i_b': parameters.ParameterName('r2a_b', **kw2).to_full_name(),
+        'etaxy_i_b': parameters.ParameterName('etaxy_b', **kw2).to_full_name(),
+        'etaz_i_b': parameters.ParameterName('etaz_b', **kw2).to_full_name(),
+        'r2_i_c': parameters.ParameterName('r2_c', **kw2).to_full_name(),
+        'r1_i_c': parameters.ParameterName('r1_c', **kw2).to_full_name(),
+        'r2a_i_c': parameters.ParameterName('r2a_c', **kw2).to_full_name(),
+        'etaxy_i_c': parameters.ParameterName('etaxy_c', **kw2).to_full_name(),
+        'etaz_i_c': parameters.ParameterName('etaz_c', **kw2).to_full_name(),
+    })
+
+    kw5 = {'temperature': temperature, 'nuclei': nuclei.assignment}
+
+    map_names.update({
+        'j_a': parameters.ParameterName('j_a', **kw5).to_full_name(),
+        'j_b': parameters.ParameterName('j_b', **kw5).to_full_name(),
+        'j_c': parameters.ParameterName('j_c', **kw5).to_full_name(),
+    })
+
+    kw6 = {'temperature': temperature, 'nuclei': nuclei.assignment, 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r1a_a': parameters.ParameterName('r1a_a', **kw6).to_full_name(),
+        'r1a_b': parameters.ParameterName('r1a_b', **kw6).to_full_name(),
+        'r1a_c': parameters.ParameterName('r1a_c', **kw6).to_full_name(),
+    })
+
+    params.add_many(
+        (map_names['dw_i_ab'], 0.0, True, None, None, None),
+        (map_names['dw_i_ac'], 0.0, False, None, None, None),
+        (map_names['cs_i_a'], 0.0, False, None, None, None),
+        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
+        (map_names['r1_i_a'], 1.0, True, 0.0, None, None),
+        (map_names['r2a_i_a'], 15.0, False, 0.0, None, None),
+        (map_names['etaxy_i_a'], 0.0, True, None, None, None),
+        (map_names['etaz_i_a'], 0.0, True, None, None, None),
+        (map_names['r1a_a'], 2.0, False, 0.0, None, None),
+        (map_names['j_a'], -93.0, False, None, None, None), )
 
     cs_i_b = '{cs_i_a} + {dw_i_ab}'.format(**map_names)
     cs_i_c = '{cs_i_a} + {dw_i_ac}'.format(**map_names)
     r1_i_c = r1_i_b = map_names['r1_i_a']
     r2_i_c = r2_i_b = map_names['r2_i_a']
-    r2a_i_c = r2a_i_b = map_names['r2a_i_a']
     r1a_c = r1a_b = map_names['r1a_a']
+    r2a_i_c = r2a_i_b = map_names['r2a_i_a']
     etaxy_i_c = etaxy_i_b = map_names['etaxy_i_a']
     etaz_i_c = etaz_i_b = map_names['etaz_i_a']
     j_c = j_b = map_names['j_a']
 
-    params = lmfit.Parameters()
-
     params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.025, True, 0.0, 1.0, None),
-        (map_names['pc'], 0.025, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['kex_bc'], 200.0, True, 0.0, None, None),
-        (map_names['kex_ac'], 0.0, False, 0.0, None, None),
-        (map_names['dw_i_ab'], 0.0, True, None, None, None),
-        (map_names['dw_i_ac'], 0.0, True, None, None, None),
-        (map_names['cs_i_a'], 0.0, False, None, None, None),
-        (map_names['r1_i_a'], 1.5, False, 0.0, None, None),
-        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
-        (map_names['r1a_a'], 3.0, False, 0.0, None, None),
-        (map_names['etaxy_i_a'], 0.0, False, None, None, None),
-        (map_names['etaz_i_a'], 0.0, False, None, None, None),
-        (map_names['j_a'], 135.0, False, None, None, None),
-        (map_names['r2a_i_a'], 3.0, False, 0.0, None, None),
         (map_names['cs_i_b'], 0.0, None, None, None, cs_i_b),
-        (map_names['r1_i_b'], 1.5, None, 0.0, None, r1_i_b),
         (map_names['r2_i_b'], 10.0, None, 0.0, None, r2_i_b),
-        (map_names['r1a_b'], 3.0, None, 0.0, None, r1a_b),
+        (map_names['r1_i_b'], 1.0, None, 0.0, None, r1_i_b),
+        (map_names['r2a_i_b'], 15.0, None, 0.0, None, r2a_i_b),
         (map_names['etaxy_i_b'], 0.0, None, None, None, etaxy_i_b),
         (map_names['etaz_i_b'], 0.0, None, None, None, etaz_i_b),
-        (map_names['j_b'], 135.0, None, None, None, j_b),
-        (map_names['r2a_i_b'], 3.0, None, 0.0, None, r2a_i_b),
+        (map_names['r1a_b'], 2.0, None, 0.0, None, r1a_b),
+        (map_names['j_b'], -93.0, None, None, None, j_b),
         (map_names['cs_i_c'], 0.0, None, None, None, cs_i_c),
-        (map_names['r1_i_c'], 1.5, None, 0.0, None, r1_i_c),
         (map_names['r2_i_c'], 10.0, None, 0.0, None, r2_i_c),
-        (map_names['r1a_c'], 3.0, None, 0.0, None, r1a_c),
+        (map_names['r1_i_c'], 1.0, None, 0.0, None, r1_i_c),
+        (map_names['r2a_i_c'], 15.0, None, 0.0, None, r2a_i_c),
         (map_names['etaxy_i_c'], 0.0, None, None, None, etaxy_i_c),
         (map_names['etaz_i_c'], 0.0, None, None, None, etaz_i_c),
-        (map_names['j_c'], 135.0, None, None, None, j_c),
-        (map_names['r2a_i_c'], 3.0, None, 0.0, None, r2a_i_c), )
-
-    map_names, params = exchange_model.update_params(params, map_names, model, temperature, p_total,
-                                                     l_total)
+        (map_names['r1a_c'], 2.0, None, 0.0, None, r1a_c),
+        (map_names['j_c'], -93.0, None, None, None, j_c), )
 
     return map_names, params

--- a/chemex/bases/three_state/iz.py
+++ b/chemex/bases/three_state/iz.py
@@ -27,19 +27,9 @@ index_iz_a = [0]
 
 # yapf: disable
 def compute_liouvillian(
-        pb=0.0, pc=0.0, kex_ab=0.0, kex_bc=0.0, kex_ac=0.0,
+        kab=0.0, kba=0.0, kac=0.0, kca=0.0, kbc=0.0, kcb=0.0,
         r1_i_a=0.0, r1_i_b=0.0, r1_i_c=0.0):
     """Compute the Liouvillian."""
-    pa = 1.0 - pb - pc
-
-    kab = kba = kbc = kcb = kac = kca = 0.0
-
-    if pa + pb:
-        kab, kba = kex_ab / (pa + pb) * np.array([pb, pa])
-    if pb + pc:
-        kbc, kcb = kex_bc / (pb + pc) * np.array([pc, pb])
-    if pa + pc:
-        kac, kca = kex_ac / (pa + pc) * np.array([pc, pa])
 
     liouvillian = (
 
@@ -59,10 +49,10 @@ def compute_liouvillian(
 # yapf: enable
 
 
-def compute_equilibrium_iz(pb=0.0, pc=0.0, **kwargs):
+def compute_equilibrium_iz(pa=0.0, pb=0.0, pc=0.0, **kwargs):
     """Compute the equilibrium magnetization."""
     mag0 = np.zeros((3, 1))
-    mag0[index_iz] = [[1.0 - pb - pc], [pb], [pc]]
+    mag0[index_iz] = [[pa], [pb], [pc]]
 
     return mag0
 
@@ -74,36 +64,25 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs3 = {'temperature': temperature, 'nuclei': nuclei, 'h_larmor_frq': h_larmor_frq}
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'pc': parameters.ParameterName('pc', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'kex_ac': parameters.ParameterName('kex_ac', **kwargs1).to_full_name(),
-        'kex_bc': parameters.ParameterName('kex_bc', **kwargs1).to_full_name(),
-        'r1_i_a': parameters.ParameterName('r1_a', **kwargs3).to_full_name(),
-        'r1_i_b': parameters.ParameterName('r1_b', **kwargs3).to_full_name(),
-        'r1_i_c': parameters.ParameterName('r1_c', **kwargs3).to_full_name(),
-    }
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
+    resonance_i, resonance_s = nuclei.resonances
+
+    kw2 = {'temperature': temperature, 'nuclei': resonance_i['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r1_i_a': parameters.ParameterName('r1_a', **kw2).to_full_name(),
+        'r1_i_b': parameters.ParameterName('r1_b', **kw2).to_full_name(),
+        'r1_i_c': parameters.ParameterName('r1_c', **kw2).to_full_name(),
+    })
+
+    params.add_many((map_names['r1_i_a'], 1.0, True, 0.0, None, None), )
 
     r1_i_c = r1_i_b = map_names['r1_i_a']
 
-    params = lmfit.Parameters()
-
     params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.025, True, 0.0, 1.0, None),
-        (map_names['pc'], 0.025, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['kex_ac'], 0.0, False, 0.0, None, None),
-        (map_names['kex_bc'], 200.0, True, 0.0, None, None),
-        (map_names['r1_i_a'], 1.0, True, 0.0, None, None),
         (map_names['r1_i_b'], 1.0, None, 0.0, None, r1_i_b),
         (map_names['r1_i_c'], 1.0, None, 0.0, None, r1_i_c), )
-
-    map_names, params = exchange_model.update_params(params, map_names, model, temperature, p_total,
-                                                     l_total)
 
     return map_names, params

--- a/chemex/bases/two_state/exchange_model.py
+++ b/chemex/bases/two_state/exchange_model.py
@@ -1,17 +1,13 @@
 """Module exchange_model contains code for setting up different two-site
 exchange models."""
 
+import lmfit
 from scipy import constants as cst
 
 from chemex import parameters
 
 
-def update_params(params=None,
-                  map_names=None,
-                  model=None,
-                  temperature=None,
-                  p_total=None,
-                  l_total=None):
+def create_exchange_params(model=None, temperature=None, p_total=None, l_total=None):
     """Update the experimental and fitting parameters depending on the model.
 
     :param params:
@@ -23,14 +19,42 @@ def update_params(params=None,
     :return:
 
     """
-    if model not in {'2st.pb_kex', '2st.eyring', '2st.kab_kd', '2st.kon_koff'}:
+
+    map_names = {}
+    params = lmfit.Parameters()
+
+    if model not in {'2st.pb_kex', '2st.eyring', '2st.binding'}:
         print("Warning: The \'model\' option should be either \'2st.pb_kex\'")
         print(", \'2st.eyring\', \'2st.kab_kd\', or \'2st.kon_koff\'.")
         print("\nSet it to the default model: \'2st.pb_kex\'.")
         model = '2st.pb_kex'
 
+    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
+
+    map_names.update({
+        'kab': parameters.ParameterName('kab', **kwargs1).to_full_name(),
+        'kba': parameters.ParameterName('kba', **kwargs1).to_full_name(),
+        'pa': parameters.ParameterName('pa', **kwargs1).to_full_name(),
+        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
+        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
+    })
+
     if model == '2st.pb_kex':
-        pass
+
+        params.add_many(
+            (map_names['pb'], 0.05, True, 0.0, 1.0, None),
+            (map_names['kex_ab'], 200.0, True, 0.0, None, None), )
+
+        pa = '1.0 - {pb}'.format(**map_names)
+
+        params.add_many((map_names['pa'], 0.95, True, 0.0, 1.0, pa), )
+
+        kab = '{kex_ab} * {pb}'.format(**map_names)
+        kba = '{kex_ab} * {pa}'.format(**map_names)
+
+        params.add_many(
+            (map_names['kab'], 10.0, True, 0.0, None, kab),
+            (map_names['kba'], 190.0, True, 0.0, None, kba), )
 
     elif model == '2st.eyring':
         map_names.update({
@@ -40,80 +64,68 @@ def update_params(params=None,
             'ds_ab': parameters.ParameterName('ds_ab').to_full_name(),
         })
 
+        params.add_many(
+            (map_names['dh_b'], 6.5e+03, True, None, None, None),
+            (map_names['ds_b'], 0.0, False, None, None, None),
+            (map_names['dh_ab'], 6.5e+04, True, None, None, None),
+            (map_names['ds_ab'], 0.0, False, None, None, None), )
+
         t_kelvin = temperature + 273.15
         kbt_h = cst.k * t_kelvin / cst.h
         rt = cst.R * t_kelvin
 
-        pb = ('(1.0 / (1.0 + exp(({dh_b} - {t_kelvin} * {ds_b}) / {rt})))'.format(
+        kab = ('{kbt_h} * exp(-({dh_ab} - {t_kelvin} * {ds_ab}) / {rt})'.format(
             kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
 
-        kex_ab = ('{kbt_h} * exp(-({dh_ab} - {t_kelvin} * {ds_ab}) / {rt}) * '
-                  '(1.0 + exp(({dh_b} - {t_kelvin} * {ds_b}) / {rt}))'.format(
-                      kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
+        kba = (
+            '{kbt_h} * exp(-(({dh_ab} - {dh_b}) - {t_kelvin} * ({ds_ab} - {ds_b})) / {rt})'.format(
+                kbt_h=kbt_h, t_kelvin=t_kelvin, rt=rt, **map_names))
 
-        params.add_many(  # Name, Value, Vary, Min, Max, Expr
-            (map_names['dh_b'], 6.5e+03, True, None, None, None),
-            (map_names['ds_b'], 0.0, False, None, None, None),
-            (map_names['dh_ab'], 6.5e+04, True, None, None, None),
-            (map_names['ds_ab'], 0.0, False, None, None, None),
+        params.add_many(
+            (map_names['kab'], 10.0, True, 0.0, None, kab),
+            (map_names['kba'], 190.0, True, 0.0, None, kba), )
+
+        pa = '{kba} / ({kab} + {kba})'.format(**map_names)
+        pb = '{kab} / ({kab} + {kba})'.format(**map_names)
+        kex_ab = '{kab} + {kba}'.format(**map_names)
+
+        params.add_many(
+            (map_names['pa'], 0.0, None, 0.0, 1.0, pa),
             (map_names['pb'], 0.0, None, 0.0, 1.0, pb),
             (map_names['kex_ab'], 0.0, None, 0.0, None, kex_ab), )
 
-    elif model == '2st.kab_kd':
+    elif model == '2st.binding':
         kwargs1 = {'temperature': temperature}
         kwargs2 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
 
         map_names.update({
             'kab': parameters.ParameterName('kab', **kwargs1).to_full_name(),
+            'kba': parameters.ParameterName('kba', **kwargs1).to_full_name(),
             'kd_ab': parameters.ParameterName('kd_ab', **kwargs1).to_full_name(),
             'l_free': parameters.ParameterName('l_free', **kwargs2).to_full_name(),
         })
 
-        l_free = (
-            '0.5 * ({l_total} - {p_total} - {kd_ab} + '
-            '(({l_total} - {p_total} - {kd_ab}) ** 2 + 4.0 * {kd_ab} * {l_total})**0.5)'.format(
-                p_total=p_total, l_total=l_total, **map_names))
-
-        kex = ('({l_free} + {kd_ab}) * {kab}'.format(p_total=p_total, l_total=l_total, **map_names))
-
-        pb = ('({l_total} - {l_free}) / {p_total}'.format(
-            l_total=l_total, p_total=p_total, **map_names))
-
-        params.add_many(  # Name, Value, Vary, Min, Max, Expr
-            (map_names['kd_ab'], 100.0, True, 0.0, None, None),
+        params.add_many(
             (map_names['kab'], 1.0e9, True, 0.0, None, None),
-            (map_names['l_free'], 0.0, None, 0.0, None, l_free),
-            (map_names['pb'], 5.0e-02, None, 0.0, 1.0, pb),
-            (map_names['kex_ab'], 2.0e+02, None, 0.0, None, kex), )
+            (map_names['kd_ab'], 100.0, True, 0.0, None, None), )
 
-    elif model == '2st.kon_koff':
-        kwargs1 = {'temperature': temperature}
-        kwargs2 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
+        kba = '{kd_ab} * {kab}'.format(**map_names)
 
-        map_names.update({
-            'kon': parameters.ParameterName('kon', **kwargs1).to_full_name(),
-            'koff': parameters.ParameterName('koff', **kwargs1).to_full_name(),
-            'kd': parameters.ParameterName('kd', **kwargs1).to_full_name(),
-            'l_free': parameters.ParameterName('l_free', **kwargs2).to_full_name(),
-        })
+        l_free = ('0.5 * ({delta} - {kd_ab} + '
+                  '(({delta} - {kd_ab}) ** 2 + 4.0 * {kd_ab} * {l_total})**0.5)'.format(
+                      delta=l_total - p_total, l_total=l_total, **map_names))
 
-        kd = ('{koff} / {kon}'.format(**map_names))
+        params.add_many(
+            (map_names['kba'], 10.0, None, 0.0, None, kba),
+            (map_names['l_free'], 0.0, None, 0.0, None, l_free), )
 
-        l_free = ('0.5 * ({l_total} - {p_total} - {kd} + '
-                  '(({l_total} - {p_total} - {kd}) ** 2 + 4.0 * {kd} * {l_total})**0.5)'.format(
-                      p_total=p_total, l_total=l_total, **map_names))
+        pa = '{kba} / ({kab} + {kba})'.format(**map_names)
+        pb = '{kab} / ({kab} + {kba})'.format(**map_names)
+        kex_ab = '{kab} + {kba}'.format(**map_names)
 
-        kex = ('{l_free} * {kon} + {koff}'.format(p_total=p_total, l_total=l_total, **map_names))
-
-        pb = ('({l_total} - {l_free}) / {p_total}'.format(
-            l_total=l_total, p_total=p_total, **map_names))
-
-        params.add_many(  # Name, Value, Vary, Min, Max, Expr
-            (map_names['kon'], 1.0e9, True, 0.0, None, None),
-            (map_names['koff'], 1.0e2, True, 0.0, None, None),
-            (map_names['kd'], 0.0, None, 0.0, None, kd),
-            (map_names['l_free'], 0.0, None, 0.0, None, l_free),
-            (map_names['pb'], 5.0e-02, None, 0.0, 1.0, pb),
-            (map_names['kex_ab'], 2.0e+02, None, 0.0, None, kex), )
+        params.add_many(
+            (map_names['pa'], 0.0, None, 0.0, 1.0, pa),
+            (map_names['pb'], 0.0, None, 0.0, 1.0, pb),
+            (map_names['kex_ab'], 0.0, None, 0.0, None, kex_ab), )
 
     return map_names, params

--- a/chemex/bases/two_state/ixysxy.py
+++ b/chemex/bases/two_state/ixysxy.py
@@ -93,54 +93,53 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
-    resonance_i, resonance_s = nuclei.resonances
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs2 = {'temperature': temperature, 'nuclei': resonance_i['name']}
-    kwargs3 = {'temperature': temperature, 'nuclei': resonance_s['name']}
-    kwargs4 = {
-        'temperature': temperature,
-        'nuclei': nuclei.assignment,
-        'h_larmor_frq': h_larmor_frq
-    }
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'dw_i_ab': parameters.ParameterName('dw_ab', **kwargs2).to_full_name(),
-        'dw_s_ab': parameters.ParameterName('dw_ab', **kwargs3).to_full_name(),
-        'cs_i_a': parameters.ParameterName('cs_a', **kwargs2).to_full_name(),
-        'cs_s_a': parameters.ParameterName('cs_a', **kwargs3).to_full_name(),
-        'r2_mq_a': parameters.ParameterName('r2_mq_a', **kwargs4).to_full_name(),
-        'mu_mq_a': parameters.ParameterName('mu_mq_a', **kwargs4).to_full_name(),
-        'cs_i_b': parameters.ParameterName('cs_b', **kwargs2).to_full_name(),
-        'cs_s_b': parameters.ParameterName('cs_b', **kwargs3).to_full_name(),
-        'r2_mq_b': parameters.ParameterName('r2_mq_b', **kwargs4).to_full_name(),
-        'mu_mq_b': parameters.ParameterName('mu_mq_b', **kwargs4).to_full_name(),
-    }
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
+    resonance_i, resonance_s = nuclei.resonances
+
+    kw1 = {'temperature': temperature, 'nuclei': resonance_i['name']}
+
+    map_names.update({
+        'dw_i_ab': parameters.ParameterName('dw_ab', **kw1).to_full_name(),
+        'cs_i_a': parameters.ParameterName('cs_a', **kw1).to_full_name(),
+        'cs_i_b': parameters.ParameterName('cs_b', **kw1).to_full_name(),
+    })
+
+    kw3 = {'temperature': temperature, 'nuclei': resonance_s['name']}
+
+    map_names.update({
+        'dw_s_ab': parameters.ParameterName('dw_ab', **kw3).to_full_name(),
+        'cs_s_a': parameters.ParameterName('cs_a', **kw3).to_full_name(),
+        'cs_s_b': parameters.ParameterName('cs_b', **kw3).to_full_name(),
+    })
+
+    kw6 = {'temperature': temperature, 'nuclei': nuclei.assignment, 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_mq_a': parameters.ParameterName('r2_mq_a', **kw6).to_full_name(),
+        'mu_mq_a': parameters.ParameterName('mu_mq_a', **kw6).to_full_name(),
+        'r2_mq_b': parameters.ParameterName('r2_mq_b', **kw6).to_full_name(),
+        'mu_mq_b': parameters.ParameterName('mu_mq_b', **kw6).to_full_name(),
+    })
+
+    params.add_many(
+        (map_names['dw_i_ab'], 0.0, True, None, None, None),
+        (map_names['dw_s_ab'], 0.0, False, None, None, None),
+        (map_names['cs_i_a'], 0.0, False, None, None, None),
+        (map_names['cs_s_a'], 0.0, False, None, None, None),
+        (map_names['mu_mq_a'], 0.0, False, None, None, None),
+        (map_names['r2_mq_a'], 10.0, False, 0.0, None, None), )
 
     cs_i_b = '{cs_i_a} + {dw_i_ab}'.format(**map_names)
     cs_s_b = '{cs_s_a} + {dw_s_ab}'.format(**map_names)
-    r2_mq_b = map_names['r2_mq_a']
     mu_mq_b = map_names['mu_mq_a']
-
-    params = lmfit.Parameters()
+    r2_mq_b = map_names['r2_mq_a']
 
     params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.05, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['dw_i_ab'], 0.0, True, None, None, None),
-        (map_names['dw_s_ab'], 0.0, True, None, None, None),
-        (map_names['cs_i_a'], 0.0, False, None, None, None),
-        (map_names['cs_s_a'], 0.0, False, None, None, None),
-        (map_names['r2_mq_a'], 10.0, True, 0.0, None, None),
-        (map_names['mu_mq_a'], 0.0, False, 0.0, None, None),
-        (map_names['cs_i_b'], 0.0, False, None, None, cs_i_b),
-        (map_names['cs_s_b'], 0.0, False, None, None, cs_s_b),
-        (map_names['r2_mq_b'], 10.0, None, 0.0, None, r2_mq_b),
-        (map_names['mu_mq_b'], 0.0, None, 0.0, None, mu_mq_b), )
-
-    map_names, params = exchange_model.update_params(params, map_names, model, temperature, p_total,
-                                                     l_total)
+        (map_names['cs_i_b'], 0.0, None, None, None, cs_i_b),
+        (map_names['cs_s_b'], 0.0, None, None, None, cs_s_b),
+        (map_names['mu_mq_b'], 0.0, None, None, None, mu_mq_b),
+        (map_names['r2_mq_b'], 10.0, None, 0.0, None, r2_mq_b), )
 
     return map_names, params

--- a/chemex/bases/two_state/ixyzsxyz.py
+++ b/chemex/bases/two_state/ixyzsxyz.py
@@ -156,67 +156,97 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
-    resonance_i, resonance_s = nuclei.resonances
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs2 = {'temperature': temperature, 'nuclei': resonance_i['name']}
-    kwargs3 = {
-        'temperature': temperature,
-        'nuclei': resonance_i['name'],
-        'h_larmor_frq': h_larmor_frq
-    }
-    kwargs4 = {'temperature': temperature, 'nuclei': resonance_s['name']}
-    kwargs5 = {
-        'temperature': temperature,
-        'nuclei': resonance_s['name'],
-        'h_larmor_frq': h_larmor_frq
-    }
-    kwargs6 = {'temperature': temperature, 'nuclei': nuclei.assignment}
-    kwargs7 = {
-        'temperature': temperature,
-        'nuclei': nuclei.assignment,
-        'h_larmor_frq': h_larmor_frq
-    }
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'dw_i_ab': parameters.ParameterName('dw_ab', **kwargs2).to_full_name(),
-        'dw_s_ab': parameters.ParameterName('dw_ab', **kwargs4).to_full_name(),
-        'cs_i_a': parameters.ParameterName('cs_a', **kwargs2).to_full_name(),
-        'r2_i_a': parameters.ParameterName('r2_a', **kwargs3).to_full_name(),
-        'r1_i_a': parameters.ParameterName('r1_a', **kwargs3).to_full_name(),
-        'r2a_i_a': parameters.ParameterName('r2a_a', **kwargs3).to_full_name(),
-        'etaxy_i_a': parameters.ParameterName('etaxy_a', **kwargs3).to_full_name(),
-        'etaz_i_a': parameters.ParameterName('etaz_a', **kwargs3).to_full_name(),
-        'cs_s_a': parameters.ParameterName('cs_a', **kwargs4).to_full_name(),
-        'r2_s_a': parameters.ParameterName('r2_a', **kwargs5).to_full_name(),
-        'r1_s_a': parameters.ParameterName('r1_a', **kwargs5).to_full_name(),
-        'r2a_s_a': parameters.ParameterName('r2a_a', **kwargs5).to_full_name(),
-        'etaxy_s_a': parameters.ParameterName('etaxy_a', **kwargs5).to_full_name(),
-        'etaz_s_a': parameters.ParameterName('etaz_a', **kwargs5).to_full_name(),
-        'r1a_a': parameters.ParameterName('r1a_a', **kwargs7).to_full_name(),
-        'r2_mq_a': parameters.ParameterName('r2_mq_a', **kwargs7).to_full_name(),
-        'mu_mq_a': parameters.ParameterName('mu_mq_a', **kwargs7).to_full_name(),
-        'sigma_a': parameters.ParameterName('sigma_a', **kwargs7).to_full_name(),
-        'j_a': parameters.ParameterName('j_a', **kwargs6).to_full_name(),
-        'cs_i_b': parameters.ParameterName('cs_b', **kwargs2).to_full_name(),
-        'r2_i_b': parameters.ParameterName('r2_b', **kwargs3).to_full_name(),
-        'r1_i_b': parameters.ParameterName('r1_b', **kwargs3).to_full_name(),
-        'r2a_i_b': parameters.ParameterName('r2a_b', **kwargs3).to_full_name(),
-        'etaxy_i_b': parameters.ParameterName('etaxy_b', **kwargs3).to_full_name(),
-        'etaz_i_b': parameters.ParameterName('etaz_b', **kwargs3).to_full_name(),
-        'cs_s_b': parameters.ParameterName('cs_b', **kwargs4).to_full_name(),
-        'r2_s_b': parameters.ParameterName('r2_b', **kwargs5).to_full_name(),
-        'r1_s_b': parameters.ParameterName('r1_b', **kwargs5).to_full_name(),
-        'r2a_s_b': parameters.ParameterName('r2a_b', **kwargs5).to_full_name(),
-        'etaxy_s_b': parameters.ParameterName('etaxy_b', **kwargs5).to_full_name(),
-        'etaz_s_b': parameters.ParameterName('etaz_b', **kwargs5).to_full_name(),
-        'r1a_b': parameters.ParameterName('r1a_b', **kwargs7).to_full_name(),
-        'r2_mq_b': parameters.ParameterName('r2_mq_b', **kwargs7).to_full_name(),
-        'mu_mq_b': parameters.ParameterName('mu_mq_b', **kwargs7).to_full_name(),
-        'sigma_b': parameters.ParameterName('sigma_b', **kwargs7).to_full_name(),
-        'j_b': parameters.ParameterName('j_b', **kwargs6).to_full_name(),
-    }
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
+    resonance_i, resonance_s = nuclei.resonances
+
+    kw1 = {'temperature': temperature, 'nuclei': resonance_i['name']}
+
+    map_names.update({
+        'dw_i_ab': parameters.ParameterName('dw_ab', **kw1).to_full_name(),
+        'cs_i_a': parameters.ParameterName('cs_a', **kw1).to_full_name(),
+        'cs_i_b': parameters.ParameterName('cs_b', **kw1).to_full_name(),
+    })
+
+    kw2 = {'temperature': temperature, 'nuclei': resonance_i['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_i_a': parameters.ParameterName('r2_a', **kw2).to_full_name(),
+        'r1_i_a': parameters.ParameterName('r1_a', **kw2).to_full_name(),
+        'r2a_i_a': parameters.ParameterName('r2a_a', **kw2).to_full_name(),
+        'etaxy_i_a': parameters.ParameterName('etaxy_a', **kw2).to_full_name(),
+        'etaz_i_a': parameters.ParameterName('etaz_a', **kw2).to_full_name(),
+        'r2_i_b': parameters.ParameterName('r2_b', **kw2).to_full_name(),
+        'r1_i_b': parameters.ParameterName('r1_b', **kw2).to_full_name(),
+        'r2a_i_b': parameters.ParameterName('r2a_b', **kw2).to_full_name(),
+        'etaxy_i_b': parameters.ParameterName('etaxy_b', **kw2).to_full_name(),
+        'etaz_i_b': parameters.ParameterName('etaz_b', **kw2).to_full_name(),
+    })
+
+    kw3 = {'temperature': temperature, 'nuclei': resonance_s['name']}
+
+    map_names.update({
+        'dw_s_ab': parameters.ParameterName('dw_ab', **kw3).to_full_name(),
+        'cs_s_a': parameters.ParameterName('cs_a', **kw3).to_full_name(),
+        'cs_s_b': parameters.ParameterName('cs_b', **kw3).to_full_name(),
+    })
+
+    kw4 = {'temperature': temperature, 'nuclei': resonance_s['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_s_a': parameters.ParameterName('r2_a', **kw4).to_full_name(),
+        'r1_s_a': parameters.ParameterName('r1_a', **kw4).to_full_name(),
+        'r2a_s_a': parameters.ParameterName('r2a_a', **kw4).to_full_name(),
+        'etaxy_s_a': parameters.ParameterName('etaxy_a', **kw4).to_full_name(),
+        'etaz_s_a': parameters.ParameterName('etaz_a', **kw4).to_full_name(),
+        'r2_s_b': parameters.ParameterName('r2_b', **kw4).to_full_name(),
+        'r1_s_b': parameters.ParameterName('r1_b', **kw4).to_full_name(),
+        'r2a_s_b': parameters.ParameterName('r2a_b', **kw4).to_full_name(),
+        'etaxy_s_b': parameters.ParameterName('etaxy_b', **kw4).to_full_name(),
+        'etaz_s_b': parameters.ParameterName('etaz_b', **kw4).to_full_name(),
+    })
+
+    kw5 = {'temperature': temperature, 'nuclei': nuclei.assignment}
+
+    map_names.update({
+        'j_a': parameters.ParameterName('j_a', **kw5).to_full_name(),
+        'j_b': parameters.ParameterName('j_b', **kw5).to_full_name(),
+    })
+
+    kw6 = {'temperature': temperature, 'nuclei': nuclei.assignment, 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r1a_a': parameters.ParameterName('r1a_a', **kw6).to_full_name(),
+        'r2_mq_a': parameters.ParameterName('r2_mq_a', **kw6).to_full_name(),
+        'mu_mq_a': parameters.ParameterName('mu_mq_a', **kw6).to_full_name(),
+        'sigma_a': parameters.ParameterName('sigma_a', **kw6).to_full_name(),
+        'r1a_b': parameters.ParameterName('r1a_b', **kw6).to_full_name(),
+        'r2_mq_b': parameters.ParameterName('r2_mq_b', **kw6).to_full_name(),
+        'mu_mq_b': parameters.ParameterName('mu_mq_b', **kw6).to_full_name(),
+        'sigma_b': parameters.ParameterName('sigma_b', **kw6).to_full_name(),
+    })
+
+    params.add_many(
+        (map_names['dw_i_ab'], 0.0, True, None, None, None),
+        (map_names['dw_s_ab'], 0.0, False, None, None, None),
+        (map_names['cs_i_a'], 0.0, False, None, None, None),
+        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
+        (map_names['r1_i_a'], 1.0, True, 0.0, None, None),
+        (map_names['r2a_i_a'], 15.0, False, 0.0, None, None),
+        (map_names['etaxy_i_a'], 0.0, True, None, None, None),
+        (map_names['etaz_i_a'], 0.0, True, None, None, None),
+        (map_names['cs_s_a'], 0.0, False, None, None, None),
+        (map_names['r2_s_a'], 10.0, False, 0.0, None, None),
+        (map_names['r1_s_a'], 1.0, False, 0.0, None, None),
+        (map_names['r2a_s_a'], 15.0, False, 0.0, None, None),
+        (map_names['etaxy_s_a'], 0.0, False, None, None, None),
+        (map_names['etaz_s_a'], 0.0, False, None, None, None),
+        (map_names['mu_mq_a'], 0.0, False, None, None, None),
+        (map_names['sigma_a'], 0.0, False, None, None, None),
+        (map_names['r2_mq_a'], 10.0, False, 0.0, None, None),
+        (map_names['r1a_a'], 2.0, False, 0.0, None, None),
+        (map_names['j_a'], -93.0, False, None, None, None), )
 
     cs_i_b = '{cs_i_a} + {dw_i_ab}'.format(**map_names)
     cs_s_b = '{cs_s_a} + {dw_s_ab}'.format(**map_names)
@@ -236,31 +266,7 @@ def create_default_params(model=None,
     r2_mq_b = map_names['r2_mq_a']
     j_b = map_names['j_a']
 
-    params = lmfit.Parameters()
-
     params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.05, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['dw_i_ab'], 0.0, True, None, None, None),
-        (map_names['dw_s_ab'], 0.0, False, None, None, None),
-        (map_names['cs_i_a'], 0.0, False, None, None, None),
-        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
-        (map_names['r1_i_a'], 1.0, True, 0.0, None, None),
-        (map_names['r2a_i_a'], 15.0, False, 0.0, None, None),
-        (map_names['etaxy_i_a'], 0.0, True, None, None, None),
-        (map_names['etaz_i_a'], 0.0, True, None, None, None),
-        (map_names['cs_s_a'], 0.0, False, None, None, None),
-        (map_names['r2_s_a'], 10.0, False, 0.0, None, None),
-        (map_names['r1_s_a'], 1.0, False, 0.0, None, None),
-        (map_names['r2a_s_a'], 15.0, False, 0.0, None, None),
-        (map_names['etaxy_s_a'], 0.0, False, None, None, None),
-        (map_names['etaz_s_a'], 0.0, False, None, None, None),
-        (map_names['mu_mq_a'], 0.0, False, None, None, None),
-        (map_names['sigma_a'], 0.0, False, None, None, None),
-        (map_names['r2_mq_a'], 10.0, False, 0.0, None, None),
-        (map_names['r1a_a'], 2.0, False, 0.0, None, None),
-        (map_names['j_a'], -93.0, False, None, None, None),
         (map_names['cs_i_b'], 0.0, None, None, None, cs_i_b),
         (map_names['r2_i_b'], 10.0, None, 0.0, None, r2_i_b),
         (map_names['r1_i_b'], 1.0, None, 0.0, None, r1_i_b),
@@ -278,8 +284,5 @@ def create_default_params(model=None,
         (map_names['r2_mq_b'], 10.0, None, 0.0, None, r2_mq_b),
         (map_names['r1a_b'], 2.0, None, 0.0, None, r1a_b),
         (map_names['j_b'], -93.0, None, None, None, j_b), )
-
-    map_names, params = exchange_model.update_params(params, map_names, model, temperature, p_total,
-                                                     l_total)
 
     return map_names, params

--- a/chemex/bases/two_state/ixyzsz.py
+++ b/chemex/bases/two_state/ixyzsz.py
@@ -127,77 +127,76 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
-    resonance_i, resonance_s = nuclei.resonances
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs2 = {'temperature': temperature, 'nuclei': resonance_i['name']}
-    kwargs3 = {
-        'temperature': temperature,
-        'nuclei': resonance_i['name'],
-        'h_larmor_frq': h_larmor_frq
-    }
-    kwargs4 = {'temperature': temperature, 'nuclei': nuclei.assignment}
-    kwargs5 = {
-        'temperature': temperature,
-        'nuclei': nuclei.assignment,
-        'h_larmor_frq': h_larmor_frq
-    }
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'dw_i_ab': parameters.ParameterName('dw_ab', **kwargs2).to_full_name(),
-        'cs_i_a': parameters.ParameterName('cs_a', **kwargs2).to_full_name(),
-        'r2_i_a': parameters.ParameterName('r2_a', **kwargs3).to_full_name(),
-        'r2a_i_a': parameters.ParameterName('r2a_a', **kwargs3).to_full_name(),
-        'r1_i_a': parameters.ParameterName('r1_a', **kwargs3).to_full_name(),
-        'r1a_a': parameters.ParameterName('r1a_a', **kwargs5).to_full_name(),
-        'etaxy_i_a': parameters.ParameterName('etaxy_a', **kwargs3).to_full_name(),
-        'etaz_i_a': parameters.ParameterName('etaz_a', **kwargs3).to_full_name(),
-        'j_a': parameters.ParameterName('j_a', **kwargs4).to_full_name(),
-        'cs_i_b': parameters.ParameterName('cs_b', **kwargs2).to_full_name(),
-        'r2_i_b': parameters.ParameterName('r2_b', **kwargs3).to_full_name(),
-        'r2a_i_b': parameters.ParameterName('r2a_b', **kwargs3).to_full_name(),
-        'r1_i_b': parameters.ParameterName('r1_b', **kwargs3).to_full_name(),
-        'r1a_b': parameters.ParameterName('r1a_b', **kwargs5).to_full_name(),
-        'etaxy_i_b': parameters.ParameterName('etaxy_b', **kwargs3).to_full_name(),
-        'etaz_i_b': parameters.ParameterName('etaz_b', **kwargs3).to_full_name(),
-        'j_b': parameters.ParameterName('j_b', **kwargs4).to_full_name(),
-    }
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
+    resonance_i, resonance_s = nuclei.resonances
+
+    kw1 = {'temperature': temperature, 'nuclei': resonance_i['name']}
+
+    map_names.update({
+        'dw_i_ab': parameters.ParameterName('dw_ab', **kw1).to_full_name(),
+        'cs_i_a': parameters.ParameterName('cs_a', **kw1).to_full_name(),
+        'cs_i_b': parameters.ParameterName('cs_b', **kw1).to_full_name(),
+    })
+
+    kw2 = {'temperature': temperature, 'nuclei': resonance_i['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r2_i_a': parameters.ParameterName('r2_a', **kw2).to_full_name(),
+        'r1_i_a': parameters.ParameterName('r1_a', **kw2).to_full_name(),
+        'r2a_i_a': parameters.ParameterName('r2a_a', **kw2).to_full_name(),
+        'etaxy_i_a': parameters.ParameterName('etaxy_a', **kw2).to_full_name(),
+        'etaz_i_a': parameters.ParameterName('etaz_a', **kw2).to_full_name(),
+        'r2_i_b': parameters.ParameterName('r2_b', **kw2).to_full_name(),
+        'r1_i_b': parameters.ParameterName('r1_b', **kw2).to_full_name(),
+        'r2a_i_b': parameters.ParameterName('r2a_b', **kw2).to_full_name(),
+        'etaxy_i_b': parameters.ParameterName('etaxy_b', **kw2).to_full_name(),
+        'etaz_i_b': parameters.ParameterName('etaz_b', **kw2).to_full_name(),
+    })
+
+    kw5 = {'temperature': temperature, 'nuclei': nuclei.assignment}
+
+    map_names.update({
+        'j_a': parameters.ParameterName('j_a', **kw5).to_full_name(),
+        'j_b': parameters.ParameterName('j_b', **kw5).to_full_name(),
+    })
+
+    kw6 = {'temperature': temperature, 'nuclei': nuclei.assignment, 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r1a_a': parameters.ParameterName('r1a_a', **kw6).to_full_name(),
+        'r1a_b': parameters.ParameterName('r1a_b', **kw6).to_full_name(),
+    })
+
+    params.add_many(
+        (map_names['dw_i_ab'], 0.0, True, None, None, None),
+        (map_names['cs_i_a'], 0.0, False, None, None, None),
+        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
+        (map_names['r1_i_a'], 1.0, True, 0.0, None, None),
+        (map_names['r2a_i_a'], 15.0, False, 0.0, None, None),
+        (map_names['etaxy_i_a'], 0.0, True, None, None, None),
+        (map_names['etaz_i_a'], 0.0, True, None, None, None),
+        (map_names['r1a_a'], 2.0, False, 0.0, None, None),
+        (map_names['j_a'], -93.0, False, None, None, None), )
 
     cs_i_b = '{cs_i_a} + {dw_i_ab}'.format(**map_names)
     r1_i_b = map_names['r1_i_a']
     r2_i_b = map_names['r2_i_a']
-    r2a_i_b = map_names['r2a_i_a']
     r1a_b = map_names['r1a_a']
+    r2a_i_b = map_names['r2a_i_a']
     etaxy_i_b = map_names['etaxy_i_a']
     etaz_i_b = map_names['etaz_i_a']
     j_b = map_names['j_a']
 
-    params = lmfit.Parameters()
-
     params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.05, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['dw_i_ab'], 0.0, True, None, None, None),
-        (map_names['cs_i_a'], 0.0, False, None, None, None),
-        (map_names['r2_i_a'], 10.0, True, 0.0, None, None),
-        (map_names['r1a_a'], 3.0, False, 0.0, None, None),
-        (map_names['etaxy_i_a'], 0.0, False, None, None, None),
-        (map_names['etaz_i_a'], 0.0, False, None, None, None),
-        (map_names['j_a'], 135.0, False, None, None, None),
-        (map_names['r2a_i_a'], 3.0, False, 0.0, None, None),
-        (map_names['r1_i_a'], 3.0, False, 0.0, None, None),
         (map_names['cs_i_b'], 0.0, None, None, None, cs_i_b),
         (map_names['r2_i_b'], 10.0, None, 0.0, None, r2_i_b),
-        (map_names['r1a_b'], 3.0, None, 0.0, None, r1a_b),
+        (map_names['r1_i_b'], 1.0, None, 0.0, None, r1_i_b),
+        (map_names['r2a_i_b'], 15.0, None, 0.0, None, r2a_i_b),
         (map_names['etaxy_i_b'], 0.0, None, None, None, etaxy_i_b),
         (map_names['etaz_i_b'], 0.0, None, None, None, etaz_i_b),
-        (map_names['j_b'], 135.0, None, None, None, j_b),
-        (map_names['r2a_i_b'], 3.0, None, 0.0, None, r2a_i_b),
-        (map_names['r1_i_b'], 3.0, None, 0.0, None, r1_i_b), )
-
-    map_names, params = exchange_model.update_params(params, map_names, model, temperature, p_total,
-                                                     l_total)
+        (map_names['r1a_b'], 2.0, None, 0.0, None, r1a_b),
+        (map_names['j_b'], -93.0, None, None, None, j_b), )
 
     return map_names, params

--- a/chemex/bases/two_state/iz.py
+++ b/chemex/bases/two_state/iz.py
@@ -56,28 +56,22 @@ def create_default_params(model=None,
                           p_total=None,
                           l_total=None):
     """Create the default experimental and fitting parameters."""
-    kwargs1 = {'temperature': temperature, 'p_total': p_total, 'l_total': l_total}
-    kwargs3 = {'temperature': temperature, 'nuclei': nuclei, 'h_larmor_frq': h_larmor_frq}
 
-    map_names = {
-        'pb': parameters.ParameterName('pb', **kwargs1).to_full_name(),
-        'kex_ab': parameters.ParameterName('kex_ab', **kwargs1).to_full_name(),
-        'r1_i_a': parameters.ParameterName('r1_a', **kwargs3).to_full_name(),
-        'r1_i_b': parameters.ParameterName('r1_b', **kwargs3).to_full_name(),
-    }
+    map_names, params = exchange_model.create_exchange_params(model, temperature, p_total, l_total)
+
+    resonance_i = nuclei.resonances[0]
+
+    kw2 = {'temperature': temperature, 'nuclei': resonance_i['name'], 'h_larmor_frq': h_larmor_frq}
+
+    map_names.update({
+        'r1_i_a': parameters.ParameterName('r1_a', **kw2).to_full_name(),
+        'r1_i_b': parameters.ParameterName('r1_b', **kw2).to_full_name(),
+    })
+
+    params.add_many((map_names['r1_i_a'], 1.0, True, 0.0, None, None), )
 
     r1_i_b = map_names['r1_i_a']
 
-    params = lmfit.Parameters()
-
-    params.add_many(
-        # Name, Value, Vary, Min, Max, Expr
-        (map_names['pb'], 0.05, True, 0.0, 1.0, None),
-        (map_names['kex_ab'], 200.0, True, 0.0, None, None),
-        (map_names['r1_i_a'], 1.0, True, 0.0, None, None),
-        (map_names['r1_i_b'], 1.0, True, 0.0, None, r1_i_b), )
-
-    map_names, params = exchange_model.update_params(params, map_names, model, temperature, p_total,
-                                                     l_total)
+    params.add_many((map_names['r1_i_b'], 1.0, None, 0.0, None, r1_i_b), )
 
     return map_names, params

--- a/chemex/experiments/cest/profiles/coupled.py
+++ b/chemex/experiments/cest/profiles/coupled.py
@@ -45,7 +45,7 @@ class Profile(cest_profile.CESTProfile):
 
         self.map_names, self.default_params = self.base.create_default_params(
             model=self.model,
-            nuclei=self.resonance_i['name'],
+            nuclei=self.peak,
             temperature=self.temperature,
             h_larmor_frq=self.h_larmor_frq,
             p_total=self.p_total,

--- a/chemex/experiments/cest/profiles/coupled.py
+++ b/chemex/experiments/cest/profiles/coupled.py
@@ -51,6 +51,10 @@ class Profile(cest_profile.CESTProfile):
             p_total=self.p_total,
             l_total=self.l_total, )
 
+        for name in ('r2_i_b', 'r2_i_c', 'r2_i_d'):
+            if name in self.map_names:
+                self.default_params[self.map_names[name]].set(vary=True)
+
     def calculate_unscaled_profile(self, **kwargs):
         """Calculate the intensity in presence of exchange after a CEST block.
 

--- a/chemex/experiments/cest/profiles/cw_dec.py
+++ b/chemex/experiments/cest/profiles/cw_dec.py
@@ -62,6 +62,10 @@ class Profile(cest_profile.CESTProfile):
             (self.map_names['r2a_s_a'], 0.0, False, 0.0, None, r2a_s_a),
             (self.map_names['r2a_s_b'], 0.0, False, 0.0, None, r2a_s_b), )
 
+        for name in ('r2_i_b', 'r2_i_c', 'r2_i_d'):
+            if name in self.map_names:
+                self.default_params[self.map_names[name]].set(vary=True)
+
         if '3st' in self.model:
             r2a_i_c = '{r2_i_c} + {r1a_c} - {r1_i_c}'.format(**self.map_names)
             r2a_s_c = '{r2_s_c} - {r1_i_c}'.format(**self.map_names)

--- a/chemex/experiments/cest/profiles/hn_ap.py
+++ b/chemex/experiments/cest/profiles/hn_ap.py
@@ -39,6 +39,10 @@ class Profile(cest_profile.CESTProfile):
             p_total=self.p_total,
             l_total=self.l_total, )
 
+        for name in ('r2_i_b', 'r2_i_c', 'r2_i_d'):
+            if name in self.map_names:
+                self.default_params[self.map_names[name]].set(vary=True)
+
         kwargs = {
             'temperature': self.temperature,
             'nuclei': self.resonance_s['name'],

--- a/chemex/experiments/cest/profiles/ip.py
+++ b/chemex/experiments/cest/profiles/ip.py
@@ -39,7 +39,7 @@ class Profile(cest_profile.CESTProfile):
 
         self.map_names, self.default_params = self.base.create_default_params(
             model=self.model,
-            nuclei=self.resonance_i['name'],
+            nuclei=self.peak,
             temperature=self.temperature,
             h_larmor_frq=self.h_larmor_frq,
             p_total=self.p_total,

--- a/chemex/experiments/cest/profiles/ip.py
+++ b/chemex/experiments/cest/profiles/ip.py
@@ -45,10 +45,9 @@ class Profile(cest_profile.CESTProfile):
             p_total=self.p_total,
             l_total=self.l_total, )
 
-        if '3st' in self.model:
-            for name in ('r2_i_b', 'r2_i_c'):
-                param = self.default_params[self.map_names[name]]
-                param.set(min=param.min, max=param.max, expr=self.map_names['r2_i_a'])
+        for name in ('r2_i_b', 'r2_i_c', 'r2_i_d'):
+            if name in self.map_names:
+                self.default_params[self.map_names[name]].set(vary=True)
 
     def calculate_unscaled_profile(self, **kwargs):
         """Calculate the CEST profile in the presence of exchange.

--- a/chemex/experiments/cpmg/profiles/cw.py
+++ b/chemex/experiments/cpmg/profiles/cw.py
@@ -57,11 +57,6 @@ class Profile(cpmg_profile.CPMGProfile):
 
         self.default_params[self.map_names['r1_i_a']].set(vary=False)
 
-        for name in ('r2_i_b', 'r2_i_c', 'r2_i_d'):
-            if name in self.map_names:
-                param = self.default_params[self.map_names[name]]
-                param.set(min=param.min, max=param.max, expr=self.map_names['r2_i_a'])
-
     def calculate_unscaled_profile(self, **kwargs):
         """Calculate the intensity in presence of exchange after a CEST block.
 

--- a/chemex/experiments/cpmg/profiles/cw.py
+++ b/chemex/experiments/cpmg/profiles/cw.py
@@ -49,7 +49,7 @@ class Profile(cpmg_profile.CPMGProfile):
 
         self.map_names, self.default_params = self.base.create_default_params(
             model=self.model,
-            nuclei=self.resonance_i['name'],
+            nuclei=self.peak,
             temperature=self.temperature,
             h_larmor_frq=self.h_larmor_frq,
             p_total=self.p_total,


### PR DESCRIPTION
This PR is related to the discussion started in issue #35.

All parameters are now declared in the `params` list and their associated constraints (if any) managed by the `lmfit` module. For example, all kinetics rate constants are now explicits. This means that their calculated values are now available in the `parameters.fit` file and their related constraints shown in the `constraints.fit` file.