### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }}


### PR DESCRIPTION
Potential fix for [https://github.com/gbouvignies/ChemEx/security/code-scanning/13](https://github.com/gbouvignies/ChemEx/security/code-scanning/13)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal token scope unless overridden. For this workflow, the best minimal setting is:

- `contents: read`

This preserves existing functionality (`actions/checkout` and test execution) while documenting and enforcing least privilege.

**Where to change:**
- File: `.github/workflows/python-test.yml`
- Insert `permissions:` after the `on:` block (or before `jobs:`), at top-level YAML indentation.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
