### PR TITLE
[codex] Increase plot output precision

### DIFF
--- a/src/chemex/printers/plot.py
+++ b/src/chemex/printers/plot.py
@@ -15,7 +15,7 @@ class PlotPrinter(Protocol):
 @dataclass
 class DataPlotPrinter:
     first_column_name: str = ""
-    first_column_fmt: str = "12.2f"
+    first_column_fmt: str = "12.5f"
 
     def print_exp(self, name: str, data: Data) -> str:
         output = [
@@ -56,7 +56,7 @@ class DataPlotPrinter:
 @dataclass
 class CpmgDataPlotPrinter(DataPlotPrinter):
     first_column_name: str = "NU_CPMG (Hz)"
-    first_column_fmt: str = "12.2f"
+    first_column_fmt: str = "12.5f"
 
     def print_exp(self, name: str, data: Data) -> str:
         output = [
@@ -92,7 +92,7 @@ class CpmgDataPlotPrinter(DataPlotPrinter):
 
 
 data_plot_printers: dict[str, PlotPrinter] = {
-    "cest": DataPlotPrinter("OFFSET (PPM)", "12.2f"),
+    "cest": DataPlotPrinter("OFFSET (PPM)", "12.5f"),
     "cpmg": CpmgDataPlotPrinter(),
     "relaxation": DataPlotPrinter("TIME (S)", "12.6f"),
 }

--- a/tests/test_plot_printers.py
+++ b/tests/test_plot_printers.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from chemex.containers.data import Data
+from chemex.printers.plot import data_plot_printers
+
+
+def test_cest_fit_printer_keeps_ppm_offsets_distinct() -> None:
+    data = Data(
+        exp=np.zeros(2),
+        err=np.zeros(2),
+        metadata=np.array([14.97012, 14.97067]),
+    )
+    data.calc = np.array([0.1, 0.2])
+
+    output = data_plot_printers["cest"].print_calc("G23CD2-HD2", data)
+
+    lines = output.splitlines()
+    assert lines[2].split()[0] == "14.97012"
+    assert lines[3].split()[0] == "14.97067"

--- a/tests/test_plot_printers.py
+++ b/tests/test_plot_printers.py
@@ -17,3 +17,17 @@ def test_cest_fit_printer_keeps_ppm_offsets_distinct() -> None:
     lines = output.splitlines()
     assert lines[2].split()[0] == "14.97012"
     assert lines[3].split()[0] == "14.97067"
+
+
+def test_cest_exp_printer_keeps_ppm_offsets_distinct() -> None:
+    data = Data(
+        exp=np.array([0.1, 0.2]),
+        err=np.array([[0.01, 0.01], [0.02, 0.02]]),
+        metadata=np.array([14.97012, 14.97067]),
+    )
+
+    output = data_plot_printers["cest"].print_exp("G23CD2-HD2", data)
+
+    lines = output.splitlines()
+    assert lines[2].split()[0] == "14.97012"
+    assert lines[3].split()[0] == "14.97067"


### PR DESCRIPTION
## Summary

- Increase plot-output first-column precision from two to five decimals for generic plot data and CPMG plot data.
- Keep CEST plot offsets in fixed-point PPM format with five decimals so adjacent 13C offsets remain distinct in generated `.fit` and `.exp` files.
- Add a regression test covering CEST `.fit` printer output for closely spaced PPM offsets.

## Why

The generated CEST plot data files rounded PPM offsets to two decimal places. That was enough for ChemEx's generated PDFs but caused visible truncation when external scripts overlaid CEST profiles and fits from the `.fit` files.

## Validation

- `uv run pytest tests/test_plot_printers.py -q`
- `uvx ruff check src/chemex/printers/plot.py tests/test_plot_printers.py`
- `uv run pytest -q`
- `uv run ty check`