### PR TITLE
[codex] Add execution settings for multicore runs

### DIFF
--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -1,5 +1,6 @@
 """The chemex module provides the entry point for the chemex script."""
 
+import os
 import sys
 from argparse import Namespace
 
@@ -18,7 +19,11 @@ from chemex.messages import (
 )
 from chemex.optimize.fitting import run_methods
 from chemex.optimize.helper import execute_simulation
-from chemex.runtime import AnalysisSession, ensure_plugins_registered
+from chemex.runtime import (
+    AnalysisSession,
+    ExecutionSettings,
+    ensure_plugins_registered,
+)
 
 
 def run_fit(
@@ -59,6 +64,12 @@ def run(args: Namespace, session: AnalysisSession | None = None) -> None:
     if session is None:
         session = AnalysisSession.create()
 
+    session.execution = ExecutionSettings.from_counts(
+        workers=getattr(args, "workers", 1),
+        native_threads=getattr(args, "native_threads", "auto"),
+    )
+    os.environ.update(session.execution.native_thread_env())
+
     # Parse kinetics model
     session.set_model(args.model)
 
@@ -88,4 +99,7 @@ def main() -> None:
 
     parser = build_parser()
     args = parser.parse_args()
-    args.func(args)
+    if args.analysis_command:
+        run(args)
+    else:
+        args.func(args)

--- a/src/chemex/cli.py
+++ b/src/chemex/cli.py
@@ -1,12 +1,53 @@
 """The parsing module contains the code for the parsing of command-line arguments."""
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 from pathlib import Path
 
-from chemex import __version__, chemex
+from chemex import __version__
 from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime.execution import ExecutionCount
 from chemex.tools.pick_cest import pick_cest
 from chemex.tools.plot_param import plot_param
+
+
+def _execution_count(value: str) -> ExecutionCount:
+    if value.lower() == "auto":
+        return "auto"
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        msg = "must be 'auto' or a non-negative integer"
+        raise ArgumentTypeError(msg) from error
+    if parsed < 0:
+        msg = "must be 'auto' or a non-negative integer"
+        raise ArgumentTypeError(msg)
+    return parsed
+
+
+def _add_fit_execution_arguments(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "--workers",
+        type=_execution_count,
+        metavar="N|auto",
+        default="auto",
+        help=(
+            "Number of ChemEx worker processes for fit statistics; "
+            "'auto' chooses a conservative CPU count and 0 uses all available "
+            "CPUs (default: auto)"
+        ),
+    )
+
+    parser.add_argument(
+        "--native-threads",
+        type=_execution_count,
+        metavar="N|auto",
+        default="auto",
+        help=(
+            "Advanced: native BLAS/OpenMP threads per worker; 'auto' uses "
+            "one native thread for parallel worker pools and leaves serial "
+            "runs unmanaged (default: auto)"
+        ),
+    )
 
 
 def build_parser() -> ArgumentParser:
@@ -21,6 +62,7 @@ def build_parser() -> ArgumentParser:
     parser = ArgumentParser(description=description, prog="chemex")
 
     parser.set_defaults(func=lambda _: parser.print_usage())
+    parser.set_defaults(analysis_command=False)
 
     parser.add_argument(
         "--version",
@@ -33,7 +75,7 @@ def build_parser() -> ArgumentParser:
     # parser for the positional argument "fit"
     fit_parser = subparsers.add_parser("fit", help="Start a fit")
 
-    fit_parser.set_defaults(func=chemex.run)
+    fit_parser.set_defaults(analysis_command=True)
 
     fit_parser.add_argument(
         "-e",
@@ -107,10 +149,12 @@ def build_parser() -> ArgumentParser:
         type=SpinSystem.from_name,
     )
 
+    _add_fit_execution_arguments(fit_parser)
+
     # parser for the positional argument "simulate"
     simulate_parser = subparsers.add_parser("simulate", help="Start a simulation")
 
-    simulate_parser.set_defaults(func=chemex.run)
+    simulate_parser.set_defaults(analysis_command=True)
 
     simulate_parser.add_argument(
         "-e",

--- a/src/chemex/configuration/methods.py
+++ b/src/chemex/configuration/methods.py
@@ -36,7 +36,7 @@ class McmcSettings(BaseModel):
     thin: PositiveInt = 1
     walkers: PositiveInt | None = None
     seed: int | None = None
-    workers: PositiveInt = 1
+    workers: PositiveInt | None = None
     update_parameters: bool = False
 
     _key_to_lower = model_validator(mode="before")(key_to_lower)

--- a/src/chemex/nmr/basis.py
+++ b/src/chemex/nmr/basis.py
@@ -411,5 +411,14 @@ class Basis:
         """Return self: Basis is immutable, so copying is unnecessary."""
         return self
 
+    def __reduce__(
+        self,
+    ) -> tuple[type[Self], tuple[str, ModelSpec, Literal["", "dq", "tq"], str]]:
+        """Reconstruct from constructor fields; cached maps are derived state."""
+        return (
+            type(self),
+            (self.type, self.model, self.extension, self.spin_system),
+        )
+
     def __len__(self) -> int:
         return len(self.components)

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -34,11 +34,20 @@ def _run_statistics(
     path: Path,
     fitmethod: str,
     statistics: Statistics | None = None,
+    *,
+    session: AnalysisSession | None = None,
 ) -> None:
     if statistics is None:
         return
 
-    run_resampling_statistics(experiments, path, fitmethod, statistics)
+    execution = session.execution if session is not None else None
+    run_resampling_statistics(
+        experiments,
+        path,
+        fitmethod,
+        statistics,
+        execution=execution,
+    )
     parameter_store = experiments.parameter_store
 
     if statistics.mcmc is None:
@@ -99,6 +108,7 @@ def _fit_groups(
             group_path,
             fitmethod,
             statistics,
+            session=session,
         )
 
     if len(groups) > 1:

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -56,7 +56,13 @@ def _run_statistics(
     print_running_statistics("MCMC")
     try:
         params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
-        run_mcmc(experiments, params_lf, statistics.mcmc, path)
+        run_mcmc(
+            experiments,
+            params_lf,
+            statistics.mcmc,
+            path,
+            execution=execution,
+        )
     except KeyboardInterrupt:
         print_calculation_stopped_error()
     except ValueError:

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from math import ceil
 from pathlib import Path
+from time import perf_counter
 from types import TracebackType
 from typing import Any, Self, cast
 
 import emcee.autocorr as emcee_autocorr
 import emcee.ensemble as emcee_ensemble
-import lmfit
 import numpy as np
-from lmfit.minimizer import MinimizerResult
 from lmfit.parameter import Parameters
 from rich.progress import Progress, TaskID
 
@@ -23,7 +22,15 @@ from chemex.messages import (
     print_mcmc_no_vary_warning,
     print_mcmc_unbounded_warning,
 )
+from chemex.optimize.mcmc_engine import (
+    EmceeSamplerResult,
+    McmcProblem,
+    run_emcee_sampler,
+)
+from chemex.optimize.statistics_plot import write_mcmc_plots
 from chemex.parameters.database import ParameterStore
+from chemex.runtime import ExecutionSettings
+from chemex.runtime.execution import native_thread_env, native_thread_environment
 from chemex.typing import Array
 
 
@@ -80,6 +87,7 @@ class EffectiveMcmcSettings:
     walkers: int
     seed: int | None
     workers: int
+    native_threads: int | None
     update_parameters: bool
 
 
@@ -125,10 +133,23 @@ class McmcResult:
         return self.lnprob.reshape(-1)
 
 
+_TIMING_KEYS = (
+    "sampling_seconds",
+    "result_processing_seconds",
+    "output_summary_seconds",
+    "output_samples_seconds",
+    "output_correlations_seconds",
+    "output_plots_seconds",
+    "output_total_seconds",
+    "total_seconds",
+)
+
+
 def resolve_mcmc_settings(
     settings: McmcSettings,
     *,
     nvarys: int,
+    execution: ExecutionSettings | None = None,
 ) -> EffectiveMcmcSettings:
     walkers = settings.walkers or max(32, 2 * nvarys)
     min_walkers = 2 * nvarys
@@ -139,13 +160,17 @@ def resolve_mcmc_settings(
         )
         raise ValueError(msg)
 
+    workers = settings.workers or (execution.workers if execution is not None else 1)
+    native_threads = execution.native_threads if execution is not None else None
+
     return EffectiveMcmcSettings(
         steps=settings.steps,
         burn=settings.burn,
         thin=settings.thin,
         walkers=walkers,
         seed=settings.seed,
-        workers=settings.workers,
+        workers=workers,
+        native_threads=native_threads,
         update_parameters=settings.update_parameters,
     )
 
@@ -187,6 +212,28 @@ def _validate_parameter_bounds(params: Parameters, var_names: tuple[str, ...]) -
         ):
             msg = f"MCMC parameter {name!r} has an empty bounded interval"
             raise ValueError(msg)
+
+
+def _parameter_bound(value: float | None, fallback: float) -> float:
+    if value is None:
+        return fallback
+    bound = float(value)
+    if np.isnan(bound):
+        return fallback
+    return bound
+
+
+def _parameter_bounds(params: Parameters, var_names: tuple[str, ...]) -> Array:
+    return np.asarray(
+        [
+            (
+                _parameter_bound(params[name].min, -np.inf),
+                _parameter_bound(params[name].max, np.inf),
+            )
+            for name in var_names
+        ],
+        dtype=float,
+    )
 
 
 def _jitter_scale(
@@ -281,10 +328,6 @@ def _correlation_matrix(samples: Array) -> Array:
     return np.corrcoef(samples, rowvar=False)
 
 
-def _result_attr(result: MinimizerResult, name: str) -> object:
-    return getattr(result, name)
-
-
 def _valid_autocorrelation_time(autocorrelation_time: object) -> Array | None:
     autocorrelation_time = np.asarray(
         cast("Array", autocorrelation_time),
@@ -376,13 +419,13 @@ def _apply_sample_window(
     return retained_chain, retained_lnprob, discarded_steps, warning
 
 
-def _result_from_lmfit(
-    result: MinimizerResult,
+def _result_from_emcee(
+    result: EmceeSamplerResult,
     settings: EffectiveMcmcSettings,
 ) -> McmcResult:
-    var_names = tuple(cast("Sequence[str]", _result_attr(result, "var_names")))
-    chain = np.asarray(cast("Array", _result_attr(result, "chain")), dtype=float)
-    lnprob = np.asarray(cast("Array", _result_attr(result, "lnprob")), dtype=float)
+    var_names = result.var_names
+    chain = result.chain
+    lnprob = result.lnprob
     autocorrelation_time, tentative_autocorrelation_time, autocorrelation_warning = (
         _estimate_autocorrelation_time(chain)
     )
@@ -413,10 +456,7 @@ def _result_from_lmfit(
             settings.thin,
         ),
         correlations=_correlation_matrix(samples),
-        acceptance_fraction=np.asarray(
-            cast("Array", _result_attr(result, "acceptance_fraction")),
-            dtype=float,
-        ),
+        acceptance_fraction=result.acceptance_fraction,
         autocorrelation_time=autocorrelation_time,
         discarded_steps=discarded_steps,
         burn_in_warning=burn_in_warning,
@@ -554,6 +594,17 @@ def _extend_autocorrelation_diagnostics(
         )
 
 
+def _extend_timing_diagnostics(
+    lines: list[str],
+    timings: Mapping[str, float],
+) -> None:
+    lines.extend(
+        f"{key} = {_format_toml_float(timings[key])}"
+        for key in _TIMING_KEYS
+        if key in timings
+    )
+
+
 def _write_summary(
     result: McmcResult,
     path: Path,
@@ -629,6 +680,7 @@ def _write_diagnostics(
     path: Path,
     parameter_store: ParameterStore,
     unbounded_parameter_ids: tuple[str, ...],
+    timings: Mapping[str, float],
 ) -> None:
     acceptance = result.acceptance_fraction
     unbounded_parameters = list(
@@ -636,7 +688,7 @@ def _write_diagnostics(
     )
     requested_burn = '"auto"' if settings.burn == "auto" else str(settings.burn)
     lines = [
-        'sampler = "emcee via lmfit.Minimizer.emcee"',
+        'sampler = "emcee via ChemEx direct EnsembleSampler"',
         f"lmfit_version = {_quote_toml_string(_package_version('lmfit'))}",
         f"emcee_version = {_quote_toml_string(_package_version('emcee'))}",
         'credible_interval = "95% equal-tailed"',
@@ -648,6 +700,7 @@ def _write_diagnostics(
         f"discarded_steps = {result.discarded_steps}",
         f"thin = {settings.thin}",
         f"walkers = {settings.walkers}",
+        f"workers = {settings.workers}",
         f"retained_steps = {result.chain.shape[0]}",
         f"retained_samples = {len(result.samples)}",
         'samples_file = "samples.tsv"',
@@ -662,6 +715,7 @@ def _write_diagnostics(
     if result.burn_in_warning is not None:
         lines.append(f"burn_in_warning = {_quote_toml_string(result.burn_in_warning)}")
     _extend_autocorrelation_diagnostics(lines, result, settings)
+    _extend_timing_diagnostics(lines, timings)
     if unbounded_parameters:
         lines.append(
             'warning = "Finite lower and upper bounds are recommended for MCMC."',
@@ -676,26 +730,47 @@ def write_mcmc_outputs(
     path: Path,
     parameter_store: ParameterStore,
     unbounded_parameter_ids: tuple[str, ...] = (),
+    timings: dict[str, float] | None = None,
 ) -> None:
+    timings = {} if timings is None else timings
+    output_start = perf_counter()
     path_mcmc = path / "Statistics" / "MCMC"
     path_mcmc.mkdir(parents=True, exist_ok=True)
-    _write_summary(result, path_mcmc, parameter_store)
-    _write_samples(result, path_mcmc, parameter_store)
-    _write_correlations(result, path_mcmc, parameter_store)
-    from chemex.optimize.statistics_plot import write_mcmc_plots
 
+    phase_start = perf_counter()
+    _write_summary(result, path_mcmc, parameter_store)
+    timings["output_summary_seconds"] = perf_counter() - phase_start
+
+    phase_start = perf_counter()
+    _write_samples(result, path_mcmc, parameter_store)
+    timings["output_samples_seconds"] = perf_counter() - phase_start
+
+    phase_start = perf_counter()
+    _write_correlations(result, path_mcmc, parameter_store)
+    timings["output_correlations_seconds"] = perf_counter() - phase_start
+
+    phase_start = perf_counter()
     write_mcmc_plots(
         result,
         settings,
         path_mcmc,
         parameter_names=_format_parameter_ids(result.var_names, parameter_store),
     )
+    timings["output_plots_seconds"] = perf_counter() - phase_start
+    timings["output_total_seconds"] = perf_counter() - output_start
+    if "sampling_seconds" in timings and "result_processing_seconds" in timings:
+        timings["total_seconds"] = (
+            timings["sampling_seconds"]
+            + timings["result_processing_seconds"]
+            + timings["output_total_seconds"]
+        )
     _write_diagnostics(
         result,
         settings,
         path_mcmc,
         parameter_store,
         unbounded_parameter_ids,
+        timings,
     )
 
 
@@ -704,13 +779,19 @@ def run_mcmc(
     params: Parameters,
     settings: McmcSettings,
     path: Path,
+    *,
+    execution: ExecutionSettings | None = None,
 ) -> McmcResult | None:
     var_names = _varying_parameter_ids(params)
     if not var_names:
         print_mcmc_no_vary_warning()
         return None
 
-    effective_settings = resolve_mcmc_settings(settings, nvarys=len(var_names))
+    effective_settings = resolve_mcmc_settings(
+        settings,
+        nvarys=len(var_names),
+        execution=execution,
+    )
     _validate_parameter_bounds(params, var_names)
 
     parameter_store = experiments.parameter_store
@@ -720,37 +801,50 @@ def run_mcmc(
             list(_format_parameter_ids(unbounded_parameter_ids, parameter_store)),
         )
 
-    minimizer = lmfit.Minimizer(experiments.residuals, params)
+    timings: dict[str, float] = {}
+    phase_start = perf_counter()
     with _use_rich_emcee_progress():
-        result_lf = minimizer.emcee(
-            params=params,
-            steps=effective_settings.steps,
-            nwalkers=effective_settings.walkers,
-            burn=0,
-            thin=1,
-            pos=_initial_positions(
-                params,
-                var_names,
-                nwalkers=effective_settings.walkers,
-                seed=effective_settings.seed,
-            ),
-            workers=effective_settings.workers,
-            is_weighted=True,
-            seed=effective_settings.seed,
-            progress=True,
+        env = native_thread_env(
+            effective_settings.native_threads,
+            parallel=effective_settings.workers > 1,
         )
-    result = _result_from_lmfit(result_lf, effective_settings)
+        with native_thread_environment(env):
+            result_emcee = run_emcee_sampler(
+                McmcProblem(
+                    experiments=experiments,
+                    params=params,
+                    var_names=var_names,
+                    bounds=_parameter_bounds(params, var_names),
+                ),
+                _initial_positions(
+                    params,
+                    var_names,
+                    nwalkers=effective_settings.walkers,
+                    seed=effective_settings.seed,
+                ),
+                steps=effective_settings.steps,
+                workers=effective_settings.workers,
+                seed=effective_settings.seed,
+                progress=True,
+            )
+    timings["sampling_seconds"] = perf_counter() - phase_start
+
+    phase_start = perf_counter()
+    result = _result_from_emcee(result_emcee, effective_settings)
+    timings["result_processing_seconds"] = perf_counter() - phase_start
     write_mcmc_outputs(
         result,
         effective_settings,
         path,
         parameter_store,
         unbounded_parameter_ids,
+        timings=timings,
     )
     if effective_settings.update_parameters:
+        updated_params = params.copy()
         for summary in result.summary:
-            result_lf.params[summary.parameter_id].value = summary.median
-            result_lf.params[summary.parameter_id].stderr = summary.stderr
-        result_lf.params.update_constraints()
-        parameter_store.update_from_parameters(result_lf.params)
+            updated_params[summary.parameter_id].value = summary.median
+            updated_params[summary.parameter_id].stderr = summary.stderr
+        updated_params.update_constraints()
+        parameter_store.update_from_parameters(updated_params)
     return result

--- a/src/chemex/optimize/mcmc_engine.py
+++ b/src/chemex/optimize/mcmc_engine.py
@@ -1,0 +1,190 @@
+"""Direct emcee execution for ChemEx MCMC sampling."""
+
+from __future__ import annotations
+
+import multiprocessing
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from typing import Protocol, cast
+
+import emcee
+import numpy as np
+from lmfit.minimizer import coerce_float64
+from lmfit.parameter import Parameters
+
+from chemex.containers.experiments import Experiments
+from chemex.typing import Array
+
+
+class _PoolLike(Protocol):
+    def map(
+        self,
+        func: Callable[[Array], float],
+        iterable: Iterable[Array],
+    ) -> Sequence[float]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class McmcProblem:
+    experiments: Experiments
+    params: Parameters
+    var_names: tuple[str, ...]
+    bounds: Array
+
+
+@dataclass(frozen=True, slots=True)
+class EmceeSamplerResult:
+    var_names: tuple[str, ...]
+    chain: Array
+    lnprob: Array
+    acceptance_fraction: Array
+
+
+@dataclass(slots=True)
+class McmcEvaluator:
+    experiments: Experiments
+    params: Parameters
+    var_names: tuple[str, ...]
+    bounds: Array
+
+    @classmethod
+    def from_problem(cls, problem: McmcProblem) -> McmcEvaluator:
+        return cls(
+            experiments=problem.experiments,
+            params=problem.params.copy(),
+            var_names=problem.var_names,
+            bounds=problem.bounds,
+        )
+
+
+@dataclass(slots=True)
+class _WorkerState:
+    evaluator: McmcEvaluator | None = None
+
+    def initialize(self, problem: McmcProblem) -> None:
+        self.evaluator = McmcEvaluator.from_problem(problem)
+
+    def clear(self) -> None:
+        self.evaluator = None
+
+
+_WORKER_STATE = _WorkerState()
+
+
+def _initialize_worker(problem: McmcProblem) -> None:
+    _WORKER_STATE.initialize(problem)
+
+
+def _clear_worker() -> None:
+    _WORKER_STATE.clear()
+
+
+def _parameter_within_bounds(theta: Array, bounds: Array) -> bool:
+    return bool(np.all(theta >= bounds[:, 0]) and np.all(theta <= bounds[:, 1]))
+
+
+def evaluate_log_probability(
+    theta: Array,
+    evaluator: McmcEvaluator,
+) -> float:
+    theta = np.asarray(theta, dtype=float)
+    if not _parameter_within_bounds(theta, evaluator.bounds):
+        return -np.inf
+
+    for name, value in zip(evaluator.var_names, theta, strict=True):
+        evaluator.params[name].value = float(value)
+    evaluator.params.update_constraints()
+
+    residuals = evaluator.experiments.residuals(evaluator.params)
+    log_probability = coerce_float64(residuals, nan_policy="raise")
+    if len(log_probability) == 0:
+        return -1.0e100
+    if log_probability.size > 1:
+        return float(-0.5 * np.sum(log_probability * log_probability))
+    return float(log_probability[0])
+
+
+def _log_probability(theta: Array) -> float:
+    evaluator = _WORKER_STATE.evaluator
+    if evaluator is None:
+        msg = "MCMC worker context is not initialized"
+        raise RuntimeError(msg)
+    return evaluate_log_probability(theta, evaluator)
+
+
+def _seed_sampler(sampler: emcee.EnsembleSampler, seed: int | None) -> None:
+    if seed is None:
+        return
+    rng = np.random.RandomState(seed)
+    sampler.random_state = rng.get_state()
+
+
+def _run_sampler(
+    problem: McmcProblem,
+    initial_positions: Array,
+    *,
+    steps: int,
+    seed: int | None,
+    progress: bool,
+    pool: _PoolLike | None,
+) -> EmceeSamplerResult:
+    nwalkers, ndim = initial_positions.shape
+    sampler = emcee.EnsembleSampler(
+        nwalkers,
+        ndim,
+        _log_probability,
+        pool=pool,
+    )
+    _seed_sampler(sampler, seed)
+    sampler.run_mcmc(initial_positions, steps, progress=progress)
+    return EmceeSamplerResult(
+        var_names=problem.var_names,
+        chain=np.asarray(sampler.get_chain(), dtype=float),
+        lnprob=np.asarray(sampler.get_log_prob(), dtype=float),
+        acceptance_fraction=np.asarray(sampler.acceptance_fraction, dtype=float),
+    )
+
+
+def run_emcee_sampler(
+    problem: McmcProblem,
+    initial_positions: Array,
+    *,
+    steps: int,
+    workers: int,
+    seed: int | None,
+    progress: bool = True,
+) -> EmceeSamplerResult:
+    if workers < 1:
+        msg = "MCMC requires at least one worker"
+        raise ValueError(msg)
+
+    if workers == 1:
+        _initialize_worker(problem)
+        try:
+            return _run_sampler(
+                problem,
+                initial_positions,
+                steps=steps,
+                seed=seed,
+                progress=progress,
+                pool=None,
+            )
+        finally:
+            _clear_worker()
+
+    try:
+        with multiprocessing.Pool(
+            processes=workers,
+            initializer=_initialize_worker,
+            initargs=(problem,),
+        ) as pool:
+            return _run_sampler(
+                problem,
+                initial_positions,
+                steps=steps,
+                seed=seed,
+                progress=progress,
+                pool=cast("_PoolLike", pool),
+            )
+    finally:
+        _clear_worker()

--- a/src/chemex/optimize/minimizer.py
+++ b/src/chemex/optimize/minimizer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 import lmfit
 import numpy as np
@@ -25,7 +25,7 @@ def _get_result_params(minimizer: lmfit.Minimizer) -> lmfit.Parameters:
     MinimizerResult sets attributes dynamically via setattr,
     so static type checkers cannot resolve them.
     """
-    result = minimizer.result
+    result = cast("Any", minimizer.result)
     params = cast("lmfit.Parameters", result.params)
     return deepcopy(params)
 

--- a/src/chemex/optimize/minimizer.py
+++ b/src/chemex/optimize/minimizer.py
@@ -26,7 +26,7 @@ def _get_result_params(minimizer: lmfit.Minimizer) -> lmfit.Parameters:
     so static type checkers cannot resolve them.
     """
     result = minimizer.result
-    params = cast(lmfit.Parameters, getattr(result, "params"))
+    params = cast("lmfit.Parameters", result.params)
     return deepcopy(params)
 
 

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import multiprocessing
+from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +23,46 @@ from chemex.optimize.helper import (
 )
 from chemex.optimize.minimizer import minimize
 from chemex.optimize.statistics_plot import write_resampling_plots
+from chemex.runtime import ExecutionSettings
+from chemex.runtime.execution import native_thread_environment
+
+
+@dataclass(frozen=True, slots=True)
+class _ResamplingMethod:
+    statistic_name: str
+    message: str
+    directory: str
+    iterations: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ResamplingContext:
+    experiments: Experiments
+    statistic_name: str
+    fitmethod: str
+    parameter_ids: tuple[str, ...]
+
+
+@dataclass(slots=True)
+class _WorkerState:
+    context: _ResamplingContext | None = None
+
+    def initialize(self, context: _ResamplingContext) -> None:
+        self.context = context
+
+    def clear(self) -> None:
+        self.context = None
+
+
+_WORKER_STATE = _WorkerState()
+
+
+def _initialize_worker(context: _ResamplingContext) -> None:
+    _WORKER_STATE.initialize(context)
+
+
+def _clear_worker() -> None:
+    _WORKER_STATE.clear()
 
 
 def _quote_toml_string(value: str) -> str:
@@ -55,12 +98,58 @@ def _format_parameter_names(
 
 def _sample_parameter_values(
     params_lf: Any,
-    parameter_ids: list[str],
+    parameter_ids: tuple[str, ...],
 ) -> list[float]:
     return [
         float(params_lf[param_id].value) if param_id in params_lf else np.nan
         for param_id in parameter_ids
     ]
+
+
+def _calculate_resampling_sample(
+    context: _ResamplingContext,
+) -> tuple[list[float], float]:
+    parameter_store = context.experiments.parameter_store
+    exp_stat = generate_exp_for_statistics(context.experiments, context.statistic_name)
+    params_lf = parameter_store.build_lmfit_params(exp_stat.param_ids)
+    params_fit = minimize(exp_stat, params_lf, context.fitmethod)
+    stats = calculate_statistics(exp_stat, params_fit)
+    chisqr = stats.get("chisqr", 1e32)
+    return _sample_parameter_values(params_fit, context.parameter_ids), float(chisqr)
+
+
+def _calculate_worker_sample(_index: int) -> tuple[list[float], float]:
+    context = _WORKER_STATE.context
+    if context is None:
+        msg = "Resampling worker context is not initialized"
+        raise RuntimeError(msg)
+    return _calculate_resampling_sample(context)
+
+
+def _iter_resampling_samples(
+    context: _ResamplingContext,
+    iterations: int,
+    *,
+    execution: ExecutionSettings,
+) -> Iterator[tuple[list[float], float]]:
+    if execution.workers == 1 or iterations == 1:
+        for _index in range(iterations):
+            yield _calculate_resampling_sample(context)
+        return
+
+    worker_count = min(execution.workers, iterations)
+    try:
+        with (
+            native_thread_environment(execution.native_thread_env(parallel=True)),
+            multiprocessing.Pool(
+                processes=worker_count,
+                initializer=_initialize_worker,
+                initargs=(context,),
+            ) as pool,
+        ):
+            yield from pool.imap(_calculate_worker_sample, range(iterations))
+    finally:
+        _clear_worker()
 
 
 def _as_sample_array(sample_rows: list[list[float]], width: int) -> np.ndarray:
@@ -152,6 +241,7 @@ def _write_resampling_diagnostics(
     fitmethod: str,
     requested_samples: int,
     completed_samples: int,
+    workers: int,
     parameter_ids: list[str],
 ) -> None:
     lines = [
@@ -159,6 +249,7 @@ def _write_resampling_diagnostics(
         f"fitmethod = {_quote_toml_string(fitmethod)}",
         f"requested_samples = {requested_samples}",
         f"completed_samples = {completed_samples}",
+        f"workers = {workers}",
         f"parameters = {_format_toml_string_list(parameter_ids)}",
         'samples_file = "samples.tsv"',
         'summary_file = "summary.toml"',
@@ -172,31 +263,41 @@ def _run_resampling_method(
     experiments: Experiments,
     path: Path,
     fitmethod: str,
-    statistic_name: str,
-    method: dict[str, str],
-    iter_nb: int,
-    ids_vary: list[str],
+    method: _ResamplingMethod,
+    parameter_ids: tuple[str, ...],
+    *,
+    execution: ExecutionSettings,
 ) -> None:
     parameter_store = experiments.parameter_store
-    statistic_path = path / "Statistics" / method["directory"]
+    statistic_path = path / "Statistics" / method.directory
     statistic_path.mkdir(parents=True, exist_ok=True)
     samples_tsv = statistic_path / "samples.tsv"
     sample_rows: list[list[float]] = []
     chisqr_rows: list[float] = []
-    parameter_names = _format_parameter_names(ids_vary, parameter_store)
+    parameter_names = _format_parameter_names(list(parameter_ids), parameter_store)
     completed_samples = 0
+    context = _ResamplingContext(
+        experiments=experiments,
+        statistic_name=method.statistic_name,
+        fitmethod=fitmethod,
+        parameter_ids=parameter_ids,
+    )
+    worker_count = min(execution.workers, method.iterations)
 
     with samples_tsv.open(mode="w", encoding="utf-8") as file_tsv:
         file_tsv.write("\t".join((*parameter_names, "chisqr")) + "\n")
 
         try:
-            for _ in track(range(iter_nb), total=iter_nb, description="   "):
-                exp_stat = generate_exp_for_statistics(experiments, statistic_name)
-                params_lf = parameter_store.build_lmfit_params(exp_stat.param_ids)
-                params_fit = minimize(exp_stat, params_lf, fitmethod)
-                stats = calculate_statistics(exp_stat, params_fit)
-                chisqr = stats.get("chisqr", 1e32)
-                sample_values = _sample_parameter_values(params_fit, ids_vary)
+            samples = _iter_resampling_samples(
+                context,
+                method.iterations,
+                execution=execution,
+            )
+            for sample_values, chisqr in track(
+                samples,
+                total=method.iterations,
+                description="   ",
+            ):
                 file_tsv.write(
                     "\t".join(
                         _format_tsv_float(value)
@@ -213,7 +314,7 @@ def _run_resampling_method(
             print_value_error()
         finally:
             file_tsv.flush()
-            samples = _as_sample_array(sample_rows, len(ids_vary))
+            samples = _as_sample_array(sample_rows, len(parameter_ids))
             _write_resampling_summary(
                 statistic_path,
                 parameter_names=parameter_names,
@@ -226,22 +327,23 @@ def _run_resampling_method(
             )
             write_resampling_plots(
                 statistic_path,
-                method=method["message"],
+                method=method.message,
                 fitmethod=fitmethod,
                 parameter_names=parameter_names,
                 samples=samples,
                 chisqr_values=np.asarray(chisqr_rows, dtype=float),
                 correlations=correlations,
-                requested_samples=iter_nb,
+                requested_samples=method.iterations,
                 completed_samples=completed_samples,
             )
             _write_resampling_diagnostics(
                 statistic_path,
-                method=method["message"],
+                method=method.message,
                 fitmethod=fitmethod,
-                requested_samples=iter_nb,
+                requested_samples=method.iterations,
                 completed_samples=completed_samples,
-                parameter_ids=ids_vary,
+                workers=worker_count,
+                parameter_ids=list(parameter_ids),
             )
 
 
@@ -250,41 +352,53 @@ def run_resampling_statistics(
     path: Path,
     fitmethod: str,
     statistics: Statistics,
+    *,
+    execution: ExecutionSettings | None = None,
 ) -> None:
     if statistics.mc is None and statistics.bs is None and statistics.bsn is None:
         return
 
-    methods = {
-        "mc": {
-            "message": "Monte Carlo",
-            "directory": "MonteCarlo",
-        },
-        "bs": {
-            "message": "bootstrap",
-            "directory": "Bootstrap",
-        },
-        "bsn": {
-            "message": "nucleus-based bootstrap",
-            "directory": "BootstrapNS",
-        },
-    }
+    execution = ExecutionSettings() if execution is None else execution
+    methods: list[_ResamplingMethod] = []
+    if statistics.mc is not None:
+        methods.append(
+            _ResamplingMethod(
+                statistic_name="mc",
+                message="Monte Carlo",
+                directory="MonteCarlo",
+                iterations=statistics.mc,
+            ),
+        )
+    if statistics.bs is not None:
+        methods.append(
+            _ResamplingMethod(
+                statistic_name="bs",
+                message="bootstrap",
+                directory="Bootstrap",
+                iterations=statistics.bs,
+            ),
+        )
+    if statistics.bsn is not None:
+        methods.append(
+            _ResamplingMethod(
+                statistic_name="bsn",
+                message="nucleus-based bootstrap",
+                directory="BootstrapNS",
+                iterations=statistics.bsn,
+            ),
+        )
 
     parameter_store = experiments.parameter_store
     params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
-    ids_vary = [param.name for param in params_lf.values() if param.vary]
+    parameter_ids = tuple(param.name for param in params_lf.values() if param.vary)
 
-    for statistic_name, method in methods.items():
-        iter_nb = getattr(statistics, statistic_name)
-        if iter_nb is None:
-            continue
-
-        print_running_statistics(method["message"])
+    for method in methods:
+        print_running_statistics(method.message)
         _run_resampling_method(
             experiments,
             path,
             fitmethod,
-            statistic_name,
             method,
-            iter_nb,
-            ids_vary,
+            parameter_ids,
+            execution=execution,
         )

--- a/src/chemex/optimize/statistics_plot.py
+++ b/src/chemex/optimize/statistics_plot.py
@@ -169,7 +169,7 @@ def _save_mcmc_summary_page(
     acceptance = result.acceptance_fraction
     burn = '"auto"' if settings.burn == "auto" else str(settings.burn)
     lines = [
-        "Sampler: emcee via lmfit.Minimizer.emcee",
+        "Sampler: emcee via ChemEx direct EnsembleSampler",
         f"Parameters: {len(parameter_names)}",
         f"Steps: {settings.steps}",
         f"Walkers: {settings.walkers}",

--- a/src/chemex/parameters/spin_system/atom.py
+++ b/src/chemex/parameters/spin_system/atom.py
@@ -33,10 +33,13 @@ class Atom:
 
     def __post_init__(self) -> None:
         """Initializes the Atom instance, correcting the atom name and determining the nucleus type."""
-        name = self.name.strip().upper()
+        self._restore_name(self.name)
+
+    def _restore_name(self, name: str) -> None:
+        name = name.strip().upper()
         self.name = CORRECT_ATOM_NAME.get(name, name)
         self.nucleus = str2nucleus(self.name[:1])
-        self.search_keys.update({self, self.nucleus})
+        self.search_keys = {self, self.nucleus}
 
     def match(self, other: Self) -> bool:
         """Checks if this atom matches another atom based on the name.
@@ -67,6 +70,14 @@ class Atom:
 
         """
         return bool(self.name)
+
+    def __getstate__(self) -> dict[str, object]:
+        """Serialize stable fields only; search keys are derived state."""
+        return {"name": self.name}
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        """Restore an Atom and rebuild self-referential search keys."""
+        self._restore_name(str(state["name"]))
 
     def __str__(self) -> str:
         """Returns the string representation of the Atom instance.

--- a/src/chemex/parameters/spin_system/group.py
+++ b/src/chemex/parameters/spin_system/group.py
@@ -4,7 +4,7 @@ from collections.abc import Hashable
 from copy import deepcopy
 from functools import cache, total_ordering
 from re import search
-from typing import Self
+from typing import Self, cast
 
 from .constants import AAA_TO_A
 
@@ -150,9 +150,9 @@ class Group:
     def __setstate__(self, state: dict[str, object]) -> None:
         """Restore a Group and rebuild self-referential search keys."""
         self._restore_parts(
-            str(state["symbol"]),
-            int(state["number"]),
-            str(state["suffix"]),
+            cast("str", state["symbol"]),
+            cast("int", state["number"]),
+            cast("str", state["suffix"]),
         )
 
     def __str__(self) -> str:

--- a/src/chemex/parameters/spin_system/group.py
+++ b/src/chemex/parameters/spin_system/group.py
@@ -59,7 +59,12 @@ class Group:
             name (str): The name of the group to be parsed.
 
         """
-        self.symbol, self.number, self.suffix = parse_group(name.strip().upper())
+        self._restore_parts(*parse_group(name.strip().upper()))
+
+    def _restore_parts(self, symbol: str, number: int, suffix: str) -> None:
+        self.symbol = symbol
+        self.number = number
+        self.suffix = suffix
         self.search_keys: set[Hashable] = {self} if self else set()
 
     @property
@@ -133,6 +138,22 @@ class Group:
 
         """
         return bool(self.name)
+
+    def __getstate__(self) -> dict[str, object]:
+        """Serialize stable fields only; search keys are derived state."""
+        return {
+            "symbol": self.symbol,
+            "number": self.number,
+            "suffix": self.suffix,
+        }
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        """Restore a Group and rebuild self-referential search keys."""
+        self._restore_parts(
+            str(state["symbol"]),
+            int(state["number"]),
+            str(state["suffix"]),
+        )
 
     def __str__(self) -> str:
         """String representation of the Group object.

--- a/src/chemex/runtime/__init__.py
+++ b/src/chemex/runtime/__init__.py
@@ -1,3 +1,4 @@
+from chemex.runtime.execution import ExecutionSettings
 from chemex.runtime.session import AnalysisSession, ensure_plugins_registered
 
-__all__ = ["AnalysisSession", "ensure_plugins_registered"]
+__all__ = ["AnalysisSession", "ExecutionSettings", "ensure_plugins_registered"]

--- a/src/chemex/runtime/execution.py
+++ b/src/chemex/runtime/execution.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Literal
+
+NATIVE_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+AUTO_WORKER_LIMIT = 8
+ExecutionCount = int | Literal["auto"]
+
+
+def available_cpu_count() -> int:
+    """Return the CPU count visible to this process."""
+    return max(1, os.process_cpu_count() or os.cpu_count() or 1)
+
+
+def auto_worker_count() -> int:
+    """Return a conservative default worker count for CLI auto mode."""
+    return min(available_cpu_count(), AUTO_WORKER_LIMIT)
+
+
+def _resolve_count(value: int) -> int:
+    if value == 0:
+        return available_cpu_count()
+    if value < 0:
+        msg = "Execution settings must be non-negative"
+        raise ValueError(msg)
+    return value
+
+
+def _resolve_workers(value: ExecutionCount | None) -> int:
+    if value is None:
+        return auto_worker_count()
+    if value == "auto":
+        return auto_worker_count()
+    return _resolve_count(value)
+
+
+def _resolve_native_threads(value: ExecutionCount | None) -> int | None:
+    if value is None or value == "auto":
+        return None
+    return _resolve_count(value)
+
+
+def native_thread_env(
+    native_threads: int | None,
+    *,
+    parallel: bool = False,
+) -> dict[str, str]:
+    if native_threads is None and not parallel:
+        return {}
+    thread_count = 1 if native_threads is None else native_threads
+    return dict.fromkeys(NATIVE_THREAD_ENV_VARS, str(thread_count))
+
+
+@contextmanager
+def native_thread_environment(env: Mapping[str, str]) -> Iterator[None]:
+    if not env:
+        yield
+        return
+
+    previous_values = {name: os.environ.get(name) for name in env}
+    os.environ.update(env)
+    try:
+        yield
+    finally:
+        for name, value in previous_values.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _validate_resolved_count(value: int | None) -> None:
+    if value is None:
+        return
+    if value < 1:
+        msg = "Execution settings must resolve to at least one worker/thread"
+        raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionSettings:
+    """Runtime controls for CPU-level parallel execution."""
+
+    workers: int = 1
+    native_threads: int | None = None
+
+    def __post_init__(self) -> None:
+        _validate_resolved_count(self.workers)
+        _validate_resolved_count(self.native_threads)
+
+    @classmethod
+    def from_counts(
+        cls,
+        *,
+        workers: ExecutionCount | None = None,
+        native_threads: ExecutionCount | None = None,
+    ) -> ExecutionSettings:
+        return cls(
+            workers=_resolve_workers(workers),
+            native_threads=_resolve_native_threads(native_threads),
+        )
+
+    @property
+    def is_parallel(self) -> bool:
+        return self.workers > 1
+
+    def native_thread_env(self, *, parallel: bool = False) -> dict[str, str]:
+        return native_thread_env(self.native_threads, parallel=parallel)

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -11,6 +11,7 @@ from chemex.parameters.database import (
     create_parameter_store,
 )
 from chemex.parameters.factory import ParameterFactory
+from chemex.runtime.execution import ExecutionSettings
 
 _PLUGIN_STATE = {"registered": False}
 
@@ -33,6 +34,7 @@ class AnalysisSession:
         model: ModelController | None = None,
         parameters: ParameterStore | None = None,
         parameter_factory: ParameterFactory | None = None,
+        execution: ExecutionSettings | None = None,
     ) -> None:
         self.model = ModelState() if model is None else model
         self.parameters = (
@@ -43,6 +45,7 @@ class AnalysisSession:
             if parameter_factory is None
             else parameter_factory
         )
+        self.execution = ExecutionSettings() if execution is None else execution
 
     @classmethod
     def create(cls) -> AnalysisSession:

--- a/tests/configuration/test_methods.py
+++ b/tests/configuration/test_methods.py
@@ -13,6 +13,7 @@ def test_statistics_parse_mcmc_short_form() -> None:
     assert statistics.mcmc.steps == 5000
     assert statistics.mcmc.burn == "auto"
     assert statistics.mcmc.thin == 1
+    assert statistics.mcmc.workers is None
 
 
 def test_statistics_parse_mcmc_expanded_form() -> None:

--- a/tests/nmr/test_liouvillian_basis_isolation.py
+++ b/tests/nmr/test_liouvillian_basis_isolation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pickle
+
 import numpy as np
 import pytest
 
@@ -28,6 +30,19 @@ def test_basis_vectors_are_read_only() -> None:
 
     with pytest.raises(ValueError, match="read-only"):
         basis.vectors["iz_a"][0, 0] = 1.0
+
+
+def test_basis_pickle_ignores_cached_mapping_proxies() -> None:
+    basis = Basis(type="ixyz", spin_system="nh", model=ModelSpec())
+
+    _ = basis.matrices
+    _ = basis.vectors
+    restored = pickle.loads(pickle.dumps(basis))  # noqa: S301
+
+    assert restored == basis
+    np.testing.assert_allclose(restored.matrices["cs_i_a"], basis.matrices["cs_i_a"])
+    with pytest.raises(ValueError, match="read-only"):
+        restored.matrices["cs_i_a"][0, 1] = 1.0
 
 
 def test_equal_basis_instances_do_not_expose_mutable_shared_vectors() -> None:

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -620,11 +620,14 @@ def test_run_statistics_dispatches_mcmc_without_resampling(
         params_arg: object,
         settings_arg: object,
         path_arg: Path,
+        *,
+        execution: object | None = None,
     ) -> None:
         recorded["experiments"] = experiments_arg
         recorded["params"] = params_arg
         recorded["settings"] = settings_arg
         recorded["path"] = path_arg
+        recorded["execution"] = execution
 
     monkeypatch.setattr(
         resampling_module,
@@ -638,12 +641,14 @@ def test_run_statistics_dispatches_mcmc_without_resampling(
         tmp_path,
         "leastsq",
         fitting_module.Statistics(mcmc=100),
+        session=session,
     )
 
     np.testing.assert_equal(recorded["experiments"], experiments)
     assert "__PB" in recorded["params"]
     assert recorded["settings"].steps == 100
     np.testing.assert_equal(recorded["path"], tmp_path)
+    np.testing.assert_equal(recorded["execution"], session.execution)
 
 
 def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None:

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Self
 
 import numpy as np
 import pytest
@@ -17,7 +18,7 @@ from chemex.optimize import resampling as resampling_module
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
 from chemex.printers import parameters as parameter_printer_module
-from chemex.runtime import AnalysisSession
+from chemex.runtime import AnalysisSession, ExecutionSettings
 from chemex.runtime import session as session_module
 
 
@@ -70,6 +71,7 @@ class StubSession:
         self.parameters = StubParameters()
         self.model_names: list[str] = []
         self.parameter_factory = StubParameterFactory()
+        self.execution = ExecutionSettings()
 
     def set_model(self, name: str) -> None:
         self.model_names.append(name)
@@ -142,7 +144,7 @@ EXPECTED_EXPERIMENT_COUNT = 2
 
 
 def make_args(command: str) -> Namespace:
-    return Namespace(
+    args = Namespace(
         commands=command,
         model="2st",
         include=None,
@@ -153,6 +155,10 @@ def make_args(command: str) -> Namespace:
         output=Path("Output"),
         plot="normal",
     )
+    if command == "fit":
+        args.workers = "auto"
+        args.native_threads = "auto"
+    return args
 
 
 def test_analysis_session_lifecycle_calls_reset_hooks(
@@ -262,6 +268,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     session = StubSession()
     experiments = FakeExperiments(parameter_store=session.parameters)
     recorded: dict[str, object] = {}
+    recorded_env: dict[str, str] = {}
 
     def fake_build_experiments(
         filenames: list[Path] | None,
@@ -285,10 +292,19 @@ def test_run_uses_explicit_session_for_fit_flow(
     monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
     monkeypatch.setattr(chemex_module, "read_defaults", lambda _filenames: defaults)
     monkeypatch.setattr(chemex_module, "run_methods", fake_run_methods)
+    monkeypatch.setattr(chemex_module.os, "environ", recorded_env)
 
-    chemex_module.run(make_args("fit"), session=session)
+    args = make_args("fit")
+    args.workers = 3
+    args.native_threads = 2
+    chemex_module.run(args, session=session)
 
     np.testing.assert_equal(session.model_names, ["2st"])
+    np.testing.assert_equal(
+        session.execution, ExecutionSettings(workers=3, native_threads=2)
+    )
+    np.testing.assert_equal(recorded_env["OMP_NUM_THREADS"], "2")
+    np.testing.assert_equal(recorded_env["VECLIB_MAXIMUM_THREADS"], "2")
     np.testing.assert_equal(session.parameters.defaults_calls, [defaults])
     np.testing.assert_equal(experiments.filtered, 1)
     np.testing.assert_equal(recorded["build"][2], session)
@@ -341,7 +357,10 @@ def test_main_bootstraps_plugins_for_non_run_commands(
 
     class StubParser:
         def parse_args(self) -> Namespace:
-            return Namespace(func=lambda _args: calls.append("func"))
+            return Namespace(
+                analysis_command=False,
+                func=lambda _args: calls.append("func"),
+            )
 
     def build_parser() -> StubParser:
         return StubParser()
@@ -357,6 +376,32 @@ def test_main_bootstraps_plugins_for_non_run_commands(
     chemex_module.main()
 
     np.testing.assert_equal(calls, ["logo", "plugins", "func"])
+
+
+def test_main_dispatches_analysis_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    class StubParser:
+        def parse_args(self) -> Namespace:
+            return Namespace(
+                analysis_command=True, func=lambda _args: calls.append("func")
+            )
+
+    def build_parser() -> StubParser:
+        return StubParser()
+
+    monkeypatch.setattr(chemex_module, "print_logo", lambda: calls.append("logo"))
+    monkeypatch.setattr(
+        chemex_module,
+        "ensure_plugins_registered",
+        lambda: calls.append("plugins"),
+    )
+    monkeypatch.setattr(chemex_module, "build_parser", build_parser)
+    monkeypatch.setattr(chemex_module, "run", lambda _args: calls.append("run"))
+
+    chemex_module.main()
+
+    np.testing.assert_equal(calls, ["logo", "plugins", "run"])
 
 
 def test_run_methods_passes_session_to_fit_groups(
@@ -406,7 +451,9 @@ def test_run_methods_skips_fit_when_selection_removes_all_profiles(
     experiments = EmptyAfterSelectExperiments(parameter_store=session.parameters)
     calls: list[str] = []
 
-    monkeypatch.setattr(fitting_module, "print_no_data", lambda: calls.append("no_data"))
+    monkeypatch.setattr(
+        fitting_module, "print_no_data", lambda: calls.append("no_data")
+    )
 
     def fail_if_called(*_args, **_kwargs) -> None:
         pytest.fail("_fit_groups should not run when no profiles remain selected")
@@ -447,9 +494,9 @@ def test_run_statistics_uses_session_for_header(
     )
 
     assert not (tmp_path / "monte_carlo.out").exists()
-    assert (
-        tmp_path / "Statistics" / "MonteCarlo" / "samples.tsv"
-    ).read_text(encoding="utf-8") == "[PB]\tchisqr\n"
+    assert (tmp_path / "Statistics" / "MonteCarlo" / "samples.tsv").read_text(
+        encoding="utf-8"
+    ) == "[PB]\tchisqr\n"
     assert (tmp_path / "Statistics" / "MonteCarlo" / "summary.toml").exists()
     assert (tmp_path / "Statistics" / "MonteCarlo" / "correlations.tsv").exists()
     assert (tmp_path / "Statistics" / "MonteCarlo" / "plots.pdf").stat().st_size > 0
@@ -459,10 +506,98 @@ def test_run_statistics_uses_session_for_header(
     assert 'method = "Monte Carlo"' in diagnostics
     assert "requested_samples = 1" in diagnostics
     assert "completed_samples = 0" in diagnostics
+    assert "workers = 1" in diagnostics
     assert 'samples_file = "samples.tsv"' in diagnostics
     assert 'summary_file = "summary.toml"' in diagnostics
     assert 'correlations_file = "correlations.tsv"' in diagnostics
     assert 'plots_file = "plots.pdf"' in diagnostics
+
+
+def test_resampling_statistics_use_execution_workers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class Store:
+        def build_lmfit_params(
+            self,
+            _param_ids: object,
+        ) -> dict[str, SimpleNamespace]:
+            return {"__PB": SimpleNamespace(name="__PB", vary=True, value=0.25)}
+
+    class FakePool:
+        def __init__(
+            self,
+            *,
+            processes: int,
+            initializer: object,
+            initargs: tuple[object, ...],
+        ) -> None:
+            captured["processes"] = processes
+            self.initializer = initializer
+            self.initargs = initargs
+
+        def __enter__(self) -> Self:
+            self.initializer(*self.initargs)
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def imap(self, function: object, iterable: object) -> object:
+            return map(function, iterable)
+
+    experiments = SimpleNamespace(
+        param_ids=["__PB"],
+        parameter_store=Store(),
+    )
+
+    monkeypatch.setattr(resampling_module.multiprocessing, "Pool", FakePool)
+    monkeypatch.setattr(
+        resampling_module,
+        "generate_exp_for_statistics",
+        lambda experiments_arg, _statistic_name: experiments_arg,
+    )
+    monkeypatch.setattr(
+        resampling_module,
+        "minimize",
+        lambda _experiments, params, _fitmethod: params,
+    )
+    monkeypatch.setattr(
+        resampling_module,
+        "calculate_statistics",
+        lambda _experiments, _params: {"chisqr": 2.0},
+    )
+    monkeypatch.setattr(
+        resampling_module,
+        "write_resampling_plots",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        resampling_module,
+        "track",
+        lambda iterable, **_kwargs: iterable,
+    )
+
+    resampling_module.run_resampling_statistics(
+        experiments,
+        tmp_path,
+        "leastsq",
+        fitting_module.Statistics(mc=2),
+        execution=ExecutionSettings(workers=3),
+    )
+
+    assert captured["processes"] == 2
+    diagnostics = (
+        tmp_path / "Statistics" / "MonteCarlo" / "diagnostics.toml"
+    ).read_text(encoding="utf-8")
+    samples = (tmp_path / "Statistics" / "MonteCarlo" / "samples.tsv").read_text(
+        encoding="utf-8"
+    )
+    assert "workers = 2" in diagnostics
+    assert "completed_samples = 2" in diagnostics
+    assert samples.count("\n") == 3
 
 
 def test_run_statistics_dispatches_mcmc_without_resampling(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+
+from chemex.cli import build_parser
+
+
+def test_fit_parser_defaults_execution_arguments_to_auto() -> None:
+    args = build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            "experiment.toml",
+            "-p",
+            "parameters.toml",
+        ],
+    )
+
+    assert args.workers == "auto"
+    assert args.native_threads == "auto"
+    assert args.analysis_command
+
+
+def test_fit_parser_accepts_execution_arguments() -> None:
+    args = build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            "experiment.toml",
+            "-p",
+            "parameters.toml",
+            "--workers",
+            "2",
+            "--native-threads",
+            "3",
+        ],
+    )
+
+    assert args.workers == 2
+    assert args.native_threads == 3
+    assert args.analysis_command
+
+
+def test_fit_parser_accepts_auto_execution_arguments() -> None:
+    args = build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            "experiment.toml",
+            "-p",
+            "parameters.toml",
+            "--workers",
+            "auto",
+            "--native-threads",
+            "auto",
+        ],
+    )
+
+    assert args.workers == "auto"
+    assert args.native_threads == "auto"
+    assert args.analysis_command
+
+
+def test_simulate_parser_does_not_accept_execution_arguments() -> None:
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(
+            [
+                "simulate",
+                "-e",
+                "experiment.toml",
+                "-p",
+                "parameters.toml",
+                "--workers",
+                "2",
+            ],
+        )

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from chemex.runtime import execution as execution_module
+from chemex.runtime.execution import ExecutionSettings
+
+
+def test_execution_settings_default_to_serial() -> None:
+    settings = ExecutionSettings()
+
+    assert settings.workers == 1
+    assert settings.native_threads is None
+    assert not settings.is_parallel
+    assert settings.native_thread_env() == {}
+
+
+def test_execution_settings_auto_uses_capped_cpu_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(execution_module.os, "process_cpu_count", lambda: 16)
+
+    settings = ExecutionSettings.from_counts(workers="auto", native_threads="auto")
+
+    assert settings.workers == 8
+    assert settings.native_threads is None
+    assert settings.is_parallel
+    assert settings.native_thread_env() == {}
+    assert settings.native_thread_env(parallel=True) == dict.fromkeys(
+        execution_module.NATIVE_THREAD_ENV_VARS,
+        "1",
+    )
+
+
+def test_execution_settings_zero_uses_available_cpu_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(execution_module.os, "process_cpu_count", lambda: 6)
+
+    settings = ExecutionSettings.from_counts(workers=0, native_threads=0)
+
+    assert settings.workers == 6
+    assert settings.native_threads == 6
+
+
+def test_execution_settings_reject_unresolved_zero() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        ExecutionSettings(workers=0)
+
+
+def test_execution_settings_reject_negative_counts() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        ExecutionSettings.from_counts(workers=-1)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        ExecutionSettings.from_counts(native_threads=-1)
+
+
+def test_execution_settings_native_thread_environment() -> None:
+    settings = ExecutionSettings(native_threads=2)
+
+    assert settings.native_thread_env() == dict.fromkeys(
+        execution_module.NATIVE_THREAD_ENV_VARS,
+        "2",
+    )
+
+
+def test_native_thread_environment_restores_previous_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OMP_NUM_THREADS", "4")
+    monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
+    env = {
+        "OMP_NUM_THREADS": "1",
+        "OPENBLAS_NUM_THREADS": "1",
+    }
+
+    with execution_module.native_thread_environment(env):
+        assert execution_module.os.environ["OMP_NUM_THREADS"] == "1"
+        assert execution_module.os.environ["OPENBLAS_NUM_THREADS"] == "1"
+
+    assert execution_module.os.environ["OMP_NUM_THREADS"] == "4"
+    assert "OPENBLAS_NUM_THREADS" not in execution_module.os.environ

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
+from typing import Self
 
 import lmfit
 import numpy as np
@@ -10,18 +10,27 @@ from emcee.autocorr import AutocorrError
 
 from chemex.configuration.methods import McmcSettings
 from chemex.optimize import mcmc as mcmc_module
+from chemex.optimize import mcmc_engine as mcmc_engine_module
 from chemex.optimize.mcmc import (
     EffectiveMcmcSettings,
     McmcResult,
     McmcSummary,
     _apply_sample_window,
-    _result_from_lmfit,
+    _initial_positions,
+    _result_from_emcee,
     resolve_mcmc_settings,
     run_mcmc,
     write_mcmc_outputs,
 )
+from chemex.optimize.mcmc_engine import (
+    EmceeSamplerResult,
+    McmcEvaluator,
+    McmcProblem,
+    evaluate_log_probability,
+)
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
+from chemex.runtime import ExecutionSettings
 
 
 class DummyParameterStore:
@@ -57,11 +66,65 @@ class DummyExperiments:
         raise AssertionError(msg)
 
 
+class ResidualExperiments:
+    def __init__(self, residuals: np.ndarray) -> None:
+        self.parameter_store = DummyParameterStore()
+        self.residual_values = residuals
+        self.calls = 0
+
+    def residuals(self, _params: lmfit.Parameters) -> np.ndarray:
+        self.calls += 1
+        return self.residual_values
+
+
+class ConstraintExperiments:
+    def __init__(self) -> None:
+        self.parameter_store = DummyParameterStore()
+        self.constrained_value: float | None = None
+
+    def residuals(self, params: lmfit.Parameters) -> np.ndarray:
+        self.constrained_value = float(params["twice_pb"].value)
+        return np.array([self.constrained_value, 0.0])
+
+
+def _single_parameter_problem(
+    experiments: object,
+    params: lmfit.Parameters,
+) -> McmcProblem:
+    return McmcProblem(
+        experiments=experiments,
+        params=params,
+        var_names=("__PB",),
+        bounds=np.array([[0.0, 1.0]]),
+    )
+
+
 def test_resolve_mcmc_settings_defaults_walkers_from_varying_parameters() -> None:
     settings = resolve_mcmc_settings(McmcSettings(steps=100), nvarys=3)
 
     assert settings.walkers == 32
     assert settings.burn == "auto"
+    assert settings.workers == 1
+
+
+def test_resolve_mcmc_settings_inherits_execution_workers() -> None:
+    settings = resolve_mcmc_settings(
+        McmcSettings(steps=100),
+        nvarys=3,
+        execution=ExecutionSettings(workers=4),
+    )
+
+    assert settings.workers == 4
+
+
+def test_resolve_mcmc_settings_method_workers_override_execution() -> None:
+    settings = resolve_mcmc_settings(
+        McmcSettings(steps=100, workers=2),
+        nvarys=3,
+        execution=ExecutionSettings(workers=4),
+    )
+
+    assert settings.workers == 2
 
 
 def test_resolve_mcmc_settings_rejects_too_few_walkers() -> None:
@@ -81,6 +144,343 @@ def test_run_mcmc_skips_when_no_parameters_vary() -> None:
     )
 
     assert result is None
+
+
+def test_log_probability_uses_weighted_vector_residuals() -> None:
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+    experiments = ResidualExperiments(np.array([1.0, 2.0]))
+    evaluator = McmcEvaluator(
+        experiments=experiments,
+        params=params.copy(),
+        var_names=("__PB",),
+        bounds=np.array([[0.0, 1.0]]),
+    )
+
+    log_probability = evaluate_log_probability(np.array([0.2]), evaluator)
+
+    assert log_probability == -2.5
+    assert experiments.calls == 1
+
+
+def test_log_probability_rejects_out_of_bounds_without_residual_call() -> None:
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+    experiments = ResidualExperiments(np.array([1.0, 2.0]))
+    evaluator = McmcEvaluator(
+        experiments=experiments,
+        params=params.copy(),
+        var_names=("__PB",),
+        bounds=np.array([[0.0, 1.0]]),
+    )
+
+    log_probability = evaluate_log_probability(np.array([1.2]), evaluator)
+
+    assert log_probability == -np.inf
+    assert experiments.calls == 0
+
+
+def test_log_probability_updates_constraints_before_residual_call() -> None:
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+    params.add("twice_pb", expr="2.0 * __PB")
+    experiments = ConstraintExperiments()
+    evaluator = McmcEvaluator(
+        experiments=experiments,
+        params=params.copy(),
+        var_names=("__PB",),
+        bounds=np.array([[0.0, 1.0]]),
+    )
+
+    log_probability = evaluate_log_probability(np.array([0.3]), evaluator)
+
+    assert experiments.constrained_value == pytest.approx(0.6)
+    assert log_probability == pytest.approx(-0.18)
+
+
+def test_log_probability_raises_for_invalid_residuals() -> None:
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+    experiments = ResidualExperiments(np.array([np.nan]))
+    evaluator = McmcEvaluator(
+        experiments=experiments,
+        params=params.copy(),
+        var_names=("__PB",),
+        bounds=np.array([[0.0, 1.0]]),
+    )
+
+    with pytest.raises(ValueError, match="NaN values detected"):
+        evaluate_log_probability(np.array([0.2]), evaluator)
+
+
+def test_initial_positions_are_seeded_reproducibly() -> None:
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+
+    first = _initial_positions(params, ("__PB",), nwalkers=4, seed=1234)
+    second = _initial_positions(params, ("__PB",), nwalkers=4, seed=1234)
+
+    assert np.array_equal(first, second)
+
+
+def test_run_emcee_sampler_uses_serial_path_without_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeSampler:
+        def __init__(
+            self,
+            nwalkers: int,
+            ndim: int,
+            log_prob_fn: object,
+            *,
+            pool: object | None,
+        ) -> None:
+            captured["sampler_pool"] = pool
+            self.acceptance_fraction = np.full(nwalkers, 0.5)
+            self._chain = np.zeros((1, nwalkers, ndim))
+            self._lnprob = np.zeros((1, nwalkers))
+
+        def run_mcmc(
+            self,
+            initial_positions: np.ndarray,
+            steps: int,
+            *,
+            progress: bool,
+        ) -> None:
+            captured["run_mcmc"] = (initial_positions.copy(), steps, progress)
+
+        def get_chain(self) -> np.ndarray:
+            return self._chain
+
+        def get_log_prob(self) -> np.ndarray:
+            return self._lnprob
+
+    def fail_pool(*_args: object, **_kwargs: object) -> object:
+        msg = "Pool should not be created for a serial MCMC run"
+        raise AssertionError(msg)
+
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+    problem = _single_parameter_problem(ResidualExperiments(np.array([0.0])), params)
+    initial_positions = np.array([[0.1], [0.2]])
+
+    monkeypatch.setattr(mcmc_engine_module.emcee, "EnsembleSampler", FakeSampler)
+    monkeypatch.setattr(mcmc_engine_module.multiprocessing, "Pool", fail_pool)
+
+    result = mcmc_engine_module.run_emcee_sampler(
+        problem,
+        initial_positions,
+        steps=3,
+        workers=1,
+        seed=1234,
+        progress=False,
+    )
+
+    assert captured["sampler_pool"] is None
+    assert isinstance(captured["run_mcmc"], tuple)
+    assert result.chain.shape == (1, 2, 1)
+
+
+def test_run_emcee_sampler_runs_direct_emcee_serial() -> None:
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+    problem = _single_parameter_problem(
+        ResidualExperiments(np.array([0.0, 0.0])), params
+    )
+    initial_positions = np.array([[0.1], [0.2], [0.3], [0.4]])
+
+    result = mcmc_engine_module.run_emcee_sampler(
+        problem,
+        initial_positions,
+        steps=2,
+        workers=1,
+        seed=1234,
+        progress=False,
+    )
+
+    assert result.var_names == ("__PB",)
+    assert result.chain.shape == (2, 4, 1)
+    assert result.lnprob.shape == (2, 4)
+    assert result.acceptance_fraction.shape == (4,)
+
+
+def test_run_emcee_sampler_initializes_multiprocessing_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakePool:
+        def __init__(
+            self,
+            *,
+            processes: int,
+            initializer: object,
+            initargs: tuple[object, ...],
+        ) -> None:
+            captured["pool_processes"] = processes
+            captured["pool_initializer"] = initializer
+            captured["pool_initargs"] = initargs
+            initializer_callable = initializer
+            assert callable(initializer_callable)
+            initializer_callable(*initargs)
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _traceback: object,
+        ) -> None:
+            return None
+
+        def map(self, func: object, iterable: object) -> list[object]:
+            assert callable(func)
+            return [func(item) for item in iterable]
+
+    class FakeSampler:
+        def __init__(
+            self,
+            nwalkers: int,
+            ndim: int,
+            log_prob_fn: object,
+            *,
+            pool: object | None,
+        ) -> None:
+            captured["sampler_pool"] = pool
+            self.acceptance_fraction = np.full(nwalkers, 0.5)
+            self._chain = np.zeros((1, nwalkers, ndim))
+            self._lnprob = np.zeros((1, nwalkers))
+
+        def run_mcmc(
+            self,
+            initial_positions: np.ndarray,
+            steps: int,
+            *,
+            progress: bool,
+        ) -> None:
+            captured["run_mcmc"] = (initial_positions.copy(), steps, progress)
+
+        def get_chain(self) -> np.ndarray:
+            return self._chain
+
+        def get_log_prob(self) -> np.ndarray:
+            return self._lnprob
+
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+    problem = _single_parameter_problem(ResidualExperiments(np.array([0.0])), params)
+    initial_positions = np.array([[0.1], [0.2]])
+
+    monkeypatch.setattr(mcmc_engine_module.multiprocessing, "Pool", FakePool)
+    monkeypatch.setattr(mcmc_engine_module.emcee, "EnsembleSampler", FakeSampler)
+
+    result = mcmc_engine_module.run_emcee_sampler(
+        problem,
+        initial_positions,
+        steps=3,
+        workers=2,
+        seed=1234,
+        progress=False,
+    )
+
+    assert captured["pool_processes"] == 2
+    assert captured["pool_initargs"] == (problem,)
+    assert captured["sampler_pool"] is not None
+    assert result.chain.shape == (1, 2, 1)
+
+
+def test_run_mcmc_passes_execution_workers_to_direct_sampler(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    params = lmfit.Parameters()
+    params.add("__PB", value=0.1, min=0.0, max=1.0, vary=True)
+
+    result = McmcResult(
+        var_names=("__PB",),
+        chain=np.array([[[0.1], [0.2]]]),
+        lnprob=np.array([[-1.0, -2.0]]),
+        summary=(
+            McmcSummary(
+                parameter_id="__PB",
+                mean=0.15,
+                standard_deviation=0.05,
+                median=0.15,
+                eti_95_lower=0.10,
+                eti_95_upper=0.20,
+                lower_1sigma=0.10,
+                upper_1sigma=0.20,
+                stderr=0.05,
+            ),
+        ),
+        correlations=np.array([[1.0]]),
+        acceptance_fraction=np.array([0.5, 0.5]),
+        autocorrelation_time=None,
+        discarded_steps=0,
+        burn_in_warning=None,
+    )
+
+    def fake_run_emcee_sampler(
+        problem: McmcProblem,
+        initial_positions: np.ndarray,
+        *,
+        steps: int,
+        workers: int,
+        seed: int | None,
+        progress: bool,
+    ) -> EmceeSamplerResult:
+        captured["problem"] = problem
+        captured["initial_positions"] = initial_positions
+        captured["sampler_kwargs"] = {
+            "steps": steps,
+            "workers": workers,
+            "seed": seed,
+            "progress": progress,
+        }
+        return EmceeSamplerResult(
+            var_names=result.var_names,
+            chain=result.chain,
+            lnprob=result.lnprob,
+            acceptance_fraction=result.acceptance_fraction,
+        )
+
+    monkeypatch.setattr(mcmc_module, "run_emcee_sampler", fake_run_emcee_sampler)
+
+    def fake_write_mcmc_outputs(*_args: object, **kwargs: object) -> None:
+        captured["output_kwargs"] = kwargs
+        captured["outputs_written"] = True
+
+    monkeypatch.setattr(mcmc_module, "write_mcmc_outputs", fake_write_mcmc_outputs)
+
+    run_mcmc(
+        DummyExperiments(),
+        params,
+        McmcSettings(steps=10),
+        tmp_path,
+        execution=ExecutionSettings(workers=7),
+    )
+
+    sampler_kwargs = captured["sampler_kwargs"]
+    assert isinstance(sampler_kwargs, dict)
+    assert sampler_kwargs["workers"] == 7
+    assert sampler_kwargs["steps"] == 10
+    assert sampler_kwargs["progress"] is True
+    assert isinstance(captured["problem"], McmcProblem)
+    initial_positions = captured["initial_positions"]
+    assert isinstance(initial_positions, np.ndarray)
+    assert initial_positions.shape == (32, 1)
+    assert captured["outputs_written"]
+    output_kwargs = captured["output_kwargs"]
+    assert isinstance(output_kwargs, dict)
+    timings = output_kwargs["timings"]
+    assert isinstance(timings, dict)
+    assert timings["sampling_seconds"] >= 0.0
+    assert timings["result_processing_seconds"] >= 0.0
 
 
 def test_apply_sample_window_uses_auto_burn_from_autocorrelation_time() -> None:
@@ -120,7 +520,7 @@ def test_apply_sample_window_keeps_samples_when_auto_burn_unavailable() -> None:
     assert np.array_equal(retained_lnprob, lnprob)
 
 
-def test_result_from_lmfit_uses_tentative_tau_for_auto_burn(
+def test_result_from_emcee_uses_tentative_tau_for_auto_burn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     chain = np.arange(20.0).reshape(10, 2, 1)
@@ -132,6 +532,7 @@ def test_result_from_lmfit_uses_tentative_tau_for_auto_burn(
         walkers=2,
         seed=None,
         workers=1,
+        native_threads=None,
         update_parameters=False,
     )
 
@@ -145,8 +546,8 @@ def test_result_from_lmfit_uses_tentative_tau_for_auto_burn(
         raise_autocorr_error,
     )
 
-    result = _result_from_lmfit(
-        SimpleNamespace(
+    result = _result_from_emcee(
+        EmceeSamplerResult(
             var_names=("__PB",),
             chain=chain,
             lnprob=lnprob,
@@ -173,6 +574,7 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
         walkers=2,
         seed=1234,
         workers=1,
+        native_threads=None,
         update_parameters=False,
     )
     result = McmcResult(
@@ -225,6 +627,7 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
         tmp_path,
         store,
         unbounded_parameter_ids=("__KEX_AB",),
+        timings={"sampling_seconds": 1.25, "result_processing_seconds": 0.5},
     )
 
     path_mcmc = tmp_path / "Statistics" / "MCMC"
@@ -248,13 +651,22 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
     assert "2.00000e-01\t2.50000e+02\t-2.00000e+00" in samples
     assert "[PB]" in correlations
     assert "5.00000e-01" in correlations
-    assert 'sampler = "emcee via lmfit.Minimizer.emcee"' in diagnostics
+    assert 'sampler = "emcee via ChemEx direct EnsembleSampler"' in diagnostics
     assert 'samples_file = "samples.tsv"' in diagnostics
     assert 'correlations_file = "correlations.tsv"' in diagnostics
     assert 'requested_burn = "auto"' in diagnostics
     assert "discarded_steps = 1" in diagnostics
     assert "retained_steps = 2" in diagnostics
     assert "retained_samples = 4" in diagnostics
+    assert "workers = 1" in diagnostics
+    assert "sampling_seconds = 1.25000e+00" in diagnostics
+    assert "result_processing_seconds = 5.00000e-01" in diagnostics
+    assert "output_summary_seconds" in diagnostics
+    assert "output_samples_seconds" in diagnostics
+    assert "output_correlations_seconds" in diagnostics
+    assert "output_plots_seconds" in diagnostics
+    assert "output_total_seconds" in diagnostics
+    assert "total_seconds" in diagnostics
     assert "min_effective_sample_size = 1.33333e+00" in diagnostics
     assert 'unbounded_parameters = ["[KEX_AB]"]' in diagnostics
     assert "autocorrelation_time = [2.00000e+00, 3.00000e+00]" in diagnostics
@@ -275,6 +687,7 @@ def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
         walkers=2,
         seed=None,
         workers=1,
+        native_threads=None,
         update_parameters=False,
     )
     result = McmcResult(
@@ -313,9 +726,9 @@ def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
 
     write_mcmc_outputs(result, settings, tmp_path, store)
 
-    diagnostics = (
-        tmp_path / "Statistics" / "MCMC" / "diagnostics.toml"
-    ).read_text(encoding="utf-8")
+    diagnostics = (tmp_path / "Statistics" / "MCMC" / "diagnostics.toml").read_text(
+        encoding="utf-8"
+    )
     summary = (tmp_path / "Statistics" / "MCMC" / "summary.toml").read_text(
         encoding="utf-8",
     )

--- a/tests/test_spin_system.py
+++ b/tests/test_spin_system.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
+import pickle
+
 from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.spin_system.atom import Atom
+from chemex.parameters.spin_system.group import Group
 
 
 def test_spin_system_name_parser_does_not_mutate_input_dict() -> None:
@@ -8,3 +14,33 @@ def test_spin_system_name_parser_does_not_mutate_input_dict() -> None:
 
     assert spin_system.name == "G23N-H"
     assert raw == {"name": "G23N-HN"}
+
+
+def test_group_pickle_rebuilds_search_keys() -> None:
+    group = Group("G23")
+
+    restored = pickle.loads(pickle.dumps(group))  # noqa: S301
+
+    assert restored == group
+    assert restored in restored.search_keys
+
+
+def test_atom_pickle_rebuilds_search_keys() -> None:
+    atom = Atom("HN")
+
+    restored = pickle.loads(pickle.dumps(atom))  # noqa: S301
+
+    assert restored == atom
+    assert restored in restored.search_keys
+    assert restored.nucleus in restored.search_keys
+
+
+def test_spin_system_pickle_rebuilds_nested_search_keys() -> None:
+    spin_system = SpinSystem.from_name("G23N-HN")
+
+    _ = spin_system.search_keys
+    _ = spin_system.groups
+    restored = pickle.loads(pickle.dumps(spin_system))  # noqa: S301
+
+    assert restored == spin_system
+    assert restored.search_keys == spin_system.search_keys

--- a/website/docs/user_guide/fitting/chemex_fit.md
+++ b/website/docs/user_guide/fitting/chemex_fit.md
@@ -24,6 +24,8 @@ The table below lists the available options for `chemex fit`. Each option links 
 | [`-d`](kinetic_models.md) or [`--model`](kinetic_models.md) | Specify the kinetic model for fitting (optional, default: `2st`). |
 | [`-o`](outputs.mdx) or [`--output`](outputs.mdx) | Set the output directory (optional, default: `./Output`). |
 | `--plot {nothing, normal, all}` | Select the plotting level (optional, default: `normal`). |
+| [`--workers N\|auto`](multicore_execution.md) | Set the number of ChemEx worker processes for fit statistics (optional, default: `auto`). |
+| [`--native-threads N\|auto`](multicore_execution.md) | Set native numerical-library threads per worker (optional, default: `auto`). |
 | `--include` | Define residues to include in the fit (optional). |
 | `--exclude` | Define residues to exclude from the fit (optional). |
 
@@ -44,7 +46,7 @@ ChemEx uses the [TOML](https://toml.io/) format for input and output files. For 
 
 ChemEx supports combined analysis of multiple experiments. To include various experiments in a fit, list the corresponding [experiment files](experiment_files.md) after the `--experiments` (or `-e`) option. This feature is particularly useful for fitting different types of CEST or CPMG experiments or a combination of both.
 
-For an example of protein-ligand binding analysis using both CPMG and CEST experiments, see [this example](examples/binding.md).
+For an example of protein-ligand binding analysis using both CPMG and CEST experiments, see [this example](../../examples/binding.md).
 
 ## Example
 
@@ -58,6 +60,12 @@ chemex fit -e Experiments/*.toml \
 ```
 
 Output files are saved in the directory specified by `-o`. By default, plots illustrating best-fit lines are generated; you can adjust this behavior with the `--plot` option.
+
+For uncertainty analyses, ChemEx can use multiple CPU cores during the statistics
+phase. The default `--workers auto` setting chooses a conservative worker count,
+and `--native-threads auto` avoids oversubscribing native numerical-library
+threads when worker processes are used. See
+[Multicore Execution](multicore_execution.md) for tuning guidance.
 
 :::tip
 For convenience, consider saving this command in a shell script, typically named `run.sh`:

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -10,7 +10,8 @@ Method files define the fitting methods used in ChemEx. In these files, you can:
 
 -   Specify which parameters to fit, fix, or constrain.
 -   Select the profiles to include in calculations.
--   Activate additional analyses, such as grid search, Monte Carlo, or bootstrap analyses.
+-   Activate additional analyses, such as grid search, Monte Carlo, bootstrap,
+    or MCMC analyses.
 
 Provide the method file to ChemEx using the `-m` or `--method` option.
 
@@ -229,8 +230,12 @@ BURN = "AUTO"
 THIN = 1
 WALKERS = 64
 SEED = 1234
-WORKERS = 1
+WORKERS = 4
 ```
+
+`STEPS` is the number of emcee sampler iterations. `WALKERS` defaults to the
+larger of 32 or twice the number of fitted parameters. `SEED` fixes the initial
+walker positions for reproducible runs.
 
 `BURN` defaults to `"AUTO"`. In automatic mode, ChemEx uses the integrated
 autocorrelation time reported by the sampler and discards twice the largest
@@ -245,6 +250,15 @@ fixed number of initial sampler steps.
 `THIN` defaults to `1`, which keeps every retained sample. Thinning is mainly a
 storage and output-size control; it is usually better to keep all post-burn-in
 samples unless the output files become too large.
+
+`WORKERS` is optional. When omitted, MCMC inherits the command-line
+[`--workers`](multicore_execution.md) setting from `chemex fit`, whose default
+is `auto`. Set `WORKERS` in the method file only when this MCMC step needs a
+specific positive worker count. Command-line `--workers 0` means all available
+CPUs, but method-file `WORKERS` must be a positive integer.
+
+See [Multicore Execution](multicore_execution.md) for performance guidance and
+the interaction between `--workers` and `--native-threads`.
 
 Sampling outputs are stored under a `Statistics` directory in the corresponding step or group output directory:
 

--- a/website/docs/user_guide/fitting/multicore_execution.md
+++ b/website/docs/user_guide/fitting/multicore_execution.md
@@ -1,0 +1,132 @@
+---
+sidebar_position: 8
+---
+
+# Multicore Execution
+
+ChemEx can use multiple CPU cores during the statistics phase of `chemex fit`.
+This is most useful for MCMC sampling and for Monte Carlo or bootstrap
+uncertainty estimates.
+
+The default command already enables the recommended modern behavior:
+
+```shell
+chemex fit -e Experiments/*.toml \
+           -p Parameters/parameters.toml \
+           -m Methods/method.toml \
+           -o Output
+```
+
+By default, `--workers auto` chooses a conservative number of worker processes,
+up to 8 CPUs. This gives typical workstations useful parallelism without
+starting an unexpectedly large number of Python processes. Use `--workers 1` for
+serial execution, or `--workers 0` to explicitly use all CPUs visible to ChemEx.
+
+## What Runs in Parallel
+
+The `--workers` option applies to fit statistics:
+
+-   MCMC sampling requested with `STATISTICS = {"MCMC" = ...}`.
+-   Monte Carlo, bootstrap, and nucleus-specific bootstrap refits requested with
+    `MC`, `BS`, or `BSN`.
+
+The normal deterministic fit still runs as one optimization task. Grid searches,
+simulation runs, plotting, and output writing are not controlled by
+`--workers`.
+
+Worker processes are created only while the parallel statistics task is running.
+For example, Activity Monitor or `top` should show multiple Python processes
+during MCMC sampling, but not necessarily during the earlier deterministic fit
+or the later output-writing phase.
+
+## Command-Line Controls
+
+### `--workers N|auto`
+
+Controls the number of ChemEx worker processes used by fit statistics.
+
+| Value | Meaning |
+| ---- | ------- |
+| `auto` | Conservative default, capped at 8 workers. |
+| `1` | Serial execution. Useful for debugging and reproducibility checks. |
+| `N` | Use `N` worker processes. |
+| `0` | Use all CPUs visible to the current process. |
+
+For long MCMC runs on a dedicated machine, it can be reasonable to set an
+explicit value:
+
+```shell
+chemex fit -e Experiments/*.toml \
+           -p Parameters/parameters.toml \
+           -m Methods/method_stat.toml \
+           -o OutputStat \
+           --workers 10
+```
+
+### `--native-threads N|auto`
+
+Controls native numerical library threads, such as BLAS or OpenMP threads.
+
+The default, `--native-threads auto`, leaves native thread settings untouched for
+serial runs. When ChemEx starts multiple worker processes, it sets native
+threads to 1 inside the worker-pool context. This avoids oversubscription, where
+each Python worker also starts many native threads.
+
+Most users should keep the default. Use an explicit value only when you are
+benchmarking a specific machine:
+
+```shell
+chemex fit -e Experiments/*.toml \
+           -p Parameters/parameters.toml \
+           -m Methods/method_stat.toml \
+           -o OutputStat \
+           --workers 10 \
+           --native-threads 1
+```
+
+## MCMC Worker Overrides
+
+MCMC settings in a method file may include an optional `WORKERS` value:
+
+```toml
+[STEP1.STATISTICS.MCMC]
+STEPS = 5000
+WORKERS = 4
+```
+
+When `WORKERS` is omitted, MCMC inherits the command-line `--workers` setting.
+Use the method-file value only when a specific MCMC step needs a different worker
+count from the rest of the fit statistics.
+
+Method-file `WORKERS` must be a positive integer. The special `0` and `auto`
+values are command-line controls only.
+
+## Practical Guidance
+
+Start with the defaults. They are designed to give useful multicore performance
+on modern machines without requiring manual tuning.
+
+Use explicit settings when you have a reason:
+
+-   `--workers 1` for serial debugging.
+-   `--workers 0` for a dedicated machine where ChemEx may use all CPUs.
+-   `--workers N --native-threads 1` for manual benchmarking of long MCMC runs.
+
+Do not expect every fit to scale linearly. Parallel execution helps most when
+each likelihood evaluation or refit is expensive enough to dominate process-pool
+overhead. Very short MCMC runs or small bootstrap jobs may show little speedup.
+
+## Diagnostics
+
+Statistics diagnostics record the effective worker count. MCMC diagnostics also
+record the direct emcee sampler engine, timing information, acceptance
+fractions, and autocorrelation diagnostics.
+
+Look at `Statistics/MCMC/diagnostics.toml` after a run to confirm the effective
+settings:
+
+```toml
+sampler = "emcee via ChemEx direct EnsembleSampler"
+workers = 8
+sampling_seconds = 120.42
+```

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Outputs
@@ -136,4 +136,13 @@ Contains optional uncertainty-analysis outputs requested with the `STATISTICS`
 method-file key. Monte Carlo and bootstrap methods write `summary.toml`,
 `samples.tsv`, `correlations.tsv`, and `diagnostics.toml` under
 `Statistics/MonteCarlo/`, `Statistics/Bootstrap/`, and `Statistics/BootstrapNS/`.
-MCMC writes the same file set under `Statistics/MCMC/`.
+MCMC writes the same file set under `Statistics/MCMC/`, plus a `plots.pdf`
+report with posterior distributions, walker traces, log-probability traces, and
+autocorrelation diagnostics.
+
+The `diagnostics.toml` files record execution details for reproducibility. For
+parallel statistics, they include the effective worker count. MCMC diagnostics
+also include the direct emcee sampler engine, timing information, acceptance
+fractions, burn-in decisions, and autocorrelation estimates. These diagnostics
+are the best place to confirm that [`--workers`](multicore_execution.md) was
+applied as intended.


### PR DESCRIPTION
## Summary

This starts the multicore implementation with a shared execution policy and applies it to independent statistical work:

- add session-scoped `ExecutionSettings` for ChemEx worker count and native BLAS/OpenMP thread count
- expose `--workers` and `--native-threads` on `fit` and `simulate`, preserving serial defaults
- apply native thread environment limits before analysis work starts so spawned worker processes inherit them
- let MCMC inherit the session worker count when method-file `WORKERS` is omitted, while explicit MCMC `WORKERS` still overrides it
- run MC/BS/BSN resampling samples through a process pool when `--workers > 1`, with serial behavior retained by default
- record effective worker counts in resampling and MCMC diagnostics
- record MCMC phase timings (`sampling_seconds`, result processing, and output subphases) so ineffective worker use is visible in diagnostics
- keep `chemex.cli` focused on parser construction and let `chemex.main()` dispatch analysis commands, avoiding circular imports while keeping imports at module top
- make derived/cached NMR basis and spin-system state pickleable so worker processes can receive ChemEx residual functions
- replace constant-name `getattr` calls in the touched minimizer/MCMC helpers with normal attribute access

## Why

This gives ChemEx a single control surface for safe process-based parallel work. It now benefits coarse-grained independent resampling immediately, while preserving the existing sequential fit ordering for group fits where parameter-store interactions need more design.

The CPMG example shows that MCMC workers are requested and passed to lmfit/emcee, but this workflow still does not get useful sustained multicore speedup during MCMC sampling. With `--workers 10 --native-threads 1`, the measured MCMC diagnostics were approximately:

- `workers = 10`
- `sampling_seconds = 9.96447e+01`
- `result_processing_seconds = 2.42235e-02`
- `output_plots_seconds = 2.66844e+00`
- `total_seconds = 1.02411e+02`

So the bottleneck is inside the sampler phase itself, not MCMC output generation. I tried a ChemEx-owned pool wrapper that initialized worker functions once, but it was slower on the same example, so it was not kept.

## Validation

- `uvx ruff check src/chemex/optimize/resampling.py src/chemex/optimize/fitting.py src/chemex/chemex.py src/chemex/optimize/minimizer.py src/chemex/optimize/mcmc.py tests/test_analysis_session.py tests/test_mcmc.py`
- `uv run pytest` -> 246 passed
- Real `CPMG_15N_IP` smoke run with `--workers 4 --native-threads 1`, output under `/private/tmp/chemex-outputstat-parallel`
  - process sampling showed worker processes during resampling and MCMC
  - `STEP1/Statistics/MonteCarlo/diagnostics.toml`: `workers = 4`
  - `STEP1/Statistics/MCMC/diagnostics.toml`: `workers = 4`
- Real `CPMG_15N_IP` timing run with `--workers 10 --native-threads 1`, output under `/private/tmp/chemex-outputstat-mcmc-timing`
  - `STEP1/Statistics/MCMC/diagnostics.toml`: `workers = 10`, `sampling_seconds = 9.96447e+01`

Note: project-wide `uvx ruff check .` and `uvx ruff format --check .` still report pre-existing unrelated findings outside the touched files.