### PR TITLE
Modernize project tooling and validation policy

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,18 +10,39 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test Python ${{ matrix.python-version }}
+  lint:
+    name: Lint and format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run linter
+        run: uv run ruff check .
+
+      - name: Check formatting
+        run: uv run ruff format --check .
+
+  typecheck:
+    name: Type check Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
         include:
-          # Python 3.14 is informational - allow failures while ecosystem catches up
+          - python-version: "3.13"
           - python-version: "3.14"
-            experimental: true
-    continue-on-error: ${{ matrix.experimental || false }}
 
     steps:
       - uses: actions/checkout@v7
@@ -35,15 +56,67 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync --all-extras --dev
+        run: uv sync --locked
 
-      - name: Run linter
-        run: uv run ruff check .
+      - name: Run type checker
+        run: uv run ty check --python-version ${{ matrix.python-version }}
+
+  test:
+    name: Test Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.13"
+          - python-version: "3.14"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --locked
 
       - name: Run tests
         run: uv run pytest -q
 
-      - name: Run type checker
-        run: uv run ty check
-        # Don't fail on type check for experimental Python versions
-        continue-on-error: ${{ matrix.experimental || false }}
+  package:
+    name: Build and validate package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Validate distribution metadata
+        run: uvx twine check dist/*
+
+      - name: Inspect distribution contents
+        run: |
+          tar -tzf dist/*.tar.gz
+          unzip -l dist/*.whl
+
+      - name: Install and smoke test wheel
+        run: |
+          uv venv --python 3.13 /tmp/chemex-install
+          uv pip install --python /tmp/chemex-install/bin/python dist/*.whl
+          /tmp/chemex-install/bin/python -c 'import chemex, importlib.metadata; assert chemex.__version__ == importlib.metadata.version("chemex")'
+          /tmp/chemex-install/bin/chemex --help

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@ as authoritative. If documentation and implementation disagree, establish the
 current behaviour from code and tests, then correct the documentation or raise
 the discrepancy.
 
+`pyproject.toml` is the authoritative package and tooling policy, and uv is the
+authoritative dependency manager. `numdifftools` is an indirect functional
+runtime dependency: lmfit uses it to estimate covariance, standard errors, and
+parameter correlations for ChemEx-supported minimizers without native
+covariance estimates. Ruff minor upgrades require a dedicated policy review and
+coordinated updates to both its development dependency range and
+`required-version`.
+
 ## Orient by task
 
 - CLI and top-level orchestration: `src/chemex/cli.py`,
@@ -187,9 +195,8 @@ Treat imports exercised by tests, benchmarks, and scripts as quasi-public; do
 not casually move or rename them.
 
 - `src/chemex/experiments/catalog/wip/` is experimental but is still
-  auto-discovered and registered. It is excluded from Ruff and `ty`; do not use
-  that exclusion to weaken stable code, and do not promote or redesign WIP code
-  without maintainer intent.
+  auto-discovered, registered, distributed, and checked by Ruff and `ty`. Do
+  not promote or redesign WIP code without maintainer intent.
 - `dist/`, `website/build/`, caches, example `Output*` directories, and ChemEx
   result directories are generated/local artifacts. Do not edit or commit them.
 - `uv.lock` and `website/package-lock.json` are generated lock files; change
@@ -207,10 +214,10 @@ schemas and examples instead of copying large key lists into prose.
 Set up the repository with:
 
 ```sh
-uv sync --all-extras --dev
+uv sync --locked
 ```
 
-The blocking Python CI target is 3.13; Python 3.14 is currently informational.
+Python 3.13 and 3.14 are supported and required CI targets.
 Run the narrowest relevant check during development, then the applicable
 repository checks:
 
@@ -218,7 +225,7 @@ repository checks:
 uv run pytest -q
 uv run ty check
 uv run ruff check .
-uv run ruff format --check <changed-python-files>
+uv run ruff format --check .
 git diff --check
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,13 @@ invariants, and detailed validation matrix.
 
 ## Development setup
 
-ChemEx requires Python 3.13 or newer. Python 3.13 is the blocking CI target;
-Python 3.14 is currently tested as an informational target.
+ChemEx supports Python 3.13 and 3.14; both are required CI targets.
 
 Install [uv](https://docs.astral.sh/uv/), clone your fork, and from the repository
 root run:
 
 ```sh
-uv sync --all-extras --dev
+uv sync --locked
 ```
 
 Create a branch and keep each pull request limited to one coherent change.
@@ -29,7 +28,7 @@ applicable repository checks:
 uv run pytest -q
 uv run ty check
 uv run ruff check .
-uv run ruff format --check <changed-python-files>
+uv run ruff format --check .
 git diff --check
 ```
 
@@ -46,6 +45,10 @@ npm run build
 ```
 
 For packaging changes, also run `uv build`.
+
+`pyproject.toml` is the authoritative tooling policy. Ruff minor upgrades
+require a dedicated policy review that updates both the development dependency
+range and Ruff's `required-version` setting.
 
 ## Tests and scientific changes
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ ChemEx is an advanced, open-source software specifically designed for analyzing 
 
 ## Prerequisites
 
-Before installing ChemEx, ensure you have **Python 3.13** installed on your system.
-
-> **Note**: ChemEx requires Python 3.13. Python 3.14 was recently released and is being tested for compatibility, but **Python 3.13 is recommended** for production use until the scientific Python ecosystem fully adopts 3.14.
+ChemEx supports **Python 3.13 and 3.14**. Ensure one of these versions is
+installed on your system.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,8 @@ keywords = ["NMR", "analysis", "chemical exchange", "spectroscopy"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",  # Experimental - ecosystem catching up
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Chemistry",
 ]
 dependencies = [
@@ -33,10 +32,10 @@ dependencies = [
 ]
 
 [project.urls]
-Changelog = "https://github.com/gbouvignies/chemex/releases"
-Documentation = "http://gbouvignies.github.io/ChemEx/"
-Homepage = "http://gbouvignies.github.io/ChemEx/"
-Repository = "https://github.com/gbouvignies/chemex"
+Changelog = "https://github.com/gbouvignies/ChemEx/releases"
+Documentation = "https://gbouvignies.github.io/ChemEx/"
+Homepage = "https://gbouvignies.github.io/ChemEx/"
+Repository = "https://github.com/gbouvignies/ChemEx"
 
 [project.scripts]
 chemex = "chemex.chemex:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,11 @@ chemex = "chemex.chemex:main"
 [dependency-groups]
 dev = [
   "pytest>=8.4.2",
-  "ruff>=0.15.20",
-  "scipy-stubs>=1.16.2.3",
-  "ty>=0.0.35",
-  "types-cachetools>=6.2.0.20250827",
+  # New Ruff minor releases require an explicit policy review.
+  "ruff>=0.16.0,<0.17.0",
+  "scipy-stubs>=1.18.0.1",
+  "ty>=0.0.65",
+  "types-cachetools>=7.0.0.20260713",
 ]
 
 [build-system]
@@ -54,60 +55,56 @@ requires = ["uv_build>=0.8.14,<0.13.0"]
 build-backend = "uv_build"
 
 [tool.ruff]
-extend-exclude = ["benchmarks", "src/chemex/experiments/catalog/wip"]
+target-version = "py313"
+line-length = 88
+src = ["src"]
+extend-exclude = ["benchmarks"]
+preview = false
+required-version = ">=0.16.0,<0.17.0"
 
 [tool.ruff.lint]
-select = ["ALL"]
-ignore = [
-  "A002",
-  "ANN002",
-  "ANN003",
-  "ANN201",
-  "ANN401",
-  "ARG002",
-  "COM812",
-  "CPY001",  # Repository-level licensing; no per-file copyright headers
-  "D1",
-  "D203",
-  "D213",
-  "D401",
-  "D417",
-  "E402",
-  "E501",
-  "ERA001",
-  "FBT001",
-  "FBT002",
-  "FIX002",
-  "ISC001",
-  "PGH003",
-  "PLC0415",
-  "PLR0913",
-  "PLR0917",  # Scientific kernels often expose equation parameters directly
-  "PLR2004",
-  "RET504",
-  "RUF002",
-  "RUF003",
-  "RUF034",
-  "S307",
-  "TC001",
-  "TC002",
-  "TC003",
-  "TD002",
-  "TD003",
-  "S311",
-  "PD011",
+explicit-preview-rules = true
+select = [
+  "B",
+  "BLE001",
+  "C4",
+  "C90",
+  "DTZ",
+  "E4",
+  "E7",
+  "E9",
+  "F",
+  "I",
+  "ISC004",
+  "LOG004",
+  "LOG007",
+  "LOG015",
+  "NPY",
+  "PERF",
+  "PIE",
+  "PLE1205",
+  "PLW1510",
+  "RUF100",
+  "S",
+  "SIM",
+  "TRY002",
+  "TRY004",
+  "TRY201",
+  "TRY203",
+  "TRY300",
+  "TRY400",
+  "TRY401",
+  "UP",
 ]
 
 [tool.ruff.lint.isort]
 known-first-party = ["chemex"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ANN001", "N806", "PLC0415", "PLR2004", "S101"]
+"src/chemex/containers/data.py" = ["S311"]
+"src/chemex/containers/experiments.py" = ["S311"]
+"tests/**/*.py" = ["S101"]
 
 [tool.ty.src]
-# Exclude work-in-progress experimental code
-exclude = ["benchmarks/", "src/chemex/experiments/catalog/wip/", "tests/"]
-
-[tool.ty.rules]
-# Downgrade warnings to avoid failing CI
-possibly-missing-attribute = "ignore"
+include = ["src"]
+exclude = ["benchmarks/"]

--- a/src/chemex/configuration/base.py
+++ b/src/chemex/configuration/base.py
@@ -36,7 +36,11 @@ class BaseSettings(BaseModel):
     _key_to_lower = model_validator(mode="before")(key_to_lower)
 
 
-class ExperimentConfiguration[ExperimentSettings: BaseModel, ConditionsSettings: BaseModel, DataSettings: BaseModel](
+class ExperimentConfiguration[
+    ExperimentSettings: BaseModel,
+    ConditionsSettings: BaseModel,
+    DataSettings: BaseModel,
+](
     BaseModel,
 ):
     model: ModelSpec = Field(default_factory=ModelSpec, exclude=True)

--- a/src/chemex/configuration/experiment.py
+++ b/src/chemex/configuration/experiment.py
@@ -61,10 +61,7 @@ def _validate_state_selection(
     if isinstance(value, str):
         return _validate_state(value, info)
     if not isinstance(value, (list, tuple)):
-        msg = (
-            f"'{field}' must be a state string or a non-empty list "
-            "of state strings"
-        )
+        msg = f"'{field}' must be a state string or a non-empty list of state strings"
         raise ValueError(msg)  # noqa: TRY004 - Pydantic field-validation error
     if not value:
         msg = f"'{field}' must contain at least one state"
@@ -237,8 +234,10 @@ class B1InhomogeneityMixin(BaseModel):
             normalized.get("b1_inh_scale") is not None
             or normalized.get("b1_inh_res") is not None
         )
-        if has_legacy and distribution is not None and not isinstance(
-            distribution, DistributionConfig
+        if (
+            has_legacy
+            and distribution is not None
+            and not isinstance(distribution, DistributionConfig)
         ):
             msg = (
                 "Use either 'b1_distribution' or the legacy "
@@ -377,11 +376,7 @@ class RelaxationSettings(DetectionSettings):
         states = self.start_states
         if not states:
             return list(components)
-        return [
-            f"{component}_{state}"
-            for state in states
-            for component in components
-        ]
+        return [f"{component}_{state}" for state in states for component in components]
 
 
 class CpmgSettings(RelaxationSettings):

--- a/src/chemex/configuration/experiment.py
+++ b/src/chemex/configuration/experiment.py
@@ -39,7 +39,7 @@ def _validate_state(value: object, info: ValidationInfo) -> str:
     field = info.field_name or "state"
     if not isinstance(value, str):
         msg = f"'{field}' must be a state string"
-        raise ValueError(msg)  # noqa: TRY004
+        raise ValueError(msg)  # noqa: TRY004 - Pydantic field-validation error
 
     state = value.lower()
     available_states = _model_states_from_context(info)
@@ -65,7 +65,7 @@ def _validate_state_selection(
             f"'{field}' must be a state string or a non-empty list "
             "of state strings"
         )
-        raise ValueError(msg)  # noqa: TRY004
+        raise ValueError(msg)  # noqa: TRY004 - Pydantic field-validation error
     if not value:
         msg = f"'{field}' must contain at least one state"
         raise ValueError(msg)

--- a/src/chemex/containers/experiments.py
+++ b/src/chemex/containers/experiments.py
@@ -55,7 +55,9 @@ def _append_hash_suffix(path: Path, filename: Path) -> Path:
 
 
 def _build_output_stems(filenames: list[Path]) -> dict[Path, Path]:
-    output_parts = {filename: _filename_parts_for_output(filename) for filename in filenames}
+    output_parts = {
+        filename: _filename_parts_for_output(filename) for filename in filenames
+    }
     depth_by_filename = dict.fromkeys(filenames, 1)
 
     while True:
@@ -89,11 +91,15 @@ def _build_output_stems(filenames: list[Path]) -> dict[Path, Path]:
             return {
                 filename: (
                     _append_hash_suffix(
-                        _suffix_path(output_parts[filename], depth_by_filename[filename]),
+                        _suffix_path(
+                            output_parts[filename], depth_by_filename[filename]
+                        ),
                         filename,
                     )
                     if filename in colliding_filenames
-                    else _suffix_path(output_parts[filename], depth_by_filename[filename])
+                    else _suffix_path(
+                        output_parts[filename], depth_by_filename[filename]
+                    )
                 )
                 for filename in filenames
             }

--- a/src/chemex/experiments/experiment_types.py
+++ b/src/chemex/experiments/experiment_types.py
@@ -513,7 +513,7 @@ def shift_type[ConfigT: ShiftFamilyConfig](
     )
 
 
-def open(filename: Path) -> ExperimentSource:  # noqa: A001
+def open(filename: Path) -> ExperimentSource:
     """Read an Experiment input once and identify its Experiment Type."""
     try:
         raw_config = load_toml(filename)

--- a/src/chemex/experiments/loader.py
+++ b/src/chemex/experiments/loader.py
@@ -24,7 +24,7 @@ def import_module(name: str) -> ExperimentModule:
     module = importlib.import_module(name)
     if not callable(getattr(module, "register", None)):
         msg = f"Experiment module {name!r} does not define a callable register()"
-        raise ImportError(msg)  # noqa: TRY004
+        raise ImportError(msg)  # noqa: TRY004 - plugin contract makes this an import failure
     return cast("ExperimentModule", module)
 
 

--- a/src/chemex/models/factory.py
+++ b/src/chemex/models/factory.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Factories for creating parameter settings."""
+
+from __future__ import annotations
 
 from builtins import set as builtins_set
 from collections.abc import Callable

--- a/src/chemex/models/kinetic/settings_3st_double_binding.py
+++ b/src/chemex/models/kinetic/settings_3st_double_binding.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """This code imports the necessary modules and functions to define a 3-state
 double binding model. The model is named "3st_double_binding" and it is
 registered in the model factory. The model requires two parameters,
@@ -9,6 +7,8 @@ the concentrations of free protein and protein bound to each ligand
 given the total protein and ligand concentrations, as well as the
 dissociation constants for each binding site.
 """
+
+from __future__ import annotations
 
 from functools import lru_cache
 

--- a/src/chemex/nmr/_engine/effective_field.py
+++ b/src/chemex/nmr/_engine/effective_field.py
@@ -78,5 +78,7 @@ def tilt_magnetization_along_i_effective_field(
             [[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]]
         )
         components = magnetization[..., [tilt.index_x, tilt.index_z], :]
-        magnetization[..., [tilt.index_x, tilt.index_z], :] = rotation_matrix @ components
+        magnetization[..., [tilt.index_x, tilt.index_z], :] = (
+            rotation_matrix @ components
+        )
     return magnetization

--- a/src/chemex/nmr/_pulses/__init__.py
+++ b/src/chemex/nmr/_pulses/__init__.py
@@ -1,2 +1,1 @@
 """Private pulse internals for chemex.nmr."""
-

--- a/src/chemex/nmr/b1.py
+++ b/src/chemex/nmr/b1.py
@@ -28,7 +28,9 @@ class FixedDistributionModel:
         values = np.asarray(distribution.values, dtype=float)
         weights = np.asarray(distribution.weights, dtype=float)
         scales = np.ones_like(values) if nominal == 0.0 else values / nominal
-        return cls(tuple(scales.tolist()), tuple(weights.tolist()), distribution.dephasing)
+        return cls(
+            tuple(scales.tolist()), tuple(weights.tolist()), distribution.dephasing
+        )
 
     def get_distribution(self, value: float) -> Distribution:
         values = value * np.asarray(self.scales, dtype=float)

--- a/src/chemex/nmr/distributions/loader.py
+++ b/src/chemex/nmr/distributions/loader.py
@@ -23,7 +23,7 @@ def import_module(name: str) -> DistributionModule:
     module = importlib.import_module(name)
     if not callable(getattr(module, "register", None)):
         msg = f"Distribution module {name!r} does not define a callable register()"
-        raise ImportError(msg)  # noqa: TRY004
+        raise ImportError(msg)  # noqa: TRY004 - plugin contract makes this an import failure
     return cast("DistributionModule", module)
 
 

--- a/src/chemex/nmr/spectrometer.py
+++ b/src/chemex/nmr/spectrometer.py
@@ -60,8 +60,7 @@ class Spectrometer:
         self.perfect180_s = self._pulse_kernel.perfect180_s
         self.zfilter = self.keep(
             self.identity,
-            components={"ie", "se", "iz", "sz", "2izsz"}
-            & set(engine.basis.components),
+            components={"ie", "se", "iz", "sz", "2izsz"} & set(engine.basis.components),
         )
 
     def keep(self, magnetization: Array, components: Iterable[str]) -> Array:

--- a/tests/configuration/test_experiment.py
+++ b/tests/configuration/test_experiment.py
@@ -34,10 +34,9 @@ def test_string_and_single_item_list_have_equivalent_detection() -> None:
     list_settings = RelaxationSettings.model_validate({"observed_state": ["a"]})
 
     assert string_settings.get_detection_expression("[iz]") == "[iz_a]"
-    assert (
-        list_settings.get_detection_expression("[iz]")
-        == string_settings.get_detection_expression("[iz]")
-    )
+    assert list_settings.get_detection_expression(
+        "[iz]"
+    ) == string_settings.get_detection_expression("[iz]")
 
 
 @pytest.mark.parametrize(

--- a/tests/experiments/test_experiment_types.py
+++ b/tests/experiments/test_experiment_types.py
@@ -158,7 +158,7 @@ def test_opened_source_is_immutable(tmp_path: Path) -> None:
     source = experiment_types.open(filename)
 
     with pytest.raises(AttributeError, match="immutable"):
-        source._filename = tmp_path / "forged.toml"  # noqa: SLF001
+        source._filename = tmp_path / "forged.toml"
 
     assert source.filename == filename
     assert source.experiment_type_name == "cest_15n"

--- a/tests/nmr/test_detection.py
+++ b/tests/nmr/test_detection.py
@@ -18,9 +18,7 @@ def test_build_detection_vector_supports_addition_and_subtraction() -> None:
     basis = Basis(type="izsz", spin_system="nh", model=ModelSpec())
 
     vector = build_detection_vector("[2izsz_a] - [iz_a] + [iz_b]", basis.vectors)
-    expected = (
-        basis.vectors["2izsz_a"] - basis.vectors["iz_a"] + basis.vectors["iz_b"]
-    )
+    expected = basis.vectors["2izsz_a"] - basis.vectors["iz_a"] + basis.vectors["iz_b"]
 
     np.testing.assert_allclose(vector, expected)
 

--- a/tests/nmr/test_effective_field.py
+++ b/tests/nmr/test_effective_field.py
@@ -37,6 +37,8 @@ def test_tilt_magnetization_along_i_effective_field_round_trips() -> None:
     original = basis.vectors["ix_a"] + 2.0 * basis.vectors["iz_b"]
 
     tilted = tilt_magnetization_along_i_effective_field(original.copy(), tilts)
-    restored = tilt_magnetization_along_i_effective_field(tilted.copy(), tilts, back=True)
+    restored = tilt_magnetization_along_i_effective_field(
+        tilted.copy(), tilts, back=True
+    )
 
     np.testing.assert_allclose(restored, original)

--- a/tests/nmr/test_liouvillian_controls.py
+++ b/tests/nmr/test_liouvillian_controls.py
@@ -36,8 +36,8 @@ def test_update_without_parameters_keeps_matrix_shaped_base_liouvillian() -> Non
 
     liouvillian.update({})
 
-    assert liouvillian._l_base.shape == (liouvillian.size, liouvillian.size)  # noqa: SLF001
-    np.testing.assert_allclose(liouvillian._l_base, 0.0)  # noqa: SLF001
+    assert liouvillian._l_base.shape == (liouvillian.size, liouvillian.size)
+    np.testing.assert_allclose(liouvillian._l_base, 0.0)
 
 
 def test_missing_s_control_terms_use_zero_liouvillian_matrices() -> None:
@@ -47,11 +47,11 @@ def test_missing_s_control_terms_use_zero_liouvillian_matrices() -> None:
     liouvillian.b1_s = 20_000.0
 
     expected_shape = (liouvillian.size, liouvillian.size)
-    assert liouvillian._l_carrier_s.shape == expected_shape  # noqa: SLF001
-    assert liouvillian._l_offset_s.shape == expected_shape  # noqa: SLF001
+    assert liouvillian._l_carrier_s.shape == expected_shape
+    assert liouvillian._l_offset_s.shape == expected_shape
     assert liouvillian.l_b1x_s.shape == expected_shape
     assert liouvillian.l_b1y_s.shape == expected_shape
-    np.testing.assert_allclose(liouvillian._l_carrier_s, 0.0)  # noqa: SLF001
-    np.testing.assert_allclose(liouvillian._l_offset_s, 0.0)  # noqa: SLF001
+    np.testing.assert_allclose(liouvillian._l_carrier_s, 0.0)
+    np.testing.assert_allclose(liouvillian._l_offset_s, 0.0)
     np.testing.assert_allclose(liouvillian.l_b1x_s, 0.0)
     np.testing.assert_allclose(liouvillian.l_b1y_s, 0.0)

--- a/tests/nmr/test_magnetization.py
+++ b/tests/nmr/test_magnetization.py
@@ -61,10 +61,9 @@ def test_build_equilibrium_magnetization_uses_populations_and_xi_ratio() -> None
     magnetization = build_equilibrium_magnetization(basis, par_values)
     expected_scale_a = 0.6 * XI_RATIO[Nucleus.N15]
     expected_scale_b = 0.4 * XI_RATIO[Nucleus.N15]
-    expected = (
-        expected_scale_a * (basis.vectors["ie_a"] + basis.vectors["iz_a"])
-        + expected_scale_b * (basis.vectors["ie_b"] + basis.vectors["iz_b"])
-    )
+    expected = expected_scale_a * (
+        basis.vectors["ie_a"] + basis.vectors["iz_a"]
+    ) + expected_scale_b * (basis.vectors["ie_b"] + basis.vectors["iz_b"])
 
     np.testing.assert_allclose(magnetization, expected)
 

--- a/tests/nmr/test_propagators.py
+++ b/tests/nmr/test_propagators.py
@@ -37,10 +37,7 @@ def test_calculate_propagators_handles_stacked_liouvillians() -> None:
 
     propagators = calculate_propagators(liouvillians, delays)
     expected = np.array(
-        [
-            [expm(liouv * delay) for liouv in liouvillians]
-            for delay in delays
-        ]
+        [[expm(liouv * delay) for liouv in liouvillians] for delay in delays]
     )
 
     np.testing.assert_allclose(propagators, expected)

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -522,7 +522,7 @@ def test_run_statistics_uses_session_for_header(
 
     monkeypatch.setattr(resampling_module, "track", lambda _iterable, **_kwargs: [])
 
-    fitting_module._run_statistics(  # noqa: SLF001
+    fitting_module._run_statistics(
         experiments,
         tmp_path,
         "leastsq",
@@ -672,7 +672,7 @@ def test_run_statistics_dispatches_mcmc_without_resampling(
     )
     monkeypatch.setattr(fitting_module, "run_mcmc", fake_run_mcmc)
 
-    fitting_module._run_statistics(  # noqa: SLF001
+    fitting_module._run_statistics(
         experiments,
         tmp_path,
         "leastsq",
@@ -695,17 +695,17 @@ def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None
         },
     )
     samples = np.array([[0.1, 200.0], [0.3, 300.0], [0.5, 400.0]])
-    parameter_names = resampling_module._format_parameter_names(  # noqa: SLF001
+    parameter_names = resampling_module._format_parameter_names(
         ["__PB", "__KEX_AB"],
         store,
     )
 
-    resampling_module._write_resampling_summary(  # noqa: SLF001
+    resampling_module._write_resampling_summary(
         tmp_path,
         parameter_names=parameter_names,
         samples=samples,
     )
-    resampling_module._write_resampling_correlations(  # noqa: SLF001
+    resampling_module._write_resampling_correlations(
         tmp_path,
         parameter_names=parameter_names,
         samples=samples,

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -304,7 +304,7 @@ def test_git_metadata_is_optional_when_git_is_unavailable(
 
     monkeypatch.setattr(run_info_module.subprocess, "run", unavailable)
 
-    assert run_info_module._git_metadata() is None  # noqa: SLF001
+    assert run_info_module._git_metadata() is None
 
 
 def test_git_metadata_is_omitted_for_repository_not_tracking_chemex(
@@ -327,7 +327,7 @@ def test_git_metadata_is_omitted_for_repository_not_tracking_chemex(
 
     monkeypatch.setattr(run_info_module, "_run_git", run_git)
 
-    assert run_info_module._git_metadata() is None  # noqa: SLF001
+    assert run_info_module._git_metadata() is None
     assert calls[0][:2] == ("ls-files", "--error-unmatch")
 
 
@@ -431,7 +431,7 @@ def test_failed_replacement_restores_existing_run_info(
     monkeypatch.setattr(Path, "replace", fail_staging_replace)
 
     with pytest.raises(OSError, match="replacement failed"):
-        run_info_module._replace_run_info(  # noqa: SLF001
+        run_info_module._replace_run_info(
             staging_path,
             run_info_path,
         )

--- a/tests/test_simulation_plotters.py
+++ b/tests/test_simulation_plotters.py
@@ -25,8 +25,12 @@ def test_cest_plot_simulation_accepts_empty_experimental_data(
     recorded: dict[str, Data] = {}
     plotter = cest_module.CestPlotter(Path("13hz.toml"), SimpleNamespace())
 
-    monkeypatch.setattr(cest_module, "print_plot_filename", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(cest_module, "create_plot_data_calc", lambda _profile: _make_calc_data())
+    monkeypatch.setattr(
+        cest_module, "print_plot_filename", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        cest_module, "create_plot_data_calc", lambda _profile: _make_calc_data()
+    )
 
     def fake_plot_profile(_pdf, _profile, data_exp: Data, data_calc: Data) -> None:
         recorded["data_exp"] = data_exp
@@ -49,7 +53,9 @@ def test_cpmg_plot_simulation_accepts_empty_experimental_data(
     recorded: dict[str, Data] = {}
     plotter = cpmg_module.CpmgPlotter(Path("500mhz.toml"), SimpleNamespace())
 
-    monkeypatch.setattr(cpmg_module, "print_plot_filename", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cpmg_module, "print_plot_filename", lambda *_args, **_kwargs: None
+    )
     monkeypatch.setattr(
         cpmg_module,
         "create_plot_data_calc",

--- a/uv.lock
+++ b/uv.lock
@@ -74,10 +74,10 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.4.2" },
-    { name = "ruff", specifier = ">=0.15.20" },
-    { name = "scipy-stubs", specifier = ">=1.16.2.3" },
-    { name = "ty", specifier = ">=0.0.35" },
-    { name = "types-cachetools", specifier = ">=6.2.0.20250827" },
+    { name = "ruff", specifier = ">=0.16.0,<0.17.0" },
+    { name = "scipy-stubs", specifier = ">=1.18.0.1" },
+    { name = "ty", specifier = ">=0.0.65" },
+    { name = "types-cachetools", specifier = ">=7.0.0.20260713" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Modernizes ChemEx's packaging, linting, typing, formatting, and CI policy while preserving scientific and runtime behavior.

### Packaging and metadata

- remove the deprecated GPL classifier while retaining SPDX license metadata;
- normalize project URLs to HTTPS and canonical repository casing;
- retain `numdifftools` as an indirect functional runtime dependency used by lmfit for covariance and uncertainty estimation with supported non-least-squares solvers.

### Ruff and formatting

- replace unstable `select = ["ALL"]` with an explicit curated rule set;
- constrain Ruff to the reviewed `0.16.x` policy series;
- include shipped WIP experiment modules in normal Ruff coverage;
- retain only narrow scientific and test-specific exceptions;
- restore two actual module docstrings;
- remove stale `noqa` suppressions;
- normalize the 13 previously unformatted files;
- enforce Ruff formatting in CI.

### Typing

- check all shipped `src/` code, including WIP modules;
- keep exploratory benchmarks excluded;
- remove the redundant `possibly-missing-attribute` override;
- require `ty` to pass for both Python 3.13 and 3.14.

### CI and package validation

- require Python 3.13 and 3.14 for tests and type checking;
- separate lint, typing, tests, and package validation into clear jobs;
- use `uv sync --locked`;
- build and validate wheel and sdist artifacts;
- inspect artifact contents;
- clean-install the built wheel;
- verify runtime and package metadata versions;
- run the installed `chemex --help` entry point.

### Documentation

- document Python 3.13 and 3.14 as supported CI targets;
- document uv as the authoritative dependency manager;
- document the Ruff minor-version policy-review process;
- clarify WIP static checking and the role of `numdifftools`.

## Validation

- `uv sync --locked`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check --python-version 3.13`
- `uv run ty check --python-version 3.14`
- Python 3.13: 336 tests passed
- Python 3.14: 336 tests passed
- wheel and sdist built successfully
- `twine check` passed for both artifacts
- artifact contents inspected
- clean Python 3.13 wheel installation succeeded
- runtime and package metadata versions matched
- installed `chemex --help` succeeded
- `git diff --check` passed

The only warning is the existing `emcee.autocorr` invalid-divide warning in the MCMC test.

No scientific or numerical behavior is intended to change.
