### PR TITLE
[codex] Add lightweight run information to fit outputs

### DIFF
--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from argparse import Namespace
+from collections.abc import Sequence
 
 from chemex.cli import build_parser
 from chemex.configuration.methods import Method, Selection, read_methods
@@ -19,6 +20,7 @@ from chemex.messages import (
 )
 from chemex.optimize.fitting import run_methods
 from chemex.optimize.helper import execute_simulation
+from chemex.run_info import write_run_info
 from chemex.runtime import (
     AnalysisSession,
     ExecutionSettings,
@@ -30,6 +32,8 @@ def run_fit(
     args: Namespace,
     experiments: Experiments,
     session: AnalysisSession,
+    *,
+    argv: Sequence[str] | None = None,
 ) -> None:
     # Filter datapoints out if necessary (e.g., on-resonance filter CEST)
     experiments.filter()
@@ -39,6 +43,8 @@ def run_fit(
         methods = read_methods(args.method)
     else:
         methods = {"": Method()}
+
+    write_run_info(args, experiments, argv=argv)
 
     print_start_fit()
     run_methods(experiments, methods, args.output, args.plot, session=session)
@@ -59,7 +65,12 @@ def run_sim(
     execute_simulation(experiments, path, plot=plot, session=session)
 
 
-def run(args: Namespace, session: AnalysisSession | None = None) -> None:
+def run(
+    args: Namespace,
+    session: AnalysisSession | None = None,
+    *,
+    argv: Sequence[str] | None = None,
+) -> None:
     """Run the fit or simulation."""
     if session is None:
         session = AnalysisSession.create()
@@ -89,7 +100,7 @@ def run(args: Namespace, session: AnalysisSession | None = None) -> None:
     if args.commands == "simulate":
         run_sim(args, experiments, session)
     else:
-        run_fit(args, experiments, session)
+        run_fit(args, experiments, session, argv=argv)
 
 
 def main() -> None:
@@ -100,6 +111,6 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
     if args.analysis_command:
-        run(args)
+        run(args, argv=sys.argv)
     else:
         args.func(args)

--- a/src/chemex/run_info.py
+++ b/src/chemex/run_info.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from argparse import Namespace
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import blake2b
+from pathlib import Path
+
+from chemex import __version__
+from chemex.containers.experiments import Experiments
+from chemex.parameters.database import ParameterStore
+from chemex.parameters.setting import ParamSetting
+
+SCHEMA_VERSION = 1
+_INPUT_CATEGORIES = ("experiments", "parameters", "methods")
+
+
+@dataclass(frozen=True, slots=True)
+class InputFile:
+    category: str
+    provided_path: Path
+    resolved_path: Path
+
+
+@dataclass(frozen=True, slots=True)
+class CopiedInputFile:
+    provided_path: Path
+    resolved_path: Path
+    copied_path: Path
+
+
+def _quote_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _quote_key(value: str) -> str:
+    return _quote_string(value)
+
+
+def _format_string_list(values: Sequence[str]) -> str:
+    return "[" + ", ".join(_quote_string(value) for value in values) + "]"
+
+
+def _format_float(value: float | None) -> str:
+    return "nan" if value is None else repr(float(value))
+
+
+def _parameter_values(parameter: ParamSetting) -> str:
+    values = [
+        _format_float(parameter.value),
+        _format_float(parameter.min),
+        _format_float(parameter.max),
+    ]
+    if parameter.brute_step is not None:
+        values.append(_format_float(parameter.brute_step))
+    return "[" + ", ".join(values) + "]"
+
+
+def _parameter_sections(
+    experiments: Experiments,
+    parameter_store: ParameterStore,
+) -> Mapping[str, Mapping[str, ParamSetting]]:
+    sections: defaultdict[str, dict[str, ParamSetting]] = defaultdict(dict)
+    parameters = parameter_store.get_parameters(experiments.param_ids)
+
+    for parameter in sorted(parameters.values(), key=lambda item: item.param_name):
+        if parameter.expr:
+            continue
+        param_name = parameter.param_name
+        if param_name.spin_system:
+            section = param_name.section
+            key = str(param_name.spin_system)
+        else:
+            section = "GLOBAL"
+            key = param_name.section_res
+        sections[section][key] = parameter
+
+    return sections
+
+
+def _serialize_parameters(
+    experiments: Experiments,
+    parameter_store: ParameterStore,
+) -> str:
+    lines = [
+        "# Starting independent parameters used by ChemEx for this fit.",
+        "# Parameters defined by expressions are omitted here because they are",
+        "# reconstructed from the independent parameters and model definition.",
+        "# This file is intended to be usable as a starting parameter file for",
+        "# re-running the fit.",
+        "# Each array is [value, minimum, maximum, optional brute-force step].",
+        "",
+    ]
+
+    for section, parameters in _parameter_sections(
+        experiments,
+        parameter_store,
+    ).items():
+        lines.append(f"[{_quote_key(section)}]")
+        lines.extend(
+            f"{_quote_key(key)} = {_parameter_values(parameter)}"
+            for key, parameter in parameters.items()
+        )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _resolve_path(path: Path, working_directory: Path) -> Path:
+    expanded = path.expanduser()
+    if not expanded.is_absolute():
+        expanded = working_directory / expanded
+    return expanded.resolve()
+
+
+def _collect_input_files(args: Namespace, working_directory: Path) -> list[InputFile]:
+    files: list[InputFile] = []
+    for category in _INPUT_CATEGORIES:
+        paths = getattr(args, category if category != "methods" else "method", None)
+        if paths is None:
+            continue
+        files.extend(
+            InputFile(
+                category,
+                path,
+                _resolve_path(path, working_directory),
+            )
+            for path in paths
+        )
+    return files
+
+
+def _copy_name(path: Path, *, collides: bool) -> str:
+    if not collides:
+        return path.name
+    digest = blake2b(str(path).encode(), digest_size=4).hexdigest()
+    return f"{path.stem}__{digest}{path.suffix}"
+
+
+def _copy_inputs(
+    input_files: Sequence[InputFile],
+    run_info_path: Path,
+) -> dict[str, list[CopiedInputFile]]:
+    copied_inputs: defaultdict[str, list[CopiedInputFile]] = defaultdict(list)
+    files_by_category: defaultdict[str, list[InputFile]] = defaultdict(list)
+
+    for input_file in input_files:
+        resolved_paths = {
+            item.resolved_path for item in files_by_category[input_file.category]
+        }
+        if input_file.resolved_path not in resolved_paths:
+            files_by_category[input_file.category].append(input_file)
+
+    for category, files in files_by_category.items():
+        name_counts = Counter(item.resolved_path.name for item in files)
+        destination_directory = run_info_path / "inputs" / category
+        destination_directory.mkdir(parents=True, exist_ok=True)
+        used_names: set[str] = set()
+
+        for input_file in files:
+            resolved_path = input_file.resolved_path
+            copy_name = _copy_name(
+                resolved_path,
+                collides=name_counts[resolved_path.name] > 1,
+            )
+            candidate = Path(copy_name)
+            index = 2
+            while copy_name in used_names:
+                copy_name = f"{candidate.stem}__{index}{candidate.suffix}"
+                index += 1
+            used_names.add(copy_name)
+            destination = destination_directory / copy_name
+            shutil.copy2(resolved_path, destination)
+            copied_inputs[category].append(
+                CopiedInputFile(
+                    input_file.provided_path,
+                    resolved_path,
+                    destination.relative_to(run_info_path),
+                ),
+            )
+
+    return dict(copied_inputs)
+
+
+def _find_git_root(start: Path) -> Path | None:
+    for directory in (start, *start.parents):
+        if (directory / ".git").exists():
+            return directory
+    return None
+
+
+def _run_git(repository: Path, *arguments: str) -> str:
+    executable = shutil.which("git")
+    if executable is None:
+        raise FileNotFoundError
+    result = subprocess.run(  # noqa: S603
+        [executable, "-C", str(repository), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=2,
+    )
+    return result.stdout.strip()
+
+
+def _git_metadata() -> dict[str, str | bool] | None:
+    source_file = Path(__file__).resolve()
+    repository = _find_git_root(source_file.parent)
+    if repository is None:
+        return None
+
+    try:
+        source_relative = source_file.relative_to(repository)
+        _run_git(
+            repository,
+            "ls-files",
+            "--error-unmatch",
+            "--",
+            source_relative.as_posix(),
+        )
+        commit = _run_git(repository, "rev-parse", "HEAD")
+        branch = _run_git(repository, "branch", "--show-current")
+        status = _run_git(repository, "status", "--porcelain")
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+
+    metadata: dict[str, str | bool] = {"commit": commit}
+    if branch:
+        metadata["branch"] = branch
+    metadata["working_tree_dirty"] = bool(status)
+    return metadata
+
+
+def _replace_run_info(staging_path: Path, run_info_path: Path) -> None:
+    backup_path = run_info_path.with_name(f".run_info-backup-{uuid.uuid4().hex}")
+    had_existing = run_info_path.exists() or run_info_path.is_symlink()
+
+    if had_existing:
+        run_info_path.replace(backup_path)
+
+    try:
+        staging_path.replace(run_info_path)
+    except OSError:
+        if had_existing:
+            backup_path.replace(run_info_path)
+        raise
+
+    if not had_existing:
+        return
+    if backup_path.is_symlink() or backup_path.is_file():
+        backup_path.unlink()
+    else:
+        shutil.rmtree(backup_path)
+
+
+def _serialize_run(
+    *,
+    timestamp: datetime,
+    working_directory: Path,
+    output_directory: Path,
+    argv: Sequence[str],
+    copied_inputs: Mapping[str, Sequence[CopiedInputFile]],
+    git_metadata: Mapping[str, str | bool] | None,
+) -> str:
+    lines = [
+        "# ChemEx run information.",
+        "# Input records distinguish the path provided by the user, its resolved",
+        "# absolute path, and the archived copy relative to this run_info directory.",
+        "",
+        f"schema_version = {SCHEMA_VERSION}",
+        f"created_at_utc = {_quote_string(timestamp.astimezone(UTC).isoformat())}",
+        "",
+        "[run]",
+        'kind = "fit"',
+        f"working_directory = {_quote_string(str(working_directory))}",
+        f"output_directory = {_quote_string(str(output_directory))}",
+        "",
+        "[chemex]",
+        f"version = {_quote_string(__version__)}",
+        "",
+        "[python]",
+        f"version = {_quote_string(platform.python_version())}",
+        f"platform = {_quote_string(platform.platform())}",
+        "",
+        "[command]",
+        "# Exact process arguments, including the executable.",
+        f"arguments = {_format_string_list(argv)}",
+        "",
+    ]
+
+    for category, files in copied_inputs.items():
+        for copied_input in files:
+            lines.extend(
+                (
+                    f"[[inputs.{category}]]",
+                    f"provided_path = {_quote_string(str(copied_input.provided_path))}",
+                    f"resolved_path = {_quote_string(str(copied_input.resolved_path))}",
+                    f"copied_path = {_quote_string(str(copied_input.copied_path))}",
+                    "",
+                ),
+            )
+
+    if git_metadata is not None:
+        lines.append("[git]")
+        for key, value in git_metadata.items():
+            formatted = (
+                str(value).lower() if isinstance(value, bool) else _quote_string(value)
+            )
+            lines.append(f"{key} = {formatted}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_run_info(
+    args: Namespace,
+    experiments: Experiments,
+    *,
+    argv: Sequence[str] | None = None,
+    working_directory: Path | None = None,
+    timestamp: datetime | None = None,
+) -> None:
+    """Write a lightweight description of a fit to its output directory."""
+    cwd = (
+        Path.cwd().resolve()
+        if working_directory is None
+        else working_directory.resolve()
+    )
+    output_directory = _resolve_path(args.output, cwd)
+    run_info_path = output_directory / "run_info"
+    input_files = _collect_input_files(args, cwd)
+    git_metadata = _git_metadata()
+
+    output_directory.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=output_directory,
+        prefix=".run_info-",
+    ) as staging_directory:
+        staging_path = Path(staging_directory)
+        copied_inputs = _copy_inputs(input_files, staging_path)
+        parameters_text = _serialize_parameters(
+            experiments,
+            experiments.parameter_store,
+        )
+        (staging_path / "parameters_used.toml").write_text(
+            parameters_text,
+            encoding="utf-8",
+        )
+
+        run_text = _serialize_run(
+            timestamp=datetime.now(UTC) if timestamp is None else timestamp,
+            working_directory=cwd,
+            output_directory=output_directory,
+            argv=tuple(sys.argv if argv is None else argv),
+            copied_inputs=copied_inputs,
+            git_metadata=git_metadata,
+        )
+        (staging_path / "run.toml").write_text(run_text, encoding="utf-8")
+
+        _replace_run_info(staging_path, run_info_path)

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -292,6 +292,11 @@ def test_run_uses_explicit_session_for_fit_flow(
     monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
     monkeypatch.setattr(chemex_module, "read_defaults", lambda _filenames: defaults)
     monkeypatch.setattr(chemex_module, "run_methods", fake_run_methods)
+    monkeypatch.setattr(
+        chemex_module,
+        "write_run_info",
+        lambda *_args, **_kwargs: recorded.setdefault("run_info", True),
+    )
     monkeypatch.setattr(chemex_module.os, "environ", recorded_env)
 
     args = make_args("fit")
@@ -309,6 +314,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     np.testing.assert_equal(experiments.filtered, 1)
     np.testing.assert_equal(recorded["build"][2], session)
     np.testing.assert_equal(recorded["run_methods"][4], session)
+    assert recorded["run_info"] is True
 
 
 def test_run_uses_explicit_session_for_simulation_flow(
@@ -397,7 +403,11 @@ def test_main_dispatches_analysis_commands(monkeypatch: pytest.MonkeyPatch) -> N
         lambda: calls.append("plugins"),
     )
     monkeypatch.setattr(chemex_module, "build_parser", build_parser)
-    monkeypatch.setattr(chemex_module, "run", lambda _args: calls.append("run"))
+    monkeypatch.setattr(
+        chemex_module,
+        "run",
+        lambda _args, **_kwargs: calls.append("run"),
+    )
 
     chemex_module.main()
 

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import subprocess
+import tomllib
+from argparse import Namespace
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from chemex import __version__
+from chemex import chemex as chemex_module
+from chemex import run_info as run_info_module
+from chemex.parameters.name import ParamName
+from chemex.parameters.setting import ParamSetting
+from chemex.parameters.spin_system import SpinSystem
+
+
+class ParameterStore:
+    def __init__(self, parameters: dict[str, ParamSetting]) -> None:
+        self.parameters = parameters
+
+    def get_parameters(self, param_ids: object) -> dict[str, ParamSetting]:
+        return {
+            param_id: parameter
+            for param_id, parameter in self.parameters.items()
+            if param_id in set(param_ids)
+        }
+
+
+class FitExperiments:
+    def __init__(self, parameter_store: ParameterStore, param_ids: set[str]) -> None:
+        self.parameter_store = parameter_store
+        self.param_ids = param_ids
+        self.filter_calls = 0
+
+    def filter(self) -> None:
+        self.filter_calls += 1
+
+
+def _write_input(path: Path, content: str = "[input]\nvalue = 1\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_write_run_info_captures_inputs_parameters_and_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    experiment_file = _write_input(tmp_path / "experiment.toml")
+    parameters_file = _write_input(
+        tmp_path / "parameters.toml",
+        "[GLOBAL]\nPB = 0.1\n",
+    )
+    method_file = _write_input(tmp_path / "method.toml")
+    output = tmp_path / "Output"
+
+    pb = ParamSetting(
+        ParamName("PB"),
+        value=0.15,
+        min=0.0,
+        max=1.0,
+    )
+    dw = ParamSetting(
+        ParamName("DW_AB", SpinSystem.from_name("15N")),
+        value=2.5,
+        min=-10.0,
+        max=10.0,
+        brute_step=0.5,
+    )
+    pa = ParamSetting(
+        ParamName("PA"),
+        value=0.85,
+        expr=f"1.0 - {pb.id_}",
+    )
+    store = ParameterStore({pb.id_: pb, dw.id_: dw, pa.id_: pa})
+    experiments = SimpleNamespace(
+        param_ids={pb.id_, dw.id_, pa.id_},
+        parameter_store=store,
+    )
+    args = Namespace(
+        experiments=[Path("experiment.toml")],
+        parameters=[Path("parameters.toml")],
+        method=[Path("method.toml")],
+        output=output,
+    )
+    argv = [
+        "chemex",
+        "fit",
+        "-e",
+        str(experiment_file),
+        "-p",
+        str(parameters_file),
+    ]
+
+    monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
+
+    run_info_module.write_run_info(
+        args,
+        experiments,
+        argv=argv,
+        working_directory=tmp_path,
+        timestamp=datetime(2026, 6, 24, 12, 30, tzinfo=UTC),
+    )
+
+    run_info_path = output / "run_info"
+    run_text = (run_info_path / "run.toml").read_text(encoding="utf-8")
+    run = tomllib.loads(run_text)
+    parameters = tomllib.loads(
+        (run_info_path / "parameters_used.toml").read_text(encoding="utf-8"),
+    )
+
+    assert run_text.startswith("# ChemEx run information.\n")
+    assert run["schema_version"] == 1
+    assert run["created_at_utc"] == "2026-06-24T12:30:00+00:00"
+    assert run["run"]["kind"] == "fit"
+    assert run["run"]["working_directory"] == str(tmp_path)
+    assert run["run"]["output_directory"] == str(output)
+    assert run["chemex"]["version"] == __version__
+    assert run["python"]["version"]
+    assert run["python"]["platform"]
+    assert run["command"]["arguments"] == argv
+    assert "git" not in run
+
+    copied_experiment = run["inputs"]["experiments"][0]
+    assert copied_experiment["provided_path"] == "experiment.toml"
+    assert copied_experiment["resolved_path"] == str(experiment_file.resolve())
+    assert (run_info_path / copied_experiment["copied_path"]).exists()
+    copied_parameter_path = (
+        run_info_path / run["inputs"]["parameters"][0]["copied_path"]
+    )
+    assert copied_parameter_path.read_text(encoding="utf-8") == ("[GLOBAL]\nPB = 0.1\n")
+    copied_method = run["inputs"]["methods"][0]
+    assert copied_method["resolved_path"] == str(method_file.resolve())
+    assert (run_info_path / copied_method["copied_path"]).exists()
+
+    parameters_text = (run_info_path / "parameters_used.toml").read_text(
+        encoding="utf-8",
+    )
+    assert parameters_text.startswith(
+        "# Starting independent parameters used by ChemEx for this fit.\n"
+    )
+    assert "intended to be usable as a starting parameter file" in parameters_text
+    assert parameters["GLOBAL"]["PB"] == [0.15, 0.0, 1.0]
+    assert parameters["DW_AB"]["15N"] == [2.5, -10.0, 10.0, 0.5]
+    assert "PA" not in parameters["GLOBAL"]
+
+
+def test_input_files_with_same_basename_are_copied_without_collision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    experiment_a = _write_input(
+        tmp_path / "field1" / "experiment.toml",
+        '[input]\nfield = "a"\n',
+    )
+    experiment_b = _write_input(
+        tmp_path / "field2" / "experiment.toml",
+        '[input]\nfield = "b"\n',
+    )
+    output = tmp_path / "Output"
+    args = Namespace(
+        experiments=[
+            Path("field1/experiment.toml"),
+            Path("field2/experiment.toml"),
+        ],
+        parameters=[],
+        method=None,
+        output=output,
+    )
+    experiments = SimpleNamespace(
+        param_ids=set(),
+        parameter_store=ParameterStore({}),
+    )
+    monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
+
+    run_info_module.write_run_info(
+        args,
+        experiments,
+        argv=["chemex", "fit"],
+        working_directory=tmp_path,
+        timestamp=datetime(2026, 6, 24, 12, 30, tzinfo=UTC),
+    )
+    run_info_path = output / "run_info"
+    run = tomllib.loads((run_info_path / "run.toml").read_text(encoding="utf-8"))
+    copied_inputs = run["inputs"]["experiments"]
+    copied_paths = [item["copied_path"] for item in copied_inputs]
+
+    assert len(set(copied_paths)) == 2
+    assert all("__" in Path(path).stem for path in copied_paths)
+    assert (run_info_path / copied_paths[0]).read_text(encoding="utf-8") == (
+        experiment_a.read_text(encoding="utf-8")
+    )
+    assert (run_info_path / copied_paths[1]).read_text(encoding="utf-8") == (
+        experiment_b.read_text(encoding="utf-8")
+    )
+
+    run_info_module.write_run_info(
+        args,
+        experiments,
+        argv=["chemex", "fit"],
+        working_directory=tmp_path,
+        timestamp=datetime(2026, 6, 24, 12, 30, tzinfo=UTC),
+    )
+    repeated_run = tomllib.loads(
+        (run_info_path / "run.toml").read_text(encoding="utf-8"),
+    )
+    repeated_paths = [
+        item["copied_path"] for item in repeated_run["inputs"]["experiments"]
+    ]
+    assert repeated_paths == copied_paths
+
+
+def test_run_fit_creates_run_info(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    experiment_file = _write_input(tmp_path / "experiment.toml")
+    parameters_file = _write_input(tmp_path / "parameters.toml")
+    parameter = ParamSetting(ParamName("PB"), value=0.2)
+    store = ParameterStore({parameter.id_: parameter})
+    experiments = FitExperiments(store, {parameter.id_})
+    output = tmp_path / "Output"
+    args = Namespace(
+        experiments=[experiment_file],
+        parameters=[parameters_file],
+        method=None,
+        output=output,
+        plot="nothing",
+    )
+    run_methods_calls: list[Path] = []
+
+    monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
+    monkeypatch.setattr(chemex_module, "print_start_fit", lambda: None)
+    monkeypatch.setattr(
+        chemex_module,
+        "run_methods",
+        lambda _experiments, _methods, path, _plot, **_kwargs: run_methods_calls.append(
+            path
+        ),
+    )
+
+    chemex_module.run_fit(
+        args,
+        experiments,
+        SimpleNamespace(),
+        argv=["chemex", "fit"],
+    )
+
+    assert experiments.filter_calls == 1
+    assert run_methods_calls == [output]
+    assert (output / "run_info" / "run.toml").exists()
+    assert (output / "run_info" / "parameters_used.toml").exists()
+
+
+def test_git_metadata_is_optional_when_git_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(run_info_module, "_find_git_root", lambda _start: tmp_path)
+
+    def unavailable(*_args, **_kwargs) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(run_info_module.subprocess, "run", unavailable)
+
+    assert run_info_module._git_metadata() is None  # noqa: SLF001
+
+
+def test_git_metadata_is_omitted_for_repository_not_tracking_chemex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    source_directory = Path(run_info_module.__file__).resolve().parent
+
+    monkeypatch.setattr(
+        run_info_module,
+        "_find_git_root",
+        lambda _start: source_directory,
+    )
+
+    def run_git(_repository: Path, *arguments: str) -> str:
+        calls.append(arguments)
+        if arguments[0] == "ls-files":
+            raise subprocess.CalledProcessError(1, arguments)
+        pytest.fail("Git metadata should stop when the source file is not tracked")
+
+    monkeypatch.setattr(run_info_module, "_run_git", run_git)
+
+    assert run_info_module._git_metadata() is None  # noqa: SLF001
+    assert calls[0][:2] == ("ls-files", "--error-unmatch")
+
+
+def test_same_output_rerun_can_use_archived_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    original_input = _write_input(tmp_path / "experiment.toml")
+    experiments = SimpleNamespace(
+        param_ids=set(),
+        parameter_store=ParameterStore({}),
+    )
+    monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
+
+    run_info_module.write_run_info(
+        Namespace(
+            experiments=[original_input],
+            parameters=[],
+            method=None,
+            output=output,
+        ),
+        experiments,
+        argv=["chemex", "fit"],
+        working_directory=tmp_path,
+    )
+    archived_input = (
+        output / "run_info" / "inputs" / "experiments" / original_input.name
+    )
+
+    run_info_module.write_run_info(
+        Namespace(
+            experiments=[archived_input],
+            parameters=[],
+            method=None,
+            output=output,
+        ),
+        experiments,
+        argv=["chemex", "fit"],
+        working_directory=tmp_path,
+    )
+
+    copied_input = output / "run_info" / "inputs" / "experiments" / original_input.name
+    assert copied_input.read_text(encoding="utf-8") == original_input.read_text(
+        encoding="utf-8",
+    )
+
+
+def test_failed_staging_preserves_existing_run_info(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    run_info_path = output / "run_info"
+    run_info_path.mkdir(parents=True)
+    existing_run = run_info_path / "run.toml"
+    existing_run.write_text("schema_version = 1\n", encoding="utf-8")
+    missing_input = tmp_path / "missing.toml"
+    experiments = SimpleNamespace(
+        param_ids=set(),
+        parameter_store=ParameterStore({}),
+    )
+    monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
+
+    with pytest.raises(FileNotFoundError):
+        run_info_module.write_run_info(
+            Namespace(
+                experiments=[missing_input],
+                parameters=[],
+                method=None,
+                output=output,
+            ),
+            experiments,
+            argv=["chemex", "fit"],
+            working_directory=tmp_path,
+        )
+
+    assert existing_run.read_text(encoding="utf-8") == "schema_version = 1\n"
+    assert not list(output.glob(".run_info-*"))
+
+
+def test_failed_replacement_restores_existing_run_info(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_info_path = tmp_path / "run_info"
+    run_info_path.mkdir()
+    existing_run = run_info_path / "run.toml"
+    existing_run.write_text("schema_version = 1\n", encoding="utf-8")
+    staging_path = tmp_path / ".run_info-staging"
+    staging_path.mkdir()
+    (staging_path / "run.toml").write_text("schema_version = 2\n", encoding="utf-8")
+    original_replace = Path.replace
+    error_message = "replacement failed"
+
+    def fail_staging_replace(path: Path, target: Path) -> Path:
+        if path == staging_path:
+            raise OSError(error_message)
+        return original_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_staging_replace)
+
+    with pytest.raises(OSError, match="replacement failed"):
+        run_info_module._replace_run_info(  # noqa: SLF001
+            staging_path,
+            run_info_path,
+        )
+
+    assert existing_run.read_text(encoding="utf-8") == "schema_version = 1\n"
+    assert staging_path.exists()
+    assert not list(tmp_path.glob(".run_info-backup-*"))

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -42,6 +42,17 @@ Output/
 
 The output directory typically includes the following files and subdirectories:
 
+### `run_info/`
+
+Records how the fit was started. `run.toml` contains runtime and command-line
+metadata grouped into run, ChemEx, Python, command, input, and optional Git
+sections. `parameters_used.toml` contains the parsed independent starting
+parameters needed to restart the fit, including values and bounds. Parameters
+calculated from expressions are not written separately because ChemEx
+reconstructs them from the independent parameters and model. `inputs/` contains
+lightweight copies of the user-provided experiment, parameter, and method TOML
+files. Raw experimental data files are not copied.
+
 ### `Parameters/`
 
 Contains results of the fitting as three files: `fitted.toml`, `fixed.toml`, and `constrained.toml`, which list parameters that were fitted, fixed, and constrained, respectively.


### PR DESCRIPTION
## Summary

Add a lightweight `run_info/` directory to ChemEx fit outputs so users can inspect how a fit was started and reuse its parsed starting parameters.

The output contains:

- structured runtime, command, path, input, and optional Git metadata in `run_info/run.toml`
- parsed independent starting parameter values and bounds in `run_info/parameters_used.toml`
- collision-safe copies of user-provided experiment, parameter, and method TOML files under `run_info/inputs/`

## Design and behavior

- Enabled by default for `chemex fit`
- Does not copy raw experimental data or export package/environment state
- Does not alter fitting, parameter interpretation, or numerical results
- Omits expression-derived parameters because ChemEx reconstructs them from the independent parameters and model
- Treats Git metadata as optional and only records it when the detected repository tracks the ChemEx source file
- Builds the archive in a staging directory and replaces the previous `run_info` only after successful completion, preserving prior output on failures and supporting same-output reruns from archived inputs

## Validation

- `265 passed` with `pytest tests -q`
- Ruff lint and formatting checks passed
- `ty` type checks passed
- `git diff --check` passed