### PR TITLE
Fix initial conditions for two-spin systems in ChemEx

### DIFF
--- a/src/chemex/configuration/experiment.py
+++ b/src/chemex/configuration/experiment.py
@@ -24,7 +24,15 @@ class RelaxationSettings(ExperimentSettings):
 
     Attributes:
         cs_evolution_prior (bool):
-            If True, use chemical shift evolution for the starting terms.
+            Controls the initial condition (equilibrium vs non-equilibrium).
+            If False (default), the initial magnetization assumes thermal
+            equilibrium with all states populated according to their equilibrium
+            populations. If True, only the observed state is initially populated
+            (non-equilibrium condition), which is appropriate when chemical shift
+            evolution occurs before the CEST/CPMG element in the pulse sequence,
+            breaking the equilibrium assumption. This can affect the accuracy of
+            extracted kinetic parameters, especially for slow exchange rates
+            (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
         detect_all_states (bool):
             If True, detection will use all states (e.g., '[iz]'),
             otherwise only the observed state (e.g., '[iz_a]').
@@ -43,7 +51,9 @@ class RelaxationSettings(ExperimentSettings):
     def suffix_start(self) -> str:
         """Suffix for starting terms.
 
-        Returns '_{observed_state}' if cs_evolution_prior is True, else ''.
+        Returns '_{observed_state}' if cs_evolution_prior is True (non-equilibrium
+        initial condition with only the observed state populated), else ''
+        (equilibrium initial condition with all states populated).
         """
         return f"_{self.observed_state}" if self.cs_evolution_prior else ""
 

--- a/src/chemex/experiments/catalog/cpmg_ch3_13c_h2c.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_13c_h2c.py
@@ -33,7 +33,6 @@ class CpmgCh313CH2cSettings(CpmgSettingsEvenNcycs):
     pw90: float
     taub: float = 2.0e-3
     time_equil: float = 0.0
-    cs_evolution_prior: bool = True
 
     @cached_property
     def t_neg(self) -> float:

--- a/src/chemex/experiments/catalog/cpmg_ch3_13c_h2c_0013.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_13c_h2c_0013.py
@@ -33,7 +33,6 @@ class CpmgCh313CH2c0013Settings(CpmgSettingsEvenNcycs):
     taub: float = 2.0e-3
     time_equil: float = 5.0e-3
     time_grad: float = 1.2e-3
-    cs_evolution_prior: bool = True
 
     @cached_property
     def t_neg(self) -> float:

--- a/website/docs/experiments/cest/cest_13c.md
+++ b/website/docs/experiments/cest/cest_13c.md
@@ -73,6 +73,13 @@ b1_frq = 25.0
 ## the longer the calculation. [optional, default: 11]
 # b1_inh_res = 11
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CEST element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cest/cest_15n.md
+++ b/website/docs/experiments/cest/cest_15n.md
@@ -63,6 +63,13 @@ b1_frq = 25.0
 ## the longer the calculation. [optional, default: 11]
 # b1_inh_res = 11
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CEST element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cest/cest_15n_cw.md
+++ b/website/docs/experiments/cest/cest_15n_cw.md
@@ -65,6 +65,13 @@ carrier_dec = 8.3
 ## B1 radio-frequency field strength of the ¹H CW decoupling, in Hz
 b1_frq_dec = 1000.0
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CEST element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cest/cest_15n_tr.md
+++ b/website/docs/experiments/cest/cest_15n_tr.md
@@ -63,6 +63,13 @@ b1_frq = 25.0
 ## Perform anti-trosy CEST experiment [optional, default: false]
 # antitrosy = false
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CEST element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cest/cest_1hn_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ap.md
@@ -58,6 +58,13 @@ b1_frq = 25.0
 ## the longer the calculation. [optional, default: 11]
 # b1_inh_res = 11
 
+## Initial condition: non-equilibrium (only observed state populated).
+## This is appropriate when chemical shift evolution occurs before the CEST
+## element. Set to false for equilibrium initial condition if your pulse
+## sequence differs (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: true]
+# cs_evolution_prior = true
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_13c_ip.md
+++ b/website/docs/experiments/cpmg/cpmg_13c_ip.md
@@ -59,6 +59,13 @@ pw90 = 15.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_13co_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_13co_ap.md
@@ -66,6 +66,13 @@ pw90 = 25.0e-6
 ## 1/2*JCC, in seconds [optional, default: 9.09e-3]
 # taucc = 9.09e-3
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_15n_ip.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_ip.md
@@ -56,6 +56,13 @@ pw90 = 35.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_15n_ip_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_ip_0013.md
@@ -60,6 +60,13 @@ ncyc_max = 40
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_15n_tr.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_tr.md
@@ -64,6 +64,13 @@ pw90 = 35.0e-6
 ## Perform anti-trosy CPMG RD experiment [optional, default: false]
 # antitrosy = false
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_15n_tr_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_tr_0013.md
@@ -70,6 +70,13 @@ ncyc_max = 40
 ## S3E trosy selection [optional, default: true]
 # s3e = true
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_1hn_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_1hn_ap.md
@@ -58,6 +58,13 @@ pw90 = 10.0e-6
 ## [optional, default: 0.0]
 # time_equil_2 = 0.0
 
+## Initial condition: non-equilibrium (only observed state populated).
+## This is appropriate when chemical shift evolution occurs before the CPMG
+## element. Set to false for equilibrium initial condition if your pulse
+## sequence differs (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: true]
+# cs_evolution_prior = true
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_1hn_ap_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_1hn_ap_0013.md
@@ -83,6 +83,13 @@ ncyc_max = 40
 ## [optional, default: 0.0]
 # time_equil_2 = 0.0
 
+## Initial condition: non-equilibrium (only observed state populated).
+## This is appropriate when chemical shift evolution occurs before the CPMG
+## element. Set to false for equilibrium initial condition if your pulse
+## sequence differs (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: true]
+# cs_evolution_prior = true
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c.md
@@ -58,6 +58,13 @@ pw90 = 15.0e-6
 ## P-element delay = 1/4J, in seconds [optional, default: 2.0e-3]
 # taub = 2.0e-3
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c_0013.md
@@ -67,6 +67,13 @@ pw90 = 15.0e-6
 ## P-element delay = 1/4J, in seconds [optional, default: 2.0e-3]
 # taub = 2.0e-3
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_dq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_dq.md
@@ -60,6 +60,13 @@ pw90 = 12.0e-6
 ## AP DQ magnetizations [optional, default: false]
 # ipap_flg = false
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_sq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_sq.md
@@ -63,6 +63,13 @@ ncyc_max = 40
 ## [optional, default: false]
 # ipap_flg = false
 
+## Initial condition: non-equilibrium (only observed state populated).
+## This is appropriate when chemical shift evolution occurs before the CPMG
+## element. Set to false for equilibrium initial condition if your pulse
+## sequence differs (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: true]
+# cs_evolution_prior = true
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_tq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_tq.md
@@ -62,6 +62,13 @@ pw90 = 12.0e-6
 ## AP TQ magnetizations [optional, default: false]
 # ipap_flg = false
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_tq_diff.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_tq_diff.md
@@ -69,6 +69,13 @@ gradient = 30.0e-2
 ## AP TQ magnetizations [optional, default: false]
 # ipap_flg = false
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_mq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_mq.md
@@ -53,6 +53,13 @@ time_t2 = 0.02
 ## Perform the calculation with the purge element [optional, default: false])
 # small_protein = false
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_chd2_1h_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_chd2_1h_ap.md
@@ -54,6 +54,13 @@ pw90 = 10.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_hn_dq_zq.md
+++ b/website/docs/experiments/cpmg/cpmg_hn_dq_zq.md
@@ -57,6 +57,13 @@ pw90_h = 15.0e-6
 ## Perform DQ CPMG RD experiment, otherwise perform ZQ CPMG RD experiment
 dq_flg = true
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CPMG element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/dcest/dcest_13c.md
+++ b/website/docs/experiments/dcest/dcest_13c.md
@@ -64,6 +64,13 @@ b1_frq = 25.0
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CEST element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/dcest/dcest_15n.md
+++ b/website/docs/experiments/dcest/dcest_15n.md
@@ -74,6 +74,13 @@ b1_frq = 25.0
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the CEST element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/relaxation/relaxation_hznz.md
+++ b/website/docs/experiments/relaxation/relaxation_hznz.md
@@ -39,6 +39,13 @@ An example use of the module is given
 ## Name of the chemex module corresponding to the experiment
 name = "relaxation_hznz"
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the relaxation element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/relaxation/relaxation_nz.md
+++ b/website/docs/experiments/relaxation/relaxation_nz.md
@@ -38,6 +38,13 @@ An example use of the module is given
 ## Name of the chemex module corresponding to the experiment
 name = "relaxation_nz"
 
+## Initial condition: equilibrium (all states populated according to their
+## equilibrium populations). Set to true for non-equilibrium initial condition
+## if chemical shift evolution occurs before the relaxation element in your pulse
+## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
+## [optional, default: false]
+# cs_evolution_prior = false
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/user_guide/fitting/experiment_files.md
+++ b/website/docs/user_guide/fitting/experiment_files.md
@@ -65,6 +65,26 @@ The `[experiment]` section defines the type and settings of the pulse sequence. 
 | `pw90`            | 90-degree pulse width, in seconds.                                                                    |
 | `b1_frq`          | B1 radio-frequency field strength, in Hz.                                                             |
 | `observed_state`  | ID of the observed state (e.g., `a`, `b`, `c`, or `d`).                                              |
+| `cs_evolution_prior` | Controls initial condition: equilibrium (False, default) vs non-equilibrium (True). See below.     |
+
+#### `cs_evolution_prior`
+
+The `cs_evolution_prior` key controls whether the initial magnetization assumes thermal equilibrium or a non-equilibrium condition:
+
+- **`False` (default)**: Equilibrium initial condition where all states are populated according to their equilibrium populations. Use this when the CEST/CPMG element starts immediately after magnetization preparation.
+
+- **`True`**: Non-equilibrium initial condition where only the observed state is initially populated. Use this when chemical shift evolution occurs **before** the CEST/CPMG element, as this breaks the equilibrium assumption.
+
+The choice can significantly affect extracted kinetic parameters, especially for slow exchange rates (see Yuwen et al., _J. Biomol. NMR_ **2016**, 65:143-156). Most experiments use the default (`False`), but some pulse sequences (e.g., `cpmg_1hn_ap`, `cest_1hn_ap`) set this to `True` by default based on their typical pulse sequence implementations. You can override the default in your experiment configuration file if your specific pulse sequence differs.
+
+Example:
+
+```toml
+[experiment]
+name = "cpmg_1hn_ap"
+# Override the default if needed for your pulse sequence
+cs_evolution_prior = false
+```
 
 ### `[conditions]`
 


### PR DESCRIPTION
Update initial conditions in various modules to ensure consistency between equilibrium and non-equilibrium states. Adjust documentation to clarify the use of the `cs_evolution_prior` parameter for different experimental setups. Fixes #386