### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./website


### PR DESCRIPTION
Potential fix for [https://github.com/gbouvignies/ChemEx/security/code-scanning/15](https://github.com/gbouvignies/ChemEx/security/code-scanning/15)

Add an explicit `permissions` block for the `build` job to enforce least privilege.  
Best fix (without changing behavior): in `.github/workflows/website-deploy.yml`, under `jobs.build` (near `runs-on`/`defaults`), add:

- `permissions:`
  - `contents: read`

This satisfies checkout/read needs and addresses CodeQL by ensuring the `build` job token is explicitly restricted. Keep existing `deploy` job permissions unchanged since they are already appropriately scoped for Pages deployment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
