### PR TITLE
Generalize residue-specific model suffix

### DIFF
--- a/examples/Experiments/CEST_1HN_IP_AP/run.sh
+++ b/examples/Experiments/CEST_1HN_IP_AP/run.sh
@@ -5,6 +5,6 @@ SELECTION="3 4 12 13 14 30 32 65 68 70 72 74 75 78 80 91 100 101 103 104 105 108
 chemex fit -e Experiments/*.toml \
            -p Parameters/parameters.toml \
            -m Methods/method.toml \
-           -d 2st_rs \
+           -d 2st.rs \
            --include $SELECTION \
            -o Output

--- a/examples/Experiments/CEST_CH3_1H_IP_AP/run.sh
+++ b/examples/Experiments/CEST_CH3_1H_IP_AP/run.sh
@@ -3,5 +3,5 @@
 chemex fit -e Experiments/*.toml \
            -p Parameters/parameters.toml \
            -m Methods/method.toml \
-           -d 2st_rs \
+           -d 2st.rs \
            -o Output

--- a/examples/Experiments/COSCEST_1HN_IP_AP/run.sh
+++ b/examples/Experiments/COSCEST_1HN_IP_AP/run.sh
@@ -5,6 +5,6 @@ SELECTION="48 61 114 115 147 151"
 chemex fit -e Experiments/*.toml \
            -p Parameters/parameters.toml \
            -m Methods/method.toml \
-           -d 2st_rs \
+           -d 2st.rs \
            --include $SELECTION \
            -o Output

--- a/examples/Experiments/CPMG_CH3_1H_SQ/run_single.sh
+++ b/examples/Experiments/CPMG_CH3_1H_SQ/run_single.sh
@@ -3,5 +3,5 @@
 # Optional, perform single-residue fit first
 chemex fit -e Experiments/*.toml \
            -p Parameters/parameters.toml \
-           -d 2st_rs \
+           -d 2st.rs \
            -o Output/Single

--- a/examples/Experiments/CPMG_CH3_1H_TQ/run_single.sh
+++ b/examples/Experiments/CPMG_CH3_1H_TQ/run_single.sh
@@ -3,5 +3,5 @@
 # Optional, perform single-residue fit first
 chemex fit -e Experiments/*.toml \
            -p Parameters/parameters.toml \
-           -d 2st_rs \
+           -d 2st.rs \
            -o Output/Single

--- a/examples/Experiments/CPMG_HN_DQ_ZQ/run_single.sh
+++ b/examples/Experiments/CPMG_HN_DQ_ZQ/run_single.sh
@@ -3,5 +3,5 @@
 # Optional, perform single-residue fit first
 chemex fit -e Experiments/*.toml \
            -p Parameters/parameters.toml \
-           -d 2st_rs \
+           -d 2st.rs \
            -o Output/Single

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -509,6 +509,25 @@ def print_model_error(name: str) -> None:
     console.print()
 
 
+def print_model_suffix_error(
+    name: str,
+    unknown_suffixes: set[str],
+    supported_suffixes: tuple[str, ...],
+) -> None:
+    """Display an error message for unsupported model suffixes."""
+    suffixes = ", ".join(f"'.{suffix}'" for suffix in sorted(unknown_suffixes))
+
+    console.print()
+    console.print(
+        f"[red] -- ERROR: The model '{name}' uses unsupported suffixes: {suffixes}.",
+    )
+    console.print()
+    console.print("The supported model suffixes are:")
+    for suffix in supported_suffixes:
+        console.print(f"    - '.{suffix}'")
+    console.print()
+
+
 def print_not_implemented_noise_method_warning(
     filename: Path,
     kind: str,

--- a/src/chemex/models/factory.py
+++ b/src/chemex/models/factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Factories for creating parameter settings."""
 
+from builtins import set as builtins_set
 from collections.abc import Callable
 from dataclasses import replace
 from typing import TYPE_CHECKING, ClassVar
@@ -53,7 +54,7 @@ class Factory:
         return settings
 
     @property
-    def set(self) -> set[str]:
+    def set(self) -> builtins_set[str]:
         return set(self.setting_makers_registry)
 
 

--- a/src/chemex/models/factory.py
+++ b/src/chemex/models/factory.py
@@ -1,13 +1,29 @@
+from __future__ import annotations
+
 """Factories for creating parameter settings."""
 
 from collections.abc import Callable
-from typing import ClassVar
+from dataclasses import replace
+from typing import TYPE_CHECKING, ClassVar
 
 from chemex.configuration.conditions import Conditions
 from chemex.parameters.setting import ParamLocalSetting
 
+if TYPE_CHECKING:
+    from chemex.models.model import ModelSpec
+
 SettingsType = dict[str, ParamLocalSetting]
 SettingMakerType = Callable[[Conditions], SettingsType]
+
+
+def make_residue_specific(settings: SettingsType) -> SettingsType:
+    for setting in settings.values():
+        name_setting = setting.name_setting
+        if not name_setting.allow_residue_specific:
+            continue
+        if name_setting.spin_system_part == "":
+            setting.name_setting = replace(name_setting, spin_system_part="g")
+    return settings
 
 
 class Factory:
@@ -25,6 +41,16 @@ class Factory:
         except KeyError:
             msg = f"Unknown type {name!r}"
             raise ValueError(msg) from None
+
+    def create_for_model(
+        self,
+        model: ModelSpec,
+        conditions: Conditions,
+    ) -> SettingsType:
+        settings = self.create(model.name, conditions)
+        if model.residue_specific:
+            return make_residue_specific(settings)
+        return settings
 
     @property
     def set(self) -> set[str]:

--- a/src/chemex/models/kinetic/settings_2st_hd.py
+++ b/src/chemex/models/kinetic/settings_2st_hd.py
@@ -13,7 +13,12 @@ def make_settings_2st_hd(conditions: Conditions) -> dict[str, ParamLocalSetting]
     d2o = conditions.d2o if conditions.d2o is not None else 0.1
     return {
         "d2o": ParamLocalSetting(
-            name_setting=NameSetting("d2o", "", ("d2o",)),
+            name_setting=NameSetting(
+                "d2o",
+                "",
+                ("d2o",),
+                allow_residue_specific=False,
+            ),
             value=d2o,
             min=0.0,
             max=1.0,

--- a/src/chemex/models/kinetic/settings_4st_hd.py
+++ b/src/chemex/models/kinetic/settings_4st_hd.py
@@ -30,7 +30,12 @@ def make_settings_4st_hd(conditions: Conditions) -> dict[str, ParamLocalSetting]
     d2o: float = conditions.d2o if conditions.d2o is not None else 0.1
     return {
         "d2o": ParamLocalSetting(
-            name_setting=NameSetting("d2o", "", ("d2o",)),
+            name_setting=NameSetting(
+                "d2o",
+                "",
+                ("d2o",),
+                allow_residue_specific=False,
+            ),
             value=d2o,
             min=0.0,
             max=1.0,

--- a/src/chemex/models/model.py
+++ b/src/chemex/models/model.py
@@ -4,7 +4,9 @@ import sys
 from dataclasses import dataclass, field
 from string import ascii_lowercase
 
-from chemex.messages import print_model_error
+from chemex.messages import print_model_error, print_model_suffix_error
+
+SUPPORTED_MODEL_EXTENSIONS = ("mf", "rs", "tc")
 
 
 @dataclass(frozen=True, order=True)
@@ -13,6 +15,7 @@ class ModelSpec:
     states: str = "ab"
     model_free: bool = False
     temp_coef: bool = False
+    residue_specific: bool = False
 
     @staticmethod
     def validate_model_name(name: str) -> str:
@@ -23,16 +26,30 @@ class ModelSpec:
             sys.exit()
         return name
 
+    @staticmethod
+    def validate_extensions(name: str, extensions: list[str]) -> set[str]:
+        unknown_suffixes = set(extensions) - set(SUPPORTED_MODEL_EXTENSIONS)
+        if unknown_suffixes:
+            print_model_suffix_error(
+                name,
+                unknown_suffixes,
+                SUPPORTED_MODEL_EXTENSIONS,
+            )
+            sys.exit()
+        return set(extensions)
+
     @classmethod
     def from_name(cls, name: str) -> ModelSpec:
         kinetic_model_name, *extensions = name.split(".")
         validated_name = cls.validate_model_name(kinetic_model_name)
+        validated_extensions = cls.validate_extensions(name, extensions)
         state_nb = int(validated_name[0])
         return cls(
             name=validated_name,
             states=ascii_lowercase[:state_nb],
-            model_free="mf" in extensions if extensions else False,
-            temp_coef="tc" in extensions if extensions else False,
+            model_free="mf" in validated_extensions,
+            temp_coef="tc" in validated_extensions,
+            residue_specific="rs" in validated_extensions,
         )
 
 
@@ -68,3 +85,7 @@ class ModelState:
     @property
     def temp_coef(self) -> bool:
         return self._spec.temp_coef
+
+    @property
+    def residue_specific(self) -> bool:
+        return self._spec.residue_specific

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -65,7 +65,7 @@ def _build_parameters(
 class ParameterFactory:
     parameter_store: ParameterStore
     _settings_cache: dict[
-        tuple[str, bool, bool, Basis, Conditions],
+        tuple[str, bool, bool, bool, Basis, Conditions],
         tuple[LocalSettings, LocalSettings],
     ] = field(default_factory=dict)
 
@@ -78,6 +78,7 @@ class ParameterFactory:
             basis.model.name,
             basis.model.model_free,
             basis.model.temp_coef,
+            basis.model.residue_specific,
             basis,
             conditions,
         )
@@ -86,7 +87,7 @@ class ParameterFactory:
                 basis,
                 conditions,
             )
-            settings_kinetics = model_factory.create(basis.model.name, conditions)
+            settings_kinetics = model_factory.create_for_model(basis.model, conditions)
             settings = settings_kinetics | settings_spins
             settings_mf = settings_kinetics | settings_spins_mf
             self._settings_cache[key] = (settings, settings_mf)

--- a/src/chemex/parameters/setting.py
+++ b/src/chemex/parameters/setting.py
@@ -22,6 +22,7 @@ class NameSetting:
     name: str
     spin_system_part: Literal["i", "s", "is", "g", ""] = ""
     conditions_part: tuple[str, ...] = field(default_factory=tuple)
+    allow_residue_specific: bool = True
 
     def get_param_name(
         self,

--- a/tests/models/kinetic/test_residue_specific.py
+++ b/tests/models/kinetic/test_residue_specific.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from chemex.configuration.conditions import Conditions
+from chemex.models.factory import model_factory
+from chemex.models.loader import register_kinetic_settings
+from chemex.models.model import ModelSpec
+from chemex.nmr.basis import Basis
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+
+
+def setup_module() -> None:
+    register_kinetic_settings()
+
+
+def test_2st_residue_specific_matches_legacy_alias() -> None:
+    conditions = Conditions()
+
+    settings = model_factory.create_for_model(ModelSpec.from_name("2st.rs"), conditions)
+    legacy_settings = model_factory.create("2st_rs", conditions)
+
+    assert settings.keys() == legacy_settings.keys()
+
+    for key in settings:
+        assert settings[key].name_setting == legacy_settings[key].name_setting
+        assert settings[key].value == legacy_settings[key].value
+        assert settings[key].min == legacy_settings[key].min
+        assert settings[key].max == legacy_settings[key].max
+        assert settings[key].vary == legacy_settings[key].vary
+        assert settings[key].expr == legacy_settings[key].expr
+
+
+def test_three_state_models_become_residue_specific_with_rs_suffix() -> None:
+    base_settings = model_factory.create("3st", Conditions())
+    residue_specific_settings = model_factory.create_for_model(
+        ModelSpec.from_name("3st.rs"),
+        Conditions(),
+    )
+
+    assert base_settings["pb"].name_setting.spin_system_part == ""
+
+    for key in ("pb", "pc", "kex_ab", "kex_ac", "kab", "kba", "kac", "kca", "pa"):
+        assert residue_specific_settings[key].name_setting.spin_system_part == "g"
+
+
+def test_hd_models_keep_d2o_global_with_rs_suffix() -> None:
+    settings = model_factory.create_for_model(
+        ModelSpec.from_name("2st_hd.rs"),
+        Conditions(d2o=0.2),
+    )
+
+    assert settings["d2o"].name_setting.spin_system_part == ""
+
+    for key in ("kdh", "phi", "kab", "kba", "pa", "pb"):
+        assert settings[key].name_setting.spin_system_part == "g"
+
+
+def test_parameter_factory_uses_residue_specific_model_settings() -> None:
+    config = SimpleNamespace(
+        conditions=Conditions(),
+        to_be_fitted=SimpleNamespace(rates=[], model_free=[]),
+    )
+    spin_system = SpinSystem.from_name("G23N-HN")
+
+    session_base = AnalysisSession.create()
+    session_base.set_model("2st")
+    base_basis = Basis(type="iz", spin_system="nh", model=session_base.model.spec)
+    base_ids = session_base.parameter_factory.create_parameters(
+        config,
+        basis=base_basis,
+        spin_system=spin_system,
+    )
+    base_pb = session_base.parameters.get_parameters([base_ids["pb"]])[base_ids["pb"]]
+
+    session_rs = AnalysisSession.create()
+    session_rs.set_model("2st.rs")
+    rs_basis = Basis(type="iz", spin_system="nh", model=session_rs.model.spec)
+    rs_ids = session_rs.parameter_factory.create_parameters(
+        config,
+        basis=rs_basis,
+        spin_system=spin_system,
+    )
+    rs_pb = session_rs.parameters.get_parameters([rs_ids["pb"]])[rs_ids["pb"]]
+
+    assert base_pb.param_name.spin_system.name == ""
+    assert rs_pb.param_name.spin_system.name == "G23"

--- a/tests/models/test_model_extensions.py
+++ b/tests/models/test_model_extensions.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from chemex.models.loader import register_kinetic_settings
+from chemex.models.model import ModelSpec
+
+
+def setup_module() -> None:
+    register_kinetic_settings()
+
+
+def test_model_spec_parses_suffix_combinations() -> None:
+    spec = ModelSpec.from_name("2st.rs.mf.tc")
+
+    assert spec.name == "2st"
+    assert spec.states == "ab"
+    assert spec.residue_specific is True
+    assert spec.model_free is True
+    assert spec.temp_coef is True
+
+
+def test_model_spec_rejects_unknown_suffix() -> None:
+    with pytest.raises(SystemExit):
+        ModelSpec.from_name("2st.xyz")

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/website/docs/user_guide/fitting/kinetic_models.md
+++ b/website/docs/user_guide/fitting/kinetic_models.md
@@ -11,7 +11,6 @@ The kinetic model (specified with the `-d` or `--model` option) defines the type
 | `2st`         | 2-state exchange model (default)                                                |
 | `3st`         | 3-state exchange model                                                          |
 | `4st`         | 4-state exchange model                                                          |
-| `2st_rs`      | 2-state exchange model for residue-specific studies                             |
 | `2st_hd`      | 2-state exchange model for H/D solvent exchange studies                         |
 | `2st_eyring`  | 2-state exchange model for temperature-dependent studies                        |
 | `3st_eyring`  | 3-state exchange model for temperature-dependent studies                        |
@@ -20,6 +19,10 @@ The kinetic model (specified with the `-d` or `--model` option) defines the type
 | `4st_hd`      | 4-state exchange model for simultaneous normal and H/D solvent exchange studies |
 
 In these models, each state in the exchange process is represented with a unique parameter suffix (`A`, `B`, `C`, `D`, etc.). For example, `R1_A` denotes the R<sub>1</sub> relaxation rate of the major (ground) state, while `R2_B` refers to the R<sub>2</sub> rate of the first minor state, and so forth.
+
+:::note
+For any kinetic model, you can add the `.rs` suffix to make the kinetic parameters residue-specific (for example, `2st.rs` or `3st_eyring.rs`). Suffixes can be combined, such as `2st.rs.mf`. The legacy `2st_rs` name remains supported as an alias for `2st.rs`.
+:::
 
 :::note
 For any kinetic model, you can add the `.mf` suffix to create a model that fits model-free parameters directly (e.g., `TAUC_A`, `S2_A`), rather than individual relaxation parameters (e.g., `R1_A`, `R2_A`). For an example, see `CEST_15N_TR/` under `Examples/Experiments/`.
@@ -98,4 +101,3 @@ The model automatically calculates all 12 rate constants (k_AB, k_BA, k_AC, k_CA
 :::note
 State A serves as the reference state with ΔH_A = ΔS_A = 0 for all Eyring models. Rate constants are automatically clipped to [0, 1×10¹⁶ s⁻¹] for numerical stability.
 :::
-

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -26,7 +26,7 @@ Output/
 
 In any fitting step, if the dataset can be divided into multiple groups (each with distinct fitting parameters), ChemEx fits each group separately. Results for each group are stored in numbered subfolders within the `Groups/` folder, with a combined summary available in the `All/` folder for convenience.
 
-For example, if all global parameters (e.g., p<sub>B</sub>, k<sub>ex</sub>) are fixed or if a residue-specific model (e.g., [`2st_rs`](kinetic_models.md)) is used, residue-specific fits are performed and organized as follows:
+For example, if all global parameters (e.g., p<sub>B</sub>, k<sub>ex</sub>) are fixed or if a residue-specific model (e.g., [`2st.rs`](kinetic_models.md)) is used, residue-specific fits are performed and organized as follows:
 
 ```shell
 Output/


### PR DESCRIPTION
## Summary
- add the .rs model suffix with explicit suffix validation
- make residue-specific kinetics a generic factory transformation with opt-outs for sample-global settings such as d2o
- add regression tests and update docs/examples to prefer 2st.rs while keeping 2st_rs as a legacy alias

## Testing
- uv run pytest
- uv run ruff check on the modified Python files
