### PR TITLE
[codex] Fix run_info path semantics and docs wording

### DIFF
--- a/src/chemex/run_info.py
+++ b/src/chemex/run_info.py
@@ -116,10 +116,9 @@ def _serialize_parameters(
 
 
 def _resolve_path(path: Path, working_directory: Path) -> Path:
-    expanded = path.expanduser()
-    if not expanded.is_absolute():
-        expanded = working_directory / expanded
-    return expanded.resolve()
+    if path.is_absolute():
+        return path.resolve()
+    return (working_directory / path).resolve()
 
 
 def _collect_input_files(args: Namespace, working_directory: Path) -> list[InputFile]:

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -148,6 +148,44 @@ def test_write_run_info_captures_inputs_parameters_and_runtime(
     assert "PA" not in parameters["GLOBAL"]
 
 
+def test_run_info_uses_chemex_path_semantics_for_literal_tilde(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    experiment_file = _write_input(tmp_path / "~" / "experiment.toml")
+    output = tmp_path / "~" / "Output"
+    args = Namespace(
+        experiments=[Path("~/experiment.toml")],
+        parameters=[],
+        method=None,
+        output=Path("~/Output"),
+    )
+    experiments = SimpleNamespace(
+        param_ids=set(),
+        parameter_store=ParameterStore({}),
+    )
+    monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
+
+    run_info_module.write_run_info(
+        args,
+        experiments,
+        argv=["chemex", "fit", "--output", "~/Output"],
+        working_directory=tmp_path,
+        timestamp=datetime(2026, 6, 24, 12, 30, tzinfo=UTC),
+    )
+
+    run_info_path = output / "run_info"
+    run = tomllib.loads((run_info_path / "run.toml").read_text(encoding="utf-8"))
+    copied_experiment = run["inputs"]["experiments"][0]
+
+    assert run["run"]["output_directory"] == str(output.resolve())
+    assert copied_experiment["provided_path"] == "~/experiment.toml"
+    assert copied_experiment["resolved_path"] == str(experiment_file.resolve())
+    assert (run_info_path / copied_experiment["copied_path"]).read_text(
+        encoding="utf-8",
+    ) == experiment_file.read_text(encoding="utf-8")
+
+
 def test_input_files_with_same_basename_are_copied_without_collision(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -45,7 +45,7 @@ The output directory typically includes the following files and subdirectories:
 ### `run_info/`
 
 Records how the fit was started. `run.toml` contains runtime and command-line
-metadata grouped into run, ChemEx, Python, command, input, and optional Git
+metadata grouped into run, ChemEx, Python, command, inputs, and optional Git
 sections. `parameters_used.toml` contains the parsed independent starting
 parameters needed to restart the fit, including values and bounds. Parameters
 calculated from expressions are not written separately because ChemEx


### PR DESCRIPTION
## Summary

- Keep `run_info` path resolution aligned with ChemEx's existing `Path` semantics by not expanding quoted `~` paths.
- Add a regression test covering literal `~` output and input paths.
- Correct the output docs wording from `input` to `inputs` to match the `run.toml` schema.

## Validation

- `PYTHONPATH=src /Users/gbouvignies/Workspace/Code/ChemEx/.venv/bin/pytest tests/test_run_info.py -q`
- `PYTHONPATH=src /Users/gbouvignies/Workspace/Code/ChemEx/.venv/bin/pytest tests/test_run_info.py tests/test_analysis_session.py -q`
- `/Users/gbouvignies/.cache/uv/archive-v0/rHZ6reVB3oUTgrYn/bin/ruff format --check src/chemex/run_info.py tests/test_run_info.py`
- `/Users/gbouvignies/.cache/uv/archive-v0/rHZ6reVB3oUTgrYn/bin/ruff check src/chemex/run_info.py tests/test_run_info.py`