### PR TITLE
Website/add_search_and_stars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/deploy.yml"
       - "website/**"
+  workflow_dispatch:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -136,6 +136,29 @@ const config = {
                 darkTheme: darkCodeTheme,
                 additionalLanguages: ['toml', "markdown"],
             },
+            algolia: {
+                // The application ID provided by Algolia
+                appId: 'THPPA40I1Q',
+
+                // Public API key: it is safe to commit it
+                apiKey: '2365f685942b90aec2a3c2dff76774e4',
+
+                indexName: 'chemex',
+
+                // Optional: see doc section below
+                contextualSearch: true,
+
+                // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
+                // externalUrlRegex: 'external\\.com|domain\\.com',
+
+                // Optional: Algolia search parameters
+                searchParameters: {},
+
+                // Optional: path for search page that enabled by default (`false` to disable it)
+                searchPagePath: 'search',
+
+                //... other Algolia params
+            },
         }),
 };
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -29,6 +29,15 @@ function HomepageHeader() {
                             Get started
                         </Link>
                     </div>
+                    <span className={styles.indexCtasGitHubButtonWrapper}>
+                        <iframe
+                            className={styles.indexCtasGitHubButton}
+                            src="https://ghbtns.com/github-btn.html?user=gbouvignies&amp;repo=chemex&amp;type=star&amp;count=true&amp;size=large"
+                            width={160}
+                            height={30}
+                            title="GitHub Stars"
+                        />
+                    </span>
                 </div>
             </div>
         </header>

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -78,3 +78,11 @@
     flex-direction: column;
   }
 }
+
+.indexCtasGitHubButtonWrapper {
+  display: flex;
+}
+
+.indexCtasGitHubButton {
+  overflow: hidden;
+}


### PR DESCRIPTION
This adds an Algolia search bar to the website and an icon showing the number of GitHub stars for the project.