### PR TITLE
Remove redundant future annotations imports

### DIFF
--- a/src/chemex/models/constraints.py
+++ b/src/chemex/models/constraints.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from functools import lru_cache
 
 import numpy as np

--- a/src/chemex/toml.py
+++ b/src/chemex/toml.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 import tomllib
 from collections.abc import Iterable, MutableMapping

--- a/tests/models/test_model_extensions.py
+++ b/tests/models/test_model_extensions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 
 from chemex.models.loader import register_kinetic_settings

--- a/tests/test_experiments_selection.py
+++ b/tests/test_experiments_selection.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/tests/test_grid_entries.py
+++ b/tests/test_grid_entries.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 
 import chemex.parameters.database as database_module

--- a/tests/test_output_paths.py
+++ b/tests/test_output_paths.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -62,7 +60,9 @@ def test_experiments_write_and_plot_use_unique_output_stems(tmp_path: Path) -> N
     assert (tmp_path / "SimPlots" / "set_b" / "experiment.sim").exists()
 
 
-def test_experiments_keep_simple_stems_when_basenames_are_unique(tmp_path: Path) -> None:
+def test_experiments_keep_simple_stems_when_basenames_are_unique(
+    tmp_path: Path,
+) -> None:
     experiments = Experiments(parameter_store=object())  # type: ignore[arg-type]
     experiment_a = RecordingExperiment(Path("set_a/alpha.toml"))
     experiment_b = RecordingExperiment(Path("set_b/beta.toml"))


### PR DESCRIPTION
## Summary
- remove redundant __future__ annotations imports where Python 3.13+ no longer needs them in these modules
- keep the files functionally unchanged apart from the import cleanup and a small formatting adjustment

## Testing
- uv run pytest -q
- uv run ruff check on the modified files
