### PR TITLE
Ensure UTF-8 encoding for all file write operations

### DIFF
--- a/chemex/containers/experiment.py
+++ b/chemex/containers/experiment.py
@@ -44,7 +44,7 @@ class Experiment:
 
     def write(self, path: Path):
         filename = (path / self.filename.name).with_suffix(".dat")
-        with filename.open("w") as file_dat:
+        with filename.open("w", encoding="utf-8") as file_dat:
             file_dat.write(self.printer.header)
             for profile in sorted(self.profiles):
                 file_dat.write(str(profile))

--- a/chemex/optimize/fitting.py
+++ b/chemex/optimize/fitting.py
@@ -37,7 +37,7 @@ from chemex.parameters import database
 def _run_statistics(
     experiments: Experiments,
     path: Path,
-    fitmethod: str | None = None,
+    fitmethod: str,
     statistics: Statistics | None = None,
 ) -> None:
     if statistics is None:
@@ -60,7 +60,7 @@ def _run_statistics(
 
         print_running_statistics(method["message"])
 
-        with (path / method["filename"]).open(mode="w") as fileout:
+        with (path / method["filename"]).open(mode="w", encoding="utf-8") as fileout:
             fileout.write(print_header(ids_vary))
 
             try:

--- a/chemex/optimize/gridding.py
+++ b/chemex/optimize/gridding.py
@@ -47,7 +47,7 @@ def run_group_grid(
     group: Group,
     grid: dict[str, ArrayFloat],
     path: Path,
-    fitmethod: str | None,
+    fitmethod: str,
 ) -> GridResult:
     group_ids = group.experiments.param_ids
     group_params = database.build_lmfit_params(group_ids)
@@ -66,7 +66,7 @@ def run_group_grid(
     best_chisqr = np.inf
     best_params = group_params
 
-    with filename.open("w") as fileout:
+    with filename.open("w", encoding="utf-8") as fileout:
         fileout.write(print_header(group_grid))
 
         chisqr_list: list[float] = []

--- a/chemex/optimize/helper.py
+++ b/chemex/optimize/helper.py
@@ -52,7 +52,7 @@ def _write_statistics(experiments: Experiments, path: Path) -> None:
     params_lf = database.build_lmfit_params(experiments.param_ids)
     stats = calculate_statistics(experiments, params_lf)
     filename = path / "statistics.toml"
-    with filename.open(mode="w") as f:
+    with filename.open("w", encoding="utf-8") as f:
         f.write(f"\"number of data points\"                = {stats['ndata']}\n")
         f.write(f"\"number of variables\"                  = {stats['nvarys']}\n")
         f.write(f"\"chi-square\"                           = {stats['chisqr']: .5e}\n")

--- a/chemex/plotters/cest.py
+++ b/chemex/plotters/cest.py
@@ -221,8 +221,8 @@ class CestPlotter(Generic[T]):
 
         with ExitStack() as stack:
             file_pdf = stack.enter_context(PdfPages(str(name_pdf)))
-            file_calc = stack.enter_context(name_fit.open("w"))
-            file_exp = stack.enter_context(name_exp.open("w"))
+            file_calc = stack.enter_context(name_fit.open("w", encoding="utf-8"))
+            file_exp = stack.enter_context(name_exp.open("w", encoding="utf-8"))
             for profile in sorted(profiles):
                 data_exp = create_plot_data_exp(profile)
                 data_calc = create_plot_data_calc(profile)
@@ -243,7 +243,7 @@ class CestPlotter(Generic[T]):
 
         with ExitStack() as stack:
             file_pdf = stack.enter_context(PdfPages(str(name_pdf)))
-            file_sim = stack.enter_context(name_sim.open("w"))
+            file_sim = stack.enter_context(name_sim.open("w", encoding="utf-8"))
             for profile in sorted(profiles):
                 data_exp = Data(np.array([]), np.array([]), np.array([]))
                 data_calc = create_plot_data_calc(profile)

--- a/chemex/plotters/cpmg.py
+++ b/chemex/plotters/cpmg.py
@@ -166,8 +166,8 @@ class CpmgPlotter(Generic[T]):
 
         with ExitStack() as stack:
             file_pdf = stack.enter_context(PdfPages(str(name_pdf)))
-            file_calc = stack.enter_context(name_fit.open("w"))
-            file_exp = stack.enter_context(name_exp.open("w"))
+            file_calc = stack.enter_context(name_fit.open("w", encoding="utf-8"))
+            file_exp = stack.enter_context(name_exp.open("w", encoding="utf-8"))
             for profile in sorted(profiles):
                 data_exp = create_plot_data_exp(profile, self.config)
                 data_calc = create_plot_data_calc(profile, self.config)
@@ -188,7 +188,7 @@ class CpmgPlotter(Generic[T]):
 
         with ExitStack() as stack:
             file_pdf = stack.enter_context(PdfPages(str(name_pdf)))
-            file_sim = stack.enter_context(name_sim.open("w"))
+            file_sim = stack.enter_context(name_sim.open("w", encoding="utf-8"))
             for profile in sorted(profiles):
                 data_exp = Data(np.array([]), np.array([]), np.array([]))
                 data_calc = create_plot_data_calc(profile, self.config)

--- a/chemex/plotters/exsy.py
+++ b/chemex/plotters/exsy.py
@@ -125,8 +125,8 @@ class EXSYPlotter:
 
         with ExitStack() as stack:
             file_pdf = stack.enter_context(PdfPages(str(name_pdf)))
-            file_calc = stack.enter_context(name_fit.open("w"))
-            file_exp = stack.enter_context(name_exp.open("w"))
+            file_calc = stack.enter_context(name_fit.open("w", encoding="utf-8"))
+            file_exp = stack.enter_context(name_exp.open("w", encoding="utf-8"))
             for profile in sorted(profiles):
                 data_exp_dict = create_plot_data_exp(profile)
                 data_calc_dict = create_plot_data_calc(profile)

--- a/chemex/plotters/relaxation.py
+++ b/chemex/plotters/relaxation.py
@@ -74,8 +74,8 @@ class RelaxationPlotter:
 
         with ExitStack() as stack:
             file_pdf = stack.enter_context(PdfPages(str(name_pdf)))
-            file_calc = stack.enter_context(name_fit.open("w"))
-            file_exp = stack.enter_context(name_exp.open("w"))
+            file_calc = stack.enter_context(name_fit.open("w", encoding="utf-8"))
+            file_exp = stack.enter_context(name_exp.open("w", encoding="utf-8"))
             for profile in sorted(profiles):
                 data_exp = create_plot_data_exp(profile)
                 data_calc = create_plot_data_calc(profile)
@@ -96,7 +96,7 @@ class RelaxationPlotter:
 
         with ExitStack() as stack:
             file_pdf = stack.enter_context(PdfPages(str(name_pdf)))
-            file_sim = stack.enter_context(name_sim.open("w"))
+            file_sim = stack.enter_context(name_sim.open("w", encoding="utf-8"))
             for profile in sorted(profiles):
                 data_exp = create_plot_data_exp(profile)
                 data_calc = create_plot_data_calc(profile)

--- a/chemex/tools/pick_cest/buttons.py
+++ b/chemex/tools/pick_cest/buttons.py
@@ -118,8 +118,8 @@ class Buttons:
         fname2 = self.out / "dw_ab.toml"
 
         with contextlib.ExitStack() as stack:
-            file1 = stack.enter_context(fname1.open("w"))
-            file2 = stack.enter_context(fname2.open("w"))
+            file1 = stack.enter_context(fname1.open("w", encoding="utf-8"))
+            file2 = stack.enter_context(fname2.open("w", encoding="utf-8"))
             file1.write("[CS_A]\n")
             file2.write("[DW_AB]\n")
 


### PR DESCRIPTION
This Pull Request explicitly sets encoding="utf-8" for all instances of path.open("w") across the ChemEx codebase. This change addresses issues related to default system encodings that are not UTF-8, such as cp1251, preventing UnicodeEncodeErrors during file write operations. It enhances the software's compatibility and reliability across different computing environments.

This should fix #196.