### PR TITLE
[codex] Clean up pydantic model validation

### DIFF
--- a/src/chemex/configuration/experiment.py
+++ b/src/chemex/configuration/experiment.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Literal, Self, TypeVar
+from typing import Any, ClassVar, Literal, TypeVar
 
 import numpy as np
 from pydantic import (
@@ -36,6 +36,24 @@ def _legacy_b1_distribution_input(
     }
 
 
+def normalize_b1_eff_alias(data: Any) -> Any:
+    """Map legacy D-CEST b1_frq input to b1_eff without populating both fields."""
+    if not isinstance(data, dict) or "b1_frq" not in data:
+        return data
+
+    b1_frq = data["b1_frq"]
+    if b1_frq is None:
+        return data
+
+    normalized = dict(data)
+    normalized.pop("b1_frq")
+    if "b1_eff" in normalized and normalized["b1_eff"] != b1_frq:
+        msg = "Use either 'b1_eff' or its legacy alias 'b1_frq', not both"
+        raise ValueError(msg)
+    normalized.setdefault("b1_eff", b1_frq)
+    return normalized
+
+
 class ExperimentSettings(BaseModel):
     observed_state: Literal["a", "b", "c", "d"] = "a"
     model_name: str = Field(default="", exclude=True)
@@ -64,9 +82,12 @@ class B1InhomogeneityMixin(BaseModel):
     """
 
     model_config = ConfigDict(
-        extra="allow",  # Mixins allow additional fields
+        extra="forbid",
         validate_assignment=True,  # Validate on attribute assignment
     )
+
+    legacy_b1_inh_scale_default: ClassVar[float | None] = None
+    legacy_b1_inh_res_default: ClassVar[int | None] = None
 
     pw90: PulseWidth | None = Field(
         default=None,
@@ -109,40 +130,37 @@ class B1InhomogeneityMixin(BaseModel):
             return data
 
         normalized = dict(data)
+        distribution = normalized.get("b1_distribution")
         has_legacy = (
             normalized.get("b1_inh_scale") is not None
             or normalized.get("b1_inh_res") is not None
         )
-        if not has_legacy:
-            return normalized
-        if normalized.get("b1_distribution") is not None:
+        if has_legacy and distribution is not None and not isinstance(
+            distribution, DistributionConfig
+        ):
             msg = (
                 "Use either 'b1_distribution' or the legacy "
                 "'b1_inh_scale'/'b1_inh_res' fields, not both"
             )
             raise ValueError(msg)
+
+        if distribution is not None:
+            return normalized
+
+        scale = normalized.get("b1_inh_scale", cls.legacy_b1_inh_scale_default)
+        res = normalized.get("b1_inh_res", cls.legacy_b1_inh_res_default)
+        if scale is None and res is None:
+            return normalized
+
+        if "b1_inh_scale" not in normalized and scale is not None:
+            normalized["b1_inh_scale"] = scale
+        if "b1_inh_res" not in normalized and res is not None:
+            normalized["b1_inh_res"] = res
         normalized["b1_distribution"] = _legacy_b1_distribution_input(
-            normalized.get("b1_inh_scale"),
-            normalized.get("b1_inh_res"),
+            scale,
+            res,
         )
         return normalized
-
-    @model_validator(mode="after")
-    def _normalize_defaulted_legacy_b1_fields(self) -> Self:
-        if self.b1_distribution is not None:
-            return self
-        if self.b1_inh_scale is None and self.b1_inh_res is None:
-            return self
-        return self.model_copy(
-            update={
-                "b1_distribution": parse_distribution_config(
-                    _legacy_b1_distribution_input(
-                        self.b1_inh_scale,
-                        self.b1_inh_res,
-                    ),
-                )
-            },
-        )
 
     def get_b1_nominal(self) -> float:
         """Nominal B1 value for distribution generation."""

--- a/src/chemex/containers/data.py
+++ b/src/chemex/containers/data.py
@@ -11,11 +11,20 @@ from pydantic import (
     PrivateAttr,
     computed_field,
     field_serializer,
+    model_validator,
 )
 
 from chemex.typing import Array
 
 rng = np.random.default_rng()
+
+_DERIVED_ARRAY_FIELDS = frozenset({"calc", "calc_unscaled", "mask", "refs"})
+
+
+def _is_compatible_error_shape(exp: Array, err: Array) -> bool:
+    if err.shape == exp.shape:
+        return True
+    return err.shape == (*exp.shape, 2)
 
 
 class Data(BaseModel):
@@ -34,7 +43,6 @@ class Data(BaseModel):
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,  # Allow numpy arrays
-        validate_assignment=True,  # Validate on assignment
     )
 
     exp: Array
@@ -46,12 +54,33 @@ class Data(BaseModel):
     refs: Array = Field(init=False, default_factory=partial(np.empty, 0, dtype=np.bool_))
     _revision: int = PrivateAttr(default=0)
 
-    def model_post_init(self, __context: Any) -> None:
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_derived_array_inputs(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        if supplied := _DERIVED_ARRAY_FIELDS & data.keys():
+            fields = ", ".join(sorted(supplied))
+            msg = f"Derived array fields are initialized internally: {fields}"
+            raise ValueError(msg)
+        return data
+
+    def model_post_init(self, __context: Any, /) -> None:
         """Set computed arrays shaped to match `exp` after initialization."""
         self.calc = np.full_like(self.exp, fill_value=1e32, dtype=np.float64)
         self.calc_unscaled = np.full_like(self.exp, fill_value=1e32, dtype=np.float64)
         self.mask = np.full_like(self.exp, fill_value=True, dtype=np.bool_)
         self.refs = np.full_like(self.exp, fill_value=False, dtype=np.bool_)
+
+    @model_validator(mode="after")
+    def _validate_array_shapes(self) -> Self:
+        if not _is_compatible_error_shape(self.exp, self.err):
+            msg = "'err' must match 'exp' shape or use trailing two-sided error bars"
+            raise ValueError(msg)
+        if self.metadata.size and self.metadata.size != self.exp.size:
+            msg = "'metadata' must be empty or have the same length as 'exp'"
+            raise ValueError(msg)
+        return self
 
     @property
     def revision(self) -> int:

--- a/src/chemex/experiments/catalog/dcest_13c.py
+++ b/src/chemex/experiments/catalog/dcest_13c.py
@@ -4,12 +4,16 @@ from typing import Literal, Self
 
 import numpy as np
 from numpy.linalg import matrix_power
-from pydantic import AliasChoices, Field, computed_field, model_validator
+from pydantic import Field, computed_field, model_validator
 
 from chemex.configuration.base import ExperimentConfiguration, ToBeFitted
 from chemex.configuration.conditions import ConditionsWithValidations
 from chemex.configuration.data import CestDataSettings
-from chemex.configuration.experiment import B1InhomogeneityMixin, MFCestSettings
+from chemex.configuration.experiment import (
+    B1InhomogeneityMixin,
+    MFCestSettings,
+    normalize_b1_eff_alias,
+)
 from chemex.configuration.types import B1Field, ChemicalShift, Delay
 from chemex.containers.data import Data
 from chemex.containers.dataset import load_relaxation_dataset
@@ -42,9 +46,10 @@ class DCest13CSettings(MFCestSettings, B1InhomogeneityMixin):
     # Accept both 'b1_eff' (preferred) and 'b1_frq' (alias) in configs.
     b1_eff: B1Field = Field(
         ...,
-        validation_alias=AliasChoices("b1_eff", "b1_frq"),
         description="Effective B1 field for DANTE excitation (Hz)",
     )
+
+    _normalize_b1_eff_alias = model_validator(mode="before")(normalize_b1_eff_alias)
 
     @model_validator(mode="after")
     def _validate_dcest_fields(self) -> Self:

--- a/src/chemex/experiments/catalog/dcest_15n.py
+++ b/src/chemex/experiments/catalog/dcest_15n.py
@@ -4,12 +4,16 @@ from typing import Literal, Self
 
 import numpy as np
 from numpy.linalg import matrix_power
-from pydantic import AliasChoices, Field, computed_field, model_validator
+from pydantic import Field, computed_field, model_validator
 
 from chemex.configuration.base import ExperimentConfiguration, ToBeFitted
 from chemex.configuration.conditions import ConditionsWithValidations
 from chemex.configuration.data import CestDataSettings
-from chemex.configuration.experiment import B1InhomogeneityMixin, MFCestSettings
+from chemex.configuration.experiment import (
+    B1InhomogeneityMixin,
+    MFCestSettings,
+    normalize_b1_eff_alias,
+)
 from chemex.configuration.types import B1Field, ChemicalShift, Delay
 from chemex.containers.data import Data
 from chemex.containers.dataset import load_relaxation_dataset
@@ -45,9 +49,10 @@ class DCest15NSettings(MFCestSettings, B1InhomogeneityMixin):
     # Accept both 'b1_eff' (preferred) and 'b1_frq' (alias) in configs.
     b1_eff: B1Field = Field(
         ...,
-        validation_alias=AliasChoices("b1_eff", "b1_frq"),
         description="Effective B1 field for DANTE excitation (Hz)",
     )
+
+    _normalize_b1_eff_alias = model_validator(mode="before")(normalize_b1_eff_alias)
 
     @model_validator(mode="after")
     def _validate_dcest_fields(self) -> Self:

--- a/src/chemex/experiments/catalog/wip/cest_15n_test.py
+++ b/src/chemex/experiments/catalog/wip/cest_15n_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 
@@ -32,8 +32,8 @@ class Cest15NSettings(CestSettings, B1InhomogeneityMixin):
     time_t1: float
     carrier: float
     b1_frq: float
-    b1_inh_scale: float = 0.1
-    b1_inh_res: int = 11
+    legacy_b1_inh_scale_default: ClassVar[float | None] = 0.1
+    legacy_b1_inh_res_default: ClassVar[int | None] = 11
 
     @cached_property
     def start_terms(self) -> list[str]:

--- a/src/chemex/experiments/catalog/wip/relaxation_15n_r1rho.py
+++ b/src/chemex/experiments/catalog/wip/relaxation_15n_r1rho.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 
@@ -28,8 +28,8 @@ class Relaxation15NR1RhoSettings(ExperimentSettings, B1InhomogeneityMixin):
 
     carrier: float
     b1_frq: float
-    b1_inh_scale: float = np.inf
-    b1_inh_res: int = 11
+    legacy_b1_inh_scale_default: ClassVar[float | None] = np.inf
+    legacy_b1_inh_res_default: ClassVar[int | None] = 11
     observed_state: Literal["a", "b", "c", "d"] = "a"
 
     @property

--- a/src/chemex/experiments/catalog/wip/relaxation_15n_r1rho_eig.py
+++ b/src/chemex/experiments/catalog/wip/relaxation_15n_r1rho_eig.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 
@@ -28,8 +28,8 @@ class Relaxation15NR1RhoSettings(ExperimentSettings, B1InhomogeneityMixin):
 
     carrier: float
     b1_frq: float
-    b1_inh_scale: float = np.inf
-    b1_inh_res: int = 11
+    legacy_b1_inh_scale_default: ClassVar[float | None] = np.inf
+    legacy_b1_inh_res_default: ClassVar[int | None] = 11
     observed_state: Literal["a", "b", "c", "d"] = "a"
 
     @property

--- a/src/chemex/nmr/distributions/registry.py
+++ b/src/chemex/nmr/distributions/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from chemex.nmr.constants import Distribution
 
@@ -15,6 +15,8 @@ DistributionGenerator = Callable[..., Distribution]
 
 class DistributionConfig(BaseModel):
     """Base class for B1 distribution configuration models."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: str
 

--- a/src/chemex/parameters/spin_system/spin_system.py
+++ b/src/chemex/parameters/spin_system/spin_system.py
@@ -51,6 +51,7 @@ class SpinSystem(BaseModel):
     @classmethod
     def parse_name(cls, model: Any) -> Any:
         if isinstance(model, dict) and "name" in model:
+            model = dict(model)
             name = str(model["name"]).strip().upper()
             model["spins"] = _parse_spin_system(name)
             model["name"] = _spins2name(model["spins"].values())

--- a/tests/configuration/test_b1_config.py
+++ b/tests/configuration/test_b1_config.py
@@ -1,11 +1,15 @@
 """Test B1FieldConfig with pw90 parameter."""
 
+from typing import ClassVar
+
 import numpy as np
 import pytest
 from pydantic import ValidationError
 
 from chemex.configuration.b1_config import B1FieldConfig
 from chemex.configuration.experiment import B1InhomogeneityMixin
+from chemex.experiments.catalog.dcest_13c import DCest13CSettings
+from chemex.experiments.catalog.dcest_15n import DCest15NSettings
 from chemex.nmr.distributions.dephasing import DephasingConfig
 from chemex.nmr.distributions.gaussian import GaussianDistributionConfig
 
@@ -15,13 +19,13 @@ class DummyB1Settings(B1InhomogeneityMixin):
 
 
 class DummyDefaultGaussianB1Settings(B1InhomogeneityMixin):
-    b1_inh_scale: float = 0.2
-    b1_inh_res: int = 7
+    legacy_b1_inh_scale_default: ClassVar[float | None] = 0.2
+    legacy_b1_inh_res_default: ClassVar[int | None] = 7
 
 
 class DummyDefaultDephasingB1Settings(B1InhomogeneityMixin):
-    b1_inh_scale: float = np.inf
-    b1_inh_res: int = 11
+    legacy_b1_inh_scale_default: ClassVar[float | None] = np.inf
+    legacy_b1_inh_res_default: ClassVar[int | None] = 11
 
 
 def test_b1_field_config_with_value():
@@ -182,6 +186,8 @@ def test_b1_inhomogeneity_mixin_normalizes_legacy_gaussian_fields():
     assert isinstance(settings.b1_distribution, GaussianDistributionConfig)
     assert settings.b1_distribution.scale == 0.2
     assert settings.b1_distribution.res == 7
+    assert settings.b1_inh_scale == 0.2
+    assert settings.b1_inh_res == 7
 
 
 def test_b1_inhomogeneity_mixin_normalizes_legacy_dephasing_scale():
@@ -201,12 +207,24 @@ def test_b1_inhomogeneity_mixin_normalizes_defaulted_legacy_gaussian_fields():
     assert isinstance(settings.b1_distribution, GaussianDistributionConfig)
     assert settings.b1_distribution.scale == 0.2
     assert settings.b1_distribution.res == 7
+    assert settings.b1_inh_scale == 0.2
+    assert settings.b1_inh_res == 7
+
+
+def test_b1_inhomogeneity_mixin_normalizes_defaulted_legacy_fields_with_init():
+    settings = DummyDefaultGaussianB1Settings(b1_frq=15.0)
+
+    assert isinstance(settings.b1_distribution, GaussianDistributionConfig)
+    assert settings.b1_distribution.scale == 0.2
+    assert settings.b1_distribution.res == 7
 
 
 def test_b1_inhomogeneity_mixin_normalizes_defaulted_legacy_dephasing_fields():
     settings = DummyDefaultDephasingB1Settings.model_validate({"b1_frq": 15.0})
 
     assert isinstance(settings.b1_distribution, DephasingConfig)
+    assert settings.b1_inh_scale == np.inf
+    assert settings.b1_inh_res == 11
 
 
 def test_b1_inhomogeneity_mixin_rejects_legacy_and_typed_distribution_together():
@@ -219,5 +237,63 @@ def test_b1_inhomogeneity_mixin_rejects_legacy_and_typed_distribution_together()
                 "b1_frq": 15.0,
                 "b1_distribution": {"type": "gaussian", "scale": 0.1, "res": 5},
                 "b1_inh_scale": 0.2,
+            }
+        )
+
+
+def test_b1_inhomogeneity_mixin_rejects_unknown_fields():
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        DummyB1Settings.model_validate({"b1_frq": 15.0, "b1_frqq": 12.0})
+
+
+@pytest.mark.parametrize(
+    ("settings_cls", "experiment_name"),
+    [
+        (DCest13CSettings, "dcest_13c"),
+        (DCest15NSettings, "dcest_15n"),
+    ],
+)
+def test_dcest_legacy_b1_frq_alias_maps_only_to_b1_eff(settings_cls, experiment_name):
+    settings = settings_cls.model_validate(
+        {
+            "name": experiment_name,
+            "time_t1": 0.1,
+            "sw": 100.0,
+            "carrier": 120.0,
+            "pw90": 25.0e-6,
+            "b1_frq": 2000.0,
+        }
+    )
+
+    assert settings.b1_eff == 2000.0
+    assert settings.b1_frq is None
+    settings.model_name = "2st"
+    assert settings.b1_eff == 2000.0
+    assert settings.b1_frq is None
+
+
+@pytest.mark.parametrize(
+    ("settings_cls", "experiment_name"),
+    [
+        (DCest13CSettings, "dcest_13c"),
+        (DCest15NSettings, "dcest_15n"),
+    ],
+)
+def test_dcest_rejects_conflicting_b1_eff_and_legacy_b1_frq(
+    settings_cls, experiment_name
+):
+    with pytest.raises(
+        ValidationError,
+        match="Use either 'b1_eff' or its legacy alias 'b1_frq'",
+    ):
+        settings_cls.model_validate(
+            {
+                "name": experiment_name,
+                "time_t1": 0.1,
+                "sw": 100.0,
+                "carrier": 120.0,
+                "pw90": 25.0e-6,
+                "b1_eff": 1500.0,
+                "b1_frq": 2000.0,
             }
         )

--- a/tests/nmr/test_distributions.py
+++ b/tests/nmr/test_distributions.py
@@ -110,6 +110,17 @@ class TestB1FieldConfig:
         with pytest.raises(ValidationError):
             B1FieldConfig.model_validate({"value": 0.0})
 
+    def test_unknown_distribution_option_rejected(self):
+        """Test that mistyped distribution options are rejected."""
+        with pytest.raises(ValidationError, match="sclae"):
+            B1FieldConfig.model_validate(
+                {
+                    "value": 15.0,
+                    "type": "gaussian",
+                    "sclae": 0.2,
+                }
+            )
+
 
 class TestGaussianDistribution:
     """Test Gaussian distribution generation."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from chemex.containers.data import Data
+
+
+def test_data_rejects_derived_array_inputs() -> None:
+    with pytest.raises(ValidationError, match="Derived array fields"):
+        Data(
+            exp=np.array([1.0]),
+            err=np.array([0.1]),
+            calc=np.array([1.0]),
+        )
+
+
+def test_data_rejects_mismatched_exp_and_err_shapes() -> None:
+    with pytest.raises(ValidationError, match="'err' must match 'exp' shape"):
+        Data(exp=np.array([1.0, 2.0]), err=np.array([0.1]))
+
+
+def test_data_accepts_two_sided_error_bars() -> None:
+    data = Data(
+        exp=np.array([1.0, 2.0]),
+        err=np.array([[0.1, 0.2], [0.3, 0.4]]),
+    )
+
+    assert data.err.shape == (2, 2)
+
+
+def test_data_rejects_mismatched_metadata_length() -> None:
+    with pytest.raises(ValidationError, match="'metadata' must be empty"):
+        Data(
+            exp=np.array([1.0, 2.0]),
+            err=np.array([0.1, 0.2]),
+            metadata=np.array([10.0]),
+        )

--- a/tests/test_spin_system.py
+++ b/tests/test_spin_system.py
@@ -1,0 +1,10 @@
+from chemex.parameters.spin_system import SpinSystem
+
+
+def test_spin_system_name_parser_does_not_mutate_input_dict() -> None:
+    raw = {"name": "G23N-HN"}
+
+    spin_system = SpinSystem.model_validate(raw)
+
+    assert spin_system.name == "G23N-H"
+    assert raw == {"name": "G23N-HN"}


### PR DESCRIPTION
## Summary

- Tighten Pydantic model validation for B1 inhomogeneity, distribution configs, data containers, and spin-system parsing.
- Preserve legacy B1 config compatibility while normalizing D-CEST `b1_frq` input without populating conflicting fields.
- Replace the prior legacy default lookup with explicit class defaults so the code no longer relies on `model_fields` or `object.__setattr__`.
- Add regression coverage for legacy B1 defaults and aliases, strict distribution options, derived data fields, error-bar shapes, metadata lengths, and spin-system input mutation.

## Root Cause

The D-CEST settings accepted `b1_frq` both as a legacy alias for `b1_eff` and as the shared B1 inhomogeneity field, which could leave both values populated during assignment validation. The earlier cleanup also used Pydantic field metadata to recover subclass defaults, which was valid class-level access but noisy in editors and more complex than necessary.

## Validation

- `uv run pytest`
- `uv run ty check src`
- `uv run ruff check src/chemex/configuration/experiment.py src/chemex/nmr/distributions/registry.py src/chemex/experiments/catalog/dcest_13c.py src/chemex/experiments/catalog/dcest_15n.py src/chemex/containers/data.py src/chemex/parameters/spin_system/spin_system.py tests/configuration/test_b1_config.py tests/nmr/test_distributions.py tests/test_data.py tests/test_spin_system.py src/chemex/experiments/catalog/wip/relaxation_15n_r1rho_eig.py src/chemex/experiments/catalog/wip/relaxation_15n_r1rho.py src/chemex/experiments/catalog/wip/cest_15n_test.py`
- `git diff --check`
- `uv run ./run.sh` from `examples/Experiments/DCEST_15N`