### PR TITLE
Resolve Pydantic v2 Error with SpinSystem Integration

### DIFF
--- a/chemex/cli.py
+++ b/chemex/cli.py
@@ -96,7 +96,7 @@ def build_parser():
         metavar="ID",
         nargs="+",
         help="Residue(s) to include in the fit",
-        type=SpinSystem,
+        type=SpinSystem.from_name,
     )
 
     fit_parser.add_argument(
@@ -105,7 +105,7 @@ def build_parser():
         metavar="ID",
         nargs="+",
         help="Residue(s) to exclude from the fit",
-        type=SpinSystem,
+        type=SpinSystem.from_name,
     )
 
     # parser for the positional argument "simulate"

--- a/chemex/configuration/base.py
+++ b/chemex/configuration/base.py
@@ -14,6 +14,8 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from chemex.configuration.utils import key_to_lower
+
 T = TypeVar("T")
 ExperimentSettings = TypeVar("ExperimentSettings", bound=BaseModel)
 ConditionsSettings = TypeVar("ConditionsSettings", bound=BaseModel)
@@ -29,10 +31,7 @@ class ToBeFitted:
 class BaseSettings(BaseModel):
     model_config = ConfigDict(str_to_lower=True)
 
-    @model_validator(mode="before")
-    def key_to_lower(cls, model: dict[str, T]) -> dict[str, T]:
-        """Model validator to convert all dictionary keys to lowercase."""
-        return {k.lower(): v for k, v in model.items()}
+    _key_to_lower = model_validator(mode="before")(key_to_lower)
 
 
 class ExperimentConfiguration(

--- a/chemex/configuration/conditions.py
+++ b/chemex/configuration/conditions.py
@@ -15,7 +15,7 @@ from pydantic import (
 )
 from typing_extensions import Self
 
-from chemex.configuration.utils import to_lower
+from chemex.configuration.utils import key_to_lower, to_lower
 
 T = TypeVar("T")
 LabelType = Annotated[Literal["1h", "2h", "13c", "15n"], BeforeValidator(to_lower)]
@@ -140,12 +140,10 @@ class Conditions(BaseModel, frozen=True):
 
 
 class ConditionsWithValidations(Conditions, frozen=True):
-    @model_validator(mode="before")
-    def key_to_lower(cls, model: dict[str, T]) -> dict[str, T]:
-        """Converts keys of the model dictionary to lowercase."""
-        return {k.lower(): v for k, v in model.items()}
+    _key_to_lower = model_validator(mode="before")(key_to_lower)
 
     @field_validator("d2o")
+    @classmethod
     def validate_d2o(cls, d2o: float | None) -> float | None:
         """Validates the d2o field for specific model requirements."""
         from chemex.models.model import model
@@ -156,6 +154,7 @@ class ConditionsWithValidations(Conditions, frozen=True):
         return d2o
 
     @field_validator("temperature")
+    @classmethod
     def validate_temperature(cls, temperature: float | None) -> float | None:
         """Validates temperature field for specific model requirements."""
         from chemex.models.model import model

--- a/chemex/configuration/data.py
+++ b/chemex/configuration/data.py
@@ -5,7 +5,7 @@ from typing import Annotated, Literal, TypeVar
 
 from pydantic import BaseModel, BeforeValidator, Field, PlainValidator, model_validator
 
-from chemex.configuration.utils import ensure_list, to_lower
+from chemex.configuration.utils import ensure_list, key_to_lower, to_lower
 from chemex.parameters.spin_system import SpinSystem
 
 T = TypeVar("T")
@@ -15,8 +15,7 @@ ErrorType = Annotated[
 ]
 PathList = Annotated[list[Path], BeforeValidator(ensure_list)]
 ProfilesType = dict[
-    Annotated[SpinSystem, PlainValidator(lambda x: SpinSystem(x))],
-    PathList,
+    Annotated[SpinSystem, PlainValidator(SpinSystem.from_name)], PathList
 ]
 
 
@@ -26,10 +25,7 @@ class DataSettings(BaseModel):
     path: Path = Path("./")
     scaled: bool = True
 
-    @model_validator(mode="before")
-    def key_to_lower(cls, model: dict[str, T]) -> dict[str, T]:
-        """Model validator to convert all dictionary keys to lowercase."""
-        return {k.lower(): v for k, v in model.items()}
+    _key_to_lower = model_validator(mode="before")(key_to_lower)
 
 
 class RelaxationDataSettings(DataSettings):

--- a/chemex/configuration/experiment.py
+++ b/chemex/configuration/experiment.py
@@ -5,6 +5,8 @@ from typing import Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from chemex.configuration.utils import key_to_lower
+
 T = TypeVar("T")
 
 
@@ -13,10 +15,7 @@ class ExperimentSettings(BaseModel):
 
     model_config = ConfigDict(str_to_lower=True)
 
-    @model_validator(mode="before")
-    def key_to_lower(cls, model: dict[str, T]) -> dict[str, T]:
-        """Model validator to convert all dictionary keys to lowercase."""
-        return {k.lower(): v for k, v in model.items()}
+    _key_to_lower = model_validator(mode="before")(key_to_lower)
 
 
 class CpmgSettings(ExperimentSettings):

--- a/chemex/configuration/utils.py
+++ b/chemex/configuration/utils.py
@@ -13,7 +13,7 @@ Typical usage example:
 """
 from __future__ import annotations
 
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 T = TypeVar("T")
 
@@ -52,3 +52,8 @@ def to_lower(string: T) -> T:
     if isinstance(string, str):
         return string.lower()
     return string
+
+
+def key_to_lower(model: dict[str, Any]) -> dict[str, Any]:
+    """Converts keys of the model dictionary to lowercase."""
+    return {k.lower(): v for k, v in model.items()}

--- a/chemex/parameters/name.py
+++ b/chemex/parameters/name.py
@@ -84,7 +84,7 @@ class ParamName:
         name = parsed.get("name")
         if name is None:
             name = ""
-        spin_system = SpinSystem(parsed.get("spin_system"))
+        spin_system = SpinSystem.from_name(parsed.get("spin_system", ""))
         conditions = Conditions.model_validate(parsed)
         return cls(name, spin_system, conditions)
 


### PR DESCRIPTION
Resolved an issue where SpinSystem not being a Pydantic model caused errors in dependent Pydantic models. The previous workaround using Annotated and BeforeValidation became ineffective under unclear circumstances. SpinSystem has been converted to a Pydantic model to rectify this.

Fixes #195