### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
Potential fix for [https://github.com/gbouvignies/ChemEx/security/code-scanning/17](https://github.com/gbouvignies/ChemEx/security/code-scanning/17)

Add an explicit `permissions` block for the `build` job, scoped to the minimum required access.  
For this job, `contents: read` is the appropriate minimal baseline and aligns with CodeQL guidance.

Best single fix (minimal change, no behavior change):
- Edit `.github/workflows/python-publish.yml`
- In the `jobs.build` section, insert:

```yml
permissions:
  contents: read
```

Place it alongside other job-level keys (e.g., after `runs-on`), before `steps`.

No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
