### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -8,6 +8,9 @@ on:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
     paths: [website/**]
 
+permissions:
+  contents: read
+
 jobs:
   test-deploy:
     name: Test deployment


### PR DESCRIPTION
Potential fix for [https://github.com/gbouvignies/ChemEx/security/code-scanning/14](https://github.com/gbouvignies/ChemEx/security/code-scanning/14)

Add an explicit `permissions` block with least privilege to the workflow.  
Best single fix here is to set workflow-level permissions so all jobs inherit it (unless overridden later). For this workflow, `contents: read` is sufficient for checkout/build operations and matches CodeQL’s minimal recommendation.

Edit **`.github/workflows/website-test.yml`** near the top-level keys:
- Insert:
  ```yml
  permissions:
    contents: read
  ```
- Place it after the `on:` block (or after `name:`) and before `jobs:` for clarity and standard structure.
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
