### PR TITLE
[codex] Streamline observed and starting state configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 
 ## [Unreleased]
 
+### Changed
+- `observed_state` now accepts a state list for unweighted multi-state
+  detection in final-magnetization experiments.
+- Replaced `detect_all_states` with an explicit `observed_state` list.
+- Replaced `cs_evolution_prior` with `start_state`; provide one or more states
+  for non-equilibrium preparation, or use an empty list for equilibrium.
+- Preserved the existing observed-state starting defaults for `cest_1hn_ap`,
+  `cpmg_1hn_ap`, `cpmg_1hn_ap_0013`, and `cpmg_ch3_1h_sq`; use
+  `start_state = []` to request equilibrium preparation for these experiments.
+
 ## [2026.06.0] - 2026-06-03
 
 ### Added

--- a/src/chemex/configuration/experiment.py
+++ b/src/chemex/configuration/experiment.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import math
-from typing import Any, ClassVar, Literal, TypeVar
+from string import ascii_lowercase
+from typing import Annotated, Any, ClassVar, TypeVar
 
 import numpy as np
 from pydantic import (
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
-    computed_field,
+    ValidationInfo,
     field_validator,
     model_validator,
 )
@@ -16,10 +18,88 @@ from pydantic import (
 from chemex.configuration.b1_config import parse_distribution_config
 from chemex.configuration.types import OptionalB1Field, PulseWidth
 from chemex.configuration.utils import key_to_lower
+from chemex.models.model import ModelSpec
+from chemex.nmr._engine.detection import build_state_detection_expression
 from chemex.nmr.constants import Distribution
 from chemex.nmr.distributions.registry import DistributionConfig
 
 T = TypeVar("T")
+_SUPPORTED_STATES = tuple(ascii_lowercase[:6])
+
+
+def _model_states_from_context(info: ValidationInfo) -> tuple[str, ...]:
+    context = info.context
+    model = context.get("model") if isinstance(context, dict) else None
+    if isinstance(model, ModelSpec):
+        return tuple(model.states)
+    return _SUPPORTED_STATES
+
+
+def _validate_state(value: object, info: ValidationInfo) -> str:
+    field = info.field_name or "state"
+    if not isinstance(value, str):
+        msg = f"'{field}' must be a state string"
+        raise ValueError(msg)  # noqa: TRY004
+
+    state = value.lower()
+    available_states = _model_states_from_context(info)
+    if state not in available_states:
+        available_list = ", ".join(repr(item) for item in available_states)
+        msg = (
+            f"Unknown {field.replace('_', ' ')}: {state!r}. "
+            f"Available states: {available_list}"
+        )
+        raise ValueError(msg)
+    return state
+
+
+def _validate_state_selection(
+    value: object,
+    info: ValidationInfo,
+) -> str | tuple[str, ...]:
+    field = info.field_name or "state"
+    if isinstance(value, str):
+        return _validate_state(value, info)
+    if not isinstance(value, (list, tuple)):
+        msg = (
+            f"'{field}' must be a state string or a non-empty list "
+            "of state strings"
+        )
+        raise ValueError(msg)  # noqa: TRY004
+    if not value:
+        msg = f"'{field}' must contain at least one state"
+        raise ValueError(msg)
+    if not all(isinstance(state, str) for state in value):
+        msg = f"Every entry in '{field}' must be a string"
+        raise ValueError(msg)
+
+    states = tuple(_validate_state(state, info) for state in value)
+    duplicates = sorted(state for state in set(states) if states.count(state) > 1)
+    if duplicates:
+        duplicate_list = ", ".join(repr(state) for state in duplicates)
+        msg = f"'{field}' contains duplicate states: {duplicate_list}"
+        raise ValueError(msg)
+    return states
+
+
+def _validate_start_state_selection(
+    value: object,
+    info: ValidationInfo,
+) -> str | tuple[str, ...]:
+    if isinstance(value, (list, tuple)) and not value:
+        return ()
+    return _validate_state_selection(value, info)
+
+
+_State = Annotated[str, BeforeValidator(_validate_state)]
+_StateSelection = Annotated[
+    str | tuple[str, ...],
+    BeforeValidator(_validate_state_selection),
+]
+_StartStateSelection = Annotated[
+    str | tuple[str, ...],
+    BeforeValidator(_validate_start_state_selection),
+]
 
 
 def _legacy_b1_distribution_input(
@@ -55,12 +135,34 @@ def normalize_b1_eff_alias(data: Any) -> Any:
 
 
 class ExperimentSettings(BaseModel):
-    observed_state: Literal["a", "b", "c", "d"] = "a"
+    observed_state: _State = "a"
     model_name: str = Field(default="", exclude=True)
 
     model_config = ConfigDict(str_to_lower=True)
 
     _key_to_lower = model_validator(mode="before")(key_to_lower)
+
+
+class DetectionSettings(ExperimentSettings):
+    """Settings for experiments that detect a final magnetization vector."""
+
+    observed_state: _StateSelection = "a"
+
+    @property
+    def observed_states(self) -> tuple[str, ...]:
+        """Normalized states contributing to final-magnetization detection."""
+        if isinstance(self.observed_state, str):
+            return (self.observed_state,)
+        return self.observed_state
+
+    @property
+    def primary_state(self) -> str:
+        """First observed state, used where a single reference state is needed."""
+        return self.observed_states[0]
+
+    def get_detection_expression(self, expression: str) -> str:
+        """Apply the selected observed states to a detection expression."""
+        return build_state_detection_expression(expression, self.observed_states)
 
 
 class B1InhomogeneityMixin(BaseModel):
@@ -185,53 +287,98 @@ class B1InhomogeneityMixin(BaseModel):
         return self.b1_distribution.get_distribution(nominal)
 
 
-class RelaxationSettings(ExperimentSettings):
+class RelaxationSettings(DetectionSettings):
     """Base settings for relaxation-based experiments (CEST, DCEST, CPMG, etc).
 
     Attributes:
-        cs_evolution_prior (bool):
-            Controls the initial condition (equilibrium vs non-equilibrium).
-            If False (default), the initial magnetization assumes thermal
-            equilibrium with all states populated according to their equilibrium
-            populations. If True, only the observed state is initially populated
-            (non-equilibrium condition), which is appropriate when chemical shift
-            evolution occurs before the CEST/CPMG element in the pulse sequence,
-            breaking the equilibrium assumption. This can affect the accuracy of
-            extracted kinetic parameters, especially for slow exchange rates
-            (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-        detect_all_states (bool):
-            If True, detection will use all states (e.g., '[iz]'),
-            otherwise only the observed state (e.g., '[iz_a]').
-
-    Properties:
-        suffix_start: Suffix for starting terms, respects cs_evolution_prior.
-        suffix_detect: Suffix for detection, respects detect_all_states.
-            Returns '' if detect_all_states is True, else '_{observed_state}'.
+        start_state:
+            Optional state or states used for non-equilibrium starting
+            magnetization. If omitted, the experiment-specific default is used;
+            this is thermal equilibrium for most experiments.
 
     """
 
-    cs_evolution_prior: bool = False
-    detect_all_states: bool = False
+    start_from_observed_by_default: ClassVar[bool] = False
+    start_state: _StartStateSelection | None = None
 
-    @computed_field
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_removed_state_flags(
+        cls,
+        data: Any,
+        info: ValidationInfo,
+    ) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        values = {str(key).lower(): value for key, value in data.items()}
+        detect_all_states = values.get("detect_all_states")
+        if detect_all_states is True:
+            states = ", ".join(
+                f'"{state}"' for state in _model_states_from_context(info)
+            )
+            msg = (
+                "'detect_all_states' has been removed; use "
+                f"'observed_state = [{states}]'"
+            )
+            raise ValueError(msg)
+        if detect_all_states is False:
+            msg = (
+                "'detect_all_states' has been removed; remove it to retain "
+                "single-state detection through 'observed_state'"
+            )
+            raise ValueError(msg)
+        if "detect_all_states" in values:
+            msg = (
+                "'detect_all_states' has been removed; configure detection with "
+                "'observed_state' instead"
+            )
+            raise ValueError(msg)
+
+        cs_evolution_prior = values.get("cs_evolution_prior")
+        if cs_evolution_prior is True:
+            msg = (
+                "'cs_evolution_prior' has been removed; set 'start_state' to "
+                "the observed state or states"
+            )
+            raise ValueError(msg)
+        if cs_evolution_prior is False:
+            replacement = (
+                "use 'start_state = []' to retain equilibrium preparation"
+                if cls.start_from_observed_by_default
+                else "remove it to retain equilibrium preparation"
+            )
+            msg = f"'cs_evolution_prior' has been removed; {replacement}"
+            raise ValueError(msg)
+        if "cs_evolution_prior" in values:
+            msg = (
+                "'cs_evolution_prior' has been removed; configure preparation "
+                "with 'start_state' instead"
+            )
+            raise ValueError(msg)
+        return data
+
     @property
-    def suffix_start(self) -> str:
-        """Suffix for starting terms.
+    def start_states(self) -> tuple[str, ...]:
+        """Normalized non-equilibrium starting states, or empty for equilibrium."""
+        if self.start_state is None:
+            if self.start_from_observed_by_default:
+                return self.observed_states
+            return ()
+        if isinstance(self.start_state, str):
+            return (self.start_state,)
+        return self.start_state
 
-        Returns '_{observed_state}' if cs_evolution_prior is True (non-equilibrium
-        initial condition with only the observed state populated), else ''
-        (equilibrium initial condition with all states populated).
-        """
-        return f"_{self.observed_state}" if self.cs_evolution_prior else ""
-
-    @computed_field
-    @property
-    def suffix_detect(self) -> str:
-        """Suffix for detection.
-
-        Returns '' if detect_all_states is True, else '_{observed_state}'.
-        """
-        return "" if self.detect_all_states else f"_{self.observed_state}"
+    def get_start_terms(self, *components: str) -> list[str]:
+        """Apply starting-state selection to basis components."""
+        states = self.start_states
+        if not states:
+            return list(components)
+        return [
+            f"{component}_{state}"
+            for state in states
+            for component in components
+        ]
 
 
 class CpmgSettings(RelaxationSettings):

--- a/src/chemex/configuration/experiment.py
+++ b/src/chemex/configuration/experiment.py
@@ -294,7 +294,10 @@ class RelaxationSettings(DetectionSettings):
         start_state:
             Optional state or states used for non-equilibrium starting
             magnetization. If omitted, the experiment-specific default is used;
-            this is thermal equilibrium for most experiments.
+            this is thermal equilibrium for most experiments. Set it when
+            chemical shift evolution or another preparation step occurs before
+            the measured relaxation/exchange element and the equilibrium
+            assumption no longer matches the pulse sequence.
 
     """
 

--- a/src/chemex/experiments/catalog/cest_13c.py
+++ b/src/chemex/experiments/catalog/cest_13c.py
@@ -37,13 +37,13 @@ class Cest13CSettings(CestSettings, B1InhomogeneityMixin):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms."""
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Cest13CConfig(
@@ -53,7 +53,7 @@ class Cest13CConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=["r2_i", f"r1_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/cest_15n.py
+++ b/src/chemex/experiments/catalog/cest_15n.py
@@ -38,13 +38,13 @@ class Cest15NSettings(CestSettings, B1InhomogeneityMixin):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms."""
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Cest15NConfig(
@@ -54,7 +54,7 @@ class Cest15NConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=["r2_i", f"r1_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/cest_15n_cw.py
+++ b/src/chemex/experiments/catalog/cest_15n_cw.py
@@ -41,13 +41,13 @@ class Cest15NCwSettings(CestSettings, B1InhomogeneityMixin):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms for the experiment."""
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator for the experiment."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Cest15NCwConfig(
@@ -57,7 +57,7 @@ class Cest15NCwConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[
                 "r2_i",

--- a/src/chemex/experiments/catalog/cest_15n_tr.py
+++ b/src/chemex/experiments/catalog/cest_15n_tr.py
@@ -43,19 +43,17 @@ class Cest15NTrSettings(CestSettings, B1InhomogeneityMixin):
         TROSY: (2IzSz + Iz) / 2
         ANTITROSY: (2IzSz - Iz) / 2.
         """
-        suffix = self.suffix_start
         if not self.antitrosy:
-            return [f"2izsz{suffix}", f"-iz{suffix}"]
-        return [f"2izsz{suffix}", f"iz{suffix}"]
+            return self.get_start_terms("2izsz", "-iz")
+        return self.get_start_terms("2izsz", "iz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator for TROSY or ANTI-TROSY component."""
-        suffix = self.suffix_detect
         if self.antitrosy:
-            return f"[2izsz{suffix}] + [iz{suffix}]"
-        return f"[2izsz{suffix}] - [iz{suffix}]"
+            return self.get_detection_expression("[2izsz] + [iz]")
+        return self.get_detection_expression("[2izsz] - [iz]")
 
 
 class Cest15NTrConfig(
@@ -65,7 +63,7 @@ class Cest15NTrConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
 
         to_be_fitted = ToBeFitted(
             rates=["r2_i", f"r1_i_{state}", "r1a_is"],

--- a/src/chemex/experiments/catalog/cest_1hn_ap.py
+++ b/src/chemex/experiments/catalog/cest_1hn_ap.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 from pydantic import Field, computed_field
@@ -32,19 +32,19 @@ class Cest1HnApSettings(CestSettings, B1InhomogeneityMixin):
     name: Literal["cest_1hn_ap"]
     time_t1: float = Field(description="Length of the CEST block in seconds")
     carrier: Frequency = Field(description="1H carrier position in Hz")
-    cs_evolution_prior: bool = True
+    start_from_observed_by_default: ClassVar[bool] = True
 
     @computed_field
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization term (anti-phase)."""
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator (anti-phase)."""
-        return f"[2izsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2izsz]")
 
 
 class Cest1HnApConfig(
@@ -54,7 +54,7 @@ class Cest1HnApConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=["r2_i", f"r1_i_{state}", f"r1_s_{state}", f"etaxy_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}", f"khh_{state}"],

--- a/src/chemex/experiments/catalog/cest_1hn_ip_ap.py
+++ b/src/chemex/experiments/catalog/cest_1hn_ip_ap.py
@@ -39,9 +39,15 @@ class Cest1HnIpApSettings(CestSettings, B1InhomogeneityMixin):
 
     @computed_field
     @property
+    def start_terms(self) -> list[str]:
+        """Starting longitudinal identity components."""
+        return self.get_start_terms("ie")
+
+    @computed_field
+    @property
     def detection(self) -> str:
         """Detection operator (anti-phase)."""
-        return f"[2izsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2izsz]")
 
     @property
     def taud(self) -> float:
@@ -61,7 +67,7 @@ class Cest1HnIpApConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[
                 "r2_i",
@@ -116,7 +122,9 @@ class Cest1HnIpApSequence:
         pp180_sx = spectrometer.perfect180_s[0]
         pp180_isx = spectrometer.perfect180_i[0] @ spectrometer.perfect180_s[0]
 
-        start = d_taud @ spectrometer.get_start_magnetization(terms=["ie"])
+        start = d_taud @ spectrometer.get_start_magnetization(
+            terms=self.settings.start_terms,
+        )
         start = spectrometer.keep(start, components=["ie", "iz"])
 
         intensities: dict[float, float] = {}

--- a/src/chemex/experiments/catalog/cest_ch3_1h_ip_ap.py
+++ b/src/chemex/experiments/catalog/cest_ch3_1h_ip_ap.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Literal
 
 import numpy as np
-from pydantic import Field
+from pydantic import Field, computed_field
 
 from chemex.configuration.base import ExperimentConfiguration, ToBeFitted
 from chemex.configuration.conditions import ConditionsWithValidations
@@ -35,9 +35,15 @@ class CestCh31HIpApSettings(CestSettings, B1InhomogeneityMixin):
     carrier: Frequency = Field(description="1H carrier position in Hz")
     taua: float = 2.00e-3
 
+    @computed_field
+    @property
+    def start_terms(self) -> list[str]:
+        """Starting longitudinal identity components."""
+        return self.get_start_terms("ie")
+
     @property
     def detection(self) -> str:
-        return f"[2izsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2izsz]")
 
 
 class CestCh31HIpApConfig(
@@ -49,7 +55,7 @@ class CestCh31HIpApConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[
                 "r2_i",
@@ -103,7 +109,9 @@ class CestCh31HIpApSequence:
         pp90_i = spectrometer.perfect90_i
         pp180_isx = spectrometer.perfect180_i[0] @ spectrometer.perfect180_s[0]
 
-        start = d_d1 @ spectrometer.get_start_magnetization(terms=["ie"])
+        start = d_d1 @ spectrometer.get_start_magnetization(
+            terms=self.settings.start_terms,
+        )
         start = spectrometer.keep(start, components=["ie", "iz"])
 
         intensities: dict[float, float] = {}

--- a/src/chemex/experiments/catalog/coscest_13c.py
+++ b/src/chemex/experiments/catalog/coscest_13c.py
@@ -42,13 +42,13 @@ class CosCest13CSettings(MFCestSettings, B1InhomogeneityMixin):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms for the experiment."""
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator for the experiment."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class CosCest13CConfig(
@@ -58,7 +58,7 @@ class CosCest13CConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=["r2_i", f"r1_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/coscest_1hn_ip_ap.py
+++ b/src/chemex/experiments/catalog/coscest_1hn_ip_ap.py
@@ -40,9 +40,15 @@ class CosCest1HnIpApSettings(MFCestSettings, B1InhomogeneityMixin):
 
     @computed_field
     @property
+    def start_terms(self) -> list[str]:
+        """Starting longitudinal identity components."""
+        return self.get_start_terms("ie")
+
+    @computed_field
+    @property
     def detection(self) -> str:
         """Detection operator (anti-phase)."""
-        return f"[2izsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2izsz]")
 
 
 class CosCest1HnIpApConfig(
@@ -54,7 +60,7 @@ class CosCest1HnIpApConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[
                 "r2_i",
@@ -146,7 +152,9 @@ class CosCest1HnIpApSequence:
         pp90_i = spectrometer.perfect90_i
         pp180_isx = spectrometer.perfect180_i[0] @ spectrometer.perfect180_s[0]
 
-        start = d_d1 @ spectrometer.get_start_magnetization(terms=["ie"])
+        start = d_d1 @ spectrometer.get_start_magnetization(
+            terms=self.settings.start_terms,
+        )
         start = spectrometer.keep(start, components=["ie", "iz"])
 
         intensities: dict[float, float] = {}

--- a/src/chemex/experiments/catalog/cpmg_13c_ip.py
+++ b/src/chemex/experiments/catalog/cpmg_13c_ip.py
@@ -44,13 +44,13 @@ class Cpmg13CIpSettings(CpmgSettings):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms for the experiment."""
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator for the experiment."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Cpmg13CIpConfig(
@@ -62,7 +62,7 @@ class Cpmg13CIpConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_13co_ap.py
+++ b/src/chemex/experiments/catalog/cpmg_13co_ap.py
@@ -46,13 +46,13 @@ class Cpmg13CoApSettings(CpmgSettings):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms (anti-phase)."""
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator (anti-phase)."""
-        return f"[2izsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2izsz]")
 
     @model_validator(mode="after")
     def _sync_even_ncycs(self) -> Cpmg13CoApSettings:
@@ -76,7 +76,7 @@ class Cpmg13CoApConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_15n_ip.py
+++ b/src/chemex/experiments/catalog/cpmg_15n_ip.py
@@ -44,13 +44,13 @@ class Cpmg15NIpSettings(CpmgSettings):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms for the experiment."""
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator for the experiment."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Cpmg15NIpConfig(
@@ -62,7 +62,7 @@ class Cpmg15NIpConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_15n_ip_0013.py
+++ b/src/chemex/experiments/catalog/cpmg_15n_ip_0013.py
@@ -73,7 +73,7 @@ class Cpmg15N0013IpSettings(CpmgSettings):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
@@ -84,7 +84,7 @@ class Cpmg15N0013IpSettings(CpmgSettings):
             Detection term for the Liouvillian calculation.
 
         """
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Cpmg15N0013IpConfig(
@@ -96,7 +96,7 @@ class Cpmg15N0013IpConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_15n_tr.py
+++ b/src/chemex/experiments/catalog/cpmg_15n_tr.py
@@ -50,14 +50,13 @@ class Cpmg15NTrSettings(CpmgSettings):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms (TROSY component)."""
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @property
     def detection(self) -> str:
-        suffix = self.suffix_detect
         if self.antitrosy:
-            return f"[2izsz{suffix}] + [iz{suffix}]"
-        return f"[2izsz{suffix}] - [iz{suffix}]"
+            return self.get_detection_expression("[2izsz] + [iz]")
+        return self.get_detection_expression("[2izsz] - [iz]")
 
 
 class Cpmg15NTrConfig(
@@ -69,7 +68,7 @@ class Cpmg15NTrConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
 
         to_be_fitted = ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 

--- a/src/chemex/experiments/catalog/cpmg_15n_tr_0013.py
+++ b/src/chemex/experiments/catalog/cpmg_15n_tr_0013.py
@@ -86,12 +86,11 @@ class Cpmg15NTr0013Settings(CpmgSettings):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        suffix = self.suffix_start
         if self.s3e:
             if self.antitrosy:
-                return [f"2izsz{suffix}", f"iz{suffix}"]
-            return [f"2izsz{suffix}", f"-iz{suffix}"]
-        return [f"2izsz{suffix}"]
+                return self.get_start_terms("2izsz", "iz")
+            return self.get_start_terms("2izsz", "-iz")
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
@@ -102,10 +101,9 @@ class Cpmg15NTr0013Settings(CpmgSettings):
             Detection term for the Liouvillian calculation.
 
         """
-        suffix = self.suffix_detect
         if self.antitrosy:
-            return f"[2izsz{suffix}] + [iz{suffix}]"
-        return f"[2izsz{suffix}] - [iz{suffix}]"
+            return self.get_detection_expression("[2izsz] + [iz]")
+        return self.get_detection_expression("[2izsz] - [iz]")
 
 
 class Cpmg15NTr0013Config(
@@ -117,7 +115,7 @@ class Cpmg15NTr0013Config(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
 
         to_be_fitted = ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 

--- a/src/chemex/experiments/catalog/cpmg_1hn_ap.py
+++ b/src/chemex/experiments/catalog/cpmg_1hn_ap.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 from numpy.linalg import matrix_power
@@ -34,7 +34,7 @@ class Cpmg1HnApSettings(CpmgSettings):
     pw90: PulseWidth = Field(description="90-degree pulse width in seconds")
     time_equil_1: Delay = 0.0
     time_equil_2: Delay = 0.0
-    cs_evolution_prior: bool = True
+    start_from_observed_by_default: ClassVar[bool] = True
 
     @computed_field
     @property
@@ -46,13 +46,13 @@ class Cpmg1HnApSettings(CpmgSettings):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms (anti-phase)."""
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator (anti-phase)."""
-        return f"[2izsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2izsz]")
 
 
 class Cpmg1HnApConfig(
@@ -64,7 +64,7 @@ class Cpmg1HnApConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_1hn_ap_0013.py
+++ b/src/chemex/experiments/catalog/cpmg_1hn_ap_0013.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import reduce
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 from pydantic import Field, computed_field
@@ -61,10 +61,7 @@ class Cpmg1HnAp0013Settings(CpmgSettings):
         ge=0.0,
         description="Second equilibration delay (seconds)",
     )
-    cs_evolution_prior: bool = Field(
-        default=True,
-        description="Flag for chemical shift evolution prior to CPMG",
-    )
+    start_from_observed_by_default: ClassVar[bool] = True
 
     @computed_field
     @property
@@ -86,7 +83,7 @@ class Cpmg1HnAp0013Settings(CpmgSettings):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
@@ -97,7 +94,7 @@ class Cpmg1HnAp0013Settings(CpmgSettings):
             Detection term for the Liouvillian calculation.
 
         """
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Cpmg1HnAp0013Config(
@@ -109,7 +106,7 @@ class Cpmg1HnAp0013Config(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_ch3_13c_h2c.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_13c_h2c.py
@@ -45,13 +45,13 @@ class CpmgCh313CH2cSettings(CpmgSettingsEvenNcycs):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms (anti-phase)."""
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator (in-phase)."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class CpmgCh313CH2cConfig(
@@ -63,7 +63,7 @@ class CpmgCh313CH2cConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_ch3_13c_h2c_0013.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_13c_h2c_0013.py
@@ -90,7 +90,7 @@ class CpmgCh313CH2c0013Settings(CpmgSettingsEvenNcycs):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
@@ -101,7 +101,7 @@ class CpmgCh313CH2c0013Settings(CpmgSettingsEvenNcycs):
             Detection term for the Liouvillian calculation.
 
         """
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class CpmgCh313CH2c0013Config(
@@ -113,7 +113,7 @@ class CpmgCh313CH2c0013Config(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_ch3_1h_dq.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_1h_dq.py
@@ -55,7 +55,7 @@ class CpmgCh31HDqSettings(CpmgSettings):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        return [f"2ixsz{self.suffix_start}"]
+        return self.get_start_terms("2ixsz")
 
     @computed_field
     @property
@@ -66,7 +66,7 @@ class CpmgCh31HDqSettings(CpmgSettings):
             Detection term for the Liouvillian calculation.
 
         """
-        return f"[2ixsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2ixsz]")
 
 
 class CpmgCh31HDqConfig(
@@ -78,7 +78,7 @@ class CpmgCh31HDqConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
 
         to_be_fitted = ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 

--- a/src/chemex/experiments/catalog/cpmg_ch3_1h_sq.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_1h_sq.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import reduce
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 from pydantic import Field, computed_field
@@ -36,19 +36,19 @@ class CpmgCh31HSqSettings(CpmgSettings):
     taua: float = 2.0e-3
     comp180_flg: bool = True
     ipap_flg: bool = False
-    cs_evolution_prior: bool = True
+    start_from_observed_by_default: ClassVar[bool] = True
 
     @computed_field
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms (transverse components)."""
-        return [f"2ixsz{self.suffix_start}", f"2iysz{self.suffix_start}"]
+        return self.get_start_terms("2ixsz", "2iysz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator."""
-        return f"[iy{self.suffix_detect}]"
+        return self.get_detection_expression("[iy]")
 
 
 class CpmgCh31HSqConfig(
@@ -60,7 +60,7 @@ class CpmgCh31HSqConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
 
         to_be_fitted = ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 

--- a/src/chemex/experiments/catalog/cpmg_ch3_1h_tq.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_1h_tq.py
@@ -40,13 +40,13 @@ class CpmgCh31HTqSettings(CpmgSettings):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms (triple-quantum)."""
-        return [f"2ixsz{self.suffix_start}"]
+        return self.get_start_terms("2ixsz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator (triple-quantum)."""
-        return f"[2ixsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2ixsz]")
 
 
 class CpmgCh31HTqConfig(
@@ -58,7 +58,7 @@ class CpmgCh31HTqConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
 
         to_be_fitted = ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 

--- a/src/chemex/experiments/catalog/cpmg_ch3_1h_tq_diff.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_1h_tq_diff.py
@@ -77,7 +77,7 @@ class CpmgCh31HTqDiffSettings(CpmgSettings):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        return [f"2ixsz{self.suffix_start}"]
+        return self.get_start_terms("2ixsz")
 
     @computed_field
     @property
@@ -88,7 +88,7 @@ class CpmgCh31HTqDiffSettings(CpmgSettings):
             Detection term for the Liouvillian calculation.
 
         """
-        return f"[2ixsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2ixsz]")
 
 
 class CpmgCh31HTqDiffConfig(
@@ -100,7 +100,7 @@ class CpmgCh31HTqDiffConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
 
         to_be_fitted = ToBeFitted(
             rates=[f"r2_i_{state}", "d_"],

--- a/src/chemex/experiments/catalog/cpmg_ch3_mq.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_mq.py
@@ -37,13 +37,13 @@ class CpmgCh3MqSettings(CpmgSettings):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms (multiple-quantum)."""
-        return [f"2iysx{self.suffix_start}"]
+        return self.get_start_terms("2iysx")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator (multiple-quantum)."""
-        return f"[2iysx{self.suffix_detect}]"
+        return self.get_detection_expression("[2iysx]")
 
 
 class CpmgCh3MqConfig(
@@ -55,7 +55,7 @@ class CpmgCh3MqConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2mq_is_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_chd2_1h_ap.py
+++ b/src/chemex/experiments/catalog/cpmg_chd2_1h_ap.py
@@ -44,13 +44,13 @@ class CpmgChd21HApSettings(CpmgSettings):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms (anti-phase)."""
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator (anti-phase)."""
-        return f"[2izsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2izsz]")
 
 
 class CpmgChd21HApConfig(
@@ -60,7 +60,7 @@ class CpmgChd21HApConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
 
 

--- a/src/chemex/experiments/catalog/cpmg_hn_dq_zq.py
+++ b/src/chemex/experiments/catalog/cpmg_hn_dq_zq.py
@@ -50,7 +50,7 @@ class CpmgHNDqZqSettings(CpmgSettingsEvenNcycs):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        return [f"2ixsx{self.suffix_start}"]
+        return self.get_start_terms("2ixsx")
 
     @computed_field
     @property
@@ -61,10 +61,9 @@ class CpmgHNDqZqSettings(CpmgSettingsEvenNcycs):
             Detection term for the Liouvillian calculation.
 
         """
-        suffix = self.suffix_detect
         if self.dq_flg:
-            return f"[2ixsx{suffix}] - [2iysy{suffix}]"
-        return f"[2ixsx{suffix}] + [2iysy{suffix}]"
+            return self.get_detection_expression("[2ixsx] - [2iysy]")
+        return self.get_detection_expression("[2ixsx] + [2iysy]")
 
 
 class CpmgHNDqZqConfig(
@@ -74,7 +73,7 @@ class CpmgHNDqZqConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[f"r2mq_is_{state}", f"mu_is_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/dcest_13c.py
+++ b/src/chemex/experiments/catalog/dcest_13c.py
@@ -98,13 +98,13 @@ class DCest13CSettings(MFCestSettings, B1InhomogeneityMixin):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms."""
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator for the experiment."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class DCest13CConfig(
@@ -114,7 +114,7 @@ class DCest13CConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=["r2_i", f"r1_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/dcest_15n.py
+++ b/src/chemex/experiments/catalog/dcest_15n.py
@@ -104,14 +104,16 @@ class DCest15NSettings(MFCestSettings, B1InhomogeneityMixin):
     @property
     def start_terms(self) -> list[str]:
         """Starting magnetization terms based on kinetic model."""
+        if self.start_state is not None:
+            return self.get_start_terms("iz")
         starts = {"2st_hd": ["iz_a"], "4st_hd": ["iz_a", "iz_b"]}
-        return starts.get(self.model_name, [f"iz{self.suffix_start}"])
+        return starts.get(self.model_name, ["iz"])
 
     @computed_field
     @property
     def detection(self) -> str:
         """Detection operator for the experiment."""
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class DCest15NConfig(
@@ -121,7 +123,7 @@ class DCest15NConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=["r2_i", f"r1_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/relaxation_hznz.py
+++ b/src/chemex/experiments/catalog/relaxation_hznz.py
@@ -37,7 +37,7 @@ class RelaxationHzNzSettings(RelaxationSettings):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        return [f"2izsz{self.suffix_start}"]
+        return self.get_start_terms("2izsz")
 
     @computed_field
     @property
@@ -48,7 +48,7 @@ class RelaxationHzNzSettings(RelaxationSettings):
             Detection term for the Liouvillian calculation.
 
         """
-        return f"[2izsz{self.suffix_detect}]"
+        return self.get_detection_expression("[2izsz]")
 
 
 class RelaxationHzNzConfig(
@@ -60,7 +60,7 @@ class RelaxationHzNzConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[f"r1a_is_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}", f"khh_{state}"],

--- a/src/chemex/experiments/catalog/relaxation_nz.py
+++ b/src/chemex/experiments/catalog/relaxation_nz.py
@@ -37,7 +37,7 @@ class RelaxationNzSettings(RelaxationSettings):
             List of initial state terms for the Liouvillian calculation.
 
         """
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @computed_field
     @property
@@ -48,7 +48,7 @@ class RelaxationNzSettings(RelaxationSettings):
             Detection term for the Liouvillian calculation.
 
         """
-        return f"[iz{self.suffix_detect}]"
+        return self.get_detection_expression("[iz]")
 
 
 class RelaxationNzConfig(
@@ -60,7 +60,7 @@ class RelaxationNzConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[f"r1_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/wip/cest_15n_test.py
+++ b/src/chemex/experiments/catalog/wip/cest_15n_test.py
@@ -37,11 +37,11 @@ class Cest15NSettings(CestSettings, B1InhomogeneityMixin):
 
     @cached_property
     def start_terms(self) -> list[str]:
-        return [f"iz{self.suffix_start}"]
+        return self.get_start_terms("iz")
 
     @cached_property
     def detection(self) -> str:
-        return f"[iz_{self.observed_state}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Cest15NTestConfig(
@@ -51,7 +51,7 @@ class Cest15NTestConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=["r2_i", f"r1_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/wip/relaxation_15n_r1rho.py
+++ b/src/chemex/experiments/catalog/wip/relaxation_15n_r1rho.py
@@ -8,7 +8,7 @@ import numpy as np
 from chemex.configuration.base import ExperimentConfiguration, ToBeFitted
 from chemex.configuration.conditions import ConditionsWithValidations
 from chemex.configuration.data import RelaxationDataSettings
-from chemex.configuration.experiment import B1InhomogeneityMixin, ExperimentSettings
+from chemex.configuration.experiment import B1InhomogeneityMixin, DetectionSettings
 from chemex.containers.data import Data
 from chemex.containers.dataset import load_relaxation_dataset
 from chemex.experiments.factories import Creators, factories
@@ -23,18 +23,17 @@ from chemex.typing import Array
 EXPERIMENT_NAME = "wip.relaxation_15n_r1rho"
 
 
-class Relaxation15NR1RhoSettings(ExperimentSettings, B1InhomogeneityMixin):
+class Relaxation15NR1RhoSettings(DetectionSettings, B1InhomogeneityMixin):
     name: Literal["wip.relaxation_15n_r1rho"]
 
     carrier: float
     b1_frq: float
     legacy_b1_inh_scale_default: ClassVar[float | None] = np.inf
     legacy_b1_inh_res_default: ClassVar[int | None] = 11
-    observed_state: Literal["a", "b", "c", "d"] = "a"
 
     @property
     def detection(self) -> str:
-        return f"[iz_{self.observed_state}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Relaxation15NR1RhoConfig(
@@ -46,7 +45,7 @@ class Relaxation15NR1RhoConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[f"r2_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/experiments/catalog/wip/relaxation_15n_r1rho_eig.py
+++ b/src/chemex/experiments/catalog/wip/relaxation_15n_r1rho_eig.py
@@ -8,7 +8,7 @@ import numpy as np
 from chemex.configuration.base import ExperimentConfiguration, ToBeFitted
 from chemex.configuration.conditions import ConditionsWithValidations
 from chemex.configuration.data import RelaxationDataSettings
-from chemex.configuration.experiment import B1InhomogeneityMixin, ExperimentSettings
+from chemex.configuration.experiment import B1InhomogeneityMixin, DetectionSettings
 from chemex.containers.data import Data
 from chemex.containers.dataset import load_relaxation_dataset
 from chemex.experiments.factories import Creators, factories
@@ -23,18 +23,17 @@ from chemex.typing import Array
 EXPERIMENT_NAME = "wip.relaxation_15n_r1rho_eig"
 
 
-class Relaxation15NR1RhoSettings(ExperimentSettings, B1InhomogeneityMixin):
+class Relaxation15NR1RhoSettings(DetectionSettings, B1InhomogeneityMixin):
     name: Literal["wip.relaxation_15n_r1rho_eig"]
 
     carrier: float
     b1_frq: float
     legacy_b1_inh_scale_default: ClassVar[float | None] = np.inf
     legacy_b1_inh_res_default: ClassVar[int | None] = 11
-    observed_state: Literal["a", "b", "c", "d"] = "a"
 
     @property
     def detection(self) -> str:
-        return f"[iz_{self.observed_state}]"
+        return self.get_detection_expression("[iz]")
 
 
 class Relaxation15NR1RhoConfig(
@@ -46,7 +45,7 @@ class Relaxation15NR1RhoConfig(
 ):
     @property
     def to_be_fitted(self) -> ToBeFitted:
-        state = self.experiment.observed_state
+        state = self.experiment.primary_state
         return ToBeFitted(
             rates=[f"r2_i_{state}"],
             model_free=[f"tauc_{state}", f"s2_{state}"],

--- a/src/chemex/filterers.py
+++ b/src/chemex/filterers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Literal, Protocol, TypeVar
+from typing import Any, Generic, Protocol, TypeVar
 
 from chemex.containers.data import Data
 from chemex.nmr.spectrometer import Spectrometer
@@ -38,7 +38,7 @@ class PlanesFilterer:
 
 
 class CestExperimentSettings(Protocol):
-    observed_state: Literal["a", "b", "c", "d"]
+    primary_state: str
     sw: float
 
 
@@ -65,7 +65,7 @@ def _filter_offsets(
     config: CestExperimentConfig,
     spectrometer: Spectrometer,
 ) -> None:
-    state = config.experiment.observed_state
+    state = config.experiment.primary_state
     state_ppm = spectrometer.par_values[f"cs_i_{state}"]
     state_offset = spectrometer.ppms_to_offsets(state_ppm)
 

--- a/src/chemex/nmr/_engine/detection.py
+++ b/src/chemex/nmr/_engine/detection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 
 import numpy as np
 
@@ -10,6 +10,64 @@ from chemex.typing import Array
 _FIRST_TERM = re.compile(r"\s*([+-]?)\s*\[([^\[\]\s]+)\]\s*")
 _NEXT_TERM = re.compile(r"([+-])\s*\[([^\[\]\s]+)\]\s*")
 _SIGNS = {"": 1.0, "+": 1.0, "-": -1.0}
+
+
+def _parse_detection_expression(expression: str) -> list[tuple[float, str]]:
+    expression_stripped = expression.strip()
+    if not expression_stripped:
+        msg = "Detection expression cannot be empty"
+        raise ValueError(msg)
+
+    match = _FIRST_TERM.match(expression_stripped)
+    if match is None:
+        msg = f"Invalid detection expression: {expression!r}"
+        raise ValueError(msg)
+
+    sign_token, component_name = match.groups()
+    terms = [(_SIGNS[sign_token], component_name)]
+    position = match.end()
+
+    while position < len(expression_stripped):
+        match = _NEXT_TERM.match(expression_stripped, position)
+        if match is None:
+            msg = f"Invalid detection expression: {expression!r}"
+            raise ValueError(msg)
+
+        operator_token, component_name = match.groups()
+        terms.append((_SIGNS[operator_token], component_name))
+        position = match.end()
+
+    return terms
+
+
+def _format_detection_expression(terms: Iterable[tuple[float, str]]) -> str:
+    formatted: list[str] = []
+    for index, (sign, component_name) in enumerate(terms):
+        if index == 0:
+            prefix = "- " if sign < 0.0 else ""
+        else:
+            prefix = " - " if sign < 0.0 else " + "
+        formatted.append(f"{prefix}[{component_name}]")
+    return "".join(formatted)
+
+
+def build_state_detection_expression(
+    expression: str,
+    states: Iterable[str],
+) -> str:
+    """Expand a state-independent detection expression over selected states."""
+    state_tuple = tuple(states)
+    if not state_tuple:
+        msg = "At least one observed state is required"
+        raise ValueError(msg)
+
+    terms = _parse_detection_expression(expression)
+    state_terms = (
+        (sign, f"{component_name}_{state}")
+        for state in state_tuple
+        for sign, component_name in terms
+    )
+    return _format_detection_expression(state_terms)
 
 
 def _get_component_vector(name: str, vectors: Mapping[str, Array]) -> Array:
@@ -26,39 +84,19 @@ def build_detection_vector(expression: str, vectors: Mapping[str, Array]) -> Arr
     Supported syntax is a sum/subtraction of bracketed basis components, such as
     ``[iz_a]`` or ``[2izsz_a] - [iz_a]``.
     """
-    expression_stripped = expression.strip()
-    if not expression_stripped:
-        msg = "Detection expression cannot be empty"
-        raise ValueError(msg)
-
     try:
         sample_vector = next(iter(vectors.values()))
     except StopIteration as error:
         msg = "Cannot build detection vector without basis vectors"
         raise ValueError(msg) from error
 
-    match = _FIRST_TERM.match(expression_stripped)
-    if match is None:
-        msg = f"Invalid detection expression: {expression!r}"
-        raise ValueError(msg)
-
-    sign_token, component_name = match.groups()
-    sign = _SIGNS[sign_token]
+    terms = _parse_detection_expression(expression)
+    sign, component_name = terms[0]
     detection_vector = sign * _get_component_vector(component_name, vectors)
-    position = match.end()
-
-    while position < len(expression_stripped):
-        match = _NEXT_TERM.match(expression_stripped, position)
-        if match is None:
-            msg = f"Invalid detection expression: {expression!r}"
-            raise ValueError(msg)
-
-        operator_token, component_name = match.groups()
-        sign = _SIGNS[operator_token]
+    for sign, component_name in terms[1:]:
         detection_vector = detection_vector + sign * _get_component_vector(
             component_name,
             vectors,
         )
-        position = match.end()
 
     return np.array(detection_vector, copy=True, dtype=sample_vector.dtype)

--- a/tests/configuration/test_experiment.py
+++ b/tests/configuration/test_experiment.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from chemex.configuration.experiment import (
+    DetectionSettings,
+    RelaxationSettings,
+)
+from chemex.experiments.catalog.shift_15n_sq import Shift15NSqSettings
+from chemex.models.model import ModelSpec
+
+
+@pytest.mark.parametrize("value", ["a", ["a"]])
+def test_observed_state_normalizes_single_state_inputs(value: object) -> None:
+    settings = DetectionSettings.model_validate({"observed_state": value})
+
+    assert settings.observed_states == ("a",)
+    assert settings.primary_state == "a"
+
+
+def test_observed_state_normalizes_multiple_states() -> None:
+    settings = DetectionSettings.model_validate(
+        {"observed_state": ["a", "c"]},
+    )
+
+    assert settings.observed_states == ("a", "c")
+    assert settings.primary_state == "a"
+    assert settings.model_dump()["observed_state"] == ("a", "c")
+
+
+def test_string_and_single_item_list_have_equivalent_detection() -> None:
+    string_settings = RelaxationSettings.model_validate({"observed_state": "a"})
+    list_settings = RelaxationSettings.model_validate({"observed_state": ["a"]})
+
+    assert string_settings.get_detection_expression("[iz]") == "[iz_a]"
+    assert (
+        list_settings.get_detection_expression("[iz]")
+        == string_settings.get_detection_expression("[iz]")
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ([], "must contain at least one state"),
+        (["a", "a"], "contains duplicate states: 'a'"),
+        (["a", 1], "Every entry in 'observed_state' must be a string"),
+        (1, "must be a state string or a non-empty list"),
+    ],
+)
+def test_observed_state_rejects_invalid_values(
+    value: object,
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        DetectionSettings.model_validate({"observed_state": value})
+
+
+def test_observed_state_rejects_unknown_state() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Unknown observed state: 'z'",
+    ):
+        DetectionSettings.model_validate({"observed_state": ["a", "z"]})
+
+
+def test_observed_state_rejects_state_missing_from_model() -> None:
+    model = ModelSpec(name="2st", states="ab")
+
+    with pytest.raises(
+        ValidationError,
+        match=r"Unknown observed state: 'c'.*Available states: 'a', 'b'",
+    ):
+        DetectionSettings.model_validate(
+            {"observed_state": ["a", "c"]},
+            context={"model": model},
+        )
+
+
+def test_observed_state_supports_states_from_larger_models() -> None:
+    model = ModelSpec(name="6st", states="abcdef")
+
+    settings = DetectionSettings.model_validate(
+        {"observed_state": ["a", "f"]},
+        context={"model": model},
+    )
+
+    assert settings.observed_states == ("a", "f")
+
+
+def test_non_detection_experiment_rejects_observed_state_list() -> None:
+    with pytest.raises(ValidationError, match="must be a state string"):
+        Shift15NSqSettings.model_validate(
+            {
+                "name": "shift_15n_sq",
+                "observed_state": ["a", "c"],
+            },
+        )
+
+
+def test_detect_all_states_reports_replacement_syntax() -> None:
+    model = ModelSpec(name="3st", states="abc")
+
+    with pytest.raises(
+        ValidationError,
+        match=r'observed_state = \["a", "b", "c"\]',
+    ):
+        RelaxationSettings.model_validate(
+            {"detect_all_states": True},
+            context={"model": model},
+        )
+
+
+def test_disabled_detect_all_states_reports_removal() -> None:
+    with pytest.raises(
+        ValidationError,
+        match=r"remove it.*single-state detection",
+    ):
+        RelaxationSettings.model_validate({"detect_all_states": False})
+
+
+def test_enabled_cs_evolution_prior_reports_replacement_syntax() -> None:
+    with pytest.raises(
+        ValidationError,
+        match=r"set 'start_state' to the observed state or states",
+    ):
+        RelaxationSettings.model_validate({"cs_evolution_prior": True})
+
+
+def test_disabled_cs_evolution_prior_reports_removal() -> None:
+    with pytest.raises(
+        ValidationError,
+        match=r"remove it.*equilibrium preparation",
+    ):
+        RelaxationSettings.model_validate({"cs_evolution_prior": False})
+
+
+def test_start_state_omitted_uses_equilibrium_components() -> None:
+    settings = RelaxationSettings.model_validate(
+        {"observed_state": ["a", "c"]},
+    )
+
+    assert settings.start_states == ()
+    assert settings.get_start_terms("iz") == ["iz"]
+
+
+def test_start_state_accepts_single_state() -> None:
+    settings = RelaxationSettings.model_validate(
+        {
+            "observed_state": ["a", "c"],
+            "start_state": "b",
+        },
+    )
+
+    assert settings.start_states == ("b",)
+    assert settings.get_start_terms("iz") == ["iz_b"]
+
+
+def test_start_state_accepts_multiple_states() -> None:
+    settings = RelaxationSettings.model_validate(
+        {
+            "observed_state": "a",
+            "start_state": ["a", "c"],
+        },
+    )
+
+    assert settings.start_states == ("a", "c")
+    assert settings.get_start_terms("2izsz", "-iz") == [
+        "2izsz_a",
+        "-iz_a",
+        "2izsz_c",
+        "-iz_c",
+    ]
+
+
+def test_empty_start_state_selects_equilibrium_preparation() -> None:
+    settings = RelaxationSettings.model_validate({"start_state": []})
+
+    assert settings.start_states == ()
+    assert settings.get_start_terms("iz") == ["iz"]
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (["a", "a"], "'start_state' contains duplicate states"),
+        (["a", "z"], "Unknown start state: 'z'"),
+    ],
+)
+def test_start_state_rejects_invalid_values(
+    value: object,
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        RelaxationSettings.model_validate({"start_state": value})

--- a/tests/experiments/test_observed_state.py
+++ b/tests/experiments/test_observed_state.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from chemex.experiments.catalog.cest_1hn_ap import Cest1HnApSettings
+from chemex.experiments.catalog.cest_1hn_ip_ap import Cest1HnIpApSettings
+from chemex.experiments.catalog.cest_ch3_1h_ip_ap import CestCh31HIpApSettings
+from chemex.experiments.catalog.coscest_1hn_ip_ap import CosCest1HnIpApSettings
+from chemex.experiments.catalog.cpmg_1hn_ap import Cpmg1HnApSettings
+from chemex.experiments.catalog.cpmg_1hn_ap_0013 import Cpmg1HnAp0013Settings
+from chemex.experiments.catalog.cpmg_15n_ip import Cpmg15NIpSettings
+from chemex.experiments.catalog.cpmg_ch3_1h_sq import CpmgCh31HSqSettings
+from chemex.experiments.catalog.dcest_15n import DCest15NSettings
+
+
+def _settings(
+    observed_state: object,
+    *,
+    start_state: object = None,
+) -> Cpmg15NIpSettings:
+    return Cpmg15NIpSettings.model_validate(
+        {
+            "name": "cpmg_15n_ip",
+            "time_t2": 0.04,
+            "carrier": 118.0,
+            "pw90": 40.0e-6,
+            "observed_state": observed_state,
+            "start_state": start_state,
+        },
+    )
+
+
+def test_cpmg_observed_state_string_remains_unchanged() -> None:
+    assert _settings("a").detection == "[iz_a]"
+
+
+def test_cpmg_observed_state_list_sums_selected_states() -> None:
+    assert _settings(["a", "c"]).detection == "[iz_a] + [iz_c]"
+
+
+def test_cpmg_start_state_list_selects_starting_components() -> None:
+    assert _settings("a", start_state=["a", "c"]).start_terms == ["iz_a", "iz_c"]
+
+
+@pytest.mark.parametrize(
+    ("settings_cls", "data"),
+    [
+        (
+            Cest1HnIpApSettings,
+            {
+                "name": "cest_1hn_ip_ap",
+                "time_t1": 0.2,
+                "carrier": 8.0,
+                "d1": 0.5,
+            },
+        ),
+        (
+            CestCh31HIpApSettings,
+            {
+                "name": "cest_ch3_1h_ip_ap",
+                "time_t1": 0.2,
+                "carrier": 0.8,
+                "d1": 0.5,
+            },
+        ),
+        (
+            CosCest1HnIpApSettings,
+            {
+                "name": "coscest_1hn_ip_ap",
+                "time_t1": 0.2,
+                "carrier": 8.0,
+                "sw": 1000.0,
+                "cos_n": 2,
+                "d1": 0.5,
+            },
+        ),
+    ],
+)
+def test_start_state_is_applied_to_identity_component_preparation(
+    settings_cls,
+    data: dict[str, object],
+) -> None:
+    settings = settings_cls.model_validate(
+        {**data, "start_state": ["a", "c"]},
+    )
+
+    assert settings.start_terms == ["ie_a", "ie_c"]
+
+
+@pytest.mark.parametrize(
+    ("settings_cls", "data"),
+    [
+        (
+            Cest1HnApSettings,
+            {
+                "name": "cest_1hn_ap",
+                "time_t1": 0.2,
+                "carrier": 8.0,
+                "b1_frq": 25.0,
+            },
+        ),
+        (
+            Cpmg1HnApSettings,
+            {
+                "name": "cpmg_1hn_ap",
+                "time_t2": 0.04,
+                "carrier": 8.0,
+                "pw90": 10.0e-6,
+            },
+        ),
+        (
+            Cpmg1HnAp0013Settings,
+            {
+                "name": "cpmg_1hn_ap_0013",
+                "time_t2": 0.04,
+                "carrier": 8.0,
+                "pw90": 10.0e-6,
+                "ncyc_max": 20,
+            },
+        ),
+        (
+            CpmgCh31HSqSettings,
+            {
+                "name": "cpmg_ch3_1h_sq",
+                "time_t2": 0.04,
+                "carrier": 0.8,
+                "pw90": 10.0e-6,
+                "ncyc_max": 20,
+            },
+        ),
+    ],
+)
+def test_legacy_non_equilibrium_defaults_are_preserved(
+    settings_cls,
+    data: dict[str, object],
+) -> None:
+    settings = settings_cls.model_validate(data)
+
+    assert settings.start_states == ("a",)
+    assert all(term.endswith("_a") for term in settings.start_terms)
+
+
+def test_legacy_non_equilibrium_default_can_be_overridden_to_equilibrium() -> None:
+    settings = Cpmg1HnApSettings.model_validate(
+        {
+            "name": "cpmg_1hn_ap",
+            "time_t2": 0.04,
+            "carrier": 8.0,
+            "pw90": 10.0e-6,
+            "start_state": [],
+        },
+    )
+
+    assert settings.start_states == ()
+    assert settings.start_terms == ["2izsz"]
+
+
+def test_disabled_cs_evolution_prior_reports_equilibrium_override() -> None:
+    with pytest.raises(
+        ValidationError,
+        match=r"start_state = \[\].*equilibrium preparation",
+    ):
+        Cpmg1HnApSettings.model_validate(
+            {
+                "name": "cpmg_1hn_ap",
+                "time_t2": 0.04,
+                "carrier": 8.0,
+                "pw90": 10.0e-6,
+                "cs_evolution_prior": False,
+            },
+        )
+
+
+def test_legacy_non_equilibrium_default_tracks_observed_states() -> None:
+    settings = Cpmg1HnApSettings.model_validate(
+        {
+            "name": "cpmg_1hn_ap",
+            "time_t2": 0.04,
+            "carrier": 8.0,
+            "pw90": 10.0e-6,
+            "observed_state": ["a", "b"],
+        },
+    )
+
+    assert settings.start_states == ("a", "b")
+    assert settings.start_terms == ["2izsz_a", "2izsz_b"]
+
+
+def test_dcest_hd_equilibrium_override_is_not_treated_as_omitted() -> None:
+    data = {
+        "name": "dcest_15n",
+        "time_t1": 0.2,
+        "sw": 1000.0,
+        "carrier": 118.0,
+        "b1_eff": 25.0,
+        "pw90": 40.0e-6,
+        "model_name": "2st_hd",
+    }
+
+    default = DCest15NSettings.model_validate(data)
+    equilibrium = DCest15NSettings.model_validate({**data, "start_state": []})
+
+    assert default.start_terms == ["iz_a"]
+    assert equilibrium.start_terms == ["iz"]

--- a/tests/nmr/test_detection.py
+++ b/tests/nmr/test_detection.py
@@ -5,7 +5,10 @@ import pytest
 
 from chemex.configuration.conditions import Conditions
 from chemex.models.model import ModelSpec
-from chemex.nmr._engine.detection import build_detection_vector
+from chemex.nmr._engine.detection import (
+    build_detection_vector,
+    build_state_detection_expression,
+)
 from chemex.nmr._engine.engine import ISLiouvillianEngine
 from chemex.nmr.basis import Basis
 from chemex.parameters.spin_system import SpinSystem
@@ -20,6 +23,42 @@ def test_build_detection_vector_supports_addition_and_subtraction() -> None:
     )
 
     np.testing.assert_allclose(vector, expected)
+
+
+def test_build_state_detection_expression_preserves_component_signs() -> None:
+    expression = build_state_detection_expression(
+        "[2izsz] - [iz]",
+        ("a", "c"),
+    )
+
+    assert expression == "[2izsz_a] - [iz_a] + [2izsz_c] - [iz_c]"
+
+
+def test_multi_state_detection_sums_selected_final_components() -> None:
+    model = ModelSpec(name="3st", states="abc")
+    basis = Basis(type="ixyz", spin_system="nh", model=model)
+    expression = build_state_detection_expression("[iz]", ("a", "c"))
+    detection_vector = build_detection_vector(expression, basis.vectors).transpose()
+    magnetization = (
+        2.0 * basis.vectors["iz_a"]
+        + 5.0 * basis.vectors["iz_b"]
+        + 7.0 * basis.vectors["iz_c"]
+    )
+
+    detected = (detection_vector @ magnetization).item()
+
+    assert detected == pytest.approx(9.0)
+
+
+def test_explicit_all_state_detection_matches_legacy_unsuffixed_component() -> None:
+    model = ModelSpec(name="3st", states="abc")
+    basis = Basis(type="ixyz", spin_system="nh", model=model)
+    expression = build_state_detection_expression("[iz]", model.states)
+
+    explicit = build_detection_vector(expression, basis.vectors)
+    legacy = build_detection_vector("[iz]", basis.vectors)
+
+    np.testing.assert_allclose(explicit, legacy)
 
 
 def test_build_detection_vector_rejects_invalid_syntax() -> None:

--- a/tests/nmr/test_magnetization.py
+++ b/tests/nmr/test_magnetization.py
@@ -84,6 +84,25 @@ def test_build_start_magnetization_respects_terms_signs_and_populations() -> Non
     np.testing.assert_allclose(magnetization, expected)
 
 
+def test_explicit_all_state_start_matches_equilibrium_component_selection() -> None:
+    model = ModelSpec(name="3st", states="abc")
+    basis = Basis(type="iz", spin_system="nh", model=model)
+    par_values = {"pa": 0.6, "pb": 0.3, "pc": 0.1}
+
+    equilibrium_terms = build_start_magnetization(
+        basis,
+        par_values,
+        terms=["iz"],
+    )
+    explicit_terms = build_start_magnetization(
+        basis,
+        par_values,
+        terms=["iz_a", "iz_b", "iz_c"],
+    )
+
+    np.testing.assert_allclose(explicit_terms, equilibrium_terms)
+
+
 def test_keep_components_masks_unselected_magnetization() -> None:
     basis = Basis(type="izsz", spin_system="nh", model=ModelSpec())
     magnetization = basis.vectors["iz_a"] + 2.0 * basis.vectors["2izsz_b"]

--- a/website/docs/experiments/cest/cest_13c.md
+++ b/website/docs/experiments/cest/cest_13c.md
@@ -69,12 +69,9 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CEST element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cest/cest_13c.md
+++ b/website/docs/experiments/cest/cest_13c.md
@@ -69,7 +69,11 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cest/cest_15n.md
+++ b/website/docs/experiments/cest/cest_15n.md
@@ -59,7 +59,11 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cest/cest_15n.md
+++ b/website/docs/experiments/cest/cest_15n.md
@@ -59,12 +59,9 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CEST element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cest/cest_15n_cw.md
+++ b/website/docs/experiments/cest/cest_15n_cw.md
@@ -61,12 +61,9 @@ carrier_dec = 8.3
 ## B1 radio-frequency field strength of the ¹H CW decoupling, in Hz
 b1_frq_dec = 1000.0
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CEST element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cest/cest_15n_cw.md
+++ b/website/docs/experiments/cest/cest_15n_cw.md
@@ -61,7 +61,11 @@ carrier_dec = 8.3
 ## B1 radio-frequency field strength of the ¹H CW decoupling, in Hz
 b1_frq_dec = 1000.0
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cest/cest_15n_tr.md
+++ b/website/docs/experiments/cest/cest_15n_tr.md
@@ -59,12 +59,9 @@ res = 11
 ## Perform anti-trosy CEST experiment [optional, default: false]
 # antitrosy = false
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CEST element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cest/cest_15n_tr.md
+++ b/website/docs/experiments/cest/cest_15n_tr.md
@@ -59,7 +59,11 @@ res = 11
 ## Perform anti-trosy CEST experiment [optional, default: false]
 # antitrosy = false
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cest/cest_1hn_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ap.md
@@ -54,12 +54,9 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Initial condition: non-equilibrium (only observed state populated).
-## This is appropriate when chemical shift evolution occurs before the CEST
-## element. Set to false for equilibrium initial condition if your pulse
-## sequence differs (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: true]
-# cs_evolution_prior = true
+## Non-equilibrium starting state(s).
+## [optional, default: observed_state; use [] for equilibrium preparation]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cest/cest_1hn_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ap.md
@@ -54,7 +54,11 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Non-equilibrium starting state(s).
+## Initial condition: non-equilibrium preparation (observed state(s) populated).
+## This is appropriate when chemical shift evolution occurs before the measured
+## relaxation/exchange element. Use start_state = [] for equilibrium
+## preparation if your pulse sequence differs (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: observed_state; use [] for equilibrium preparation]
 # start_state = "a"
 

--- a/website/docs/experiments/cest/cest_1hn_ip_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ip_ap.md
@@ -69,6 +69,10 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cest/cest_1hn_ip_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ip_ap.md
@@ -69,7 +69,11 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cest/cest_ch3_1h_ip_ap.md
+++ b/website/docs/experiments/cest/cest_ch3_1h_ip_ap.md
@@ -63,7 +63,11 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cest/cest_ch3_1h_ip_ap.md
+++ b/website/docs/experiments/cest/cest_ch3_1h_ip_ap.md
@@ -63,6 +63,10 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_13c_ip.md
+++ b/website/docs/experiments/cpmg/cpmg_13c_ip.md
@@ -59,7 +59,11 @@ pw90 = 15.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_13c_ip.md
+++ b/website/docs/experiments/cpmg/cpmg_13c_ip.md
@@ -59,12 +59,9 @@ pw90 = 15.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_13co_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_13co_ap.md
@@ -66,7 +66,11 @@ pw90 = 25.0e-6
 ## 1/2*JCC, in seconds [optional, default: 9.09e-3]
 # taucc = 9.09e-3
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_13co_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_13co_ap.md
@@ -66,12 +66,9 @@ pw90 = 25.0e-6
 ## 1/2*JCC, in seconds [optional, default: 9.09e-3]
 # taucc = 9.09e-3
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_15n_ip.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_ip.md
@@ -56,7 +56,11 @@ pw90 = 35.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_15n_ip.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_ip.md
@@ -56,12 +56,9 @@ pw90 = 35.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_15n_ip_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_ip_0013.md
@@ -60,7 +60,11 @@ ncyc_max = 40
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_15n_ip_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_ip_0013.md
@@ -60,12 +60,9 @@ ncyc_max = 40
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_15n_tr.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_tr.md
@@ -64,12 +64,9 @@ pw90 = 35.0e-6
 ## Perform anti-trosy CPMG RD experiment [optional, default: false]
 # antitrosy = false
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_15n_tr.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_tr.md
@@ -64,7 +64,11 @@ pw90 = 35.0e-6
 ## Perform anti-trosy CPMG RD experiment [optional, default: false]
 # antitrosy = false
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_15n_tr_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_tr_0013.md
@@ -70,7 +70,11 @@ ncyc_max = 40
 ## S3E trosy selection [optional, default: true]
 # s3e = true
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_15n_tr_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_tr_0013.md
@@ -70,12 +70,9 @@ ncyc_max = 40
 ## S3E trosy selection [optional, default: true]
 # s3e = true
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_1hn_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_1hn_ap.md
@@ -58,7 +58,11 @@ pw90 = 10.0e-6
 ## [optional, default: 0.0]
 # time_equil_2 = 0.0
 
-## Non-equilibrium starting state(s).
+## Initial condition: non-equilibrium preparation (observed state(s) populated).
+## This is appropriate when chemical shift evolution occurs before the measured
+## relaxation/exchange element. Use start_state = [] for equilibrium
+## preparation if your pulse sequence differs (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: observed_state; use [] for equilibrium preparation]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_1hn_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_1hn_ap.md
@@ -58,12 +58,9 @@ pw90 = 10.0e-6
 ## [optional, default: 0.0]
 # time_equil_2 = 0.0
 
-## Initial condition: non-equilibrium (only observed state populated).
-## This is appropriate when chemical shift evolution occurs before the CPMG
-## element. Set to false for equilibrium initial condition if your pulse
-## sequence differs (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: true]
-# cs_evolution_prior = true
+## Non-equilibrium starting state(s).
+## [optional, default: observed_state; use [] for equilibrium preparation]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_1hn_ap_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_1hn_ap_0013.md
@@ -83,7 +83,11 @@ ncyc_max = 40
 ## [optional, default: 0.0]
 # time_equil_2 = 0.0
 
-## Non-equilibrium starting state(s).
+## Initial condition: non-equilibrium preparation (observed state(s) populated).
+## This is appropriate when chemical shift evolution occurs before the measured
+## relaxation/exchange element. Use start_state = [] for equilibrium
+## preparation if your pulse sequence differs (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: observed_state; use [] for equilibrium preparation]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_1hn_ap_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_1hn_ap_0013.md
@@ -83,12 +83,9 @@ ncyc_max = 40
 ## [optional, default: 0.0]
 # time_equil_2 = 0.0
 
-## Initial condition: non-equilibrium (only observed state populated).
-## This is appropriate when chemical shift evolution occurs before the CPMG
-## element. Set to false for equilibrium initial condition if your pulse
-## sequence differs (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: true]
-# cs_evolution_prior = true
+## Non-equilibrium starting state(s).
+## [optional, default: observed_state; use [] for equilibrium preparation]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c.md
@@ -58,12 +58,9 @@ pw90 = 15.0e-6
 ## P-element delay = 1/4J, in seconds [optional, default: 2.0e-3]
 # taub = 2.0e-3
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c.md
@@ -58,7 +58,11 @@ pw90 = 15.0e-6
 ## P-element delay = 1/4J, in seconds [optional, default: 2.0e-3]
 # taub = 2.0e-3
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c_0013.md
@@ -67,7 +67,11 @@ pw90 = 15.0e-6
 ## P-element delay = 1/4J, in seconds [optional, default: 2.0e-3]
 # taub = 2.0e-3
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c_0013.md
@@ -67,12 +67,9 @@ pw90 = 15.0e-6
 ## P-element delay = 1/4J, in seconds [optional, default: 2.0e-3]
 # taub = 2.0e-3
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_dq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_dq.md
@@ -60,12 +60,9 @@ pw90 = 12.0e-6
 ## AP DQ magnetizations [optional, default: false]
 # ipap_flg = false
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_dq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_dq.md
@@ -60,7 +60,11 @@ pw90 = 12.0e-6
 ## AP DQ magnetizations [optional, default: false]
 # ipap_flg = false
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_sq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_sq.md
@@ -63,7 +63,11 @@ ncyc_max = 40
 ## [optional, default: false]
 # ipap_flg = false
 
-## Non-equilibrium starting state(s).
+## Initial condition: non-equilibrium preparation (observed state(s) populated).
+## This is appropriate when chemical shift evolution occurs before the measured
+## relaxation/exchange element. Use start_state = [] for equilibrium
+## preparation if your pulse sequence differs (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: observed_state; use [] for equilibrium preparation]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_sq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_sq.md
@@ -63,12 +63,9 @@ ncyc_max = 40
 ## [optional, default: false]
 # ipap_flg = false
 
-## Initial condition: non-equilibrium (only observed state populated).
-## This is appropriate when chemical shift evolution occurs before the CPMG
-## element. Set to false for equilibrium initial condition if your pulse
-## sequence differs (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: true]
-# cs_evolution_prior = true
+## Non-equilibrium starting state(s).
+## [optional, default: observed_state; use [] for equilibrium preparation]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_tq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_tq.md
@@ -62,7 +62,11 @@ pw90 = 12.0e-6
 ## AP TQ magnetizations [optional, default: false]
 # ipap_flg = false
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_tq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_tq.md
@@ -62,12 +62,9 @@ pw90 = 12.0e-6
 ## AP TQ magnetizations [optional, default: false]
 # ipap_flg = false
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_tq_diff.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_tq_diff.md
@@ -69,12 +69,9 @@ gradient = 30.0e-2
 ## AP TQ magnetizations [optional, default: false]
 # ipap_flg = false
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_tq_diff.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_tq_diff.md
@@ -69,7 +69,11 @@ gradient = 30.0e-2
 ## AP TQ magnetizations [optional, default: false]
 # ipap_flg = false
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_mq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_mq.md
@@ -53,7 +53,11 @@ time_t2 = 0.02
 ## Perform the calculation with the purge element [optional, default: false])
 # small_protein = false
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_ch3_mq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_mq.md
@@ -53,12 +53,9 @@ time_t2 = 0.02
 ## Perform the calculation with the purge element [optional, default: false])
 # small_protein = false
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_chd2_1h_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_chd2_1h_ap.md
@@ -54,12 +54,9 @@ pw90 = 10.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_chd2_1h_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_chd2_1h_ap.md
@@ -54,7 +54,11 @@ pw90 = 10.0e-6
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/cpmg/cpmg_hn_dq_zq.md
+++ b/website/docs/experiments/cpmg/cpmg_hn_dq_zq.md
@@ -57,12 +57,9 @@ pw90_h = 15.0e-6
 ## Perform DQ CPMG RD experiment, otherwise perform ZQ CPMG RD experiment
 dq_flg = true
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CPMG element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/cpmg/cpmg_hn_dq_zq.md
+++ b/website/docs/experiments/cpmg/cpmg_hn_dq_zq.md
@@ -57,7 +57,11 @@ pw90_h = 15.0e-6
 ## Perform DQ CPMG RD experiment, otherwise perform ZQ CPMG RD experiment
 dq_flg = true
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/dcest/coscest_1hn_ip_ap.md
+++ b/website/docs/experiments/dcest/coscest_1hn_ip_ap.md
@@ -65,6 +65,10 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
+
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
 

--- a/website/docs/experiments/dcest/coscest_1hn_ip_ap.md
+++ b/website/docs/experiments/dcest/coscest_1hn_ip_ap.md
@@ -65,7 +65,11 @@ type = "gaussian"
 scale = 0.1
 res = 11
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/dcest/dcest_13c.md
+++ b/website/docs/experiments/dcest/dcest_13c.md
@@ -69,12 +69,9 @@ res = 11           # number of sampling points across the distribution
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CEST element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/dcest/dcest_13c.md
+++ b/website/docs/experiments/dcest/dcest_13c.md
@@ -69,7 +69,11 @@ res = 11           # number of sampling points across the distribution
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/dcest/dcest_15n.md
+++ b/website/docs/experiments/dcest/dcest_15n.md
@@ -85,8 +85,11 @@ res = 11
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Non-equilibrium starting state(s). Omit for the model-specific default
-## (equilibrium except for the HD models); use [] to force equilibrium.
+## Initial condition: omit start_state for the model-specific default
+## (equilibrium except for the HD models). Set start_state for
+## non-equilibrium preparation when chemical shift evolution occurs before the
+## measured relaxation/exchange element (see Yuwen et al., J. Biomol. NMR
+## 2016, 65:143-156). Use [] to force equilibrium.
 ## [optional]
 # start_state = "a"
 

--- a/website/docs/experiments/dcest/dcest_15n.md
+++ b/website/docs/experiments/dcest/dcest_15n.md
@@ -85,12 +85,10 @@ res = 11
 ## [optional, default: 0.0]
 # time_equil = 0.0
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the CEST element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for the model-specific default
+## (equilibrium except for the HD models); use [] to force equilibrium.
+## [optional]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/relaxation/relaxation_hznz.md
+++ b/website/docs/experiments/relaxation/relaxation_hznz.md
@@ -39,7 +39,11 @@ An example use of the module is given
 ## Name of the chemex module corresponding to the experiment
 name = "relaxation_hznz"
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/relaxation/relaxation_hznz.md
+++ b/website/docs/experiments/relaxation/relaxation_hznz.md
@@ -39,12 +39,9 @@ An example use of the module is given
 ## Name of the chemex module corresponding to the experiment
 name = "relaxation_hznz"
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the relaxation element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/experiments/relaxation/relaxation_nz.md
+++ b/website/docs/experiments/relaxation/relaxation_nz.md
@@ -38,7 +38,11 @@ An example use of the module is given
 ## Name of the chemex module corresponding to the experiment
 name = "relaxation_nz"
 
-## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## Initial condition: equilibrium preparation (all states populated according to
+## their equilibrium populations). Set start_state for non-equilibrium
+## preparation when chemical shift evolution occurs before the measured
+## relaxation/exchange element in your pulse sequence (see Yuwen et al.,
+## J. Biomol. NMR 2016, 65:143-156).
 ## [optional, default: equilibrium]
 # start_state = "a"
 

--- a/website/docs/experiments/relaxation/relaxation_nz.md
+++ b/website/docs/experiments/relaxation/relaxation_nz.md
@@ -38,12 +38,9 @@ An example use of the module is given
 ## Name of the chemex module corresponding to the experiment
 name = "relaxation_nz"
 
-## Initial condition: equilibrium (all states populated according to their
-## equilibrium populations). Set to true for non-equilibrium initial condition
-## if chemical shift evolution occurs before the relaxation element in your pulse
-## sequence (see Yuwen et al., J. Biomol. NMR 2016, 65:143-156).
-## [optional, default: false]
-# cs_evolution_prior = false
+## Non-equilibrium starting state(s). Omit for equilibrium preparation.
+## [optional, default: equilibrium]
+# start_state = "a"
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"

--- a/website/docs/user_guide/fitting/experiment_files.md
+++ b/website/docs/user_guide/fitting/experiment_files.md
@@ -64,27 +64,82 @@ The `[experiment]` section defines the type and settings of the pulse sequence. 
 | `time_t2`, `time_t1` | Relaxation delays in seconds (e.g., for CPMG relaxation dispersion experiments).                   |
 | `pw90`            | 90-degree pulse width, in seconds.                                                                    |
 | `b1_frq`          | B1 radio-frequency field strength, in Hz.                                                             |
-| `observed_state`  | ID of the observed state (e.g., `a`, `b`, `c`, or `d`).                                              |
-| `cs_evolution_prior` | Controls initial condition: equilibrium (False, default) vs non-equilibrium (True). See below.     |
+| `observed_state`  | Observed state; final-magnetization experiments also accept a list whose components are summed.       |
+| `start_state`     | Optional state or list of states used for non-equilibrium starting magnetization.                     |
 
-#### `cs_evolution_prior`
+#### `observed_state`
 
-The `cs_evolution_prior` key controls whether the initial magnetization assumes thermal equilibrium or a non-equilibrium condition:
-
-- **`False` (default)**: Equilibrium initial condition where all states are populated according to their equilibrium populations. Use this when the CEST/CPMG element starts immediately after magnetization preparation.
-
-- **`True`**: Non-equilibrium initial condition where only the observed state is initially populated. Use this when chemical shift evolution occurs **before** the CEST/CPMG element, as this breaks the equilibrium assumption.
-
-The choice can significantly affect extracted kinetic parameters, especially for slow exchange rates (see Yuwen et al., _J. Biomol. NMR_ **2016**, 65:143-156). Most experiments use the default (`False`), but some pulse sequences (e.g., `cpmg_1hn_ap`, `cest_1hn_ap`) set this to `True` by default based on their typical pulse sequence implementations. You can override the default in your experiment configuration file if your specific pulse sequence differs.
-
-Example:
+The existing string form selects one state:
 
 ```toml
-[experiment]
-name = "cpmg_1hn_ap"
-# Override the default if needed for your pulse sequence
-cs_evolution_prior = false
+observed_state = "a"
 ```
+
+For experiments that detect a final magnetization vector, such as CPMG, CEST,
+D-CEST, and relaxation experiments, a list selects several states and detects
+the unweighted sum of their final magnetization components:
+
+```toml
+observed_state = ["a", "c"]
+```
+
+This is equivalent to detecting the A component plus the C component; the sum
+is not divided by the number of states. Experiments that require a single state
+for another purpose, such as chemical-shift measurements, continue to require
+the string form.
+
+The first observed state is used as the reference state for state-specific
+parameter defaults and offset filtering. This does not constrain the starting
+magnetization.
+
+To detect all states, list every state in the active model:
+
+```toml
+observed_state = ["a", "b", "c"]
+```
+
+This replaces the removed `detect_all_states` option.
+
+#### `start_state`
+
+For most experiments, omitting `start_state` uses the thermal-equilibrium
+populations of all states. A string selects one non-equilibrium starting state:
+
+```toml
+start_state = "a"
+```
+
+A list selects several starting states:
+
+```toml
+start_state = ["a", "c"]
+```
+
+Each selected state's starting component is scaled by that state's equilibrium
+population. Selecting several states does not renormalize their populations;
+listing every state therefore reproduces the corresponding equilibrium
+component.
+
+For backward compatibility, `cest_1hn_ap`, `cpmg_1hn_ap`,
+`cpmg_1hn_ap_0013`, and `cpmg_ch3_1h_sq` default their starting states to
+`observed_state`, matching the previous `cs_evolution_prior = true` behavior.
+Use an empty list to select equilibrium preparation for these experiments:
+
+```toml
+start_state = []
+```
+
+This replaces `cs_evolution_prior`: omit `start_state` for equilibrium
+preparation in experiments whose default is equilibrium, use an empty list to
+override a state-specific experiment default, or set one or more states for
+non-equilibrium preparation. This choice can significantly affect extracted
+kinetic parameters, especially for slow exchange rates (see Yuwen et al.,
+_J. Biomol. NMR_ **2016**, 65:143-156).
+
+Multi-state detection and preparation are approximate component-selection
+models. They do not model acquisition, spectral lineshapes, peak overlap,
+integration windows, or the full transition between slow-, intermediate-, and
+fast-exchange lineshapes.
 
 ### `[conditions]`
 

--- a/website/docs/user_guide/fitting/experiment_files.md
+++ b/website/docs/user_guide/fitting/experiment_files.md
@@ -103,7 +103,12 @@ This replaces the removed `detect_all_states` option.
 #### `start_state`
 
 For most experiments, omitting `start_state` uses the thermal-equilibrium
-populations of all states. A string selects one non-equilibrium starting state:
+populations of all states. This is appropriate when the measured relaxation or
+exchange element starts from equilibrium magnetization.
+
+Set `start_state` for a non-equilibrium initial condition, for example when
+chemical shift evolution occurs before the measured CEST/CPMG element. A string
+selects one non-equilibrium starting state:
 
 ```toml
 start_state = "a"


### PR DESCRIPTION
## Summary

- Allow `observed_state` to select one or more states and sum their final magnetization components.
- Replace the active `detect_all_states` and `cs_evolution_prior` flags with explicit `observed_state` and `start_state` syntax.
- Allow `start_state` to select one or more population-scaled starting components, with `[]` explicitly requesting equilibrium preparation.
- Preserve experiment-specific legacy defaults while centralizing state validation, detection expansion, and starting-term construction.
- Update experiment documentation, migration errors, and regression coverage.

## Motivation

The previous suffix-based implementation coupled detection and preparation to a single observed state. It could not naturally express multi-state detection or preparation and made experiment-specific defaults difficult to reason about. Explicit state selections provide a smaller and more composable configuration model.

## User-facing syntax

```toml
observed_state = ["a", "c"]
start_state = ["a", "c"]
```

To detect all states, list every state in the active model. Use `start_state = []` to force equilibrium preparation when an experiment otherwise defaults to starting from the observed state.

Removed fields produce value-aware validation errors with the corresponding replacement syntax.

## Validation

- `306 passed` with the full pytest suite
- `ty check` passed
- Ruff checks passed for all changed Python areas
- `git diff --check` passed
