### PR TITLE
MAINT: update minimum lmfit version and require asteval.

### DIFF
--- a/chemex/parameters.py
+++ b/chemex/parameters.py
@@ -9,7 +9,7 @@ import os.path
 import re
 
 import lmfit
-from lmfit import astutils
+from asteval import astutils
 import numpy as np
 
 from chemex import peaks, util

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
 scipy
 matplotlib>=2.0.0
-lmfit>=0.9.6
+lmfit>=0.9.9
+asteval>=0.9.12

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'scipy',
         'matplotlib',
         'lmfit',
+        'asteval',
     ],
 
     entry_points={


### PR DESCRIPTION
Lmfit no longer ships its own copy of asteval anymore so now the asteval package is required and the import of astutils needed to be updated.