### PR TITLE
[codex] Implement MCMC uncertainty analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   uncertainty, with text outputs for posterior summaries, samples,
   correlations, and diagnostics, including automatic autocorrelation-based
   burn-in reporting and 95% equal-tailed credible intervals.
+- Added canonical `Statistics/<method>/` output directories for sampling-based
+  uncertainty analyses, with summaries, correlations, and diagnostics for Monte
+  Carlo and bootstrap runs.
 
 ## [2026.05.1] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 ### Added
 - Added MCMC posterior sampling as a `STATISTICS` method for fitted parameter
   uncertainty, with text outputs for posterior summaries, samples,
-  correlations, and diagnostics.
+  correlations, and diagnostics, including automatic autocorrelation-based
+  burn-in reporting and 95% equal-tailed credible intervals.
 
 ## [2026.05.1] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 - Added MCMC posterior sampling as a `STATISTICS` method for fitted parameter
   uncertainty, with text outputs for posterior summaries, samples,
   correlations, diagnostics, and a PDF visual report, including automatic
-  autocorrelation-based burn-in reporting and 95% equal-tailed credible
-  intervals.
+  autocorrelation-based burn-in reporting, tentative short-chain burn-in
+  handling, and 95% equal-tailed credible intervals.
 - Added canonical `Statistics/<method>/` output directories for sampling-based
   uncertainty analyses, with TSV sample/correlation tables, summaries, and
   diagnostics and PDF visual reports for Monte Carlo and bootstrap runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   correlations, and diagnostics, including automatic autocorrelation-based
   burn-in reporting and 95% equal-tailed credible intervals.
 - Added canonical `Statistics/<method>/` output directories for sampling-based
-  uncertainty analyses, with summaries, correlations, and diagnostics for Monte
-  Carlo and bootstrap runs.
+  uncertainty analyses, with TSV sample/correlation tables, summaries, and
+  diagnostics for Monte Carlo and bootstrap runs.
 
 ## [2026.05.1] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   intervals.
 - Added canonical `Statistics/<method>/` output directories for sampling-based
   uncertainty analyses, with TSV sample/correlation tables, summaries, and
-  diagnostics for Monte Carlo and bootstrap runs.
+  diagnostics and PDF visual reports for Monte Carlo and bootstrap runs.
 
 ## [2026.05.1] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to ChemEx will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO).
 
+## [Unreleased]
+
+### Added
+- Added MCMC posterior sampling as a `STATISTICS` method for fitted parameter
+  uncertainty, with text outputs for posterior summaries, samples,
+  correlations, and diagnostics.
+
 ## [2026.05.1] - 2026-05-13
 
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 ### Added
 - Added MCMC posterior sampling as a `STATISTICS` method for fitted parameter
   uncertainty, with text outputs for posterior summaries, samples,
-  correlations, and diagnostics, including automatic autocorrelation-based
-  burn-in reporting and 95% equal-tailed credible intervals.
+  correlations, diagnostics, and a PDF visual report, including automatic
+  autocorrelation-based burn-in reporting and 95% equal-tailed credible
+  intervals.
 - Added canonical `Statistics/<method>/` output directories for sampling-based
   uncertainty analyses, with TSV sample/correlation tables, summaries, and
   diagnostics for Monte Carlo and bootstrap runs.

--- a/docs/development/mcmc-implementation-plan.md
+++ b/docs/development/mcmc-implementation-plan.md
@@ -190,8 +190,8 @@ Output/
     Statistics/
       MCMC/
         summary.toml
-        samples.out
-        correlations.out
+        samples.tsv
+        correlations.tsv
         diagnostics.toml
 ```
 
@@ -231,15 +231,14 @@ effective_sample_size = 1.18000e+03
 mcse_mean = 3.46109e-05
 ```
 
-`samples.out` should use the same lightweight text-table style as existing
-statistics output:
+`samples.tsv` should be a tab-separated table with a header row:
 
-```text
-# KEX_AB PB [lnprob]
-  3.81511e+02  7.02971e-02 -1.23456e+03
+```tsv
+KEX_AB	PB	lnprob
+3.81511e+02	7.02971e-02	-1.23456e+03
 ```
 
-`correlations.out` should be a square matrix with parameter names in a header.
+`correlations.tsv` should be a square matrix with parameter names in a header.
 
 `diagnostics.toml` should include:
 
@@ -298,7 +297,7 @@ Add focused unit tests rather than expensive end-to-end MCMC tests:
   - default walkers are derived from number of varied parameters;
   - no varied parameters is handled without invoking the sampler;
 - writer tests:
-  - `summary.toml`, `samples.out`, `correlations.out`, and `diagnostics.toml`
+  - `summary.toml`, `samples.tsv`, `correlations.tsv`, and `diagnostics.toml`
     formatting from a small synthetic `McmcResult`;
 - integration dispatch:
   - `_run_statistics()` calls MCMC without generating bootstrap/Monte Carlo

--- a/docs/development/mcmc-implementation-plan.md
+++ b/docs/development/mcmc-implementation-plan.md
@@ -240,6 +240,16 @@ KEX_AB	PB	lnprob
 
 `correlations.tsv` should be a square matrix with parameter names in a header.
 
+`plots.pdf` should be a derived visual report with:
+
+- a summary page for sampler settings and diagnostics;
+- one-dimensional posterior distributions for every varied parameter;
+- walker traces for every varied parameter, with the burn-in zone shown when
+  available;
+- a log-probability trace;
+- two-dimensional posterior distributions for parameter pairs whose absolute
+  correlation is at least 0.5.
+
 `diagnostics.toml` should include:
 
 - `steps`
@@ -251,10 +261,7 @@ KEX_AB	PB	lnprob
 - autocorrelation time when available
 - ESS and retained chain length relative to autocorrelation time when available
 - a warning field when autocorrelation could not be estimated
-
-Avoid adding plots in the first PR. Chain and corner plots are valuable, but they
-introduce heavier dependencies and test surface. Text outputs are enough for the
-initial feature.
+- the relative `plots.pdf` path
 
 ## Integration Points
 
@@ -297,8 +304,8 @@ Add focused unit tests rather than expensive end-to-end MCMC tests:
   - default walkers are derived from number of varied parameters;
   - no varied parameters is handled without invoking the sampler;
 - writer tests:
-  - `summary.toml`, `samples.tsv`, `correlations.tsv`, and `diagnostics.toml`
-    formatting from a small synthetic `McmcResult`;
+  - `summary.toml`, `samples.tsv`, `correlations.tsv`, `diagnostics.toml`, and
+    `plots.pdf` generation from a small synthetic `McmcResult`;
 - integration dispatch:
   - `_run_statistics()` calls MCMC without generating bootstrap/Monte Carlo
     experiments;
@@ -317,6 +324,7 @@ Update the user guide:
 - document the short and expanded syntax;
 - recommend finite parameter bounds;
 - document output files and diagnostics;
+- document the `plots.pdf` report;
 - clarify that MCMC uncertainty is posterior-based, while `MC`/`BS` refit
   synthetic datasets.
 
@@ -337,7 +345,6 @@ statistics methods, not only as `FITMETHOD = "emcee"`.
 ## Non-Goals For The First Implementation
 
 - custom priors beyond current bounds;
-- posterior plotting;
 - resumable chains;
 - replacing best-fit parameters by default;
 - multiprocessing defaults above one worker;

--- a/docs/development/mcmc-implementation-plan.md
+++ b/docs/development/mcmc-implementation-plan.md
@@ -250,6 +250,12 @@ KEX_AB	PB	lnprob
 - two-dimensional posterior distributions for parameter pairs whose absolute
   correlation is at least 0.5.
 
+The Monte Carlo and bootstrap statistics methods should write the same
+`plots.pdf` filename under their own `Statistics/<method>/` directories, with
+the same summary, one-dimensional distribution, and significant two-dimensional
+distribution pages. MCMC additionally includes walker and log-probability trace
+pages.
+
 `diagnostics.toml` should include:
 
 - `steps`

--- a/docs/development/mcmc-implementation-plan.md
+++ b/docs/development/mcmc-implementation-plan.md
@@ -181,16 +181,18 @@ recommended for meaningful MCMC priors.
 
 ## Output Design
 
-Create a dedicated `MCMC` directory under the current group or step output path:
+Create a dedicated `Statistics/MCMC` directory under the current group or step
+output path:
 
 ```text
 Output/
   STEP1/
-    MCMC/
-      summary.toml
-      samples.out
-      correlations.out
-      diagnostics.toml
+    Statistics/
+      MCMC/
+        summary.toml
+        samples.out
+        correlations.out
+        diagnostics.toml
 ```
 
 `summary.toml` should be human-readable and stable:

--- a/docs/development/mcmc-implementation-plan.md
+++ b/docs/development/mcmc-implementation-plan.md
@@ -65,7 +65,7 @@ Introduce a small Pydantic model:
 ```python
 class McmcSettings(BaseModel):
     steps: PositiveInt
-    burn: NonNegativeInt = 0
+    burn: NonNegativeInt | Literal["auto"] = "auto"
     thin: PositiveInt = 1
     walkers: PositiveInt | None = None
     seed: int | None = None
@@ -86,10 +86,16 @@ class Statistics(BaseModel):
 Validation rules:
 
 - Convert `STATISTICS = {"MCMC" = 5000}` to `McmcSettings(steps=5000)`.
-- Require `burn < steps`.
+- Require numeric `burn < steps`.
 - Require enough retained samples after burn/thinning.
 - If `walkers` is omitted, default to `max(32, 2 * nvarys)` at runtime, because
   the value depends on the current group.
+- Default `burn` to `"auto"` and resolve it from the integrated
+  autocorrelation time after the sampler has run. If autocorrelation time is not
+  available or implies discarding the whole chain, keep the full chain and record
+  a diagnostic warning.
+- Default `thin` to `1`. Thinning is kept as an explicit storage/output-size
+  control instead of an automatic convergence tool.
 - Keep `update_parameters = false` initially so MCMC does not silently replace
   deterministic best-fit output with posterior medians. This makes the new
   feature observational by default and avoids surprising existing workflows.
@@ -125,10 +131,16 @@ through the application:
 @dataclass(frozen=True)
 class McmcSummary:
     parameter_id: str
+    mean: float
+    standard_deviation: float
     median: float
+    eti_95_lower: float
+    eti_95_upper: float
     lower_1sigma: float
     upper_1sigma: float
     stderr: float
+    effective_sample_size: float | None
+    mcse_mean: float | None
 
 @dataclass(frozen=True)
 class McmcResult:
@@ -139,6 +151,8 @@ class McmcResult:
     correlations: Array
     acceptance_fraction: Array
     autocorrelation_time: Array | None
+    discarded_steps: int
+    burn_in_warning: str | None
 ```
 
 This keeps external-library details localized and makes tests independent of
@@ -183,16 +197,36 @@ Output/
 
 ```toml
 [GLOBAL.KEX_AB]
+prior = "uniform"
+prior_lower = 1.00000e+00
+prior_upper = 5.00000e+03
+credible_interval = "95% equal-tailed"
+mean = 3.81511e+02
+standard_deviation = 9.10234e+00
 median = 3.81511e+02
+eti_95_lower = 3.64001e+02
+eti_95_upper = 3.99020e+02
 lower_1sigma = 3.72602e+02
 upper_1sigma = 3.90420e+02
 stderr = 8.90870e+00
+effective_sample_size = 1.25000e+03
+mcse_mean = 2.57446e-01
 
 [GLOBAL.PB]
+prior = "uniform"
+prior_lower = 0.00000e+00
+prior_upper = 1.00000e+00
+credible_interval = "95% equal-tailed"
+mean = 7.02971e-02
+standard_deviation = 1.18903e-03
 median = 7.02971e-02
+eti_95_lower = 6.80343e-02
+eti_95_upper = 7.25599e-02
 lower_1sigma = 6.91493e-02
 upper_1sigma = 7.14449e-02
 stderr = 1.14780e-03
+effective_sample_size = 1.18000e+03
+mcse_mean = 3.46109e-05
 ```
 
 `samples.out` should use the same lightweight text-table style as existing
@@ -208,12 +242,13 @@ statistics output:
 `diagnostics.toml` should include:
 
 - `steps`
-- `burn`
+- requested burn-in setting and actual discarded steps
 - `thin`
 - `walkers`
 - number of retained samples
 - mean/min/max acceptance fraction
 - autocorrelation time when available
+- ESS and retained chain length relative to autocorrelation time when available
 - a warning field when autocorrelation could not be estimated
 
 Avoid adding plots in the first PR. Chain and corner plots are valuable, but they

--- a/docs/development/mcmc-implementation-plan.md
+++ b/docs/development/mcmc-implementation-plan.md
@@ -1,0 +1,311 @@
+# MCMC Parameter Uncertainty Implementation Plan
+
+## Goal
+
+Add Markov chain Monte Carlo sampling as a first-class uncertainty analysis in
+ChemEx, alongside the existing Monte Carlo and bootstrap statistics. The feature
+should reuse the current fitting, parameter, and output infrastructure, keep the
+initial implementation small, and leave a clear path for richer posterior
+diagnostics later.
+
+## Current Architecture
+
+ChemEx already has the right extension points:
+
+- `chemex.configuration.methods.Statistics` parses the `STATISTICS` method-file
+  section and currently supports `MC`, `BS`, and `BSN`.
+- `chemex.optimize.fitting._run_statistics()` is called after each normal fit and
+  writes one statistics output file per enabled method.
+- `chemex.optimize.minimizer.minimize()` and `minimize_with_report()` wrap
+  `lmfit.Minimizer`.
+- `chemex.optimize.helper.calculate_statistics()` computes fit statistics from
+  the weighted residual vector.
+- `chemex.parameters.database.ParameterStore.build_lmfit_params()` reconstructs
+  the active `lmfit.Parameters`, including bounds, expressions, and current
+  best-fit values.
+
+The project already depends on `emcee>=3.1.6`, and `lmfit` provides an
+`emcee()` wrapper that samples the posterior from the same residual function that
+ChemEx already uses for deterministic fitting.
+
+## Product Behavior
+
+MCMC should be an uncertainty/statistics method, not a replacement for the normal
+best-fit step. Users should still run a deterministic fit first, then sample the
+posterior around that fitted solution.
+
+Minimal method-file syntax:
+
+```toml
+[STEP1]
+FITMETHOD = "leastsq"
+STATISTICS = { "MCMC" = 5000 }
+```
+
+Expanded syntax for advanced users:
+
+```toml
+[STEP1.STATISTICS.MCMC]
+STEPS = 5000
+BURN = 1000
+THIN = 10
+WALKERS = 64
+SEED = 1234
+WORKERS = 1
+```
+
+The short form keeps parity with `MC`, `BS`, and `BSN`: the integer means
+`steps`. The expanded form is needed for reproducibility and basic convergence
+control.
+
+## Configuration Design
+
+Introduce a small Pydantic model:
+
+```python
+class McmcSettings(BaseModel):
+    steps: PositiveInt
+    burn: NonNegativeInt = 0
+    thin: PositiveInt = 1
+    walkers: PositiveInt | None = None
+    seed: int | None = None
+    workers: PositiveInt = 1
+    update_parameters: bool = False
+```
+
+Then change `Statistics` to accept either short-form or expanded MCMC settings:
+
+```python
+class Statistics(BaseModel):
+    mc: PositiveInt | None = None
+    bs: PositiveInt | None = None
+    bsn: PositiveInt | None = None
+    mcmc: PositiveInt | McmcSettings | None = None
+```
+
+Validation rules:
+
+- Convert `STATISTICS = {"MCMC" = 5000}` to `McmcSettings(steps=5000)`.
+- Require `burn < steps`.
+- Require enough retained samples after burn/thinning.
+- If `walkers` is omitted, default to `max(32, 2 * nvarys)` at runtime, because
+  the value depends on the current group.
+- Keep `update_parameters = false` initially so MCMC does not silently replace
+  deterministic best-fit output with posterior medians. This makes the new
+  feature observational by default and avoids surprising existing workflows.
+
+## Sampling Architecture
+
+Add a new module, `chemex.optimize.mcmc`, with these responsibilities:
+
+- define the immutable runtime settings dataclass or Pydantic model used by the
+  sampler;
+- validate the active parameter set before sampling;
+- run `lmfit.Minimizer(experiments.residuals, params).emcee(...)`;
+- transform the `lmfit.MinimizerResult` into ChemEx-owned result objects;
+- write summary, samples, and correlation outputs.
+
+Keep MCMC-specific code out of `fitting.py` except for dispatch. A good public
+surface is:
+
+```python
+def run_mcmc(
+    experiments: Experiments,
+    params: lmfit.Parameters,
+    settings: McmcSettings,
+    path: Path,
+) -> McmcResult:
+    ...
+```
+
+Use ChemEx-owned result containers instead of passing `lmfit.MinimizerResult`
+through the application:
+
+```python
+@dataclass(frozen=True)
+class McmcSummary:
+    parameter_id: str
+    median: float
+    lower_1sigma: float
+    upper_1sigma: float
+    stderr: float
+
+@dataclass(frozen=True)
+class McmcResult:
+    var_names: tuple[str, ...]
+    chain: Array
+    lnprob: Array
+    summary: tuple[McmcSummary, ...]
+    correlations: Array
+    acceptance_fraction: Array
+    autocorrelation_time: Array | None
+```
+
+This keeps external-library details localized and makes tests independent of
+`lmfit` internals.
+
+## Statistical Model
+
+Use ChemEx's existing weighted residuals and call `lmfit.Minimizer.emcee()` with
+`is_weighted=True`. The resulting log likelihood is consistent with the current
+error model: residuals are already `(experiment - model) / error`.
+
+Use existing `lmfit.Parameter.min` and `max` values as uniform priors. This is
+the least surprising first implementation because users already set bounds in
+parameter files:
+
+```toml
+[GLOBAL]
+PB = [0.05, 0.0, 1.0]
+KEX_AB = [200.0, 1.0, 5000.0]
+```
+
+Before sampling, warn when any varied parameter has an infinite bound. This
+should not be a hard error in the first implementation, because many current
+ChemEx defaults are one-sided. The warning should explain that finite bounds are
+recommended for meaningful MCMC priors.
+
+## Output Design
+
+Create a dedicated `MCMC` directory under the current group or step output path:
+
+```text
+Output/
+  STEP1/
+    MCMC/
+      summary.toml
+      samples.out
+      correlations.out
+      diagnostics.toml
+```
+
+`summary.toml` should be human-readable and stable:
+
+```toml
+[GLOBAL.KEX_AB]
+median = 3.81511e+02
+lower_1sigma = 3.72602e+02
+upper_1sigma = 3.90420e+02
+stderr = 8.90870e+00
+
+[GLOBAL.PB]
+median = 7.02971e-02
+lower_1sigma = 6.91493e-02
+upper_1sigma = 7.14449e-02
+stderr = 1.14780e-03
+```
+
+`samples.out` should use the same lightweight text-table style as existing
+statistics output:
+
+```text
+# KEX_AB PB [lnprob]
+  3.81511e+02  7.02971e-02 -1.23456e+03
+```
+
+`correlations.out` should be a square matrix with parameter names in a header.
+
+`diagnostics.toml` should include:
+
+- `steps`
+- `burn`
+- `thin`
+- `walkers`
+- number of retained samples
+- mean/min/max acceptance fraction
+- autocorrelation time when available
+- a warning field when autocorrelation could not be estimated
+
+Avoid adding plots in the first PR. Chain and corner plots are valuable, but they
+introduce heavier dependencies and test surface. Text outputs are enough for the
+initial feature.
+
+## Integration Points
+
+Change `_run_statistics()` in `chemex.optimize.fitting` to separate resampling
+statistics from posterior sampling:
+
+- keep the existing `MC`, `BS`, and `BSN` loop unchanged;
+- dispatch `MCMC` to `chemex.optimize.mcmc.run_mcmc()`;
+- do not call `generate_exp_for_statistics()` for MCMC;
+- pass the current best-fit parameters from `parameter_store.build_lmfit_params()`.
+
+The call should happen after `execute_post_fit()` and after
+`parameter_store.update_from_parameters(best_lmfit_params)`, which is already
+the current flow. That ensures the sampler starts from the fitted solution.
+
+## Error Handling
+
+Use specific validation and user-facing errors where possible:
+
+- no varied parameters: skip MCMC with a clear warning;
+- invalid burn/thin settings: fail method parsing before fitting starts;
+- insufficient finite bounds: warn, do not fail in the first implementation;
+- sampler interruption: handle `KeyboardInterrupt` like current statistics;
+- `ValueError` from `lmfit` or `emcee`: print ChemEx's existing value-error
+  message and leave partial outputs flushed when possible.
+
+Avoid catching broad `Exception`; sampler failures should be visible during
+development and CI.
+
+## Testing Plan
+
+Add focused unit tests rather than expensive end-to-end MCMC tests:
+
+- configuration parsing:
+  - short-form `STATISTICS = {"MCMC" = 100}`;
+  - expanded `[STEP.STATISTICS.MCMC]`;
+  - lower-case key coercion;
+  - invalid `burn >= steps`;
+- runtime defaults:
+  - default walkers are derived from number of varied parameters;
+  - no varied parameters is handled without invoking the sampler;
+- writer tests:
+  - `summary.toml`, `samples.out`, `correlations.out`, and `diagnostics.toml`
+    formatting from a small synthetic `McmcResult`;
+- integration dispatch:
+  - `_run_statistics()` calls MCMC without generating bootstrap/Monte Carlo
+    experiments;
+  - existing `MC`, `BS`, and `BSN` behavior remains unchanged.
+
+For one smoke test, monkeypatch the actual sampler call to return a tiny fixed
+chain. This avoids making CI slow or nondeterministic while still validating the
+ChemEx integration.
+
+## Documentation Plan
+
+Update the user guide:
+
+- add MCMC to the "Estimating Parameter Uncertainty" section;
+- explain that MCMC samples the posterior after a normal fit;
+- document the short and expanded syntax;
+- recommend finite parameter bounds;
+- document output files and diagnostics;
+- clarify that MCMC uncertainty is posterior-based, while `MC`/`BS` refit
+  synthetic datasets.
+
+Update `messages.py` help text if needed so `MCMC` appears alongside the
+statistics methods, not only as `FITMETHOD = "emcee"`.
+
+## Implementation Phases
+
+1. Add configuration models and tests.
+2. Add `chemex.optimize.mcmc` result containers, sampler wrapper, validation,
+   and output writers.
+3. Wire MCMC into `_run_statistics()`.
+4. Add focused tests for dispatch and output generation.
+5. Update website documentation.
+6. Run `pytest` for the touched tests, then the broader suite if runtime is
+   acceptable.
+
+## Non-Goals For The First Implementation
+
+- custom priors beyond current bounds;
+- posterior plotting;
+- resumable chains;
+- replacing best-fit parameters by default;
+- multiprocessing defaults above one worker;
+- adding `pandas` solely for `result.flatchain`.
+
+These can be added later without changing the core architecture if the first
+implementation keeps MCMC isolated behind ChemEx-owned result objects.

--- a/docs/development/mcmc-implementation-plan.md
+++ b/docs/development/mcmc-implementation-plan.md
@@ -92,8 +92,10 @@ Validation rules:
   the value depends on the current group.
 - Default `burn` to `"auto"` and resolve it from the integrated
   autocorrelation time after the sampler has run. If autocorrelation time is not
-  available or implies discarding the whole chain, keep the full chain and record
-  a diagnostic warning.
+  reliable but emcee reports a tentative short-chain estimate, use that estimate
+  for automatic burn-in only and record a diagnostic warning. If autocorrelation
+  time is unavailable or implies discarding the whole chain, keep the full chain
+  and record a diagnostic warning.
 - Default `thin` to `1`. Thinning is kept as an explicit storage/output-size
   control instead of an automatic convergence tool.
 - Keep `update_parameters = false` initially so MCMC does not silently replace
@@ -247,6 +249,8 @@ KEX_AB	PB	lnprob
 - walker traces for every varied parameter, with the burn-in zone shown when
   available;
 - a log-probability trace;
+- an autocorrelation monitor showing tau estimates as a function of chain
+  length;
 - two-dimensional posterior distributions for parameter pairs whose absolute
   correlation is at least 0.5.
 
@@ -265,6 +269,8 @@ pages.
 - number of retained samples
 - mean/min/max acceptance fraction
 - autocorrelation time when available
+- tentative autocorrelation time and recommended chain lengths when emcee
+  reports a short-chain autocorrelation warning
 - ESS and retained chain length relative to autocorrelation time when available
 - a warning field when autocorrelation could not be estimated
 - the relative `plots.pdf` path

--- a/src/chemex/configuration/methods.py
+++ b/src/chemex/configuration/methods.py
@@ -4,7 +4,7 @@ import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Self
 
 from pydantic import (
     BaseModel,
@@ -16,7 +16,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from pydantic.types import PositiveInt
+from pydantic.types import NonNegativeInt, PositiveInt
 
 from chemex.configuration.utils import key_to_lower
 from chemex.messages import print_method_error
@@ -29,12 +29,43 @@ CoercedSpinSystem = Annotated[SpinSystem, PlainValidator(SpinSystem.from_name)]
 SelectionType = list[SpinSystem] | Literal["*"] | None
 
 
+class McmcSettings(BaseModel):
+    steps: PositiveInt
+    burn: NonNegativeInt = 0
+    thin: PositiveInt = 1
+    walkers: PositiveInt | None = None
+    seed: int | None = None
+    workers: PositiveInt = 1
+    update_parameters: bool = False
+
+    _key_to_lower = model_validator(mode="before")(key_to_lower)
+
+    @model_validator(mode="after")
+    def validate_sample_window(self) -> Self:
+        if self.burn >= self.steps:
+            msg = "MCMC burn must be smaller than steps"
+            raise ValueError(msg)
+        retained = (self.steps - self.burn) // self.thin
+        if retained < 1:
+            msg = "MCMC settings must retain at least one sample"
+            raise ValueError(msg)
+        return self
+
+
 class Statistics(BaseModel):
     mc: PositiveInt | None = None
     bs: PositiveInt | None = None
     bsn: PositiveInt | None = None
+    mcmc: McmcSettings | None = None
 
     _key_to_lower = model_validator(mode="before")(key_to_lower)
+
+    @field_validator("mcmc", mode="before")
+    @classmethod
+    def parse_mcmc_settings(cls, value: int | dict | None) -> dict | None:
+        if isinstance(value, int):
+            return {"steps": value}
+        return value
 
 
 @dataclass

--- a/src/chemex/configuration/methods.py
+++ b/src/chemex/configuration/methods.py
@@ -27,11 +27,12 @@ from chemex.toml import read_toml
 AllType = Annotated[Literal["*", "all"], BeforeValidator(str.lower)]
 CoercedSpinSystem = Annotated[SpinSystem, PlainValidator(SpinSystem.from_name)]
 SelectionType = list[SpinSystem] | Literal["*"] | None
+McmcBurnSetting = NonNegativeInt | Literal["auto"]
 
 
 class McmcSettings(BaseModel):
     steps: PositiveInt
-    burn: NonNegativeInt = 0
+    burn: McmcBurnSetting = "auto"
     thin: PositiveInt = 1
     walkers: PositiveInt | None = None
     seed: int | None = None
@@ -40,12 +41,20 @@ class McmcSettings(BaseModel):
 
     _key_to_lower = model_validator(mode="before")(key_to_lower)
 
+    @field_validator("burn", mode="before")
+    @classmethod
+    def parse_burn(cls, value: object) -> object:
+        if isinstance(value, str) and value.lower() == "auto":
+            return "auto"
+        return value
+
     @model_validator(mode="after")
     def validate_sample_window(self) -> Self:
-        if self.burn >= self.steps:
+        burn = 0 if self.burn == "auto" else self.burn
+        if burn >= self.steps:
             msg = "MCMC burn must be smaller than steps"
             raise ValueError(msg)
-        retained = (self.steps - self.burn) // self.thin
+        retained = (self.steps - burn) // self.thin
         if retained < 1:
             msg = "MCMC settings must retain at least one sample"
             raise ValueError(msg)

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -491,6 +491,33 @@ def print_grid_statistic_warning() -> None:
     console.print()
 
 
+def print_mcmc_no_vary_warning() -> None:
+    """Warn that MCMC was requested without fitted parameters."""
+    console.print()
+    console.print(
+        "[yellow] -- WARNING: MCMC was requested, but no parameters are marked "
+        "as fitted. Skipping MCMC.",
+    )
+    console.print()
+
+
+def print_mcmc_unbounded_warning(parameters: list[str]) -> None:
+    """Warn that MCMC was requested with unbounded parameters."""
+    console.print()
+    console.print(
+        "[yellow] -- WARNING: Some fitted parameters do not have finite MCMC "
+        "bounds.",
+    )
+    console.print(
+        "Uniform priors are inferred from parameter bounds; finite lower and "
+        "upper bounds are recommended for MCMC.",
+    )
+    console.print("Affected parameters:")
+    for parameter in parameters:
+        console.print(f"    - {parameter}")
+    console.print()
+
+
 def print_model_error(name: str) -> None:
     """Display an error message for unavailable models.
 
@@ -631,9 +658,9 @@ GRID_ERROR_MESSAGE = """\
     ]"""
 
 STATISTICS_ERROR_MESSAGE = """\
-  - "STATISTICS" must be a dictionary with keys 'MC', 'BS', 'BSN'
+  - "STATISTICS" must be a dictionary with keys 'MC', 'BS', 'BSN', 'MCMC'
 
-    Example: { "MC"=10 } or { "MC"=10, "BS"=10 }"""
+    Example: { "MC"=10 }, { "MCMC"=5000 }, or { "MC"=10, "BS"=10 }"""
 
 METHOD_ERROR_MESSAGES = {
     "fitmethod": FITMETHOD_ERROR_MESSAGE,

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -2,10 +2,8 @@
 
 from pathlib import Path
 
-from rich.progress import track
-
 from chemex.configuration.methods import Methods, Statistics
-from chemex.containers.experiments import Experiments, generate_exp_for_statistics
+from chemex.containers.experiments import Experiments
 from chemex.messages import (
     print_calculation_stopped_error,
     print_fitmethod,
@@ -20,17 +18,14 @@ from chemex.messages import (
 from chemex.optimize.gridding import run_grid
 from chemex.optimize.grouping import create_groups
 from chemex.optimize.helper import (
-    calculate_statistics,
     execute_post_fit,
     execute_post_fit_groups,
-    print_header,
-    print_values_stat,
 )
 from chemex.optimize.mcmc import run_mcmc
 from chemex.optimize.minimizer import (
-    minimize,
     minimize_with_report,
 )
+from chemex.optimize.resampling import run_resampling_statistics
 from chemex.runtime import AnalysisSession
 
 
@@ -43,42 +38,8 @@ def _run_statistics(
     if statistics is None:
         return
 
-    methods = {
-        "mc": {"message": "Monte Carlo", "filename": "monte_carlo.out"},
-        "bs": {"message": "bootstrap", "filename": "bootstrap.out"},
-        "bsn": {"message": "nucleus-based bootstrap", "filename": "bootstrap_ns.out"},
-    }
-
+    run_resampling_statistics(experiments, path, fitmethod, statistics)
     parameter_store = experiments.parameter_store
-    params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
-    ids_vary = [param.name for param in params_lf.values() if param.vary]
-
-    for statistic_name, method in methods.items():
-        iter_nb = getattr(statistics, statistic_name)
-        if iter_nb is None:
-            continue
-
-        print_running_statistics(method["message"])
-
-        with (path / method["filename"]).open(mode="w", encoding="utf-8") as fileout:
-            fileout.write(print_header(ids_vary, parameter_store=parameter_store))
-
-            try:
-                for _ in track(range(iter_nb), total=iter_nb, description="   "):
-                    exp_stat = generate_exp_for_statistics(experiments, statistic_name)
-                    params_lf = parameter_store.build_lmfit_params(exp_stat.param_ids)
-                    params_fit = minimize(exp_stat, params_lf, fitmethod)
-                    stats = calculate_statistics(exp_stat, params_fit)
-                    chisqr = stats.get("chisqr", 1e32)
-                    fileout.write(
-                        print_values_stat(params_fit, ids_vary, chisqr),
-                    )
-            except KeyboardInterrupt:
-                print_calculation_stopped_error()
-            except ValueError:
-                print_value_error()
-            finally:
-                fileout.flush()
 
     if statistics.mcmc is None:
         return

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -26,6 +26,7 @@ from chemex.optimize.helper import (
     print_header,
     print_values_stat,
 )
+from chemex.optimize.mcmc import run_mcmc
 from chemex.optimize.minimizer import (
     minimize,
     minimize_with_report,
@@ -52,11 +53,10 @@ def _run_statistics(
     params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
     ids_vary = [param.name for param in params_lf.values() if param.vary]
 
-    for statistic_name, iter_nb in statistics.model_dump().items():
+    for statistic_name, method in methods.items():
+        iter_nb = getattr(statistics, statistic_name)
         if iter_nb is None:
             continue
-
-        method = methods[statistic_name]
 
         print_running_statistics(method["message"])
 
@@ -79,6 +79,18 @@ def _run_statistics(
                 print_value_error()
             finally:
                 fileout.flush()
+
+    if statistics.mcmc is None:
+        return
+
+    print_running_statistics("MCMC")
+    try:
+        params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
+        run_mcmc(experiments, params_lf, statistics.mcmc, path)
+    except KeyboardInterrupt:
+        print_calculation_stopped_error()
+    except ValueError:
+        print_value_error()
 
 
 def _fit_groups(

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from math import ceil
 from pathlib import Path
-from typing import cast
+from types import TracebackType
+from typing import Any, Self, cast
 
+import emcee.ensemble as emcee_ensemble
 import lmfit
 import numpy as np
 from lmfit.minimizer import MinimizerResult
 from lmfit.parameter import Parameters
+from rich.progress import Progress, TaskID
 
 from chemex.configuration.methods import McmcBurnSetting, McmcSettings
 from chemex.containers.experiments import Experiments
@@ -20,6 +24,51 @@ from chemex.messages import (
 )
 from chemex.parameters.database import ParameterStore
 from chemex.typing import Array
+
+
+class _RichEmceeProgressBar:
+    def __init__(self, total: int) -> None:
+        self._total = total
+        self._progress = Progress()
+        self._task_id: TaskID | None = None
+
+    def __enter__(self) -> Self:
+        self._progress.start()
+        self._task_id = self._progress.add_task("   ", total=self._total)
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self._progress.stop()
+
+    def update(self, count: int) -> None:
+        if self._task_id is not None:
+            self._progress.update(self._task_id, advance=count)
+
+
+@contextmanager
+def _use_rich_emcee_progress() -> Iterator[None]:
+    original_get_progress_bar = emcee_ensemble.get_progress_bar
+
+    def get_progress_bar(
+        display: bool | str,
+        total: int,
+        **_kwargs: object,
+    ) -> object:
+        if display:
+            return _RichEmceeProgressBar(total)
+        return original_get_progress_bar(display, total, **_kwargs)
+
+    emcee_ensemble_dynamic = cast("Any", emcee_ensemble)
+    emcee_ensemble_dynamic.get_progress_bar = get_progress_bar
+    try:
+        yield
+    finally:
+        emcee_ensemble_dynamic.get_progress_bar = original_get_progress_bar
 
 
 @dataclass(frozen=True)
@@ -520,7 +569,7 @@ def write_mcmc_outputs(
     _write_summary(result, path_mcmc, parameter_store)
     _write_samples(result, path_mcmc, parameter_store)
     _write_correlations(result, path_mcmc, parameter_store)
-    from chemex.optimize.mcmc_plot import write_mcmc_plots
+    from chemex.optimize.statistics_plot import write_mcmc_plots
 
     write_mcmc_plots(
         result,
@@ -559,23 +608,24 @@ def run_mcmc(
         )
 
     minimizer = lmfit.Minimizer(experiments.residuals, params)
-    result_lf = minimizer.emcee(
-        params=params,
-        steps=effective_settings.steps,
-        nwalkers=effective_settings.walkers,
-        burn=0,
-        thin=1,
-        pos=_initial_positions(
-            params,
-            var_names,
+    with _use_rich_emcee_progress():
+        result_lf = minimizer.emcee(
+            params=params,
+            steps=effective_settings.steps,
             nwalkers=effective_settings.walkers,
+            burn=0,
+            thin=1,
+            pos=_initial_positions(
+                params,
+                var_names,
+                nwalkers=effective_settings.walkers,
+                seed=effective_settings.seed,
+            ),
+            workers=effective_settings.workers,
+            is_weighted=True,
             seed=effective_settings.seed,
-        ),
-        workers=effective_settings.workers,
-        is_weighted=True,
-        seed=effective_settings.seed,
-        progress=False,
-    )
+            progress=True,
+        )
     result = _result_from_lmfit(result_lf, effective_settings)
     write_mcmc_outputs(
         result,

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -320,7 +320,7 @@ def _estimate_autocorrelation_time(
     autocorrelation_time = _valid_autocorrelation_time(autocorrelation_time)
     if autocorrelation_time is None:
         return None, None, "autocorrelation time invalid"
-    return autocorrelation_time, autocorrelation_time, None
+    return autocorrelation_time, None, None
 
 
 def _resolve_discarded_steps(
@@ -462,10 +462,96 @@ def _autocorrelation_status(result: McmcResult) -> str:
     return "unavailable"
 
 
-def _autocorrelation_steps(result: McmcResult) -> int:
+def _autocorrelation_steps(
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+) -> int:
     if result.raw_chain is not None:
         return int(result.raw_chain.shape[0])
-    return int(result.discarded_steps + result.chain.shape[0])
+    return int(result.discarded_steps + result.chain.shape[0] * settings.thin)
+
+
+def _autocorrelation_time_for_reporting(
+    result: McmcResult,
+) -> tuple[Array | None, bool]:
+    if result.autocorrelation_time is not None:
+        return result.autocorrelation_time, True
+    if result.tentative_autocorrelation_time is not None:
+        return result.tentative_autocorrelation_time, False
+    return None, False
+
+
+def _extend_autocorrelation_diagnostics(
+    lines: list[str],
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+) -> None:
+    autocorrelation_time, is_reliable = _autocorrelation_time_for_reporting(result)
+    if autocorrelation_time is None:
+        warning = result.autocorrelation_warning or "not available"
+        lines.append(f"autocorrelation_warning = {_quote_toml_string(warning)}")
+        return
+
+    max_tau = float(np.max(autocorrelation_time))
+    suffix = "" if is_reliable else "_tentative"
+    tau_key = f"autocorrelation_time{suffix}"
+    max_tau_key = f"max_autocorrelation_time{suffix}"
+    lines.extend(
+        [
+            f"{tau_key} = {_format_toml_float_list(autocorrelation_time.tolist())}",
+            f"{max_tau_key} = {_format_toml_float(max_tau)}",
+        ],
+    )
+    if max_tau <= 0.0:
+        lines.append('autocorrelation_warning = "autocorrelation time is not positive"')
+        return
+
+    autocorrelation_steps = _autocorrelation_steps(result, settings)
+    lines.extend(
+        [
+            "steps_over_max_autocorrelation_time = "
+            f"{_format_toml_float(autocorrelation_steps / max_tau)}",
+            f"recommended_min_steps_50tau = {ceil(50.0 * max_tau)}",
+            f"recommended_min_steps_100tau = {ceil(100.0 * max_tau)}",
+        ],
+    )
+    if not is_reliable:
+        warning = (
+            result.autocorrelation_warning
+            or "chain shorter than 50 times the autocorrelation time"
+        )
+        lines.extend(
+            [
+                f"autocorrelation_warning = {_quote_toml_string(warning)}",
+                'effective_sample_size_warning = "not reported: autocorrelation time '
+                'estimate is unreliable"',
+            ],
+        )
+        return
+
+    retained_steps_over_tau = result.chain.shape[0] * settings.thin / max_tau
+    min_effective_sample_size = min(
+        (
+            summary.effective_sample_size
+            for summary in result.summary
+            if summary.effective_sample_size is not None
+        ),
+        default=None,
+    )
+    lines.append(
+        "retained_steps_over_max_autocorrelation_time = "
+        f"{_format_toml_float(retained_steps_over_tau)}",
+    )
+    if min_effective_sample_size is not None:
+        lines.append(
+            "min_effective_sample_size = "
+            f"{_format_toml_float(min_effective_sample_size)}",
+        )
+    if retained_steps_over_tau < 50.0:
+        lines.append(
+            'autocorrelation_warning = "Retained chain length is shorter '
+            'than 50 times the maximum autocorrelation time."',
+        )
 
 
 def _write_summary(
@@ -575,88 +661,7 @@ def _write_diagnostics(
     ]
     if result.burn_in_warning is not None:
         lines.append(f"burn_in_warning = {_quote_toml_string(result.burn_in_warning)}")
-    if result.autocorrelation_time is None and result.tentative_autocorrelation_time is None:
-        warning = result.autocorrelation_warning or "not available"
-        lines.append(f"autocorrelation_warning = {_quote_toml_string(warning)}")
-    else:
-        autocorrelation_time = (
-            result.autocorrelation_time
-            if result.autocorrelation_time is not None
-            else result.tentative_autocorrelation_time
-        )
-        autocorrelation_time = cast("Array", autocorrelation_time)
-        max_tau = float(np.max(autocorrelation_time))
-        tau_key = (
-            "autocorrelation_time"
-            if result.autocorrelation_time is not None
-            else "autocorrelation_time_tentative"
-        )
-        max_tau_key = (
-            "max_autocorrelation_time"
-            if result.autocorrelation_time is not None
-            else "max_autocorrelation_time_tentative"
-        )
-        lines.append(
-            f"{tau_key} = "
-            f"{_format_toml_float_list(autocorrelation_time.tolist())}",
-        )
-        lines.append(f"{max_tau_key} = {_format_toml_float(max_tau)}")
-        if max_tau <= 0.0:
-            lines.append(
-                'autocorrelation_warning = "autocorrelation time is not positive"',
-            )
-        else:
-            autocorrelation_steps = _autocorrelation_steps(result)
-            steps_over_tau = autocorrelation_steps / max_tau
-            lines.append(
-                "steps_over_max_autocorrelation_time = "
-                f"{_format_toml_float(steps_over_tau)}",
-            )
-            lines.append(
-                "recommended_min_steps_50tau = "
-                f"{ceil(50.0 * max_tau)}",
-            )
-            lines.append(
-                "recommended_min_steps_100tau = "
-                f"{ceil(100.0 * max_tau)}",
-            )
-            if result.autocorrelation_time is not None:
-                retained_steps_over_tau = result.chain.shape[0] * settings.thin / max_tau
-                min_effective_sample_size = min(
-                    (
-                        summary.effective_sample_size
-                        for summary in result.summary
-                        if summary.effective_sample_size is not None
-                    ),
-                    default=None,
-                )
-                lines.append(
-                    "retained_steps_over_max_autocorrelation_time = "
-                    f"{_format_toml_float(retained_steps_over_tau)}",
-                )
-                if min_effective_sample_size is not None:
-                    lines.append(
-                        "min_effective_sample_size = "
-                        f"{_format_toml_float(min_effective_sample_size)}",
-                    )
-                if retained_steps_over_tau < 50.0:
-                    lines.append(
-                        'autocorrelation_warning = "Retained chain length is shorter '
-                        'than 50 times the maximum autocorrelation time."',
-                    )
-            else:
-                warning = (
-                    result.autocorrelation_warning
-                    or "chain shorter than 50 times the autocorrelation time"
-                )
-                lines.append(
-                    "autocorrelation_warning = "
-                    f"{_quote_toml_string(warning)}",
-                )
-                lines.append(
-                    'effective_sample_size_warning = "not reported: autocorrelation time '
-                    'estimate is unreliable"',
-                )
+    _extend_autocorrelation_diagnostics(lines, result, settings)
     if unbounded_parameters:
         lines.append(
             'warning = "Finite lower and upper bounds are recommended for MCMC."',

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from math import ceil
 from pathlib import Path
 from typing import cast
 
@@ -10,7 +12,7 @@ import numpy as np
 from lmfit.minimizer import MinimizerResult
 from lmfit.parameter import Parameters
 
-from chemex.configuration.methods import McmcSettings
+from chemex.configuration.methods import McmcBurnSetting, McmcSettings
 from chemex.containers.experiments import Experiments
 from chemex.messages import (
     print_mcmc_no_vary_warning,
@@ -23,7 +25,7 @@ from chemex.typing import Array
 @dataclass(frozen=True)
 class EffectiveMcmcSettings:
     steps: int
-    burn: int
+    burn: McmcBurnSetting
     thin: int
     walkers: int
     seed: int | None
@@ -34,10 +36,16 @@ class EffectiveMcmcSettings:
 @dataclass(frozen=True)
 class McmcSummary:
     parameter_id: str
+    mean: float
+    standard_deviation: float
     median: float
+    eti_95_lower: float
+    eti_95_upper: float
     lower_1sigma: float
     upper_1sigma: float
     stderr: float
+    effective_sample_size: float | None = None
+    mcse_mean: float | None = None
 
 
 @dataclass(frozen=True)
@@ -49,6 +57,8 @@ class McmcResult:
     correlations: Array
     acceptance_fraction: Array
     autocorrelation_time: Array | None
+    discarded_steps: int
+    burn_in_warning: str | None
 
     @property
     def samples(self) -> Array:
@@ -88,7 +98,9 @@ def resolve_mcmc_settings(
 
 def _varying_parameter_ids(params: Parameters) -> tuple[str, ...]:
     return tuple(
-        name for name, parameter in params.items() if parameter.vary and not parameter.expr
+        name
+        for name, parameter in params.items()
+        if parameter.vary and not parameter.expr
     )
 
 
@@ -100,7 +112,10 @@ def _format_parameter_ids(
     return tuple(str(parameters[param_id].param_name) for param_id in parameter_ids)
 
 
-def _find_unbounded_parameter_ids(params: Parameters, var_names: tuple[str, ...]) -> tuple[str, ...]:
+def _find_unbounded_parameter_ids(
+    params: Parameters,
+    var_names: tuple[str, ...],
+) -> tuple[str, ...]:
     return tuple(
         name
         for name in var_names
@@ -120,7 +135,12 @@ def _validate_parameter_bounds(params: Parameters, var_names: tuple[str, ...]) -
             raise ValueError(msg)
 
 
-def _jitter_scale(value: float, lower: float, upper: float, stderr: float | None) -> float:
+def _jitter_scale(
+    value: float,
+    lower: float,
+    upper: float,
+    stderr: float | None,
+) -> float:
     scales = [abs(value) * 1.0e-4, 1.0e-8]
     if np.isfinite(lower) and np.isfinite(upper):
         scales.append((upper - lower) * 1.0e-4)
@@ -166,18 +186,36 @@ def _initial_positions(
 def _summarize_chain(
     var_names: tuple[str, ...],
     samples: Array,
+    autocorrelation_time: Array | None,
+    thin: int,
 ) -> tuple[McmcSummary, ...]:
-    quantiles = np.percentile(samples, [15.87, 50.0, 84.13], axis=0)
+    quantiles = np.percentile(samples, [2.5, 15.87, 50.0, 84.13, 97.5], axis=0)
     summaries: list[McmcSummary] = []
     for index, name in enumerate(var_names):
-        lower, median, upper = quantiles[:, index]
+        lower_95, lower, median, upper, upper_95 = quantiles[:, index]
+        values = samples[:, index]
+        standard_deviation = float(np.std(values, ddof=1)) if len(values) > 1 else 0.0
+        effective_sample_size = None
+        mcse_mean = None
+        if autocorrelation_time is not None:
+            tau = float(autocorrelation_time[index])
+            if np.isfinite(tau) and tau > 0.0:
+                tau_in_retained_steps = max(tau / thin, 1.0)
+                effective_sample_size = len(values) / tau_in_retained_steps
+                mcse_mean = standard_deviation / np.sqrt(effective_sample_size)
         summaries.append(
             McmcSummary(
                 parameter_id=name,
+                mean=float(np.mean(values)),
+                standard_deviation=standard_deviation,
                 median=float(median),
+                eti_95_lower=float(lower_95),
+                eti_95_upper=float(upper_95),
                 lower_1sigma=float(lower),
                 upper_1sigma=float(upper),
                 stderr=0.5 * float(upper - lower),
+                effective_sample_size=effective_sample_size,
+                mcse_mean=mcse_mean,
             ),
         )
     return tuple(summaries)
@@ -193,27 +231,98 @@ def _result_attr(result: MinimizerResult, name: str) -> object:
     return getattr(result, name)
 
 
-def _result_from_lmfit(result: MinimizerResult) -> McmcResult:
+def _autocorrelation_time(result: MinimizerResult) -> Array | None:
+    if not hasattr(result, "acor"):
+        return None
+    autocorrelation_time = np.asarray(
+        cast("Array", _result_attr(result, "acor")),
+        dtype=float,
+    )
+    if autocorrelation_time.ndim != 1 or not np.all(np.isfinite(autocorrelation_time)):
+        return None
+    return autocorrelation_time
+
+
+def _resolve_discarded_steps(
+    burn: McmcBurnSetting,
+    *,
+    nsteps: int,
+    autocorrelation_time: Array | None,
+) -> tuple[int, str | None]:
+    if burn != "auto":
+        return int(burn), None
+    if autocorrelation_time is None:
+        return 0, "autocorrelation time unavailable; automatic burn-in was not applied"
+    max_tau = float(np.max(autocorrelation_time))
+    if not np.isfinite(max_tau) or max_tau <= 0.0:
+        return 0, "autocorrelation time invalid; automatic burn-in was not applied"
+    discarded_steps = ceil(2.0 * max_tau)
+    if discarded_steps >= nsteps:
+        return (
+            0,
+            "estimated automatic burn-in is longer than the chain; "
+            "automatic burn-in was not applied",
+        )
+    return discarded_steps, None
+
+
+def _apply_sample_window(
+    chain: Array,
+    lnprob: Array,
+    *,
+    burn: McmcBurnSetting,
+    thin: int,
+    autocorrelation_time: Array | None,
+) -> tuple[Array, Array, int, str | None]:
+    discarded_steps, warning = _resolve_discarded_steps(
+        burn,
+        nsteps=chain.shape[0],
+        autocorrelation_time=autocorrelation_time,
+    )
+    retained_chain = chain[discarded_steps::thin]
+    retained_lnprob = lnprob[discarded_steps::thin]
+    if retained_chain.shape[0] < 1:
+        msg = "MCMC settings did not retain any samples"
+        raise ValueError(msg)
+    return retained_chain, retained_lnprob, discarded_steps, warning
+
+
+def _result_from_lmfit(
+    result: MinimizerResult,
+    settings: EffectiveMcmcSettings,
+) -> McmcResult:
     var_names = tuple(cast("Sequence[str]", _result_attr(result, "var_names")))
     chain = np.asarray(cast("Array", _result_attr(result, "chain")), dtype=float)
     lnprob = np.asarray(cast("Array", _result_attr(result, "lnprob")), dtype=float)
-    samples = chain.reshape((-1, len(var_names)))
-    autocorrelation_time = (
-        np.asarray(cast("Array", _result_attr(result, "acor")), dtype=float)
-        if hasattr(result, "acor")
-        else None
+    autocorrelation_time = _autocorrelation_time(result)
+    retained_chain, retained_lnprob, discarded_steps, burn_in_warning = (
+        _apply_sample_window(
+            chain,
+            lnprob,
+            burn=settings.burn,
+            thin=settings.thin,
+            autocorrelation_time=autocorrelation_time,
+        )
     )
+    samples = retained_chain.reshape((-1, len(var_names)))
     return McmcResult(
         var_names=var_names,
-        chain=chain,
-        lnprob=lnprob,
-        summary=_summarize_chain(var_names, samples),
+        chain=retained_chain,
+        lnprob=retained_lnprob,
+        summary=_summarize_chain(
+            var_names,
+            samples,
+            autocorrelation_time,
+            settings.thin,
+        ),
         correlations=_correlation_matrix(samples),
         acceptance_fraction=np.asarray(
             cast("Array", _result_attr(result, "acceptance_fraction")),
             dtype=float,
         ),
         autocorrelation_time=autocorrelation_time,
+        discarded_steps=discarded_steps,
+        burn_in_warning=burn_in_warning,
     )
 
 
@@ -227,10 +336,21 @@ def _format_toml_string_list(values: list[str]) -> str:
     return "[" + ", ".join(_quote_toml_string(value) for value in values) + "]"
 
 
+def _format_toml_float(value: float) -> str:
+    return f"{value:.5e}"
+
+
 def _format_toml_float_list(values: list[float]) -> str:
     if not values:
         return "[]"
-    return "[" + ", ".join(f"{value:.5e}" for value in values) + "]"
+    return "[" + ", ".join(_format_toml_float(value) for value in values) + "]"
+
+
+def _package_version(package_name: str) -> str:
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return "unknown"
 
 
 def _write_summary(
@@ -241,17 +361,33 @@ def _write_summary(
     parameters = parameter_store.get_parameters(result.var_names)
     lines: list[str] = []
     for summary in result.summary:
-        parameter_name = str(parameters[summary.parameter_id].param_name).strip("[]")
+        parameter = parameters[summary.parameter_id]
+        parameter_name = str(parameter.param_name).strip("[]")
         lines.extend(
             [
                 f"[{_quote_toml_string(parameter_name)}]",
-                f"median = {summary.median:.5e}",
-                f"lower_1sigma = {summary.lower_1sigma:.5e}",
-                f"upper_1sigma = {summary.upper_1sigma:.5e}",
-                f"stderr = {summary.stderr:.5e}",
-                "",
+                'prior = "uniform"',
+                f"prior_lower = {_format_toml_float(float(parameter.min))}",
+                f"prior_upper = {_format_toml_float(float(parameter.max))}",
+                'credible_interval = "95% equal-tailed"',
+                f"mean = {_format_toml_float(summary.mean)}",
+                f"standard_deviation = {_format_toml_float(summary.standard_deviation)}",
+                f"median = {_format_toml_float(summary.median)}",
+                f"eti_95_lower = {_format_toml_float(summary.eti_95_lower)}",
+                f"eti_95_upper = {_format_toml_float(summary.eti_95_upper)}",
+                f"lower_1sigma = {_format_toml_float(summary.lower_1sigma)}",
+                f"upper_1sigma = {_format_toml_float(summary.upper_1sigma)}",
+                f"stderr = {_format_toml_float(summary.stderr)}",
             ],
         )
+        if summary.effective_sample_size is not None:
+            lines.append(
+                "effective_sample_size = "
+                f"{_format_toml_float(summary.effective_sample_size)}",
+            )
+        if summary.mcse_mean is not None:
+            lines.append(f"mcse_mean = {_format_toml_float(summary.mcse_mean)}")
+        lines.append("")
     (path / "summary.toml").write_text("\n".join(lines), encoding="utf-8")
 
 
@@ -298,24 +434,65 @@ def _write_diagnostics(
     unbounded_parameters = list(
         _format_parameter_ids(unbounded_parameter_ids, parameter_store),
     )
+    requested_burn = '"auto"' if settings.burn == "auto" else str(settings.burn)
     lines = [
+        'sampler = "emcee via lmfit.Minimizer.emcee"',
+        f"lmfit_version = {_quote_toml_string(_package_version('lmfit'))}",
+        f"emcee_version = {_quote_toml_string(_package_version('emcee'))}",
+        'credible_interval = "95% equal-tailed"',
+        'convergence_diagnostic = "integrated_autocorrelation_time"',
+        'rhat = "not computed: emcee ensemble walkers are not independent chains"',
         f"steps = {settings.steps}",
-        f"burn = {settings.burn}",
+        f"requested_burn = {requested_burn}",
+        f"discarded_steps = {result.discarded_steps}",
         f"thin = {settings.thin}",
         f"walkers = {settings.walkers}",
+        f"retained_steps = {result.chain.shape[0]}",
         f"retained_samples = {len(result.samples)}",
-        f"acceptance_fraction_mean = {float(np.mean(acceptance)):.5e}",
-        f"acceptance_fraction_min = {float(np.min(acceptance)):.5e}",
-        f"acceptance_fraction_max = {float(np.max(acceptance)):.5e}",
+        f"acceptance_fraction_mean = {_format_toml_float(float(np.mean(acceptance)))}",
+        f"acceptance_fraction_min = {_format_toml_float(float(np.min(acceptance)))}",
+        f"acceptance_fraction_max = {_format_toml_float(float(np.max(acceptance)))}",
         f"unbounded_parameters = {_format_toml_string_list(unbounded_parameters)}",
     ]
+    if result.burn_in_warning is not None:
+        lines.append(f"burn_in_warning = {_quote_toml_string(result.burn_in_warning)}")
     if result.autocorrelation_time is None:
         lines.append('autocorrelation_warning = "not available"')
     else:
+        max_tau = float(np.max(result.autocorrelation_time))
         lines.append(
             "autocorrelation_time = "
             f"{_format_toml_float_list(result.autocorrelation_time.tolist())}",
         )
+        lines.append(f"max_autocorrelation_time = {_format_toml_float(max_tau)}")
+        if max_tau <= 0.0:
+            lines.append(
+                'autocorrelation_warning = "autocorrelation time is not positive"',
+            )
+        else:
+            retained_steps_over_tau = result.chain.shape[0] * settings.thin / max_tau
+            min_effective_sample_size = min(
+                (
+                    summary.effective_sample_size
+                    for summary in result.summary
+                    if summary.effective_sample_size is not None
+                ),
+                default=None,
+            )
+            lines.append(
+                "retained_steps_over_max_autocorrelation_time = "
+                f"{_format_toml_float(retained_steps_over_tau)}",
+            )
+            if min_effective_sample_size is not None:
+                lines.append(
+                    "min_effective_sample_size = "
+                    f"{_format_toml_float(min_effective_sample_size)}",
+                )
+            if retained_steps_over_tau < 50.0:
+                lines.append(
+                    'autocorrelation_warning = "Retained chain length is shorter '
+                    'than 50 times the maximum autocorrelation time."',
+                )
     if unbounded_parameters:
         lines.append(
             'warning = "Finite lower and upper bounds are recommended for MCMC."',
@@ -371,8 +548,8 @@ def run_mcmc(
         params=params,
         steps=effective_settings.steps,
         nwalkers=effective_settings.walkers,
-        burn=effective_settings.burn,
-        thin=effective_settings.thin,
+        burn=0,
+        thin=1,
         pos=_initial_positions(
             params,
             var_names,
@@ -384,7 +561,7 @@ def run_mcmc(
         seed=effective_settings.seed,
         progress=False,
     )
-    result = _result_from_lmfit(result_lf)
+    result = _result_from_lmfit(result_lf, effective_settings)
     write_mcmc_outputs(
         result,
         effective_settings,
@@ -393,5 +570,9 @@ def run_mcmc(
         unbounded_parameter_ids,
     )
     if effective_settings.update_parameters:
+        for summary in result.summary:
+            result_lf.params[summary.parameter_id].value = summary.median
+            result_lf.params[summary.parameter_id].stderr = summary.stderr
+        result_lf.params.update_constraints()
         parameter_store.update_from_parameters(result_lf.params)
     return result

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -59,6 +59,8 @@ class McmcResult:
     autocorrelation_time: Array | None
     discarded_steps: int
     burn_in_warning: str | None
+    raw_chain: Array | None = None
+    raw_lnprob: Array | None = None
 
     @property
     def samples(self) -> Array:
@@ -323,6 +325,8 @@ def _result_from_lmfit(
         autocorrelation_time=autocorrelation_time,
         discarded_steps=discarded_steps,
         burn_in_warning=burn_in_warning,
+        raw_chain=chain,
+        raw_lnprob=lnprob,
     )
 
 
@@ -451,6 +455,7 @@ def _write_diagnostics(
         'samples_file = "samples.tsv"',
         'summary_file = "summary.toml"',
         'correlations_file = "correlations.tsv"',
+        'plots_file = "plots.pdf"',
         f"acceptance_fraction_mean = {_format_toml_float(float(np.mean(acceptance)))}",
         f"acceptance_fraction_min = {_format_toml_float(float(np.min(acceptance)))}",
         f"acceptance_fraction_max = {_format_toml_float(float(np.max(acceptance)))}",
@@ -515,6 +520,14 @@ def write_mcmc_outputs(
     _write_summary(result, path_mcmc, parameter_store)
     _write_samples(result, path_mcmc, parameter_store)
     _write_correlations(result, path_mcmc, parameter_store)
+    from chemex.optimize.mcmc_plot import write_mcmc_plots
+
+    write_mcmc_plots(
+        result,
+        settings,
+        path_mcmc,
+        parameter_names=_format_parameter_ids(result.var_names, parameter_store),
+    )
     _write_diagnostics(
         result,
         settings,

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -508,7 +508,7 @@ def write_mcmc_outputs(
     parameter_store: ParameterStore,
     unbounded_parameter_ids: tuple[str, ...] = (),
 ) -> None:
-    path_mcmc = path / "MCMC"
+    path_mcmc = path / "Statistics" / "MCMC"
     path_mcmc.mkdir(parents=True, exist_ok=True)
     _write_summary(result, path_mcmc, parameter_store)
     _write_samples(result, path_mcmc, parameter_store)

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -399,9 +399,9 @@ def _write_samples(
     parameter_names = _format_parameter_ids(result.var_names, parameter_store)
     values = np.column_stack((result.samples, result.log_probabilities))
 
-    with (path / "samples.out").open("w", encoding="utf-8") as fileout:
-        fileout.write(f"# {' '.join(parameter_names)} [lnprob]\n")
-        np.savetxt(fileout, values, fmt="%12.5e")
+    with (path / "samples.tsv").open("w", encoding="utf-8") as fileout:
+        fileout.write("\t".join((*parameter_names, "lnprob")) + "\n")
+        np.savetxt(fileout, values, fmt="%.5e", delimiter="\t")
 
 
 def _write_correlations(
@@ -410,17 +410,16 @@ def _write_correlations(
     parameter_store: ParameterStore,
 ) -> None:
     parameter_names = _format_parameter_ids(result.var_names, parameter_store)
-    name_width = max(len(name) for name in parameter_names)
 
-    with (path / "correlations.out").open("w", encoding="utf-8") as fileout:
-        fileout.write(f"# {' '.join(f'{name:>12s}' for name in parameter_names)}\n")
+    with (path / "correlations.tsv").open("w", encoding="utf-8") as fileout:
+        fileout.write("parameter\t" + "\t".join(parameter_names) + "\n")
         for name, values in zip(
             parameter_names,
             result.correlations,
             strict=True,
         ):
-            row = " ".join(f"{value:12.5e}" for value in values)
-            fileout.write(f"{name:<{name_width}s} {row}\n")
+            row = "\t".join(f"{value:.5e}" for value in values)
+            fileout.write(f"{name}\t{row}\n")
 
 
 def _write_diagnostics(
@@ -449,6 +448,9 @@ def _write_diagnostics(
         f"walkers = {settings.walkers}",
         f"retained_steps = {result.chain.shape[0]}",
         f"retained_samples = {len(result.samples)}",
+        'samples_file = "samples.tsv"',
+        'summary_file = "summary.toml"',
+        'correlations_file = "correlations.tsv"',
         f"acceptance_fraction_mean = {_format_toml_float(float(np.mean(acceptance)))}",
         f"acceptance_fraction_min = {_format_toml_float(float(np.min(acceptance)))}",
         f"acceptance_fraction_max = {_format_toml_float(float(np.max(acceptance)))}",

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, Self, cast
 
+import emcee.autocorr as emcee_autocorr
 import emcee.ensemble as emcee_ensemble
 import lmfit
 import numpy as np
@@ -108,6 +109,8 @@ class McmcResult:
     autocorrelation_time: Array | None
     discarded_steps: int
     burn_in_warning: str | None
+    tentative_autocorrelation_time: Array | None = None
+    autocorrelation_warning: str | None = None
     raw_chain: Array | None = None
     raw_lnprob: Array | None = None
 
@@ -282,16 +285,42 @@ def _result_attr(result: MinimizerResult, name: str) -> object:
     return getattr(result, name)
 
 
-def _autocorrelation_time(result: MinimizerResult) -> Array | None:
-    if not hasattr(result, "acor"):
-        return None
+def _valid_autocorrelation_time(autocorrelation_time: object) -> Array | None:
     autocorrelation_time = np.asarray(
-        cast("Array", _result_attr(result, "acor")),
+        cast("Array", autocorrelation_time),
         dtype=float,
     )
-    if autocorrelation_time.ndim != 1 or not np.all(np.isfinite(autocorrelation_time)):
+    if (
+        autocorrelation_time.ndim != 1
+        or not np.all(np.isfinite(autocorrelation_time))
+        or np.any(autocorrelation_time <= 0.0)
+    ):
         return None
     return autocorrelation_time
+
+
+def _estimate_autocorrelation_time(
+    chain: Array,
+) -> tuple[Array | None, Array | None, str | None]:
+    try:
+        autocorrelation_time = emcee_autocorr.integrated_time(chain, quiet=False)
+    except emcee_autocorr.AutocorrError as error:
+        tentative_autocorrelation_time = _valid_autocorrelation_time(error.tau)
+        if tentative_autocorrelation_time is None:
+            return None, None, "autocorrelation time unavailable"
+        return (
+            None,
+            tentative_autocorrelation_time,
+            "chain shorter than 50 times the autocorrelation time; "
+            "tentative estimate reported",
+        )
+    except (FloatingPointError, ValueError):
+        return None, None, "autocorrelation time unavailable"
+
+    autocorrelation_time = _valid_autocorrelation_time(autocorrelation_time)
+    if autocorrelation_time is None:
+        return None, None, "autocorrelation time invalid"
+    return autocorrelation_time, autocorrelation_time, None
 
 
 def _resolve_discarded_steps(
@@ -299,6 +328,7 @@ def _resolve_discarded_steps(
     *,
     nsteps: int,
     autocorrelation_time: Array | None,
+    autocorrelation_time_reliable: bool = True,
 ) -> tuple[int, str | None]:
     if burn != "auto":
         return int(burn), None
@@ -314,6 +344,12 @@ def _resolve_discarded_steps(
             "estimated automatic burn-in is longer than the chain; "
             "automatic burn-in was not applied",
         )
+    if not autocorrelation_time_reliable:
+        return (
+            discarded_steps,
+            "autocorrelation time estimate is unreliable; "
+            "tentative automatic burn-in was applied",
+        )
     return discarded_steps, None
 
 
@@ -324,11 +360,13 @@ def _apply_sample_window(
     burn: McmcBurnSetting,
     thin: int,
     autocorrelation_time: Array | None,
+    autocorrelation_time_reliable: bool = True,
 ) -> tuple[Array, Array, int, str | None]:
     discarded_steps, warning = _resolve_discarded_steps(
         burn,
         nsteps=chain.shape[0],
         autocorrelation_time=autocorrelation_time,
+        autocorrelation_time_reliable=autocorrelation_time_reliable,
     )
     retained_chain = chain[discarded_steps::thin]
     retained_lnprob = lnprob[discarded_steps::thin]
@@ -345,14 +383,22 @@ def _result_from_lmfit(
     var_names = tuple(cast("Sequence[str]", _result_attr(result, "var_names")))
     chain = np.asarray(cast("Array", _result_attr(result, "chain")), dtype=float)
     lnprob = np.asarray(cast("Array", _result_attr(result, "lnprob")), dtype=float)
-    autocorrelation_time = _autocorrelation_time(result)
+    autocorrelation_time, tentative_autocorrelation_time, autocorrelation_warning = (
+        _estimate_autocorrelation_time(chain)
+    )
+    burn_in_autocorrelation_time = (
+        autocorrelation_time
+        if autocorrelation_time is not None
+        else tentative_autocorrelation_time
+    )
     retained_chain, retained_lnprob, discarded_steps, burn_in_warning = (
         _apply_sample_window(
             chain,
             lnprob,
             burn=settings.burn,
             thin=settings.thin,
-            autocorrelation_time=autocorrelation_time,
+            autocorrelation_time=burn_in_autocorrelation_time,
+            autocorrelation_time_reliable=autocorrelation_time is not None,
         )
     )
     samples = retained_chain.reshape((-1, len(var_names)))
@@ -374,6 +420,8 @@ def _result_from_lmfit(
         autocorrelation_time=autocorrelation_time,
         discarded_steps=discarded_steps,
         burn_in_warning=burn_in_warning,
+        tentative_autocorrelation_time=tentative_autocorrelation_time,
+        autocorrelation_warning=autocorrelation_warning,
         raw_chain=chain,
         raw_lnprob=lnprob,
     )
@@ -404,6 +452,20 @@ def _package_version(package_name: str) -> str:
         return version(package_name)
     except PackageNotFoundError:
         return "unknown"
+
+
+def _autocorrelation_status(result: McmcResult) -> str:
+    if result.autocorrelation_time is not None:
+        return "reliable"
+    if result.tentative_autocorrelation_time is not None:
+        return "unreliable_short_chain"
+    return "unavailable"
+
+
+def _autocorrelation_steps(result: McmcResult) -> int:
+    if result.raw_chain is not None:
+        return int(result.raw_chain.shape[0])
+    return int(result.discarded_steps + result.chain.shape[0])
 
 
 def _write_summary(
@@ -493,6 +555,7 @@ def _write_diagnostics(
         f"emcee_version = {_quote_toml_string(_package_version('emcee'))}",
         'credible_interval = "95% equal-tailed"',
         'convergence_diagnostic = "integrated_autocorrelation_time"',
+        f"autocorrelation_status = {_quote_toml_string(_autocorrelation_status(result))}",
         'rhat = "not computed: emcee ensemble walkers are not independent chains"',
         f"steps = {settings.steps}",
         f"requested_burn = {requested_burn}",
@@ -512,42 +575,87 @@ def _write_diagnostics(
     ]
     if result.burn_in_warning is not None:
         lines.append(f"burn_in_warning = {_quote_toml_string(result.burn_in_warning)}")
-    if result.autocorrelation_time is None:
-        lines.append('autocorrelation_warning = "not available"')
+    if result.autocorrelation_time is None and result.tentative_autocorrelation_time is None:
+        warning = result.autocorrelation_warning or "not available"
+        lines.append(f"autocorrelation_warning = {_quote_toml_string(warning)}")
     else:
-        max_tau = float(np.max(result.autocorrelation_time))
-        lines.append(
-            "autocorrelation_time = "
-            f"{_format_toml_float_list(result.autocorrelation_time.tolist())}",
+        autocorrelation_time = (
+            result.autocorrelation_time
+            if result.autocorrelation_time is not None
+            else result.tentative_autocorrelation_time
         )
-        lines.append(f"max_autocorrelation_time = {_format_toml_float(max_tau)}")
+        autocorrelation_time = cast("Array", autocorrelation_time)
+        max_tau = float(np.max(autocorrelation_time))
+        tau_key = (
+            "autocorrelation_time"
+            if result.autocorrelation_time is not None
+            else "autocorrelation_time_tentative"
+        )
+        max_tau_key = (
+            "max_autocorrelation_time"
+            if result.autocorrelation_time is not None
+            else "max_autocorrelation_time_tentative"
+        )
+        lines.append(
+            f"{tau_key} = "
+            f"{_format_toml_float_list(autocorrelation_time.tolist())}",
+        )
+        lines.append(f"{max_tau_key} = {_format_toml_float(max_tau)}")
         if max_tau <= 0.0:
             lines.append(
                 'autocorrelation_warning = "autocorrelation time is not positive"',
             )
         else:
-            retained_steps_over_tau = result.chain.shape[0] * settings.thin / max_tau
-            min_effective_sample_size = min(
-                (
-                    summary.effective_sample_size
-                    for summary in result.summary
-                    if summary.effective_sample_size is not None
-                ),
-                default=None,
+            autocorrelation_steps = _autocorrelation_steps(result)
+            steps_over_tau = autocorrelation_steps / max_tau
+            lines.append(
+                "steps_over_max_autocorrelation_time = "
+                f"{_format_toml_float(steps_over_tau)}",
             )
             lines.append(
-                "retained_steps_over_max_autocorrelation_time = "
-                f"{_format_toml_float(retained_steps_over_tau)}",
+                "recommended_min_steps_50tau = "
+                f"{ceil(50.0 * max_tau)}",
             )
-            if min_effective_sample_size is not None:
-                lines.append(
-                    "min_effective_sample_size = "
-                    f"{_format_toml_float(min_effective_sample_size)}",
+            lines.append(
+                "recommended_min_steps_100tau = "
+                f"{ceil(100.0 * max_tau)}",
+            )
+            if result.autocorrelation_time is not None:
+                retained_steps_over_tau = result.chain.shape[0] * settings.thin / max_tau
+                min_effective_sample_size = min(
+                    (
+                        summary.effective_sample_size
+                        for summary in result.summary
+                        if summary.effective_sample_size is not None
+                    ),
+                    default=None,
                 )
-            if retained_steps_over_tau < 50.0:
                 lines.append(
-                    'autocorrelation_warning = "Retained chain length is shorter '
-                    'than 50 times the maximum autocorrelation time."',
+                    "retained_steps_over_max_autocorrelation_time = "
+                    f"{_format_toml_float(retained_steps_over_tau)}",
+                )
+                if min_effective_sample_size is not None:
+                    lines.append(
+                        "min_effective_sample_size = "
+                        f"{_format_toml_float(min_effective_sample_size)}",
+                    )
+                if retained_steps_over_tau < 50.0:
+                    lines.append(
+                        'autocorrelation_warning = "Retained chain length is shorter '
+                        'than 50 times the maximum autocorrelation time."',
+                    )
+            else:
+                warning = (
+                    result.autocorrelation_warning
+                    or "chain shorter than 50 times the autocorrelation time"
+                )
+                lines.append(
+                    "autocorrelation_warning = "
+                    f"{_quote_toml_string(warning)}",
+                )
+                lines.append(
+                    'effective_sample_size_warning = "not reported: autocorrelation time '
+                    'estimate is unreliable"',
                 )
     if unbounded_parameters:
         lines.append(

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import lmfit
+import numpy as np
+from lmfit.minimizer import MinimizerResult
+from lmfit.parameter import Parameters
+
+from chemex.configuration.methods import McmcSettings
+from chemex.containers.experiments import Experiments
+from chemex.messages import (
+    print_mcmc_no_vary_warning,
+    print_mcmc_unbounded_warning,
+)
+from chemex.parameters.database import ParameterStore
+from chemex.typing import Array
+
+
+@dataclass(frozen=True)
+class EffectiveMcmcSettings:
+    steps: int
+    burn: int
+    thin: int
+    walkers: int
+    seed: int | None
+    workers: int
+    update_parameters: bool
+
+
+@dataclass(frozen=True)
+class McmcSummary:
+    parameter_id: str
+    median: float
+    lower_1sigma: float
+    upper_1sigma: float
+    stderr: float
+
+
+@dataclass(frozen=True)
+class McmcResult:
+    var_names: tuple[str, ...]
+    chain: Array
+    lnprob: Array
+    summary: tuple[McmcSummary, ...]
+    correlations: Array
+    acceptance_fraction: Array
+    autocorrelation_time: Array | None
+
+    @property
+    def samples(self) -> Array:
+        """Return the flattened retained chain."""
+        return self.chain.reshape((-1, len(self.var_names)))
+
+    @property
+    def log_probabilities(self) -> Array:
+        """Return the flattened retained log probabilities."""
+        return self.lnprob.reshape(-1)
+
+
+def resolve_mcmc_settings(
+    settings: McmcSettings,
+    *,
+    nvarys: int,
+) -> EffectiveMcmcSettings:
+    walkers = settings.walkers or max(32, 2 * nvarys)
+    min_walkers = 2 * nvarys
+    if walkers < min_walkers:
+        msg = (
+            f"MCMC requires at least {min_walkers} walkers for {nvarys} fitted "
+            f"parameters"
+        )
+        raise ValueError(msg)
+
+    return EffectiveMcmcSettings(
+        steps=settings.steps,
+        burn=settings.burn,
+        thin=settings.thin,
+        walkers=walkers,
+        seed=settings.seed,
+        workers=settings.workers,
+        update_parameters=settings.update_parameters,
+    )
+
+
+def _varying_parameter_ids(params: Parameters) -> tuple[str, ...]:
+    return tuple(
+        name for name, parameter in params.items() if parameter.vary and not parameter.expr
+    )
+
+
+def _format_parameter_ids(
+    parameter_ids: tuple[str, ...],
+    parameter_store: ParameterStore,
+) -> tuple[str, ...]:
+    parameters = parameter_store.get_parameters(parameter_ids)
+    return tuple(str(parameters[param_id].param_name) for param_id in parameter_ids)
+
+
+def _find_unbounded_parameter_ids(params: Parameters, var_names: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        name
+        for name in var_names
+        if not np.isfinite(params[name].min) or not np.isfinite(params[name].max)
+    )
+
+
+def _validate_parameter_bounds(params: Parameters, var_names: tuple[str, ...]) -> None:
+    for name in var_names:
+        parameter = params[name]
+        if (
+            np.isfinite(parameter.min)
+            and np.isfinite(parameter.max)
+            and parameter.min >= parameter.max
+        ):
+            msg = f"MCMC parameter {name!r} has an empty bounded interval"
+            raise ValueError(msg)
+
+
+def _jitter_scale(value: float, lower: float, upper: float, stderr: float | None) -> float:
+    scales = [abs(value) * 1.0e-4, 1.0e-8]
+    if np.isfinite(lower) and np.isfinite(upper):
+        scales.append((upper - lower) * 1.0e-4)
+    if stderr is not None and np.isfinite(stderr) and stderr > 0.0:
+        scales.append(stderr * 1.0e-2)
+    return max(scales)
+
+
+def _clip_to_bounds(values: Array, lower: float, upper: float) -> Array:
+    if np.isfinite(lower) and np.isfinite(upper):
+        width = upper - lower
+        eps = max(width * 1.0e-10, np.finfo(float).eps)
+        return np.clip(values, lower + eps, upper - eps)
+    if np.isfinite(lower):
+        return np.maximum(values, lower + np.finfo(float).eps)
+    if np.isfinite(upper):
+        return np.minimum(values, upper - np.finfo(float).eps)
+    return values
+
+
+def _initial_positions(
+    params: Parameters,
+    var_names: tuple[str, ...],
+    *,
+    nwalkers: int,
+    seed: int | None,
+) -> Array:
+    rng = np.random.default_rng(seed)
+    positions = np.empty((nwalkers, len(var_names)), dtype=float)
+
+    for index, name in enumerate(var_names):
+        parameter = params[name]
+        value = float(parameter.value)
+        lower = float(parameter.min)
+        upper = float(parameter.max)
+        scale = _jitter_scale(value, lower, upper, parameter.stderr)
+        values = value + scale * rng.standard_normal(nwalkers)
+        positions[:, index] = _clip_to_bounds(values, lower, upper)
+
+    return positions
+
+
+def _summarize_chain(
+    var_names: tuple[str, ...],
+    samples: Array,
+) -> tuple[McmcSummary, ...]:
+    quantiles = np.percentile(samples, [15.87, 50.0, 84.13], axis=0)
+    summaries: list[McmcSummary] = []
+    for index, name in enumerate(var_names):
+        lower, median, upper = quantiles[:, index]
+        summaries.append(
+            McmcSummary(
+                parameter_id=name,
+                median=float(median),
+                lower_1sigma=float(lower),
+                upper_1sigma=float(upper),
+                stderr=0.5 * float(upper - lower),
+            ),
+        )
+    return tuple(summaries)
+
+
+def _correlation_matrix(samples: Array) -> Array:
+    if samples.shape[1] == 1:
+        return np.ones((1, 1), dtype=float)
+    return np.corrcoef(samples, rowvar=False)
+
+
+def _result_attr(result: MinimizerResult, name: str) -> object:
+    return getattr(result, name)
+
+
+def _result_from_lmfit(result: MinimizerResult) -> McmcResult:
+    var_names = tuple(cast("Sequence[str]", _result_attr(result, "var_names")))
+    chain = np.asarray(cast("Array", _result_attr(result, "chain")), dtype=float)
+    lnprob = np.asarray(cast("Array", _result_attr(result, "lnprob")), dtype=float)
+    samples = chain.reshape((-1, len(var_names)))
+    autocorrelation_time = (
+        np.asarray(cast("Array", _result_attr(result, "acor")), dtype=float)
+        if hasattr(result, "acor")
+        else None
+    )
+    return McmcResult(
+        var_names=var_names,
+        chain=chain,
+        lnprob=lnprob,
+        summary=_summarize_chain(var_names, samples),
+        correlations=_correlation_matrix(samples),
+        acceptance_fraction=np.asarray(
+            cast("Array", _result_attr(result, "acceptance_fraction")),
+            dtype=float,
+        ),
+        autocorrelation_time=autocorrelation_time,
+    )
+
+
+def _quote_toml_string(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _format_toml_string_list(values: list[str]) -> str:
+    if not values:
+        return "[]"
+    return "[" + ", ".join(_quote_toml_string(value) for value in values) + "]"
+
+
+def _format_toml_float_list(values: list[float]) -> str:
+    if not values:
+        return "[]"
+    return "[" + ", ".join(f"{value:.5e}" for value in values) + "]"
+
+
+def _write_summary(
+    result: McmcResult,
+    path: Path,
+    parameter_store: ParameterStore,
+) -> None:
+    parameters = parameter_store.get_parameters(result.var_names)
+    lines: list[str] = []
+    for summary in result.summary:
+        parameter_name = str(parameters[summary.parameter_id].param_name).strip("[]")
+        lines.extend(
+            [
+                f"[{_quote_toml_string(parameter_name)}]",
+                f"median = {summary.median:.5e}",
+                f"lower_1sigma = {summary.lower_1sigma:.5e}",
+                f"upper_1sigma = {summary.upper_1sigma:.5e}",
+                f"stderr = {summary.stderr:.5e}",
+                "",
+            ],
+        )
+    (path / "summary.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_samples(
+    result: McmcResult,
+    path: Path,
+    parameter_store: ParameterStore,
+) -> None:
+    parameter_names = _format_parameter_ids(result.var_names, parameter_store)
+    values = np.column_stack((result.samples, result.log_probabilities))
+
+    with (path / "samples.out").open("w", encoding="utf-8") as fileout:
+        fileout.write(f"# {' '.join(parameter_names)} [lnprob]\n")
+        np.savetxt(fileout, values, fmt="%12.5e")
+
+
+def _write_correlations(
+    result: McmcResult,
+    path: Path,
+    parameter_store: ParameterStore,
+) -> None:
+    parameter_names = _format_parameter_ids(result.var_names, parameter_store)
+    name_width = max(len(name) for name in parameter_names)
+
+    with (path / "correlations.out").open("w", encoding="utf-8") as fileout:
+        fileout.write(f"# {' '.join(f'{name:>12s}' for name in parameter_names)}\n")
+        for name, values in zip(
+            parameter_names,
+            result.correlations,
+            strict=True,
+        ):
+            row = " ".join(f"{value:12.5e}" for value in values)
+            fileout.write(f"{name:<{name_width}s} {row}\n")
+
+
+def _write_diagnostics(
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+    path: Path,
+    parameter_store: ParameterStore,
+    unbounded_parameter_ids: tuple[str, ...],
+) -> None:
+    acceptance = result.acceptance_fraction
+    unbounded_parameters = list(
+        _format_parameter_ids(unbounded_parameter_ids, parameter_store),
+    )
+    lines = [
+        f"steps = {settings.steps}",
+        f"burn = {settings.burn}",
+        f"thin = {settings.thin}",
+        f"walkers = {settings.walkers}",
+        f"retained_samples = {len(result.samples)}",
+        f"acceptance_fraction_mean = {float(np.mean(acceptance)):.5e}",
+        f"acceptance_fraction_min = {float(np.min(acceptance)):.5e}",
+        f"acceptance_fraction_max = {float(np.max(acceptance)):.5e}",
+        f"unbounded_parameters = {_format_toml_string_list(unbounded_parameters)}",
+    ]
+    if result.autocorrelation_time is None:
+        lines.append('autocorrelation_warning = "not available"')
+    else:
+        lines.append(
+            "autocorrelation_time = "
+            f"{_format_toml_float_list(result.autocorrelation_time.tolist())}",
+        )
+    if unbounded_parameters:
+        lines.append(
+            'warning = "Finite lower and upper bounds are recommended for MCMC."',
+        )
+
+    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_mcmc_outputs(
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+    path: Path,
+    parameter_store: ParameterStore,
+    unbounded_parameter_ids: tuple[str, ...] = (),
+) -> None:
+    path_mcmc = path / "MCMC"
+    path_mcmc.mkdir(parents=True, exist_ok=True)
+    _write_summary(result, path_mcmc, parameter_store)
+    _write_samples(result, path_mcmc, parameter_store)
+    _write_correlations(result, path_mcmc, parameter_store)
+    _write_diagnostics(
+        result,
+        settings,
+        path_mcmc,
+        parameter_store,
+        unbounded_parameter_ids,
+    )
+
+
+def run_mcmc(
+    experiments: Experiments,
+    params: Parameters,
+    settings: McmcSettings,
+    path: Path,
+) -> McmcResult | None:
+    var_names = _varying_parameter_ids(params)
+    if not var_names:
+        print_mcmc_no_vary_warning()
+        return None
+
+    effective_settings = resolve_mcmc_settings(settings, nvarys=len(var_names))
+    _validate_parameter_bounds(params, var_names)
+
+    parameter_store = experiments.parameter_store
+    unbounded_parameter_ids = _find_unbounded_parameter_ids(params, var_names)
+    if unbounded_parameter_ids:
+        print_mcmc_unbounded_warning(
+            list(_format_parameter_ids(unbounded_parameter_ids, parameter_store)),
+        )
+
+    minimizer = lmfit.Minimizer(experiments.residuals, params)
+    result_lf = minimizer.emcee(
+        params=params,
+        steps=effective_settings.steps,
+        nwalkers=effective_settings.walkers,
+        burn=effective_settings.burn,
+        thin=effective_settings.thin,
+        pos=_initial_positions(
+            params,
+            var_names,
+            nwalkers=effective_settings.walkers,
+            seed=effective_settings.seed,
+        ),
+        workers=effective_settings.workers,
+        is_weighted=True,
+        seed=effective_settings.seed,
+        progress=False,
+    )
+    result = _result_from_lmfit(result_lf)
+    write_mcmc_outputs(
+        result,
+        effective_settings,
+        path,
+        parameter_store,
+        unbounded_parameter_ids,
+    )
+    if effective_settings.update_parameters:
+        parameter_store.update_from_parameters(result_lf.params)
+    return result

--- a/src/chemex/optimize/mcmc_plot.py
+++ b/src/chemex/optimize/mcmc_plot.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+
+from chemex.typing import Array
+
+if TYPE_CHECKING:
+    from chemex.optimize.mcmc import EffectiveMcmcSettings, McmcResult
+
+
+_CORRELATION_THRESHOLD = 0.5
+_PAGE_SIZE = (8.27, 11.69)
+
+
+def _format_float(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    if not np.isfinite(value):
+        return "n/a"
+    return f"{value:.5g}"
+
+
+def _finite_values(values: Array) -> Array:
+    return values[np.isfinite(values)]
+
+
+def _correlated_pairs(
+    correlations: Array,
+    *,
+    threshold: float,
+) -> list[tuple[int, int, float]]:
+    pairs: list[tuple[int, int, float]] = []
+    for index_x, index_y in combinations(range(correlations.shape[0]), 2):
+        correlation = float(correlations[index_x, index_y])
+        if np.isfinite(correlation) and abs(correlation) >= threshold:
+            pairs.append((index_x, index_y, correlation))
+    pairs.sort(key=lambda pair: abs(pair[2]), reverse=True)
+    return pairs
+
+
+def _save_text_page(pdf: PdfPages, title: str, lines: list[str]) -> None:
+    fig = plt.figure(figsize=_PAGE_SIZE)
+    fig.text(0.08, 0.95, title, fontsize=16, weight="bold", va="top")
+    fig.text(
+        0.08,
+        0.90,
+        "\n".join(lines),
+        family="monospace",
+        fontsize=9,
+        va="top",
+    )
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _save_summary_page(
+    pdf: PdfPages,
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+    parameter_names: tuple[str, ...],
+    correlated_pairs: list[tuple[int, int, float]],
+) -> None:
+    acceptance = result.acceptance_fraction
+    burn = '"auto"' if settings.burn == "auto" else str(settings.burn)
+    lines = [
+        "Sampler: emcee via lmfit.Minimizer.emcee",
+        f"Parameters: {len(parameter_names)}",
+        f"Steps: {settings.steps}",
+        f"Walkers: {settings.walkers}",
+        f"Requested burn: {burn}",
+        f"Discarded steps: {result.discarded_steps}",
+        f"Thin: {settings.thin}",
+        f"Retained steps: {result.chain.shape[0]}",
+        f"Retained samples: {len(result.samples)}",
+        (
+            "Acceptance fraction: "
+            f"mean={_format_float(float(np.mean(acceptance)))}, "
+            f"min={_format_float(float(np.min(acceptance)))}, "
+            f"max={_format_float(float(np.max(acceptance)))}"
+        ),
+    ]
+    if result.autocorrelation_time is None:
+        lines.append("Autocorrelation time: unavailable")
+    else:
+        max_tau = float(np.max(result.autocorrelation_time))
+        lines.append(f"Max autocorrelation time: {_format_float(max_tau)}")
+    if result.burn_in_warning is not None:
+        lines.append(f"Burn-in warning: {result.burn_in_warning}")
+
+    lines.extend(["", "Posterior summaries:"])
+    for name, summary in zip(parameter_names, result.summary, strict=True):
+        lines.append(
+            f"{name}: median={_format_float(summary.median)}, "
+            f"95% ETI=[{_format_float(summary.eti_95_lower)}, "
+            f"{_format_float(summary.eti_95_upper)}], "
+            f"ESS={_format_float(summary.effective_sample_size)}",
+        )
+
+    lines.extend(["", f"Correlation threshold: |r| >= {_CORRELATION_THRESHOLD:g}"])
+    if correlated_pairs:
+        for index_x, index_y, correlation in correlated_pairs:
+            lines.append(
+                f"{parameter_names[index_x]} vs {parameter_names[index_y]}: "
+                f"r={correlation:.3f}",
+            )
+    else:
+        lines.append("No parameter pairs exceeded the correlation threshold.")
+
+    _save_text_page(pdf, "MCMC Diagnostics", lines)
+
+
+def _save_distribution_pages(
+    pdf: PdfPages,
+    result: McmcResult,
+    parameter_names: tuple[str, ...],
+) -> None:
+    samples = result.samples
+    for index, (name, summary) in enumerate(
+        zip(parameter_names, result.summary, strict=True),
+    ):
+        values = _finite_values(samples[:, index])
+        fig, ax = plt.subplots(figsize=(7.5, 5.0))
+        if len(values):
+            ax.hist(values, bins="auto", density=True, color="#4C72B0", alpha=0.85)
+            ax.axvspan(
+                summary.eti_95_lower,
+                summary.eti_95_upper,
+                color="#4C72B0",
+                alpha=0.15,
+                label="95% ETI",
+            )
+            ax.axvline(
+                summary.median,
+                color="#C44E52",
+                linestyle="--",
+                linewidth=1.2,
+                label="median",
+            )
+            ax.legend()
+        else:
+            ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
+        ax.set_title(f"Posterior distribution: {name}")
+        ax.set_xlabel(name)
+        ax.set_ylabel("Density")
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+
+def _trace_chain(result: McmcResult) -> tuple[Array, bool]:
+    if result.raw_chain is not None:
+        return result.raw_chain, True
+    return result.chain, False
+
+
+def _trace_lnprob(result: McmcResult) -> tuple[Array, bool]:
+    if result.raw_lnprob is not None:
+        return result.raw_lnprob, True
+    return result.lnprob, False
+
+
+def _trace_steps(
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+    length: int,
+    *,
+    raw: bool,
+) -> Array:
+    if raw:
+        return np.arange(length)
+    return result.discarded_steps + np.arange(length) * settings.thin
+
+
+def _mark_burn_in(ax: plt.Axes, result: McmcResult, *, raw: bool) -> None:
+    if raw and result.discarded_steps > 0:
+        ax.axvspan(
+            0,
+            result.discarded_steps,
+            color="0.9",
+            label="discarded burn-in",
+            zorder=-1,
+        )
+        ax.axvline(result.discarded_steps, color="0.5", linestyle="--", linewidth=1.0)
+
+
+def _save_trace_pages(
+    pdf: PdfPages,
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+    parameter_names: tuple[str, ...],
+) -> None:
+    chain, raw = _trace_chain(result)
+    steps = _trace_steps(result, settings, chain.shape[0], raw=raw)
+    for index, name in enumerate(parameter_names):
+        fig, ax = plt.subplots(figsize=(7.5, 5.0))
+        _mark_burn_in(ax, result, raw=raw)
+        for walker in range(chain.shape[1]):
+            ax.plot(steps, chain[:, walker, index], linewidth=0.5, alpha=0.35)
+        ax.set_title(f"MCMC trace: {name}")
+        ax.set_xlabel("Step")
+        ax.set_ylabel(name)
+        handles, labels = ax.get_legend_handles_labels()
+        if handles:
+            ax.legend(handles[:1], labels[:1], loc="best")
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+
+def _save_log_probability_page(
+    pdf: PdfPages,
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+) -> None:
+    lnprob, raw = _trace_lnprob(result)
+    steps = _trace_steps(result, settings, lnprob.shape[0], raw=raw)
+    fig, ax = plt.subplots(figsize=(7.5, 5.0))
+    _mark_burn_in(ax, result, raw=raw)
+    for walker in range(lnprob.shape[1]):
+        ax.plot(steps, lnprob[:, walker], linewidth=0.5, alpha=0.35)
+    ax.set_title("MCMC log-probability trace")
+    ax.set_xlabel("Step")
+    ax.set_ylabel("lnprob")
+    handles, labels = ax.get_legend_handles_labels()
+    if handles:
+        ax.legend(handles[:1], labels[:1], loc="best")
+    fig.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _save_correlation_pages(
+    pdf: PdfPages,
+    result: McmcResult,
+    parameter_names: tuple[str, ...],
+    correlated_pairs: list[tuple[int, int, float]],
+) -> None:
+    samples = result.samples
+    for index_x, index_y, correlation in correlated_pairs:
+        values_x = samples[:, index_x]
+        values_y = samples[:, index_y]
+        finite = np.isfinite(values_x) & np.isfinite(values_y)
+        fig, ax = plt.subplots(figsize=(7.5, 5.5))
+        if np.any(finite):
+            image = ax.hist2d(
+                values_x[finite],
+                values_y[finite],
+                bins=40,
+                cmap="Blues",
+            )
+            cbar = fig.colorbar(image[3], ax=ax)
+            cbar.set_label("Samples")
+        else:
+            ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
+        ax.set_title(
+            f"Posterior pair: {parameter_names[index_x]} vs "
+            f"{parameter_names[index_y]} (r = {correlation:.3f})",
+        )
+        ax.set_xlabel(parameter_names[index_x])
+        ax.set_ylabel(parameter_names[index_y])
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+
+def write_mcmc_plots(
+    result: McmcResult,
+    settings: EffectiveMcmcSettings,
+    path: Path,
+    *,
+    parameter_names: tuple[str, ...],
+) -> None:
+    correlated_pairs = _correlated_pairs(
+        result.correlations,
+        threshold=_CORRELATION_THRESHOLD,
+    )
+    with PdfPages(str(path / "plots.pdf")) as pdf:
+        _save_summary_page(pdf, result, settings, parameter_names, correlated_pairs)
+        _save_distribution_pages(pdf, result, parameter_names)
+        _save_trace_pages(pdf, result, settings, parameter_names)
+        _save_log_probability_page(pdf, result, settings)
+        _save_correlation_pages(pdf, result, parameter_names, correlated_pairs)

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
@@ -18,8 +17,6 @@ from chemex.messages import (
 )
 from chemex.optimize.helper import (
     calculate_statistics,
-    print_header,
-    print_values_stat,
 )
 from chemex.optimize.minimizer import minimize
 
@@ -158,7 +155,6 @@ def _write_resampling_diagnostics(
     requested_samples: int,
     completed_samples: int,
     parameter_ids: list[str],
-    legacy_output: str,
 ) -> None:
     lines = [
         f"method = {_quote_toml_string(method)}",
@@ -169,7 +165,6 @@ def _write_resampling_diagnostics(
         'samples_file = "samples.tsv"',
         'summary_file = "summary.toml"',
         'correlations_file = "correlations.tsv"',
-        f"legacy_samples_file = {_quote_toml_string(legacy_output)}",
     ]
     (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -187,18 +182,12 @@ def _run_resampling_method(
     statistic_path = path / "Statistics" / method["directory"]
     statistic_path.mkdir(parents=True, exist_ok=True)
     samples_tsv = statistic_path / "samples.tsv"
-    samples_legacy = path / method["filename"]
     sample_rows: list[list[float]] = []
     completed_samples = 0
 
-    with ExitStack() as stack:
-        file_tsv = stack.enter_context(samples_tsv.open(mode="w", encoding="utf-8"))
-        file_legacy = stack.enter_context(
-            samples_legacy.open(mode="w", encoding="utf-8"),
-        )
+    with samples_tsv.open(mode="w", encoding="utf-8") as file_tsv:
         parameter_names = _format_parameter_names(ids_vary, parameter_store)
         file_tsv.write("\t".join((*parameter_names, "chisqr")) + "\n")
-        file_legacy.write(print_header(ids_vary, parameter_store=parameter_store))
 
         try:
             for _ in track(range(iter_nb), total=iter_nb, description="   "):
@@ -215,7 +204,6 @@ def _run_resampling_method(
                     )
                     + "\n",
                 )
-                file_legacy.write(print_values_stat(params_fit, ids_vary, chisqr))
                 sample_rows.append(sample_values)
                 completed_samples += 1
         except KeyboardInterrupt:
@@ -224,7 +212,6 @@ def _run_resampling_method(
             print_value_error()
         finally:
             file_tsv.flush()
-            file_legacy.flush()
             samples = _as_sample_array(sample_rows, len(ids_vary))
             _write_resampling_summary(
                 statistic_path,
@@ -245,7 +232,6 @@ def _run_resampling_method(
                 requested_samples=iter_nb,
                 completed_samples=completed_samples,
                 parameter_ids=ids_vary,
-                legacy_output=method["filename"],
             )
 
 
@@ -262,17 +248,14 @@ def run_resampling_statistics(
         "mc": {
             "message": "Monte Carlo",
             "directory": "MonteCarlo",
-            "filename": "monte_carlo.out",
         },
         "bs": {
             "message": "bootstrap",
             "directory": "Bootstrap",
-            "filename": "bootstrap.out",
         },
         "bsn": {
             "message": "nucleus-based bootstrap",
             "directory": "BootstrapNS",
-            "filename": "bootstrap_ns.out",
         },
     }
 

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -1,0 +1,287 @@
+"""Output handling for resampling-based uncertainty analyses."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from rich.progress import track
+
+from chemex.configuration.methods import Statistics
+from chemex.containers.experiments import Experiments, generate_exp_for_statistics
+from chemex.messages import (
+    print_calculation_stopped_error,
+    print_running_statistics,
+    print_value_error,
+)
+from chemex.optimize.helper import (
+    calculate_statistics,
+    print_header,
+    print_values_stat,
+)
+from chemex.optimize.minimizer import minimize
+
+
+def _quote_toml_string(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _format_toml_string_list(values: list[str]) -> str:
+    if not values:
+        return "[]"
+    return "[" + ", ".join(_quote_toml_string(value) for value in values) + "]"
+
+
+def _format_toml_float(value: float) -> str:
+    return f"{value:.5e}"
+
+
+def _format_parameter_names(
+    parameter_ids: list[str],
+    parameter_store: Any,
+) -> tuple[str, ...]:
+    if not hasattr(parameter_store, "get_parameters"):
+        return tuple(parameter_ids)
+    parameters = parameter_store.get_parameters(parameter_ids)
+    return tuple(
+        str(parameters[param_id].param_name) if param_id in parameters else param_id
+        for param_id in parameter_ids
+    )
+
+
+def _sample_parameter_values(
+    params_lf: Any,
+    parameter_ids: list[str],
+) -> list[float]:
+    return [
+        float(params_lf[param_id].value) if param_id in params_lf else np.nan
+        for param_id in parameter_ids
+    ]
+
+
+def _as_sample_array(sample_rows: list[list[float]], width: int) -> np.ndarray:
+    if not sample_rows:
+        return np.empty((0, width), dtype=float)
+    return np.asarray(sample_rows, dtype=float)
+
+
+def _write_resampling_summary(
+    path: Path,
+    *,
+    parameter_ids: list[str],
+    parameter_store: Any,
+    samples: np.ndarray,
+) -> None:
+    parameter_names = _format_parameter_names(parameter_ids, parameter_store)
+    lines: list[str] = []
+    for index, parameter_name in enumerate(parameter_names):
+        values = samples[:, index] if samples.size else np.empty(0, dtype=float)
+        values = values[np.isfinite(values)]
+        lines.extend(
+            [
+                f"[{_quote_toml_string(parameter_name.strip('[]'))}]",
+                'interval = "95% percentile"',
+                f"sample_count = {len(values)}",
+            ],
+        )
+        if len(values) > 0:
+            lower_95, lower, median, upper, upper_95 = np.percentile(
+                values,
+                [2.5, 15.87, 50.0, 84.13, 97.5],
+            )
+            standard_deviation = (
+                float(np.std(values, ddof=1)) if len(values) > 1 else 0.0
+            )
+            lines.extend(
+                [
+                    f"mean = {_format_toml_float(float(np.mean(values)))}",
+                    f"standard_deviation = {_format_toml_float(standard_deviation)}",
+                    f"median = {_format_toml_float(float(median))}",
+                    f"percentile_95_lower = {_format_toml_float(float(lower_95))}",
+                    f"percentile_95_upper = {_format_toml_float(float(upper_95))}",
+                    f"lower_1sigma = {_format_toml_float(float(lower))}",
+                    f"upper_1sigma = {_format_toml_float(float(upper))}",
+                    f"stderr = {_format_toml_float(0.5 * float(upper - lower))}",
+                ],
+            )
+        lines.append("")
+    (path / "summary.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _pairwise_correlation(samples: np.ndarray, index_a: int, index_b: int) -> float:
+    values_a = samples[:, index_a]
+    values_b = samples[:, index_b]
+    valid = np.isfinite(values_a) & np.isfinite(values_b)
+    if int(np.sum(valid)) < 2:
+        return np.nan
+    return float(np.corrcoef(values_a[valid], values_b[valid])[0, 1])
+
+
+def _write_resampling_correlations(
+    path: Path,
+    *,
+    parameter_ids: list[str],
+    parameter_store: Any,
+    samples: np.ndarray,
+) -> None:
+    parameter_names = _format_parameter_names(parameter_ids, parameter_store)
+    if not parameter_names:
+        (path / "correlations.out").write_text("", encoding="utf-8")
+        return
+    name_width = max(len(name) for name in parameter_names)
+    correlations = np.empty((len(parameter_names), len(parameter_names)), dtype=float)
+    for index_a in range(len(parameter_names)):
+        for index_b in range(len(parameter_names)):
+            correlations[index_a, index_b] = (
+                1.0
+                if index_a == index_b
+                else _pairwise_correlation(samples, index_a, index_b)
+            )
+
+    with (path / "correlations.out").open("w", encoding="utf-8") as fileout:
+        fileout.write(f"# {' '.join(f'{name:>12s}' for name in parameter_names)}\n")
+        for name, values in zip(parameter_names, correlations, strict=True):
+            row = " ".join(f"{value:12.5e}" for value in values)
+            fileout.write(f"{name:<{name_width}s} {row}\n")
+
+
+def _write_resampling_diagnostics(
+    path: Path,
+    *,
+    method: str,
+    fitmethod: str,
+    requested_samples: int,
+    completed_samples: int,
+    parameter_ids: list[str],
+    legacy_output: str,
+) -> None:
+    lines = [
+        f"method = {_quote_toml_string(method)}",
+        f"fitmethod = {_quote_toml_string(fitmethod)}",
+        f"requested_samples = {requested_samples}",
+        f"completed_samples = {completed_samples}",
+        f"parameters = {_format_toml_string_list(parameter_ids)}",
+        'samples_file = "samples.out"',
+        'summary_file = "summary.toml"',
+        'correlations_file = "correlations.out"',
+        f"legacy_samples_file = {_quote_toml_string(legacy_output)}",
+    ]
+    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_resampling_method(
+    experiments: Experiments,
+    path: Path,
+    fitmethod: str,
+    statistic_name: str,
+    method: dict[str, str],
+    iter_nb: int,
+    ids_vary: list[str],
+) -> None:
+    parameter_store = experiments.parameter_store
+    statistic_path = path / "Statistics" / method["directory"]
+    statistic_path.mkdir(parents=True, exist_ok=True)
+    sample_paths = (statistic_path / "samples.out", path / method["filename"])
+    sample_rows: list[list[float]] = []
+    completed_samples = 0
+
+    with ExitStack() as stack:
+        files = [
+            stack.enter_context(filename.open(mode="w", encoding="utf-8"))
+            for filename in sample_paths
+        ]
+        header = print_header(ids_vary, parameter_store=parameter_store)
+        for fileout in files:
+            fileout.write(header)
+
+        try:
+            for _ in track(range(iter_nb), total=iter_nb, description="   "):
+                exp_stat = generate_exp_for_statistics(experiments, statistic_name)
+                params_lf = parameter_store.build_lmfit_params(exp_stat.param_ids)
+                params_fit = minimize(exp_stat, params_lf, fitmethod)
+                stats = calculate_statistics(exp_stat, params_fit)
+                chisqr = stats.get("chisqr", 1e32)
+                values = print_values_stat(params_fit, ids_vary, chisqr)
+                for fileout in files:
+                    fileout.write(values)
+                sample_rows.append(_sample_parameter_values(params_fit, ids_vary))
+                completed_samples += 1
+        except KeyboardInterrupt:
+            print_calculation_stopped_error()
+        except ValueError:
+            print_value_error()
+        finally:
+            for fileout in files:
+                fileout.flush()
+            samples = _as_sample_array(sample_rows, len(ids_vary))
+            _write_resampling_summary(
+                statistic_path,
+                parameter_ids=ids_vary,
+                parameter_store=parameter_store,
+                samples=samples,
+            )
+            _write_resampling_correlations(
+                statistic_path,
+                parameter_ids=ids_vary,
+                parameter_store=parameter_store,
+                samples=samples,
+            )
+            _write_resampling_diagnostics(
+                statistic_path,
+                method=method["message"],
+                fitmethod=fitmethod,
+                requested_samples=iter_nb,
+                completed_samples=completed_samples,
+                parameter_ids=ids_vary,
+                legacy_output=method["filename"],
+            )
+
+
+def run_resampling_statistics(
+    experiments: Experiments,
+    path: Path,
+    fitmethod: str,
+    statistics: Statistics,
+) -> None:
+    if statistics.mc is None and statistics.bs is None and statistics.bsn is None:
+        return
+
+    methods = {
+        "mc": {
+            "message": "Monte Carlo",
+            "directory": "MonteCarlo",
+            "filename": "monte_carlo.out",
+        },
+        "bs": {
+            "message": "bootstrap",
+            "directory": "Bootstrap",
+            "filename": "bootstrap.out",
+        },
+        "bsn": {
+            "message": "nucleus-based bootstrap",
+            "directory": "BootstrapNS",
+            "filename": "bootstrap_ns.out",
+        },
+    }
+
+    parameter_store = experiments.parameter_store
+    params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
+    ids_vary = [param.name for param in params_lf.values() if param.vary]
+
+    for statistic_name, method in methods.items():
+        iter_nb = getattr(statistics, statistic_name)
+        if iter_nb is None:
+            continue
+
+        print_running_statistics(method["message"])
+        _run_resampling_method(
+            experiments,
+            path,
+            fitmethod,
+            statistic_name,
+            method,
+            iter_nb,
+            ids_vary,
+        )

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -19,6 +19,7 @@ from chemex.optimize.helper import (
     calculate_statistics,
 )
 from chemex.optimize.minimizer import minimize
+from chemex.optimize.statistics_plot import write_resampling_plots
 
 
 def _quote_toml_string(value: str) -> str:
@@ -126,11 +127,11 @@ def _write_resampling_correlations(
     parameter_ids: list[str],
     parameter_store: Any,
     samples: np.ndarray,
-) -> None:
+) -> np.ndarray:
     parameter_names = _format_parameter_names(parameter_ids, parameter_store)
     if not parameter_names:
         (path / "correlations.tsv").write_text("", encoding="utf-8")
-        return
+        return np.empty((0, 0), dtype=float)
     correlations = np.empty((len(parameter_names), len(parameter_names)), dtype=float)
     for index_a in range(len(parameter_names)):
         for index_b in range(len(parameter_names)):
@@ -145,6 +146,7 @@ def _write_resampling_correlations(
         for name, values in zip(parameter_names, correlations, strict=True):
             row = "\t".join(_format_tsv_float(value) for value in values)
             fileout.write(f"{name}\t{row}\n")
+    return correlations
 
 
 def _write_resampling_diagnostics(
@@ -165,6 +167,7 @@ def _write_resampling_diagnostics(
         'samples_file = "samples.tsv"',
         'summary_file = "summary.toml"',
         'correlations_file = "correlations.tsv"',
+        'plots_file = "plots.pdf"',
     ]
     (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -183,6 +186,7 @@ def _run_resampling_method(
     statistic_path.mkdir(parents=True, exist_ok=True)
     samples_tsv = statistic_path / "samples.tsv"
     sample_rows: list[list[float]] = []
+    chisqr_rows: list[float] = []
     completed_samples = 0
 
     with samples_tsv.open(mode="w", encoding="utf-8") as file_tsv:
@@ -205,6 +209,7 @@ def _run_resampling_method(
                     + "\n",
                 )
                 sample_rows.append(sample_values)
+                chisqr_rows.append(float(chisqr))
                 completed_samples += 1
         except KeyboardInterrupt:
             print_calculation_stopped_error()
@@ -219,11 +224,22 @@ def _run_resampling_method(
                 parameter_store=parameter_store,
                 samples=samples,
             )
-            _write_resampling_correlations(
+            correlations = _write_resampling_correlations(
                 statistic_path,
                 parameter_ids=ids_vary,
                 parameter_store=parameter_store,
                 samples=samples,
+            )
+            write_resampling_plots(
+                statistic_path,
+                method=method["message"],
+                fitmethod=fitmethod,
+                parameter_names=_format_parameter_names(ids_vary, parameter_store),
+                samples=samples,
+                chisqr_values=np.asarray(chisqr_rows, dtype=float),
+                correlations=correlations,
+                requested_samples=iter_nb,
+                completed_samples=completed_samples,
             )
             _write_resampling_diagnostics(
                 statistic_path,

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -38,6 +38,10 @@ def _format_toml_float(value: float) -> str:
     return f"{value:.5e}"
 
 
+def _format_tsv_float(value: float) -> str:
+    return "nan" if not np.isfinite(value) else f"{value:.5e}"
+
+
 def _format_parameter_names(
     parameter_ids: list[str],
     parameter_store: Any,
@@ -128,9 +132,8 @@ def _write_resampling_correlations(
 ) -> None:
     parameter_names = _format_parameter_names(parameter_ids, parameter_store)
     if not parameter_names:
-        (path / "correlations.out").write_text("", encoding="utf-8")
+        (path / "correlations.tsv").write_text("", encoding="utf-8")
         return
-    name_width = max(len(name) for name in parameter_names)
     correlations = np.empty((len(parameter_names), len(parameter_names)), dtype=float)
     for index_a in range(len(parameter_names)):
         for index_b in range(len(parameter_names)):
@@ -140,11 +143,11 @@ def _write_resampling_correlations(
                 else _pairwise_correlation(samples, index_a, index_b)
             )
 
-    with (path / "correlations.out").open("w", encoding="utf-8") as fileout:
-        fileout.write(f"# {' '.join(f'{name:>12s}' for name in parameter_names)}\n")
+    with (path / "correlations.tsv").open("w", encoding="utf-8") as fileout:
+        fileout.write("parameter\t" + "\t".join(parameter_names) + "\n")
         for name, values in zip(parameter_names, correlations, strict=True):
-            row = " ".join(f"{value:12.5e}" for value in values)
-            fileout.write(f"{name:<{name_width}s} {row}\n")
+            row = "\t".join(_format_tsv_float(value) for value in values)
+            fileout.write(f"{name}\t{row}\n")
 
 
 def _write_resampling_diagnostics(
@@ -163,9 +166,9 @@ def _write_resampling_diagnostics(
         f"requested_samples = {requested_samples}",
         f"completed_samples = {completed_samples}",
         f"parameters = {_format_toml_string_list(parameter_ids)}",
-        'samples_file = "samples.out"',
+        'samples_file = "samples.tsv"',
         'summary_file = "summary.toml"',
-        'correlations_file = "correlations.out"',
+        'correlations_file = "correlations.tsv"',
         f"legacy_samples_file = {_quote_toml_string(legacy_output)}",
     ]
     (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -183,18 +186,19 @@ def _run_resampling_method(
     parameter_store = experiments.parameter_store
     statistic_path = path / "Statistics" / method["directory"]
     statistic_path.mkdir(parents=True, exist_ok=True)
-    sample_paths = (statistic_path / "samples.out", path / method["filename"])
+    samples_tsv = statistic_path / "samples.tsv"
+    samples_legacy = path / method["filename"]
     sample_rows: list[list[float]] = []
     completed_samples = 0
 
     with ExitStack() as stack:
-        files = [
-            stack.enter_context(filename.open(mode="w", encoding="utf-8"))
-            for filename in sample_paths
-        ]
-        header = print_header(ids_vary, parameter_store=parameter_store)
-        for fileout in files:
-            fileout.write(header)
+        file_tsv = stack.enter_context(samples_tsv.open(mode="w", encoding="utf-8"))
+        file_legacy = stack.enter_context(
+            samples_legacy.open(mode="w", encoding="utf-8"),
+        )
+        parameter_names = _format_parameter_names(ids_vary, parameter_store)
+        file_tsv.write("\t".join((*parameter_names, "chisqr")) + "\n")
+        file_legacy.write(print_header(ids_vary, parameter_store=parameter_store))
 
         try:
             for _ in track(range(iter_nb), total=iter_nb, description="   "):
@@ -203,18 +207,24 @@ def _run_resampling_method(
                 params_fit = minimize(exp_stat, params_lf, fitmethod)
                 stats = calculate_statistics(exp_stat, params_fit)
                 chisqr = stats.get("chisqr", 1e32)
-                values = print_values_stat(params_fit, ids_vary, chisqr)
-                for fileout in files:
-                    fileout.write(values)
-                sample_rows.append(_sample_parameter_values(params_fit, ids_vary))
+                sample_values = _sample_parameter_values(params_fit, ids_vary)
+                file_tsv.write(
+                    "\t".join(
+                        _format_tsv_float(value)
+                        for value in (*sample_values, float(chisqr))
+                    )
+                    + "\n",
+                )
+                file_legacy.write(print_values_stat(params_fit, ids_vary, chisqr))
+                sample_rows.append(sample_values)
                 completed_samples += 1
         except KeyboardInterrupt:
             print_calculation_stopped_error()
         except ValueError:
             print_value_error()
         finally:
-            for fileout in files:
-                fileout.flush()
+            file_tsv.flush()
+            file_legacy.flush()
             samples = _as_sample_array(sample_rows, len(ids_vary))
             _write_resampling_summary(
                 statistic_path,

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -72,11 +72,9 @@ def _as_sample_array(sample_rows: list[list[float]], width: int) -> np.ndarray:
 def _write_resampling_summary(
     path: Path,
     *,
-    parameter_ids: list[str],
-    parameter_store: Any,
+    parameter_names: tuple[str, ...],
     samples: np.ndarray,
 ) -> None:
-    parameter_names = _format_parameter_names(parameter_ids, parameter_store)
     lines: list[str] = []
     for index, parameter_name in enumerate(parameter_names):
         values = samples[:, index] if samples.size else np.empty(0, dtype=float)
@@ -124,11 +122,9 @@ def _pairwise_correlation(samples: np.ndarray, index_a: int, index_b: int) -> fl
 def _write_resampling_correlations(
     path: Path,
     *,
-    parameter_ids: list[str],
-    parameter_store: Any,
+    parameter_names: tuple[str, ...],
     samples: np.ndarray,
 ) -> np.ndarray:
-    parameter_names = _format_parameter_names(parameter_ids, parameter_store)
     if not parameter_names:
         (path / "correlations.tsv").write_text("", encoding="utf-8")
         return np.empty((0, 0), dtype=float)
@@ -187,10 +183,10 @@ def _run_resampling_method(
     samples_tsv = statistic_path / "samples.tsv"
     sample_rows: list[list[float]] = []
     chisqr_rows: list[float] = []
+    parameter_names = _format_parameter_names(ids_vary, parameter_store)
     completed_samples = 0
 
     with samples_tsv.open(mode="w", encoding="utf-8") as file_tsv:
-        parameter_names = _format_parameter_names(ids_vary, parameter_store)
         file_tsv.write("\t".join((*parameter_names, "chisqr")) + "\n")
 
         try:
@@ -220,21 +216,19 @@ def _run_resampling_method(
             samples = _as_sample_array(sample_rows, len(ids_vary))
             _write_resampling_summary(
                 statistic_path,
-                parameter_ids=ids_vary,
-                parameter_store=parameter_store,
+                parameter_names=parameter_names,
                 samples=samples,
             )
             correlations = _write_resampling_correlations(
                 statistic_path,
-                parameter_ids=ids_vary,
-                parameter_store=parameter_store,
+                parameter_names=parameter_names,
                 samples=samples,
             )
             write_resampling_plots(
                 statistic_path,
                 method=method["message"],
                 fitmethod=fitmethod,
-                parameter_names=_format_parameter_names(ids_vary, parameter_store),
+                parameter_names=parameter_names,
                 samples=samples,
                 chisqr_values=np.asarray(chisqr_rows, dtype=float),
                 correlations=correlations,

--- a/src/chemex/optimize/statistics_plot.py
+++ b/src/chemex/optimize/statistics_plot.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from itertools import combinations
+from math import ceil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
+from emcee.autocorr import AutocorrError, integrated_time
 from matplotlib.backends.backend_pdf import PdfPages
 
 from chemex.typing import Array
@@ -28,6 +30,20 @@ def _format_float(value: float | None) -> str:
 
 def _finite_values(values: Array) -> Array:
     return values[np.isfinite(values)]
+
+
+def _mcmc_autocorrelation_time(result: McmcResult) -> Array | None:
+    if result.autocorrelation_time is not None:
+        return result.autocorrelation_time
+    return result.tentative_autocorrelation_time
+
+
+def _mcmc_autocorrelation_status(result: McmcResult) -> str:
+    if result.autocorrelation_time is not None:
+        return "reliable"
+    if result.tentative_autocorrelation_time is not None:
+        return "unreliable short chain"
+    return "unavailable"
 
 
 def _correlated_pairs(
@@ -85,11 +101,17 @@ def _save_mcmc_summary_page(
             f"max={_format_float(float(np.max(acceptance)))}"
         ),
     ]
-    if result.autocorrelation_time is None:
+    autocorrelation_time = _mcmc_autocorrelation_time(result)
+    lines.append(f"Autocorrelation status: {_mcmc_autocorrelation_status(result)}")
+    if autocorrelation_time is None:
         lines.append("Autocorrelation time: unavailable")
     else:
-        max_tau = float(np.max(result.autocorrelation_time))
+        max_tau = float(np.max(autocorrelation_time))
         lines.append(f"Max autocorrelation time: {_format_float(max_tau)}")
+        lines.append(f"Recommended steps (50 tau): {ceil(50.0 * max_tau)}")
+        lines.append(f"Recommended steps (100 tau): {ceil(100.0 * max_tau)}")
+    if result.autocorrelation_warning is not None:
+        lines.append(f"Autocorrelation warning: {result.autocorrelation_warning}")
     if result.burn_in_warning is not None:
         lines.append(f"Burn-in warning: {result.burn_in_warning}")
 
@@ -235,6 +257,57 @@ def _save_log_probability_page(
     plt.close(fig)
 
 
+def _autocorrelation_monitor_values(chain: Array) -> tuple[Array, Array, Array]:
+    nsteps = chain.shape[0]
+    if nsteps < 4:
+        empty = np.empty(0, dtype=float)
+        return empty, empty, empty
+
+    start = max(4, min(100, nsteps // 10))
+    lengths = np.unique(np.geomspace(start, nsteps, num=12).astype(int))
+    mean_tau: list[float] = []
+    max_tau: list[float] = []
+    used_lengths: list[int] = []
+    for length in lengths:
+        try:
+            tau = integrated_time(chain[:length], quiet=False)
+        except AutocorrError as error:
+            tau = error.tau
+        except (FloatingPointError, ValueError):
+            continue
+        tau = np.asarray(tau, dtype=float)
+        if tau.ndim != 1 or not np.all(np.isfinite(tau)) or np.any(tau <= 0.0):
+            continue
+        used_lengths.append(int(length))
+        mean_tau.append(float(np.mean(tau)))
+        max_tau.append(float(np.max(tau)))
+    return (
+        np.asarray(used_lengths, dtype=float),
+        np.asarray(mean_tau, dtype=float),
+        np.asarray(max_tau, dtype=float),
+    )
+
+
+def _save_autocorrelation_monitor_page(pdf: PdfPages, result: McmcResult) -> None:
+    chain, _raw = _trace_chain(result)
+    lengths, mean_tau, max_tau = _autocorrelation_monitor_values(chain)
+    fig, ax = plt.subplots(figsize=(7.5, 5.0))
+    if len(lengths):
+        ax.plot(lengths, mean_tau, "o-", label="mean tau")
+        ax.plot(lengths, max_tau, "o-", label="max tau")
+        ax.plot(lengths, lengths / 50.0, "--", color="0.4", label="N / 50")
+        ax.plot(lengths, lengths / 100.0, ":", color="0.4", label="N / 100")
+        ax.legend()
+    else:
+        ax.text(0.5, 0.5, "Autocorrelation unavailable", ha="center", va="center")
+    ax.set_title("MCMC autocorrelation monitor")
+    ax.set_xlabel("Steps")
+    ax.set_ylabel("Integrated autocorrelation time")
+    fig.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
 def _save_mcmc_correlation_pages(
     pdf: PdfPages,
     result: McmcResult,
@@ -291,6 +364,7 @@ def write_mcmc_plots(
         _save_mcmc_distribution_pages(pdf, result, parameter_names)
         _save_trace_pages(pdf, result, settings, parameter_names)
         _save_log_probability_page(pdf, result, settings)
+        _save_autocorrelation_monitor_page(pdf, result)
         _save_mcmc_correlation_pages(pdf, result, parameter_names, correlated_pairs)
 
 

--- a/src/chemex/optimize/statistics_plot.py
+++ b/src/chemex/optimize/statistics_plot.py
@@ -59,7 +59,7 @@ def _save_text_page(pdf: PdfPages, title: str, lines: list[str]) -> None:
     plt.close(fig)
 
 
-def _save_summary_page(
+def _save_mcmc_summary_page(
     pdf: PdfPages,
     result: McmcResult,
     settings: EffectiveMcmcSettings,
@@ -115,7 +115,7 @@ def _save_summary_page(
     _save_text_page(pdf, "MCMC Diagnostics", lines)
 
 
-def _save_distribution_pages(
+def _save_mcmc_distribution_pages(
     pdf: PdfPages,
     result: McmcResult,
     parameter_names: tuple[str, ...],
@@ -235,7 +235,7 @@ def _save_log_probability_page(
     plt.close(fig)
 
 
-def _save_correlation_pages(
+def _save_mcmc_correlation_pages(
     pdf: PdfPages,
     result: McmcResult,
     parameter_names: tuple[str, ...],
@@ -281,8 +281,194 @@ def write_mcmc_plots(
         threshold=_CORRELATION_THRESHOLD,
     )
     with PdfPages(str(path / "plots.pdf")) as pdf:
-        _save_summary_page(pdf, result, settings, parameter_names, correlated_pairs)
-        _save_distribution_pages(pdf, result, parameter_names)
+        _save_mcmc_summary_page(
+            pdf,
+            result,
+            settings,
+            parameter_names,
+            correlated_pairs,
+        )
+        _save_mcmc_distribution_pages(pdf, result, parameter_names)
         _save_trace_pages(pdf, result, settings, parameter_names)
         _save_log_probability_page(pdf, result, settings)
-        _save_correlation_pages(pdf, result, parameter_names, correlated_pairs)
+        _save_mcmc_correlation_pages(pdf, result, parameter_names, correlated_pairs)
+
+
+def _save_resampling_summary_page(
+    pdf: PdfPages,
+    *,
+    method: str,
+    fitmethod: str,
+    parameter_names: tuple[str, ...],
+    correlations: Array,
+    requested_samples: int,
+    completed_samples: int,
+    chisqr_values: Array,
+) -> list[tuple[int, int, float]]:
+    correlated_pairs = _correlated_pairs(
+        correlations,
+        threshold=_CORRELATION_THRESHOLD,
+    )
+    finite_chisqr = _finite_values(chisqr_values)
+    lines = [
+        f"Method: {method}",
+        f"Fit method: {fitmethod}",
+        f"Parameters: {len(parameter_names)}",
+        f"Requested samples: {requested_samples}",
+        f"Completed samples: {completed_samples}",
+    ]
+    if len(finite_chisqr):
+        lines.extend(
+            [
+                f"chisqr mean: {_format_float(float(np.mean(finite_chisqr)))}",
+                f"chisqr median: {_format_float(float(np.median(finite_chisqr)))}",
+                f"chisqr min: {_format_float(float(np.min(finite_chisqr)))}",
+                f"chisqr max: {_format_float(float(np.max(finite_chisqr)))}",
+            ],
+        )
+    else:
+        lines.append("chisqr: no finite values")
+
+    lines.extend(["", f"Correlation threshold: |r| >= {_CORRELATION_THRESHOLD:g}"])
+    if correlated_pairs:
+        for index_x, index_y, correlation in correlated_pairs:
+            lines.append(
+                f"{parameter_names[index_x]} vs {parameter_names[index_y]}: "
+                f"r={correlation:.3f}",
+            )
+    else:
+        lines.append("No parameter pairs exceeded the correlation threshold.")
+
+    _save_text_page(pdf, f"{method} Diagnostics", lines)
+    return correlated_pairs
+
+
+def _save_resampling_distribution_pages(
+    pdf: PdfPages,
+    *,
+    samples: Array,
+    parameter_names: tuple[str, ...],
+) -> None:
+    for index, name in enumerate(parameter_names):
+        values = _finite_values(samples[:, index]) if samples.size else np.empty(0)
+        fig, ax = plt.subplots(figsize=(7.5, 5.0))
+        if len(values):
+            ax.hist(values, bins="auto", density=True, color="#55A868", alpha=0.85)
+            lower_95, median, upper_95 = np.percentile(values, [2.5, 50.0, 97.5])
+            ax.axvspan(
+                lower_95,
+                upper_95,
+                color="#55A868",
+                alpha=0.15,
+                label="95% percentile",
+            )
+            ax.axvline(
+                median,
+                color="#C44E52",
+                linestyle="--",
+                linewidth=1.2,
+                label="median",
+            )
+            ax.legend()
+        else:
+            ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
+        ax.set_title(f"Sample distribution: {name}")
+        ax.set_xlabel(name)
+        ax.set_ylabel("Density")
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+
+def _save_chisqr_distribution_page(pdf: PdfPages, chisqr_values: Array) -> None:
+    values = _finite_values(chisqr_values)
+    fig, ax = plt.subplots(figsize=(7.5, 5.0))
+    if len(values):
+        ax.hist(values, bins="auto", color="#8172B3", alpha=0.85)
+        ax.axvline(
+            float(np.median(values)),
+            color="#C44E52",
+            linestyle="--",
+            linewidth=1.2,
+            label="median",
+        )
+        ax.legend()
+    else:
+        ax.text(0.5, 0.5, "No finite chisqr values", ha="center", va="center")
+    ax.set_title("chisqr distribution")
+    ax.set_xlabel("chisqr")
+    ax.set_ylabel("Samples")
+    fig.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _save_resampling_correlation_pages(
+    pdf: PdfPages,
+    *,
+    samples: Array,
+    parameter_names: tuple[str, ...],
+    correlated_pairs: list[tuple[int, int, float]],
+) -> None:
+    for index_x, index_y, correlation in correlated_pairs:
+        values_x = samples[:, index_x]
+        values_y = samples[:, index_y]
+        finite = np.isfinite(values_x) & np.isfinite(values_y)
+        fig, ax = plt.subplots(figsize=(7.5, 5.5))
+        if np.any(finite):
+            image = ax.hist2d(
+                values_x[finite],
+                values_y[finite],
+                bins=40,
+                cmap="Greens",
+            )
+            cbar = fig.colorbar(image[3], ax=ax)
+            cbar.set_label("Samples")
+        else:
+            ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
+        ax.set_title(
+            f"Sample pair: {parameter_names[index_x]} vs "
+            f"{parameter_names[index_y]} (r = {correlation:.3f})",
+        )
+        ax.set_xlabel(parameter_names[index_x])
+        ax.set_ylabel(parameter_names[index_y])
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+
+def write_resampling_plots(
+    path: Path,
+    *,
+    method: str,
+    fitmethod: str,
+    parameter_names: tuple[str, ...],
+    samples: Array,
+    chisqr_values: Array,
+    correlations: Array,
+    requested_samples: int,
+    completed_samples: int,
+) -> None:
+    with PdfPages(str(path / "plots.pdf")) as pdf:
+        correlated_pairs = _save_resampling_summary_page(
+            pdf,
+            method=method,
+            fitmethod=fitmethod,
+            parameter_names=parameter_names,
+            correlations=correlations,
+            requested_samples=requested_samples,
+            completed_samples=completed_samples,
+            chisqr_values=chisqr_values,
+        )
+        _save_resampling_distribution_pages(
+            pdf,
+            samples=samples,
+            parameter_names=parameter_names,
+        )
+        _save_chisqr_distribution_page(pdf, chisqr_values)
+        _save_resampling_correlation_pages(
+            pdf,
+            samples=samples,
+            parameter_names=parameter_names,
+            correlated_pairs=correlated_pairs,
+        )

--- a/src/chemex/optimize/statistics_plot.py
+++ b/src/chemex/optimize/statistics_plot.py
@@ -75,6 +75,90 @@ def _save_text_page(pdf: PdfPages, title: str, lines: list[str]) -> None:
     plt.close(fig)
 
 
+def _save_histogram_page(
+    pdf: PdfPages,
+    *,
+    values: Array,
+    title: str,
+    xlabel: str,
+    ylabel: str,
+    color: str,
+    density: bool,
+    interval: tuple[float, float] | None = None,
+    interval_label: str | None = None,
+    median: float | None = None,
+    empty_message: str = "No finite samples",
+) -> None:
+    values = _finite_values(values)
+    fig, ax = plt.subplots(figsize=(7.5, 5.0))
+    if len(values):
+        ax.hist(values, bins="auto", density=density, color=color, alpha=0.85)
+        if interval is not None:
+            lower, upper = interval
+            ax.axvspan(
+                lower,
+                upper,
+                color=color,
+                alpha=0.15,
+                label=interval_label,
+            )
+        if median is not None:
+            ax.axvline(
+                median,
+                color="#C44E52",
+                linestyle="--",
+                linewidth=1.2,
+                label="median",
+            )
+        handles, _labels = ax.get_legend_handles_labels()
+        if handles:
+            ax.legend()
+    else:
+        ax.text(0.5, 0.5, empty_message, ha="center", va="center")
+    ax.set_title(title)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    fig.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _save_pair_distribution_page(
+    pdf: PdfPages,
+    *,
+    samples: Array,
+    parameter_names: tuple[str, ...],
+    pair: tuple[int, int, float],
+    title_prefix: str,
+    cmap: str,
+) -> None:
+    index_x, index_y, correlation = pair
+    values_x = samples[:, index_x]
+    values_y = samples[:, index_y]
+    finite = np.isfinite(values_x) & np.isfinite(values_y)
+    fig, ax = plt.subplots(figsize=(7.5, 5.5))
+    if np.any(finite):
+        image = ax.hist2d(
+            values_x[finite],
+            values_y[finite],
+            bins=40,
+            cmap=cmap,
+        )
+        cbar = fig.colorbar(image[3], ax=ax)
+        cbar.set_label("Samples")
+    else:
+        ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
+    ax.set_title(
+        f"{title_prefix}: {parameter_names[index_x]} vs "
+        f"{parameter_names[index_y]} (r = {correlation:.3f})",
+    )
+    ax.set_xlabel(parameter_names[index_x])
+    ax.set_ylabel(parameter_names[index_y])
+    fig.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
 def _save_mcmc_summary_page(
     pdf: PdfPages,
     result: McmcResult,
@@ -146,33 +230,18 @@ def _save_mcmc_distribution_pages(
     for index, (name, summary) in enumerate(
         zip(parameter_names, result.summary, strict=True),
     ):
-        values = _finite_values(samples[:, index])
-        fig, ax = plt.subplots(figsize=(7.5, 5.0))
-        if len(values):
-            ax.hist(values, bins="auto", density=True, color="#4C72B0", alpha=0.85)
-            ax.axvspan(
-                summary.eti_95_lower,
-                summary.eti_95_upper,
-                color="#4C72B0",
-                alpha=0.15,
-                label="95% ETI",
-            )
-            ax.axvline(
-                summary.median,
-                color="#C44E52",
-                linestyle="--",
-                linewidth=1.2,
-                label="median",
-            )
-            ax.legend()
-        else:
-            ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
-        ax.set_title(f"Posterior distribution: {name}")
-        ax.set_xlabel(name)
-        ax.set_ylabel("Density")
-        fig.tight_layout()
-        pdf.savefig(fig)
-        plt.close(fig)
+        _save_histogram_page(
+            pdf,
+            values=samples[:, index],
+            title=f"Posterior distribution: {name}",
+            xlabel=name,
+            ylabel="Density",
+            color="#4C72B0",
+            density=True,
+            interval=(summary.eti_95_lower, summary.eti_95_upper),
+            interval_label="95% ETI",
+            median=summary.median,
+        )
 
 
 def _trace_chain(result: McmcResult) -> tuple[Array, bool]:
@@ -315,31 +384,15 @@ def _save_mcmc_correlation_pages(
     correlated_pairs: list[tuple[int, int, float]],
 ) -> None:
     samples = result.samples
-    for index_x, index_y, correlation in correlated_pairs:
-        values_x = samples[:, index_x]
-        values_y = samples[:, index_y]
-        finite = np.isfinite(values_x) & np.isfinite(values_y)
-        fig, ax = plt.subplots(figsize=(7.5, 5.5))
-        if np.any(finite):
-            image = ax.hist2d(
-                values_x[finite],
-                values_y[finite],
-                bins=40,
-                cmap="Blues",
-            )
-            cbar = fig.colorbar(image[3], ax=ax)
-            cbar.set_label("Samples")
-        else:
-            ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
-        ax.set_title(
-            f"Posterior pair: {parameter_names[index_x]} vs "
-            f"{parameter_names[index_y]} (r = {correlation:.3f})",
+    for pair in correlated_pairs:
+        _save_pair_distribution_page(
+            pdf,
+            samples=samples,
+            parameter_names=parameter_names,
+            pair=pair,
+            title_prefix="Posterior pair",
+            cmap="Blues",
         )
-        ax.set_xlabel(parameter_names[index_x])
-        ax.set_ylabel(parameter_names[index_y])
-        fig.tight_layout()
-        pdf.savefig(fig)
-        plt.close(fig)
 
 
 def write_mcmc_plots(
@@ -424,57 +477,45 @@ def _save_resampling_distribution_pages(
     parameter_names: tuple[str, ...],
 ) -> None:
     for index, name in enumerate(parameter_names):
-        values = _finite_values(samples[:, index]) if samples.size else np.empty(0)
-        fig, ax = plt.subplots(figsize=(7.5, 5.0))
-        if len(values):
-            ax.hist(values, bins="auto", density=True, color="#55A868", alpha=0.85)
-            lower_95, median, upper_95 = np.percentile(values, [2.5, 50.0, 97.5])
-            ax.axvspan(
-                lower_95,
-                upper_95,
-                color="#55A868",
-                alpha=0.15,
-                label="95% percentile",
+        values = samples[:, index] if samples.size else np.empty(0, dtype=float)
+        finite_values = _finite_values(values)
+        interval = None
+        median = None
+        if len(finite_values):
+            lower_95, median, upper_95 = np.percentile(
+                finite_values,
+                [2.5, 50.0, 97.5],
             )
-            ax.axvline(
-                median,
-                color="#C44E52",
-                linestyle="--",
-                linewidth=1.2,
-                label="median",
-            )
-            ax.legend()
-        else:
-            ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
-        ax.set_title(f"Sample distribution: {name}")
-        ax.set_xlabel(name)
-        ax.set_ylabel("Density")
-        fig.tight_layout()
-        pdf.savefig(fig)
-        plt.close(fig)
+            interval = (float(lower_95), float(upper_95))
+            median = float(median)
+        _save_histogram_page(
+            pdf,
+            values=values,
+            title=f"Sample distribution: {name}",
+            xlabel=name,
+            ylabel="Density",
+            color="#55A868",
+            density=True,
+            interval=interval,
+            interval_label="95% percentile",
+            median=median,
+        )
 
 
 def _save_chisqr_distribution_page(pdf: PdfPages, chisqr_values: Array) -> None:
     values = _finite_values(chisqr_values)
-    fig, ax = plt.subplots(figsize=(7.5, 5.0))
-    if len(values):
-        ax.hist(values, bins="auto", color="#8172B3", alpha=0.85)
-        ax.axvline(
-            float(np.median(values)),
-            color="#C44E52",
-            linestyle="--",
-            linewidth=1.2,
-            label="median",
-        )
-        ax.legend()
-    else:
-        ax.text(0.5, 0.5, "No finite chisqr values", ha="center", va="center")
-    ax.set_title("chisqr distribution")
-    ax.set_xlabel("chisqr")
-    ax.set_ylabel("Samples")
-    fig.tight_layout()
-    pdf.savefig(fig)
-    plt.close(fig)
+    median = float(np.median(values)) if len(values) else None
+    _save_histogram_page(
+        pdf,
+        values=values,
+        title="chisqr distribution",
+        xlabel="chisqr",
+        ylabel="Samples",
+        color="#8172B3",
+        density=False,
+        median=median,
+        empty_message="No finite chisqr values",
+    )
 
 
 def _save_resampling_correlation_pages(
@@ -484,31 +525,15 @@ def _save_resampling_correlation_pages(
     parameter_names: tuple[str, ...],
     correlated_pairs: list[tuple[int, int, float]],
 ) -> None:
-    for index_x, index_y, correlation in correlated_pairs:
-        values_x = samples[:, index_x]
-        values_y = samples[:, index_y]
-        finite = np.isfinite(values_x) & np.isfinite(values_y)
-        fig, ax = plt.subplots(figsize=(7.5, 5.5))
-        if np.any(finite):
-            image = ax.hist2d(
-                values_x[finite],
-                values_y[finite],
-                bins=40,
-                cmap="Greens",
-            )
-            cbar = fig.colorbar(image[3], ax=ax)
-            cbar.set_label("Samples")
-        else:
-            ax.text(0.5, 0.5, "No finite samples", ha="center", va="center")
-        ax.set_title(
-            f"Sample pair: {parameter_names[index_x]} vs "
-            f"{parameter_names[index_y]} (r = {correlation:.3f})",
+    for pair in correlated_pairs:
+        _save_pair_distribution_page(
+            pdf,
+            samples=samples,
+            parameter_names=parameter_names,
+            pair=pair,
+            title_prefix="Sample pair",
+            cmap="Greens",
         )
-        ax.set_xlabel(parameter_names[index_x])
-        ax.set_ylabel(parameter_names[index_y])
-        fig.tight_layout()
-        pdf.savefig(fig)
-        plt.close(fig)
 
 
 def write_resampling_plots(

--- a/tests/configuration/test_methods.py
+++ b/tests/configuration/test_methods.py
@@ -11,7 +11,7 @@ def test_statistics_parse_mcmc_short_form() -> None:
 
     assert statistics.mcmc is not None
     assert statistics.mcmc.steps == 5000
-    assert statistics.mcmc.burn == 0
+    assert statistics.mcmc.burn == "auto"
     assert statistics.mcmc.thin == 1
 
 
@@ -44,3 +44,12 @@ def test_statistics_parse_mcmc_expanded_form() -> None:
 def test_statistics_rejects_mcmc_burn_greater_than_steps() -> None:
     with pytest.raises(ValidationError, match="burn must be smaller than steps"):
         Statistics.model_validate({"MCMC": {"STEPS": 100, "BURN": 100}})
+
+
+def test_statistics_parse_mcmc_auto_burn_case_insensitive() -> None:
+    statistics = Statistics.model_validate(
+        {"MCMC": {"STEPS": 100, "BURN": "AUTO"}},
+    )
+
+    assert statistics.mcmc is not None
+    assert statistics.mcmc.burn == "auto"

--- a/tests/configuration/test_methods.py
+++ b/tests/configuration/test_methods.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from chemex.configuration.methods import Method, Statistics
+
+
+def test_statistics_parse_mcmc_short_form() -> None:
+    statistics = Statistics.model_validate({"MCMC": 5000})
+
+    assert statistics.mcmc is not None
+    assert statistics.mcmc.steps == 5000
+    assert statistics.mcmc.burn == 0
+    assert statistics.mcmc.thin == 1
+
+
+def test_statistics_parse_mcmc_expanded_form() -> None:
+    method = Method.model_validate(
+        {
+            "STATISTICS": {
+                "MCMC": {
+                    "STEPS": 5000,
+                    "BURN": 1000,
+                    "THIN": 10,
+                    "WALKERS": 64,
+                    "SEED": 1234,
+                    "WORKERS": 2,
+                },
+            },
+        },
+    )
+
+    assert method.statistics is not None
+    assert method.statistics.mcmc is not None
+    assert method.statistics.mcmc.steps == 5000
+    assert method.statistics.mcmc.burn == 1000
+    assert method.statistics.mcmc.thin == 10
+    assert method.statistics.mcmc.walkers == 64
+    assert method.statistics.mcmc.seed == 1234
+    assert method.statistics.mcmc.workers == 2
+
+
+def test_statistics_rejects_mcmc_burn_greater_than_steps() -> None:
+    with pytest.raises(ValidationError, match="burn must be smaller than steps"):
+        Statistics.model_validate({"MCMC": {"STEPS": 100, "BURN": 100}})

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -451,18 +451,19 @@ def test_run_statistics_uses_session_for_header(
     np.testing.assert_equal(recorded["parameter_store"], session.parameters)
     assert (tmp_path / "monte_carlo.out").read_text(encoding="utf-8") == "# header\n"
     assert (
-        tmp_path / "Statistics" / "MonteCarlo" / "samples.out"
-    ).read_text(encoding="utf-8") == "# header\n"
+        tmp_path / "Statistics" / "MonteCarlo" / "samples.tsv"
+    ).read_text(encoding="utf-8") == "PB\tchisqr\n"
     assert (tmp_path / "Statistics" / "MonteCarlo" / "summary.toml").exists()
-    assert (tmp_path / "Statistics" / "MonteCarlo" / "correlations.out").exists()
+    assert (tmp_path / "Statistics" / "MonteCarlo" / "correlations.tsv").exists()
     diagnostics = (
         tmp_path / "Statistics" / "MonteCarlo" / "diagnostics.toml"
     ).read_text(encoding="utf-8")
     assert 'method = "Monte Carlo"' in diagnostics
     assert "requested_samples = 1" in diagnostics
     assert "completed_samples = 0" in diagnostics
+    assert 'samples_file = "samples.tsv"' in diagnostics
     assert 'summary_file = "summary.toml"' in diagnostics
-    assert 'correlations_file = "correlations.out"' in diagnostics
+    assert 'correlations_file = "correlations.tsv"' in diagnostics
     assert 'legacy_samples_file = "monte_carlo.out"' in diagnostics
 
 
@@ -535,7 +536,7 @@ def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None
     )
 
     summary = (tmp_path / "summary.toml").read_text(encoding="utf-8")
-    correlations = (tmp_path / "correlations.out").read_text(encoding="utf-8")
+    correlations = (tmp_path / "correlations.tsv").read_text(encoding="utf-8")
 
     assert '["PB"]' in summary
     assert 'interval = "95% percentile"' in summary

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -519,17 +519,19 @@ def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None
         },
     )
     samples = np.array([[0.1, 200.0], [0.3, 300.0], [0.5, 400.0]])
+    parameter_names = resampling_module._format_parameter_names(  # noqa: SLF001
+        ["__PB", "__KEX_AB"],
+        store,
+    )
 
     resampling_module._write_resampling_summary(  # noqa: SLF001
         tmp_path,
-        parameter_ids=["__PB", "__KEX_AB"],
-        parameter_store=store,
+        parameter_names=parameter_names,
         samples=samples,
     )
     resampling_module._write_resampling_correlations(  # noqa: SLF001
         tmp_path,
-        parameter_ids=["__PB", "__KEX_AB"],
-        parameter_store=store,
+        parameter_names=parameter_names,
         samples=samples,
     )
 

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -450,6 +450,52 @@ def test_run_statistics_uses_session_for_header(
     np.testing.assert_equal(recorded["parameter_store"], session.parameters)
 
 
+def test_run_statistics_dispatches_mcmc_without_resampling(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    recorded: dict[str, object] = {}
+    session = StubSession()
+    session.parameters = StatisticsParameterStore()
+    experiments = SimpleNamespace(
+        param_ids=["__PB"],
+        parameter_store=session.parameters,
+    )
+
+    def fail_generate_exp_for_statistics(*_args, **_kwargs) -> None:
+        pytest.fail("MCMC should not generate resampled experiments")
+
+    def fake_run_mcmc(
+        experiments_arg: object,
+        params_arg: object,
+        settings_arg: object,
+        path_arg: Path,
+    ) -> None:
+        recorded["experiments"] = experiments_arg
+        recorded["params"] = params_arg
+        recorded["settings"] = settings_arg
+        recorded["path"] = path_arg
+
+    monkeypatch.setattr(
+        fitting_module,
+        "generate_exp_for_statistics",
+        fail_generate_exp_for_statistics,
+    )
+    monkeypatch.setattr(fitting_module, "run_mcmc", fake_run_mcmc)
+
+    fitting_module._run_statistics(  # noqa: SLF001
+        experiments,
+        tmp_path,
+        "leastsq",
+        fitting_module.Statistics(mcmc=100),
+    )
+
+    np.testing.assert_equal(recorded["experiments"], experiments)
+    assert "__PB" in recorded["params"]
+    assert recorded["settings"].steps == 100
+    np.testing.assert_equal(recorded["path"], tmp_path)
+
+
 def test_execute_post_fit_writes_parameters_from_session_store(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -90,7 +90,18 @@ class WriterParameterStore:
 class StatisticsParameterStore(StubParameters):
     def build_lmfit_params(self, param_ids: object) -> dict[str, SimpleNamespace]:
         _ = param_ids
-        return {"__PB": SimpleNamespace(name="PB", vary=True)}
+        return {"__PB": SimpleNamespace(name="__PB", vary=True)}
+
+    def get_parameters(self, param_ids: object) -> dict[str, ParamSetting]:
+        parameters = {
+            "__PB": ParamSetting(ParamName("PB"), value=0.15, vary=True),
+            "__KEX_AB": ParamSetting(ParamName("KEX_AB"), value=250.0, vary=True),
+        }
+        return {
+            param_id: parameter
+            for param_id, parameter in parameters.items()
+            if param_id in set(param_ids)
+        }
 
 
 class FakeExperiments:
@@ -419,7 +430,6 @@ def test_run_statistics_uses_session_for_header(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    recorded: dict[str, object] = {}
     session = StubSession()
     session.parameters = StatisticsParameterStore()
     experiments = SimpleNamespace(
@@ -429,17 +439,6 @@ def test_run_statistics_uses_session_for_header(
 
     monkeypatch.setattr(resampling_module, "track", lambda _iterable, **_kwargs: [])
 
-    def fake_print_header(
-        grid: object,
-        *,
-        parameter_store: object,
-    ) -> str:
-        recorded["grid"] = grid
-        recorded["parameter_store"] = parameter_store
-        return "# header\n"
-
-    monkeypatch.setattr(resampling_module, "print_header", fake_print_header)
-
     fitting_module._run_statistics(  # noqa: SLF001
         experiments,
         tmp_path,
@@ -447,12 +446,10 @@ def test_run_statistics_uses_session_for_header(
         fitting_module.Statistics(mc=1),
     )
 
-    np.testing.assert_equal(recorded["grid"], ["PB"])
-    np.testing.assert_equal(recorded["parameter_store"], session.parameters)
-    assert (tmp_path / "monte_carlo.out").read_text(encoding="utf-8") == "# header\n"
+    assert not (tmp_path / "monte_carlo.out").exists()
     assert (
         tmp_path / "Statistics" / "MonteCarlo" / "samples.tsv"
-    ).read_text(encoding="utf-8") == "PB\tchisqr\n"
+    ).read_text(encoding="utf-8") == "[PB]\tchisqr\n"
     assert (tmp_path / "Statistics" / "MonteCarlo" / "summary.toml").exists()
     assert (tmp_path / "Statistics" / "MonteCarlo" / "correlations.tsv").exists()
     diagnostics = (
@@ -464,7 +461,6 @@ def test_run_statistics_uses_session_for_header(
     assert 'samples_file = "samples.tsv"' in diagnostics
     assert 'summary_file = "summary.toml"' in diagnostics
     assert 'correlations_file = "correlations.tsv"' in diagnostics
-    assert 'legacy_samples_file = "monte_carlo.out"' in diagnostics
 
 
 def test_run_statistics_dispatches_mcmc_without_resampling(

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -13,6 +13,7 @@ from chemex.experiments import builder as builder_module
 from chemex.nmr.basis import Basis
 from chemex.optimize import fitting as fitting_module
 from chemex.optimize import helper as helper_module
+from chemex.optimize import resampling as resampling_module
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
 from chemex.printers import parameters as parameter_printer_module
@@ -426,7 +427,7 @@ def test_run_statistics_uses_session_for_header(
         parameter_store=session.parameters,
     )
 
-    monkeypatch.setattr(fitting_module, "track", lambda _iterable, **_kwargs: [])
+    monkeypatch.setattr(resampling_module, "track", lambda _iterable, **_kwargs: [])
 
     def fake_print_header(
         grid: object,
@@ -437,7 +438,7 @@ def test_run_statistics_uses_session_for_header(
         recorded["parameter_store"] = parameter_store
         return "# header\n"
 
-    monkeypatch.setattr(fitting_module, "print_header", fake_print_header)
+    monkeypatch.setattr(resampling_module, "print_header", fake_print_header)
 
     fitting_module._run_statistics(  # noqa: SLF001
         experiments,
@@ -448,6 +449,21 @@ def test_run_statistics_uses_session_for_header(
 
     np.testing.assert_equal(recorded["grid"], ["PB"])
     np.testing.assert_equal(recorded["parameter_store"], session.parameters)
+    assert (tmp_path / "monte_carlo.out").read_text(encoding="utf-8") == "# header\n"
+    assert (
+        tmp_path / "Statistics" / "MonteCarlo" / "samples.out"
+    ).read_text(encoding="utf-8") == "# header\n"
+    assert (tmp_path / "Statistics" / "MonteCarlo" / "summary.toml").exists()
+    assert (tmp_path / "Statistics" / "MonteCarlo" / "correlations.out").exists()
+    diagnostics = (
+        tmp_path / "Statistics" / "MonteCarlo" / "diagnostics.toml"
+    ).read_text(encoding="utf-8")
+    assert 'method = "Monte Carlo"' in diagnostics
+    assert "requested_samples = 1" in diagnostics
+    assert "completed_samples = 0" in diagnostics
+    assert 'summary_file = "summary.toml"' in diagnostics
+    assert 'correlations_file = "correlations.out"' in diagnostics
+    assert 'legacy_samples_file = "monte_carlo.out"' in diagnostics
 
 
 def test_run_statistics_dispatches_mcmc_without_resampling(
@@ -477,7 +493,7 @@ def test_run_statistics_dispatches_mcmc_without_resampling(
         recorded["path"] = path_arg
 
     monkeypatch.setattr(
-        fitting_module,
+        resampling_module,
         "generate_exp_for_statistics",
         fail_generate_exp_for_statistics,
     )
@@ -494,6 +510,40 @@ def test_run_statistics_dispatches_mcmc_without_resampling(
     assert "__PB" in recorded["params"]
     assert recorded["settings"].steps == 100
     np.testing.assert_equal(recorded["path"], tmp_path)
+
+
+def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None:
+    store = WriterParameterStore(
+        {
+            "__PB": ParamSetting(ParamName("PB"), value=0.15, vary=True),
+            "__KEX_AB": ParamSetting(ParamName("KEX_AB"), value=250.0, vary=True),
+        },
+    )
+    samples = np.array([[0.1, 200.0], [0.3, 300.0], [0.5, 400.0]])
+
+    resampling_module._write_resampling_summary(  # noqa: SLF001
+        tmp_path,
+        parameter_ids=["__PB", "__KEX_AB"],
+        parameter_store=store,
+        samples=samples,
+    )
+    resampling_module._write_resampling_correlations(  # noqa: SLF001
+        tmp_path,
+        parameter_ids=["__PB", "__KEX_AB"],
+        parameter_store=store,
+        samples=samples,
+    )
+
+    summary = (tmp_path / "summary.toml").read_text(encoding="utf-8")
+    correlations = (tmp_path / "correlations.out").read_text(encoding="utf-8")
+
+    assert '["PB"]' in summary
+    assert 'interval = "95% percentile"' in summary
+    assert "sample_count = 3" in summary
+    assert "median = 3.00000e-01" in summary
+    assert "[PB]" in correlations
+    assert "[KEX_AB]" in correlations
+    assert "1.00000e+00" in correlations
 
 
 def test_execute_post_fit_writes_parameters_from_session_store(

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -452,6 +452,7 @@ def test_run_statistics_uses_session_for_header(
     ).read_text(encoding="utf-8") == "[PB]\tchisqr\n"
     assert (tmp_path / "Statistics" / "MonteCarlo" / "summary.toml").exists()
     assert (tmp_path / "Statistics" / "MonteCarlo" / "correlations.tsv").exists()
+    assert (tmp_path / "Statistics" / "MonteCarlo" / "plots.pdf").stat().st_size > 0
     diagnostics = (
         tmp_path / "Statistics" / "MonteCarlo" / "diagnostics.toml"
     ).read_text(encoding="utf-8")
@@ -461,6 +462,7 @@ def test_run_statistics_uses_session_for_header(
     assert 'samples_file = "samples.tsv"' in diagnostics
     assert 'summary_file = "summary.toml"' in diagnostics
     assert 'correlations_file = "correlations.tsv"' in diagnostics
+    assert 'plots_file = "plots.pdf"' in diagnostics
 
 
 def test_run_statistics_dispatches_mcmc_without_resampling(

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -11,6 +11,7 @@ from chemex.optimize.mcmc import (
     EffectiveMcmcSettings,
     McmcResult,
     McmcSummary,
+    _apply_sample_window,
     resolve_mcmc_settings,
     run_mcmc,
     write_mcmc_outputs,
@@ -22,8 +23,13 @@ from chemex.parameters.setting import ParamSetting
 class DummyParameterStore:
     def __init__(self) -> None:
         self.parameters = {
-            "__PB": ParamSetting(ParamName("PB"), value=0.1),
-            "__KEX_AB": ParamSetting(ParamName("KEX_AB"), value=200.0),
+            "__PB": ParamSetting(ParamName("PB"), value=0.1, min=0.0, max=1.0),
+            "__KEX_AB": ParamSetting(
+                ParamName("KEX_AB"),
+                value=200.0,
+                min=1.0,
+                max=5000.0,
+            ),
         }
         self.updated = False
 
@@ -51,6 +57,7 @@ def test_resolve_mcmc_settings_defaults_walkers_from_varying_parameters() -> Non
     settings = resolve_mcmc_settings(McmcSettings(steps=100), nvarys=3)
 
     assert settings.walkers == 32
+    assert settings.burn == "auto"
 
 
 def test_resolve_mcmc_settings_rejects_too_few_walkers() -> None:
@@ -72,11 +79,48 @@ def test_run_mcmc_skips_when_no_parameters_vary() -> None:
     assert result is None
 
 
+def test_apply_sample_window_uses_auto_burn_from_autocorrelation_time() -> None:
+    chain = np.arange(20.0).reshape(10, 2, 1)
+    lnprob = np.arange(20.0).reshape(10, 2)
+
+    retained_chain, retained_lnprob, discarded_steps, warning = _apply_sample_window(
+        chain,
+        lnprob,
+        burn="auto",
+        thin=2,
+        autocorrelation_time=np.array([1.6]),
+    )
+
+    assert discarded_steps == 4
+    assert warning is None
+    assert retained_chain.shape == (3, 2, 1)
+    assert np.array_equal(retained_chain[:, :, 0], chain[4::2, :, 0])
+    assert np.array_equal(retained_lnprob, lnprob[4::2])
+
+
+def test_apply_sample_window_keeps_samples_when_auto_burn_unavailable() -> None:
+    chain = np.arange(12.0).reshape(3, 2, 2)
+    lnprob = np.arange(6.0).reshape(3, 2)
+
+    retained_chain, retained_lnprob, discarded_steps, warning = _apply_sample_window(
+        chain,
+        lnprob,
+        burn="auto",
+        thin=1,
+        autocorrelation_time=None,
+    )
+
+    assert discarded_steps == 0
+    assert "autocorrelation time unavailable" in str(warning)
+    assert np.array_equal(retained_chain, chain)
+    assert np.array_equal(retained_lnprob, lnprob)
+
+
 def test_write_mcmc_outputs(tmp_path: Path) -> None:
     store = DummyParameterStore()
     settings = EffectiveMcmcSettings(
         steps=4,
-        burn=1,
+        burn="auto",
         thin=1,
         walkers=2,
         seed=1234,
@@ -93,12 +137,38 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
         ),
         lnprob=np.array([[-1.0, -2.0], [-3.0, -4.0]]),
         summary=(
-            McmcSummary("__PB", 0.25, 0.12, 0.38, 0.13),
-            McmcSummary("__KEX_AB", 275.0, 210.0, 340.0, 65.0),
+            McmcSummary(
+                parameter_id="__PB",
+                mean=0.25,
+                standard_deviation=0.13,
+                median=0.25,
+                eti_95_lower=0.11,
+                eti_95_upper=0.39,
+                lower_1sigma=0.12,
+                upper_1sigma=0.38,
+                stderr=0.13,
+                effective_sample_size=2.0,
+                mcse_mean=0.09,
+            ),
+            McmcSummary(
+                parameter_id="__KEX_AB",
+                mean=275.0,
+                standard_deviation=65.0,
+                median=275.0,
+                eti_95_lower=205.0,
+                eti_95_upper=345.0,
+                lower_1sigma=210.0,
+                upper_1sigma=340.0,
+                stderr=65.0,
+                effective_sample_size=1.3333333333,
+                mcse_mean=56.2916512459,
+            ),
         ),
         correlations=np.array([[1.0, 0.5], [0.5, 1.0]]),
         acceptance_fraction=np.array([0.25, 0.50]),
         autocorrelation_time=np.array([2.0, 3.0]),
+        discarded_steps=1,
+        burn_in_warning=None,
     )
 
     write_mcmc_outputs(
@@ -119,11 +189,21 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
     )
 
     assert '["PB"]' in summary
+    assert 'prior = "uniform"' in summary
+    assert "prior_lower = 0.00000e+00" in summary
+    assert 'credible_interval = "95% equal-tailed"' in summary
     assert "median = 2.50000e-01" in summary
+    assert "eti_95_lower = 1.10000e-01" in summary
+    assert "effective_sample_size = 2.00000e+00" in summary
     assert "# [PB] [KEX_AB] [lnprob]" in samples
     assert "2.00000e-01  2.50000e+02 -2.00000e+00" in samples
     assert "[PB]" in correlations
     assert "5.00000e-01" in correlations
+    assert 'sampler = "emcee via lmfit.Minimizer.emcee"' in diagnostics
+    assert 'requested_burn = "auto"' in diagnostics
+    assert "discarded_steps = 1" in diagnostics
+    assert "retained_steps = 2" in diagnostics
     assert "retained_samples = 4" in diagnostics
+    assert "min_effective_sample_size = 1.33333e+00" in diagnostics
     assert 'unbounded_parameters = ["[KEX_AB]"]' in diagnostics
     assert "autocorrelation_time = [2.00000e+00, 3.00000e+00]" in diagnostics

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import lmfit
+import numpy as np
+import pytest
+
+from chemex.configuration.methods import McmcSettings
+from chemex.optimize.mcmc import (
+    EffectiveMcmcSettings,
+    McmcResult,
+    McmcSummary,
+    resolve_mcmc_settings,
+    run_mcmc,
+    write_mcmc_outputs,
+)
+from chemex.parameters.name import ParamName
+from chemex.parameters.setting import ParamSetting
+
+
+class DummyParameterStore:
+    def __init__(self) -> None:
+        self.parameters = {
+            "__PB": ParamSetting(ParamName("PB"), value=0.1),
+            "__KEX_AB": ParamSetting(ParamName("KEX_AB"), value=200.0),
+        }
+        self.updated = False
+
+    def get_parameters(self, param_ids: tuple[str, ...]) -> dict[str, ParamSetting]:
+        return {
+            param_id: parameter
+            for param_id, parameter in self.parameters.items()
+            if param_id in param_ids
+        }
+
+    def update_from_parameters(self, _params: lmfit.Parameters) -> None:
+        self.updated = True
+
+
+class DummyExperiments:
+    def __init__(self) -> None:
+        self.parameter_store = DummyParameterStore()
+
+    def residuals(self, _params: lmfit.Parameters) -> np.ndarray:
+        msg = "Sampler should not run"
+        raise AssertionError(msg)
+
+
+def test_resolve_mcmc_settings_defaults_walkers_from_varying_parameters() -> None:
+    settings = resolve_mcmc_settings(McmcSettings(steps=100), nvarys=3)
+
+    assert settings.walkers == 32
+
+
+def test_resolve_mcmc_settings_rejects_too_few_walkers() -> None:
+    with pytest.raises(ValueError, match="at least 6 walkers"):
+        resolve_mcmc_settings(McmcSettings(steps=100, walkers=5), nvarys=3)
+
+
+def test_run_mcmc_skips_when_no_parameters_vary() -> None:
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, vary=False)
+
+    result = run_mcmc(
+        DummyExperiments(),
+        params,
+        McmcSettings(steps=100),
+        Path("unused"),
+    )
+
+    assert result is None
+
+
+def test_write_mcmc_outputs(tmp_path: Path) -> None:
+    store = DummyParameterStore()
+    settings = EffectiveMcmcSettings(
+        steps=4,
+        burn=1,
+        thin=1,
+        walkers=2,
+        seed=1234,
+        workers=1,
+        update_parameters=False,
+    )
+    result = McmcResult(
+        var_names=("__PB", "__KEX_AB"),
+        chain=np.array(
+            [
+                [[0.10, 200.0], [0.20, 250.0]],
+                [[0.30, 300.0], [0.40, 350.0]],
+            ],
+        ),
+        lnprob=np.array([[-1.0, -2.0], [-3.0, -4.0]]),
+        summary=(
+            McmcSummary("__PB", 0.25, 0.12, 0.38, 0.13),
+            McmcSummary("__KEX_AB", 275.0, 210.0, 340.0, 65.0),
+        ),
+        correlations=np.array([[1.0, 0.5], [0.5, 1.0]]),
+        acceptance_fraction=np.array([0.25, 0.50]),
+        autocorrelation_time=np.array([2.0, 3.0]),
+    )
+
+    write_mcmc_outputs(
+        result,
+        settings,
+        tmp_path,
+        store,
+        unbounded_parameter_ids=("__KEX_AB",),
+    )
+
+    summary = (tmp_path / "MCMC" / "summary.toml").read_text(encoding="utf-8")
+    samples = (tmp_path / "MCMC" / "samples.out").read_text(encoding="utf-8")
+    correlations = (tmp_path / "MCMC" / "correlations.out").read_text(
+        encoding="utf-8",
+    )
+    diagnostics = (tmp_path / "MCMC" / "diagnostics.toml").read_text(
+        encoding="utf-8",
+    )
+
+    assert '["PB"]' in summary
+    assert "median = 2.50000e-01" in summary
+    assert "# [PB] [KEX_AB] [lnprob]" in samples
+    assert "2.00000e-01  2.50000e+02 -2.00000e+00" in samples
+    assert "[PB]" in correlations
+    assert "5.00000e-01" in correlations
+    assert "retained_samples = 4" in diagnostics
+    assert 'unbounded_parameters = ["[KEX_AB]"]' in diagnostics
+    assert "autocorrelation_time = [2.00000e+00, 3.00000e+00]" in diagnostics

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -179,12 +179,13 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
         unbounded_parameter_ids=("__KEX_AB",),
     )
 
-    summary = (tmp_path / "MCMC" / "summary.toml").read_text(encoding="utf-8")
-    samples = (tmp_path / "MCMC" / "samples.out").read_text(encoding="utf-8")
-    correlations = (tmp_path / "MCMC" / "correlations.out").read_text(
+    path_mcmc = tmp_path / "Statistics" / "MCMC"
+    summary = (path_mcmc / "summary.toml").read_text(encoding="utf-8")
+    samples = (path_mcmc / "samples.out").read_text(encoding="utf-8")
+    correlations = (path_mcmc / "correlations.out").read_text(
         encoding="utf-8",
     )
-    diagnostics = (tmp_path / "MCMC" / "diagnostics.toml").read_text(
+    diagnostics = (path_mcmc / "diagnostics.toml").read_text(
         encoding="utf-8",
     )
 

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -181,8 +181,8 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
 
     path_mcmc = tmp_path / "Statistics" / "MCMC"
     summary = (path_mcmc / "summary.toml").read_text(encoding="utf-8")
-    samples = (path_mcmc / "samples.out").read_text(encoding="utf-8")
-    correlations = (path_mcmc / "correlations.out").read_text(
+    samples = (path_mcmc / "samples.tsv").read_text(encoding="utf-8")
+    correlations = (path_mcmc / "correlations.tsv").read_text(
         encoding="utf-8",
     )
     diagnostics = (path_mcmc / "diagnostics.toml").read_text(
@@ -196,11 +196,13 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
     assert "median = 2.50000e-01" in summary
     assert "eti_95_lower = 1.10000e-01" in summary
     assert "effective_sample_size = 2.00000e+00" in summary
-    assert "# [PB] [KEX_AB] [lnprob]" in samples
-    assert "2.00000e-01  2.50000e+02 -2.00000e+00" in samples
+    assert "[PB]\t[KEX_AB]\tlnprob" in samples
+    assert "2.00000e-01\t2.50000e+02\t-2.00000e+00" in samples
     assert "[PB]" in correlations
     assert "5.00000e-01" in correlations
     assert 'sampler = "emcee via lmfit.Minimizer.emcee"' in diagnostics
+    assert 'samples_file = "samples.tsv"' in diagnostics
+    assert 'correlations_file = "correlations.tsv"' in diagnostics
     assert 'requested_burn = "auto"' in diagnostics
     assert "discarded_steps = 1" in diagnostics
     assert "retained_steps = 2" in diagnostics

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -210,3 +210,5 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
     assert "min_effective_sample_size = 1.33333e+00" in diagnostics
     assert 'unbounded_parameters = ["[KEX_AB]"]' in diagnostics
     assert "autocorrelation_time = [2.00000e+00, 3.00000e+00]" in diagnostics
+    assert 'plots_file = "plots.pdf"' in diagnostics
+    assert (path_mcmc / "plots.pdf").stat().st_size > 0

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import lmfit
 import numpy as np
 import pytest
+from emcee.autocorr import AutocorrError
 
 from chemex.configuration.methods import McmcSettings
+from chemex.optimize import mcmc as mcmc_module
 from chemex.optimize.mcmc import (
     EffectiveMcmcSettings,
     McmcResult,
     McmcSummary,
     _apply_sample_window,
+    _result_from_lmfit,
     resolve_mcmc_settings,
     run_mcmc,
     write_mcmc_outputs,
@@ -116,6 +120,50 @@ def test_apply_sample_window_keeps_samples_when_auto_burn_unavailable() -> None:
     assert np.array_equal(retained_lnprob, lnprob)
 
 
+def test_result_from_lmfit_uses_tentative_tau_for_auto_burn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chain = np.arange(20.0).reshape(10, 2, 1)
+    lnprob = np.arange(20.0).reshape(10, 2)
+    settings = EffectiveMcmcSettings(
+        steps=10,
+        burn="auto",
+        thin=1,
+        walkers=2,
+        seed=None,
+        workers=1,
+        update_parameters=False,
+    )
+
+    def raise_autocorr_error(_chain: np.ndarray, *, quiet: bool) -> np.ndarray:
+        _ = quiet
+        raise AutocorrError(np.array([1.6]), "short chain")
+
+    monkeypatch.setattr(
+        mcmc_module.emcee_autocorr,
+        "integrated_time",
+        raise_autocorr_error,
+    )
+
+    result = _result_from_lmfit(
+        SimpleNamespace(
+            var_names=("__PB",),
+            chain=chain,
+            lnprob=lnprob,
+            acceptance_fraction=np.array([0.25, 0.5]),
+        ),
+        settings,
+    )
+
+    assert result.autocorrelation_time is None
+    assert result.tentative_autocorrelation_time is not None
+    assert np.array_equal(result.tentative_autocorrelation_time, np.array([1.6]))
+    assert result.discarded_steps == 4
+    assert "tentative automatic burn-in was applied" in str(result.burn_in_warning)
+    assert "shorter than 50 times" in str(result.autocorrelation_warning)
+    assert result.summary[0].effective_sample_size is None
+
+
 def test_write_mcmc_outputs(tmp_path: Path) -> None:
     store = DummyParameterStore()
     settings = EffectiveMcmcSettings(
@@ -210,5 +258,73 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
     assert "min_effective_sample_size = 1.33333e+00" in diagnostics
     assert 'unbounded_parameters = ["[KEX_AB]"]' in diagnostics
     assert "autocorrelation_time = [2.00000e+00, 3.00000e+00]" in diagnostics
+    assert 'autocorrelation_status = "reliable"' in diagnostics
+    assert "recommended_min_steps_50tau = 150" in diagnostics
     assert 'plots_file = "plots.pdf"' in diagnostics
     assert (path_mcmc / "plots.pdf").stat().st_size > 0
+
+
+def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
+    tmp_path: Path,
+) -> None:
+    store = DummyParameterStore()
+    settings = EffectiveMcmcSettings(
+        steps=10,
+        burn="auto",
+        thin=1,
+        walkers=2,
+        seed=None,
+        workers=1,
+        update_parameters=False,
+    )
+    result = McmcResult(
+        var_names=("__PB",),
+        chain=np.array([[[0.30], [0.40]], [[0.50], [0.60]]]),
+        lnprob=np.array([[-3.0, -4.0], [-5.0, -6.0]]),
+        summary=(
+            McmcSummary(
+                parameter_id="__PB",
+                mean=0.45,
+                standard_deviation=0.13,
+                median=0.45,
+                eti_95_lower=0.31,
+                eti_95_upper=0.59,
+                lower_1sigma=0.32,
+                upper_1sigma=0.58,
+                stderr=0.13,
+            ),
+        ),
+        correlations=np.array([[1.0]]),
+        acceptance_fraction=np.array([0.25, 0.50]),
+        autocorrelation_time=None,
+        discarded_steps=4,
+        burn_in_warning=(
+            "autocorrelation time estimate is unreliable; "
+            "tentative automatic burn-in was applied"
+        ),
+        tentative_autocorrelation_time=np.array([1.6]),
+        autocorrelation_warning=(
+            "chain shorter than 50 times the autocorrelation time; "
+            "tentative estimate reported"
+        ),
+        raw_chain=np.arange(20.0).reshape(10, 2, 1),
+        raw_lnprob=np.arange(20.0).reshape(10, 2),
+    )
+
+    write_mcmc_outputs(result, settings, tmp_path, store)
+
+    diagnostics = (
+        tmp_path / "Statistics" / "MCMC" / "diagnostics.toml"
+    ).read_text(encoding="utf-8")
+    summary = (tmp_path / "Statistics" / "MCMC" / "summary.toml").read_text(
+        encoding="utf-8",
+    )
+
+    assert "effective_sample_size" not in summary
+    assert 'autocorrelation_status = "unreliable_short_chain"' in diagnostics
+    assert "autocorrelation_time_tentative = [1.60000e+00]" in diagnostics
+    assert "max_autocorrelation_time_tentative = 1.60000e+00" in diagnostics
+    assert "steps_over_max_autocorrelation_time = 6.25000e+00" in diagnostics
+    assert "recommended_min_steps_50tau = 80" in diagnostics
+    assert "recommended_min_steps_100tau = 160" in diagnostics
+    assert "effective_sample_size_warning" in diagnostics

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -235,9 +235,12 @@ WORKERS = 1
 `BURN` defaults to `"AUTO"`. In automatic mode, ChemEx uses the integrated
 autocorrelation time reported by the sampler and discards twice the largest
 autocorrelation time when that estimate is available and shorter than the chain.
-If autocorrelation time cannot be estimated reliably, ChemEx keeps the full chain
-and records the reason in `diagnostics.toml`. A numeric `BURN` value can still be
-provided to discard a fixed number of initial sampler steps.
+If the chain is too short for emcee's reliability threshold but still provides a
+tentative autocorrelation estimate, ChemEx uses that tentative estimate for
+automatic burn-in and records the warning in `diagnostics.toml`. If
+autocorrelation time cannot be estimated at all, ChemEx keeps the full chain and
+records the reason. A numeric `BURN` value can still be provided to discard a
+fixed number of initial sampler steps.
 
 `THIN` defaults to `1`, which keeps every retained sample. Thinning is mainly a
 storage and output-size control; it is usually better to keep all post-burn-in
@@ -275,4 +278,4 @@ Statistics/
 
 For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`. Their `plots.pdf` reports provide a summary page, one-dimensional sample distributions, a χ² distribution, and two-dimensional sample distributions for parameter pairs with `|r| >= 0.5`.
 
-For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions. The `plots.pdf` report provides a summary page, one-dimensional posterior distributions, walker traces, the log-probability trace, and two-dimensional posterior distributions for parameter pairs with `|r| >= 0.5`.
+For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when the autocorrelation estimate passes emcee's reliability threshold. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, reliable or tentative autocorrelation time, recommended chain lengths, and burn-in decisions. The `plots.pdf` report provides a summary page, one-dimensional posterior distributions, walker traces, the log-probability trace, an autocorrelation monitor, and two-dimensional posterior distributions for parameter pairs with `|r| >= 0.5`.

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -252,16 +252,19 @@ Statistics/
     samples.tsv
     correlations.tsv
     diagnostics.toml
+    plots.pdf
   Bootstrap/
     summary.toml
     samples.tsv
     correlations.tsv
     diagnostics.toml
+    plots.pdf
   BootstrapNS/
     summary.toml
     samples.tsv
     correlations.tsv
     diagnostics.toml
+    plots.pdf
   MCMC/
     summary.toml
     samples.tsv
@@ -270,6 +273,6 @@ Statistics/
     plots.pdf
 ```
 
-For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`.
+For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`. Their `plots.pdf` reports provide a summary page, one-dimensional sample distributions, a χ² distribution, and two-dimensional sample distributions for parameter pairs with `|r| >= 0.5`.
 
 For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions. The `plots.pdf` report provides a summary page, one-dimensional posterior distributions, walker traces, the log-probability trace, and two-dimensional posterior distributions for parameter pairs with `|r| >= 0.5`.

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -243,6 +243,32 @@ provided to discard a fixed number of initial sampler steps.
 storage and output-size control; it is usually better to keep all post-burn-in
 samples unless the output files become too large.
 
-Outputs are stored in a file in the corresponding step directory. When data is unavailable (e.g., in nucleus-specific bootstrap), placeholders (`"--"`) are used.
+Sampling outputs are stored under a `Statistics` directory in the corresponding step or group output directory:
 
-MCMC outputs are stored in a dedicated `MCMC` directory containing `summary.toml`, `samples.out`, `correlations.out`, and `diagnostics.toml`. The summary reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. Diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions.
+```text
+Statistics/
+  MonteCarlo/
+    summary.toml
+    samples.out
+    correlations.out
+    diagnostics.toml
+  Bootstrap/
+    summary.toml
+    samples.out
+    correlations.out
+    diagnostics.toml
+  BootstrapNS/
+    summary.toml
+    samples.out
+    correlations.out
+    diagnostics.toml
+  MCMC/
+    summary.toml
+    samples.out
+    correlations.out
+    diagnostics.toml
+```
+
+For Monte Carlo and bootstrap methods, `samples.out` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.out` reports parameter correlations across the fitted synthetic datasets. When data is unavailable (e.g., in nucleus-specific bootstrap), placeholders (`"--"`) are used. ChemEx also writes the legacy top-level `monte_carlo.out`, `bootstrap.out`, and `bootstrap_ns.out` files for compatibility.
+
+For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions.

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -267,8 +267,9 @@ Statistics/
     samples.tsv
     correlations.tsv
     diagnostics.toml
+    plots.pdf
 ```
 
 For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`.
 
-For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions.
+For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions. The `plots.pdf` report provides a summary page, one-dimensional posterior distributions, walker traces, the log-probability trace, and two-dimensional posterior distributions for parameter pairs with `|r| >= 0.5`.

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -269,6 +269,6 @@ Statistics/
     diagnostics.toml
 ```
 
-For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`. ChemEx also writes the legacy top-level `monte_carlo.out`, `bootstrap.out`, and `bootstrap_ns.out` files for compatibility.
+For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`.
 
 For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions.

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -225,13 +225,24 @@ Advanced MCMC settings can be provided as a nested table:
 ```toml
 [STEP1.STATISTICS.MCMC]
 STEPS = 5000
-BURN = 1000
-THIN = 10
+BURN = "AUTO"
+THIN = 1
 WALKERS = 64
 SEED = 1234
 WORKERS = 1
 ```
 
+`BURN` defaults to `"AUTO"`. In automatic mode, ChemEx uses the integrated
+autocorrelation time reported by the sampler and discards twice the largest
+autocorrelation time when that estimate is available and shorter than the chain.
+If autocorrelation time cannot be estimated reliably, ChemEx keeps the full chain
+and records the reason in `diagnostics.toml`. A numeric `BURN` value can still be
+provided to discard a fixed number of initial sampler steps.
+
+`THIN` defaults to `1`, which keeps every retained sample. Thinning is mainly a
+storage and output-size control; it is usually better to keep all post-burn-in
+samples unless the output files become too large.
+
 Outputs are stored in a file in the corresponding step directory. When data is unavailable (e.g., in nucleus-specific bootstrap), placeholders (`"--"`) are used.
 
-MCMC outputs are stored in a dedicated `MCMC` directory containing `summary.toml`, `samples.out`, `correlations.out`, and `diagnostics.toml`.
+MCMC outputs are stored in a dedicated `MCMC` directory containing `summary.toml`, `samples.out`, `correlations.out`, and `diagnostics.toml`. The summary reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. Diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions.

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -166,7 +166,7 @@ Results are stored in the `grid.toml` file, with 1D and 2D plots generated. If m
 
 ## Estimating Parameter Uncertainty
 
-ChemEx offers additional methods for estimating uncertainty, including Monte Carlo, bootstrap, and nucleus-specific bootstrap analyses.
+ChemEx offers additional methods for estimating uncertainty, including Monte Carlo, bootstrap, nucleus-specific bootstrap, and MCMC analyses.
 
 ### Monte Carlo Simulations
 
@@ -184,6 +184,12 @@ In nucleus-specific bootstrap, profiles are resampled based on the associated nu
 Nucleus-specific bootstrap can create datasets of varying sizes, unlike standard bootstrap analysis.
 :::
 
+### MCMC Analysis
+
+MCMC analysis samples the posterior distribution after the normal fit has converged. It uses the fitted parameters as the starting point, ChemEx's weighted residuals as the likelihood, and the parameter bounds as uniform priors.
+
+For meaningful MCMC results, set finite lower and upper bounds for the fitted parameters in the parameter file. Parameters without finite bounds are still accepted, but ChemEx will print a warning because the implied prior is weakly constrained.
+
 ### Syntax
 
 Run these analyses at the end of any fitting step using the `STATISTICS` key.
@@ -198,6 +204,7 @@ Available types:
 -   `"MC"` for Monte Carlo
 -   `"BS"` for bootstrap
 -   `"BSN"` for nucleus-specific bootstrap
+-   `"MCMC"` for posterior sampling with MCMC
 
 To perform multiple analyses:
 
@@ -206,4 +213,25 @@ To perform multiple analyses:
 STATISTICS = {"MC"= 100, "BS"= 100}
 ```
 
+For MCMC, the compact form sets the number of sampler steps:
+
+```toml
+[STEP1]
+STATISTICS = {"MCMC"= 5000}
+```
+
+Advanced MCMC settings can be provided as a nested table:
+
+```toml
+[STEP1.STATISTICS.MCMC]
+STEPS = 5000
+BURN = 1000
+THIN = 10
+WALKERS = 64
+SEED = 1234
+WORKERS = 1
+```
+
 Outputs are stored in a file in the corresponding step directory. When data is unavailable (e.g., in nucleus-specific bootstrap), placeholders (`"--"`) are used.
+
+MCMC outputs are stored in a dedicated `MCMC` directory containing `summary.toml`, `samples.out`, `correlations.out`, and `diagnostics.toml`.

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -249,26 +249,26 @@ Sampling outputs are stored under a `Statistics` directory in the corresponding 
 Statistics/
   MonteCarlo/
     summary.toml
-    samples.out
-    correlations.out
+    samples.tsv
+    correlations.tsv
     diagnostics.toml
   Bootstrap/
     summary.toml
-    samples.out
-    correlations.out
+    samples.tsv
+    correlations.tsv
     diagnostics.toml
   BootstrapNS/
     summary.toml
-    samples.out
-    correlations.out
+    samples.tsv
+    correlations.tsv
     diagnostics.toml
   MCMC/
     summary.toml
-    samples.out
-    correlations.out
+    samples.tsv
+    correlations.tsv
     diagnostics.toml
 ```
 
-For Monte Carlo and bootstrap methods, `samples.out` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.out` reports parameter correlations across the fitted synthetic datasets. When data is unavailable (e.g., in nucleus-specific bootstrap), placeholders (`"--"`) are used. ChemEx also writes the legacy top-level `monte_carlo.out`, `bootstrap.out`, and `bootstrap_ns.out` files for compatibility.
+For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`. ChemEx also writes the legacy top-level `monte_carlo.out`, `bootstrap.out`, and `bootstrap_ns.out` files for compatibility.
 
 For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when autocorrelation time is available. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, autocorrelation time, and burn-in decisions.

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -134,6 +134,6 @@ Contains goodness-of-fit statistics, such as χ<sup>2</sup>.
 
 Contains optional uncertainty-analysis outputs requested with the `STATISTICS`
 method-file key. Monte Carlo and bootstrap methods write `summary.toml`,
-`samples.out`, `correlations.out`, and `diagnostics.toml` under
+`samples.tsv`, `correlations.tsv`, and `diagnostics.toml` under
 `Statistics/MonteCarlo/`, `Statistics/Bootstrap/`, and `Statistics/BootstrapNS/`.
 MCMC writes the same file set under `Statistics/MCMC/`.

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -129,3 +129,11 @@ Contains goodness-of-fit statistics, such as χ<sup>2</sup>.
 "reduced-chi-square"                   =  2.04143e+00
 "Akaike Information Criterion (AIC)"   =  1.80479e+02
 ```
+
+### `Statistics/`
+
+Contains optional uncertainty-analysis outputs requested with the `STATISTICS`
+method-file key. Monte Carlo and bootstrap methods write `summary.toml`,
+`samples.out`, `correlations.out`, and `diagnostics.toml` under
+`Statistics/MonteCarlo/`, `Statistics/Bootstrap/`, and `Statistics/BootstrapNS/`.
+MCMC writes the same file set under `Statistics/MCMC/`.


### PR DESCRIPTION
## Summary

This PR implements MCMC-based parameter uncertainty as a `STATISTICS` method in ChemEx and regularizes sampling output for all `STATISTICS` methods.

MCMC remains a post-fit uncertainty analysis, not a replacement for the deterministic fit. Sampler-specific code is isolated in `chemex.optimize.mcmc`, shared statistics visual reporting is isolated in `chemex.optimize.statistics_plot`, and resampling output handling for existing Monte Carlo/bootstrap methods is isolated in `chemex.optimize.resampling`.

## Reporting and MCMC Choices

The reporting/output choices follow Bayesian reporting guidance and MCMC diagnostics best practices while keeping ChemEx changes focused:

- Report the uniform prior implied by each varied parameter's bounds.
- Report posterior mean, standard deviation, median, 95% equal-tailed credible interval, and the existing 68.26% interval used for `stderr`.
- Report ESS and Monte Carlo standard error only when the integrated autocorrelation estimate passes emcee's reliability threshold.
- Use tentative short-chain autocorrelation estimates for `BURN = "AUTO"` when emcee reports them, but keep them clearly labeled as unreliable and do not use them for strict ESS/MCSE reporting.
- Report sampler/software metadata, acceptance fractions, retained sample counts, reliable or tentative autocorrelation time, recommended chain lengths, and burn-in decisions in `diagnostics.toml`.
- Write a derived `plots.pdf` visual report for every statistics method. Monte Carlo/bootstrap reports include summary, 1D sample distributions, chi-square distribution, and 2D sample distributions for parameter pairs with `|r| >= 0.5`; MCMC additionally includes walker traces, the log-probability trace, and an autocorrelation monitor page.
- Show MCMC sampler progress through ChemEx/Rich progress output.
- Do not compute R-hat for the emcee ensemble, because walkers from the same ensemble are not independent chains; diagnostics record this explicitly.
- Default `BURN` to `"AUTO"`: ChemEx runs the sampler once, estimates autocorrelation time from the full chain, and discards `ceil(2 * max(tau))` steps when a reliable or tentative usable tau estimate is available and shorter than the chain. If autocorrelation time is unavailable or unusable, it keeps the full chain and records a warning.
- Default `THIN` to `1`: thinning is treated as an explicit output/storage control, not as a convergence fix.

## Output Layout

Sampling outputs now use a canonical `Statistics/<method>/` directory under the current step/group output path:

```text
Statistics/
  MonteCarlo/
    summary.toml
    samples.tsv
    correlations.tsv
    diagnostics.toml
    plots.pdf
  Bootstrap/
    summary.toml
    samples.tsv
    correlations.tsv
    diagnostics.toml
    plots.pdf
  BootstrapNS/
    summary.toml
    samples.tsv
    correlations.tsv
    diagnostics.toml
    plots.pdf
  MCMC/
    summary.toml
    samples.tsv
    correlations.tsv
    diagnostics.toml
    plots.pdf
```

TSV is now the only sampling table format. All methods write sample and correlation tables under `Statistics/<method>/`; ChemEx no longer writes legacy top-level `.out` sampling files.

## What Changed

- Added `STATISTICS = {"MCMC" = <steps>}` support.
- Added expanded `[STEP.STATISTICS.MCMC]` settings for `STEPS`, `BURN`, `THIN`, `WALKERS`, `SEED`, `WORKERS`, and `UPDATE_PARAMETERS`.
- Added `chemex.optimize.mcmc` for sampler setup, result conversion, validation, post-processing, reliable/tentative autocorrelation handling, MCMC output writing, and Rich-backed emcee progress.
- Added `chemex.optimize.statistics_plot` for dependency-light Matplotlib/PdfPages visual reporting across all statistics methods.
- Added `chemex.optimize.resampling` for Monte Carlo/bootstrap TSV sample, summary, correlation, diagnostic, and plot output writing.
- Dropped legacy top-level `monte_carlo.out`, `bootstrap.out`, and `bootstrap_ns.out` sampling files.
- Wired MCMC into the existing statistics flow without reusing Monte Carlo/bootstrap resampling.
- Added warnings for no fitted parameters and unbounded MCMC parameters.
- Updated user documentation, changelog, and the development implementation plan.

## Validation

- GitHub Actions on the merged head: Python Tests -> success; Website Test -> success.
- `.venv/bin/python -m pytest tests` -> 229 passed
- `.venv/bin/python -m pytest tests/test_mcmc.py tests/test_analysis_session.py` -> 22 passed
- `uvx ruff check src/chemex/optimize/mcmc.py src/chemex/optimize/statistics_plot.py src/chemex/optimize/resampling.py tests/test_mcmc.py tests/test_analysis_session.py` -> passed
- `.venv/bin/ty check src/chemex/optimize/mcmc.py src/chemex/optimize/statistics_plot.py src/chemex/optimize/resampling.py` -> passed
- `git diff --check` -> passed
- Tiny real `lmfit.emcee` smoke test with Rich progress, tentative autocorrelation diagnostics, and `Statistics/MCMC/plots.pdf` -> passed

## Merge

Squash-merged into `main` as `81d5fd00adb2a82949c7b94570aff63c37d076db`.