### PR TITLE
fix: resolve Python 3.14 deepcopy failure for MappingProxyType

### DIFF
--- a/src/chemex/nmr/_engine/readout.py
+++ b/src/chemex/nmr/_engine/readout.py
@@ -13,7 +13,7 @@ class LiouvillianReadout:
     """Detection expression state and scalar readout for a Liouvillian."""
 
     def __init__(self, vectors: Mapping[str, Array]) -> None:
-        self._vectors = vectors
+        self._vectors = dict(vectors)
         self._detection = ""
         self._detect_vector: Array = np.array([])
 

--- a/src/chemex/nmr/basis.py
+++ b/src/chemex/nmr/basis.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from functools import cache, cached_property, partial
 from itertools import permutations, product
 from types import MappingProxyType
-from typing import Literal
+from typing import Literal, Self
 
 import numpy as np
 
@@ -406,6 +406,10 @@ class Basis:
 
     def copy_matrices(self) -> DictArray:
         return {name: matrix.copy() for name, matrix in self.matrices.items()}
+
+    def __deepcopy__(self, memo: dict) -> Self:
+        """Return self: Basis is immutable, so copying is unnecessary."""
+        return self
 
     def __len__(self) -> int:
         return len(self.components)


### PR DESCRIPTION
## Problem

Python 3.14 broke `deepcopy` of `mappingproxy` objects (`types.MappingProxyType`), causing Monte Carlo and bootstrap simulations to crash immediately:

```
TypeError: cannot pickle 'mappingproxy' object
```

The traceback originates in `Profile.monte_carlo()` → `deepcopy(self)`, which traverses the `Spectrometer` → `ISLiouvillianEngine` → two sources of `MappingProxyType`:

1. `Basis.vectors` / `Basis.matrices` — `@cached_property` values stored in the instance `__dict__` after first access.
2. `LiouvillianReadout._vectors` — stored directly from `basis.vectors`.

## Fix

### `basis.py` — `Basis.__deepcopy__`

`Basis` is a `frozen=True` dataclass whose four fields (`type`, `model`, `extension`, `spin_system`) are all immutable. Following the standard Python idiom for immutable types (same contract as `str`, `int`, `frozenset`), `__deepcopy__` simply returns `self`. This skips the cached `MappingProxyType` values entirely and requires no copying at all.

```python
def __deepcopy__(self, memo: dict) -> Self:
    return self
```

### `readout.py` — `LiouvillianReadout.__init__`

Store `dict(vectors)` instead of the `MappingProxyType` directly, making the attribute deepcopy-safe while retaining full mapping behaviour.

```python
self._vectors = dict(vectors)
```