### PR TITLE
Fix build issue with version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     ],
     keywords="nmr protein dynamics chemical exchange cpmg cest relaxation data fitting",
     packages=find_packages(),
+    setup_requires=['setuptools_scm'],
     install_requires=[
         "numpy>=1.0",
         "scipy>=1.0",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     keywords="nmr protein dynamics chemical exchange cpmg cest relaxation data fitting",
     packages=find_packages(),


### PR DESCRIPTION
Currently, the dependency ```setuptools_scm``` is not listed, which results in the version number being "0.0.0". The use of ```use_scm_version=True``` in ```setup.py``` also needs a ```setup_requires``` statement.  Additionally, I've added Python 3.8 to the Trove classifiers in ```setup.py```.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.