### PR TITLE
Remove the unused B1FieldConfig adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 
 ## [Unreleased]
 
+### Infrastructure
+- Removed the unused `B1FieldConfig` model and its `default_distribution_config`
+  helper from `b1_config.py`; the flat-table `b1_frq` schema it implemented was
+  never wired to any experiment. `B1InhomogeneityMixin` remains the single B1
+  configuration path, and the distribution-union parsing it depends on is
+  unchanged.
+
 ## [2026.06.1] - 2026-06-26
 
 ### Added

--- a/src/chemex/configuration/b1_config.py
+++ b/src/chemex/configuration/b1_config.py
@@ -1,28 +1,18 @@
 """B1 field inhomogeneity configuration.
 
-This module wires ChemEx configuration to the B1 distribution plugin system.
-It supports both simple (float) and advanced (flat TOML table) configs,
+This module wires ChemEx configuration to the B1 distribution plugin system,
 building the discriminated union of distribution configs dynamically from the
-registered plugins. Adding a new distribution requires no changes here.
+registered plugins and parsing TOML input against it. Adding a new
+distribution requires no changes here.
 """
 
 from __future__ import annotations
 
 import operator
 from functools import reduce
-from typing import TYPE_CHECKING, Annotated, Self, cast
+from typing import Annotated, cast
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    TypeAdapter,
-    field_validator,
-    model_validator,
-)
-
-if TYPE_CHECKING:
-    from chemex.nmr.constants import Distribution
+from pydantic import Field, TypeAdapter
 
 from chemex.nmr.distributions import registry  # Triggers plugin auto-registration
 from chemex.nmr.distributions.registry import DistributionConfig
@@ -37,14 +27,6 @@ def _build_distribution_union() -> object:
     return reduce(operator.or_, classes)
 
 
-def _default_distribution() -> DistributionConfig:
-    config = registry.get_config_class("gaussian").model_validate({"type": "gaussian"})
-    if isinstance(config, DistributionConfig):
-        return config
-    msg = "Invalid default B1 distribution configuration"
-    raise TypeError(msg)
-
-
 def _build_distribution_adapter() -> TypeAdapter:
     """Construct a discriminated TypeAdapter for the registered distribution configs."""
     distribution_union = _build_distribution_union()
@@ -56,11 +38,6 @@ def _build_distribution_adapter() -> TypeAdapter:
 
 # Discriminated union of all dynamically-registered distribution configs
 _DISTRIBUTION_ADAPTER = _build_distribution_adapter()
-
-
-def default_distribution_config() -> DistributionConfig:
-    """Build the default Gaussian distribution config."""
-    return _default_distribution()
 
 
 def parse_distribution_config(value: object) -> DistributionConfig:
@@ -77,142 +54,3 @@ def parse_distribution_config(value: object) -> DistributionConfig:
         return parsed
     msg = "Invalid B1 distribution configuration"
     raise TypeError(msg)
-
-
-class B1FieldConfig(BaseModel):
-    """Complete B1 field configuration including nominal value and distribution.
-
-    This model is used when b1_frq is specified as a table in TOML.
-
-    Attributes
-    ----------
-    value : float | None
-        Nominal B1 field value (in kHz). Either this or pw90 must be specified.
-    pw90 : float | None
-        90-degree pulse width (in seconds). If specified, value is calculated
-        as 1/(4*pw90).
-    distribution : DistributionConfig
-        Distribution configuration (dynamically typed based on registered plugins)
-
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",  # Reject unknown fields at top level
-        validate_assignment=True,  # Validate on attribute assignment
-        str_strip_whitespace=True,  # Auto-strip strings
-    )
-
-    value: float | None = Field(
-        default=None,
-        gt=0.0,
-        description="Nominal B1 field strength (Hz or kHz)",
-        examples=[25.0, 700.0],
-    )
-    pw90: float | None = Field(
-        default=None,
-        gt=0.0,
-        description="90-degree pulse width (seconds)",
-        examples=[45e-6, 96e-6],
-    )
-    # Default to Gaussian distribution if available
-    distribution: DistributionConfig = Field(
-        default_factory=_default_distribution,
-        description="B1 distribution configuration",
-    )
-
-    # Accept only flat TOML schema: all distribution params at top level
-    @model_validator(mode="before")
-    @classmethod
-    def _normalize_flat_schema(cls, data: object) -> object:
-        if not isinstance(data, dict):
-            return data
-
-        flat_schema: dict[str, object] = {}
-        for key, value in data.items():
-            if not isinstance(key, str):
-                return data
-            flat_schema[key] = value
-
-        # Reject nested schema (where distribution is a sub-dict)
-        if "distribution" in flat_schema and isinstance(
-            flat_schema["distribution"], dict
-        ):
-            msg = (
-                "Nested distribution schema is not supported. "
-                "Use flat schema: put all keys (value, type, scale, etc.) "
-                "at the same level under [experiment.b1_frq]"
-            )
-            raise ValueError(msg)
-
-        # If top-level contains a distribution type alongside value or pw90,
-        # fold keys into a nested 'distribution' object internally
-        if ("value" in flat_schema or "pw90" in flat_schema) and "type" in flat_schema:
-            # Move all keys except 'value' and 'pw90' into the 'distribution' sub-dict
-            distribution = {
-                key: value
-                for key, value in flat_schema.items()
-                if key not in {"value", "pw90"}
-            }
-            result: dict[str, object] = {"distribution": distribution}
-            if "value" in flat_schema:
-                result["value"] = flat_schema["value"]
-            if "pw90" in flat_schema:
-                result["pw90"] = flat_schema["pw90"]
-            return result
-
-        return flat_schema
-
-    @model_validator(mode="after")
-    def _validate_value_or_pw90(self) -> Self:
-        """Ensure exactly one of value or pw90 is specified."""
-        has_value = self.value is not None
-        has_pw90 = self.pw90 is not None
-
-        if not (has_value ^ has_pw90):  # XOR: exactly one must be True
-            msg = (
-                "Exactly one of 'value' or 'pw90' must be specified in B1 field "
-                "config, not both or neither"
-            )
-            raise ValueError(msg)
-        return self
-
-    # Parse the distribution using the dynamic union adapter
-    @field_validator("distribution", mode="before")
-    @classmethod
-    def _parse_distribution(cls, value: object) -> DistributionConfig:
-        """Parse distribution config using dynamic union adapter."""
-        return parse_distribution_config(value)
-
-    @property
-    def b1_nominal(self) -> float:
-        """Get the nominal B1 field value.
-
-        Returns
-        -------
-        float
-            B1 field value in kHz (calculated from pw90 if necessary)
-
-        """
-        if self.value is not None:
-            return self.value
-        if self.pw90 is None:
-            msg = "Either value or pw90 must be set"
-            raise ValueError(msg)
-        return 1.0 / (4.0 * self.pw90)
-
-    def get_distribution(self) -> Distribution:
-        """Generate the B1 distribution based on the configuration.
-
-        Returns
-        -------
-        Distribution
-            B1 values and weights for numerical integration
-
-        """
-        return self.distribution.get_distribution(self.b1_nominal)
-
-
-# Type alias for the b1_frq field that accepts either float or table
-# When float: use default Gaussian with separate b1_inh_scale/b1_inh_res
-# When dict/table: use B1FieldConfig
-B1Field = float | B1FieldConfig

--- a/tests/configuration/test_b1_config.py
+++ b/tests/configuration/test_b1_config.py
@@ -1,4 +1,4 @@
-"""Test B1FieldConfig with pw90 parameter."""
+"""Test B1InhomogeneityMixin configuration parsing."""
 
 from typing import ClassVar
 
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 
-from chemex.configuration.b1_config import B1FieldConfig
 from chemex.configuration.experiment import B1InhomogeneityMixin
 from chemex.experiments.catalog.dcest_13c import DCest13CSettings
 from chemex.experiments.catalog.dcest_15n import DCest15NSettings
@@ -26,98 +25,6 @@ class DummyDefaultGaussianB1Settings(B1InhomogeneityMixin):
 class DummyDefaultDephasingB1Settings(B1InhomogeneityMixin):
     legacy_b1_inh_scale_default: ClassVar[float | None] = np.inf
     legacy_b1_inh_res_default: ClassVar[int | None] = 11
-
-
-def test_b1_field_config_with_value():
-    """Test B1FieldConfig with explicit value using flat schema."""
-    # Simulate TOML flat schema parsing
-    data = {
-        "value": 10.0,
-        "type": "gaussian",
-        "scale": 0.1,
-        "res": 5,
-    }
-    config = B1FieldConfig.model_validate(data)
-    assert config.b1_nominal == 10.0
-    distribution = config.get_distribution()
-    assert len(distribution.values) == 5
-    assert len(distribution.weights) == 5
-
-
-def test_b1_field_config_with_pw90():
-    """Test B1FieldConfig with pw90 parameter using flat schema."""
-    pw90 = 25.0e-6  # 25 microseconds
-    expected_b1 = 1.0 / (4.0 * pw90)
-
-    # Simulate TOML flat schema parsing
-    data = {
-        "pw90": pw90,
-        "type": "gaussian",
-        "scale": 0.1,
-        "res": 5,
-    }
-    config = B1FieldConfig.model_validate(data)
-    assert config.b1_nominal == pytest.approx(expected_b1)
-    distribution = config.get_distribution()
-    assert len(distribution.values) == 5
-    assert len(distribution.weights) == 5
-
-
-def test_b1_field_config_missing_both():
-    """Test that B1FieldConfig requires either value or pw90."""
-    # When neither value nor pw90 is provided, but distribution params are,
-    # Pydantic rejects the extra fields before model validation
-
-    data = {
-        "type": "gaussian",
-        "scale": 0.1,
-        "res": 5,
-    }
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-        B1FieldConfig.model_validate(data)
-
-
-def test_b1_field_config_both_specified():
-    """Test that B1FieldConfig rejects both value and pw90."""
-    data = {
-        "value": 10.0,
-        "pw90": 25.0e-6,
-        "type": "gaussian",
-        "scale": 0.1,
-        "res": 5,
-    }
-    with pytest.raises(
-        ValueError, match="Exactly one of 'value' or 'pw90' must be specified"
-    ):
-        B1FieldConfig.model_validate(data)
-
-
-def test_b1_field_config_flat_schema_with_pw90():
-    """Test flat TOML schema with pw90."""
-    # Simulate TOML parsing
-    data = {
-        "pw90": 25.0e-6,
-        "type": "gaussian",
-        "scale": 0.1,
-        "res": 5,
-    }
-    config = B1FieldConfig.model_validate(data)
-    expected_b1 = 1.0 / (4.0 * 25.0e-6)
-    assert config.b1_nominal == pytest.approx(expected_b1)
-
-
-def test_b1_field_config_flat_schema_with_value():
-    """Test flat TOML schema with value."""
-    # Simulate TOML parsing
-    data = {
-        "value": 15.95,
-        "type": "skewed",
-        "scale": 0.15,
-        "skewness": -0.5,
-        "res": 11,
-    }
-    config = B1FieldConfig.model_validate(data)
-    assert config.b1_nominal == 15.95
 
 
 def test_b1_inhomogeneity_mixin_parses_distribution_to_typed_config():

--- a/tests/nmr/test_distributions.py
+++ b/tests/nmr/test_distributions.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 
-from chemex.configuration.b1_config import B1FieldConfig
+from chemex.configuration.b1_config import parse_distribution_config
 from chemex.nmr.distributions import registry
 
 
@@ -38,84 +38,53 @@ class TestDistributionRegistry:
             registry.get_generator("nonexistent")
 
 
-class TestB1FieldConfig:
-    """Test the B1FieldConfig model and schema validation."""
-
-    def test_default_uses_gaussian(self):
-        """Test that default distribution is Gaussian."""
-        config = B1FieldConfig.model_validate({"value": 15.0})
-        assert config.distribution.type == "gaussian"
+class TestDistributionConfigParsing:
+    """Test parsing distribution configs via the registered plugin union."""
 
     def test_flat_schema_gaussian(self):
         """Test flat TOML schema for Gaussian distribution."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "gaussian",
                 "scale": 0.1,
                 "res": 11,
             }
         )
-        assert config.value == 15.0
-        assert config.distribution.type == "gaussian"
-        assert config.distribution.scale == 0.1
-        assert config.distribution.res == 11
+        assert config.type == "gaussian"
+        assert config.scale == 0.1
+        assert config.res == 11
 
     def test_flat_schema_skewed(self):
         """Test flat TOML schema for skewed distribution."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.95,
                 "type": "skewed",
                 "scale": 0.15,
                 "skewness": -0.5,
                 "res": 11,
             }
         )
-        assert config.distribution.type == "skewed"
-        assert config.distribution.skewness == -0.5
+        assert config.type == "skewed"
+        assert config.skewness == -0.5
 
     def test_flat_schema_custom(self):
         """Test flat TOML schema for custom distribution."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.95,
                 "type": "custom",
                 "scales": [0.95, 1.0, 1.03],
                 "weights": [0.25, 0.5, 0.25],
             }
         )
-        assert config.distribution.type == "custom"
-        assert config.distribution.scales == [0.95, 1.0, 1.03]
-        assert config.distribution.weights == [0.25, 0.5, 0.25]
-
-    def test_nested_schema_rejected(self):
-        """Test that nested schema is rejected."""
-        with pytest.raises(ValueError, match="Nested distribution schema"):
-            B1FieldConfig.model_validate(
-                {
-                    "value": 15.0,
-                    "distribution": {
-                        "type": "gaussian",
-                        "scale": 0.1,
-                        "res": 11,
-                    },
-                }
-            )
-
-    def test_invalid_value_rejected(self):
-        """Test that invalid nominal values are rejected."""
-        with pytest.raises(ValidationError):
-            B1FieldConfig.model_validate({"value": -5.0})
-        with pytest.raises(ValidationError):
-            B1FieldConfig.model_validate({"value": 0.0})
+        assert config.type == "custom"
+        assert config.scales == [0.95, 1.0, 1.03]
+        assert config.weights == [0.25, 0.5, 0.25]
 
     def test_unknown_distribution_option_rejected(self):
         """Test that mistyped distribution options are rejected."""
         with pytest.raises(ValidationError, match="sclae"):
-            B1FieldConfig.model_validate(
+            parse_distribution_config(
                 {
-                    "value": 15.0,
                     "type": "gaussian",
                     "sclae": 0.2,
                 }
@@ -127,57 +96,53 @@ class TestGaussianDistribution:
 
     def test_gaussian_generates_correct_shape(self):
         """Test that Gaussian distribution has correct number of points."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "gaussian",
                 "scale": 0.1,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         assert len(dist.values) == 11
         assert len(dist.weights) == 11
 
     def test_gaussian_weights_normalized(self):
         """Test that Gaussian weights sum to 1.0."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "gaussian",
                 "scale": 0.1,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         assert np.isclose(dist.weights.sum(), 1.0)
 
     def test_gaussian_centered_at_nominal(self):
         """Test that Gaussian is approximately centered at nominal value."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "gaussian",
                 "scale": 0.1,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         # Mean should be close to nominal value
         weighted_mean = np.sum(dist.values * dist.weights)
         assert np.isclose(weighted_mean, 15.0, rtol=0.01)
 
     def test_gaussian_scale_zero_gives_single_point(self):
         """Test that scale=0 gives a single point distribution."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "gaussian",
                 "scale": 0.0,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         assert len(dist.values) == 1
         assert dist.values[0] == 15.0
         assert dist.weights[0] == 1.0
@@ -188,29 +153,27 @@ class TestHermiteDistribution:
 
     def test_hermite_generates_correct_shape(self):
         """Test that Hermite distribution has correct number of points."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "hermite",
                 "scale": 0.1,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         assert len(dist.values) == 11
         assert len(dist.weights) == 11
 
     def test_hermite_weights_normalized(self):
         """Test that Hermite weights sum to 1.0."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "hermite",
                 "scale": 0.1,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         assert np.isclose(dist.weights.sum(), 1.0)
 
 
@@ -219,54 +182,50 @@ class TestSkewedDistribution:
 
     def test_skewed_generates_correct_shape(self):
         """Test that skewed distribution has correct number of points."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.95,
                 "type": "skewed",
                 "scale": 0.15,
                 "skewness": -0.5,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.95)
         assert len(dist.values) == 11
         assert len(dist.weights) == 11
 
     def test_skewed_weights_normalized(self):
         """Test that skewed weights sum to 1.0."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.95,
                 "type": "skewed",
                 "scale": 0.15,
                 "skewness": -0.5,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.95)
         assert np.isclose(dist.weights.sum(), 1.0)
 
     def test_skewed_zero_skewness_uses_hermite(self):
         """Test that zero skewness falls back to Hermite."""
-        config_skewed = B1FieldConfig.model_validate(
+        config_skewed = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "skewed",
                 "scale": 0.1,
                 "skewness": 0.0,
                 "res": 11,
             }
         )
-        config_hermite = B1FieldConfig.model_validate(
+        config_hermite = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "hermite",
                 "scale": 0.1,
                 "res": 11,
             }
         )
-        dist_skewed = config_skewed.get_distribution()
-        dist_hermite = config_hermite.get_distribution()
+        dist_skewed = config_skewed.get_distribution(15.0)
+        dist_hermite = config_hermite.get_distribution(15.0)
         # Should be identical
         assert np.allclose(dist_skewed.values, dist_hermite.values)
         assert np.allclose(dist_skewed.weights, dist_hermite.weights)
@@ -277,58 +236,54 @@ class TestCustomDistribution:
 
     def test_custom_basic(self):
         """Test basic custom distribution creation."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.95,
                 "type": "custom",
                 "scales": [0.95, 1.0, 1.03],
                 "weights": [0.25, 0.5, 0.25],
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.95)
         assert len(dist.values) == 3
         assert len(dist.weights) == 3
 
     def test_custom_correct_values(self):
         """Test that custom distribution computes correct B1 values."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 10.0,
                 "type": "custom",
                 "scales": [0.9, 1.0, 1.1],
                 "weights": [1.0, 1.0, 1.0],
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(10.0)
         expected_values = np.array([9.0, 10.0, 11.0])
         assert np.allclose(dist.values, expected_values)
 
     def test_custom_weights_normalized(self):
         """Test that custom weights are auto-normalized."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "custom",
                 "scales": [0.9, 1.0, 1.1],
                 "weights": [1.0, 2.0, 1.0],  # Sum = 4.0
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         assert np.isclose(dist.weights.sum(), 1.0)
         expected_weights = np.array([0.25, 0.5, 0.25])
         assert np.allclose(dist.weights, expected_weights)
 
     def test_custom_single_point(self):
         """Test custom distribution with single point."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": "custom",
                 "scales": [1.0],
                 "weights": [1.0],
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         assert len(dist.values) == 1
         assert dist.values[0] == 15.0
         assert dist.weights[0] == 1.0
@@ -336,9 +291,8 @@ class TestCustomDistribution:
     def test_custom_mismatched_lengths_rejected(self):
         """Test that mismatched scales and weights are rejected."""
         with pytest.raises(ValidationError, match="same length"):
-            B1FieldConfig.model_validate(
+            parse_distribution_config(
                 {
-                    "value": 15.0,
                     "type": "custom",
                     "scales": [0.95, 1.0, 1.05],
                     "weights": [0.5, 0.5],  # Wrong length!
@@ -348,9 +302,8 @@ class TestCustomDistribution:
     def test_custom_negative_scale_rejected(self):
         """Test that negative scales are rejected."""
         with pytest.raises(ValidationError, match="positive"):
-            B1FieldConfig.model_validate(
+            parse_distribution_config(
                 {
-                    "value": 15.0,
                     "type": "custom",
                     "scales": [-0.95, 1.0],
                     "weights": [0.5, 0.5],
@@ -360,9 +313,8 @@ class TestCustomDistribution:
     def test_custom_negative_weight_rejected(self):
         """Test that negative weights are rejected."""
         with pytest.raises(ValidationError, match="positive"):
-            B1FieldConfig.model_validate(
+            parse_distribution_config(
                 {
-                    "value": 15.0,
                     "type": "custom",
                     "scales": [0.95, 1.0],
                     "weights": [-0.5, 1.5],
@@ -376,35 +328,14 @@ class TestOtherDistributions:
     @pytest.mark.parametrize("dist_type", ["beta"])
     def test_distribution_generates(self, dist_type):
         """Test that distribution generates and has normalized weights."""
-        config = B1FieldConfig.model_validate(
+        config = parse_distribution_config(
             {
-                "value": 15.0,
                 "type": dist_type,
                 "scale": 0.1,
                 "res": 11,
             }
         )
-        dist = config.get_distribution()
+        dist = config.get_distribution(15.0)
         assert len(dist.values) > 0
         assert len(dist.weights) > 0
-        assert np.isclose(dist.weights.sum(), 1.0)
-
-
-class TestBackwardCompatibility:
-    """Test backward compatibility with legacy float format."""
-
-    def test_float_value_creates_gaussian_default(self):
-        """Test that a simple float value defaults to Gaussian."""
-        config = B1FieldConfig.model_validate({"value": 13.0})
-        assert config.value == 13.0
-        assert config.distribution.type == "gaussian"
-        # Should use default scale and res
-        assert config.distribution.scale == 0.1
-        assert config.distribution.res == 11
-
-    def test_get_distribution_from_default(self):
-        """Test getting distribution from default config."""
-        config = B1FieldConfig.model_validate({"value": 13.0})
-        dist = config.get_distribution()
-        assert len(dist.values) == 11
         assert np.isclose(dist.weights.sum(), 1.0)


### PR DESCRIPTION
## Summary

`B1FieldConfig` (in `src/chemex/configuration/b1_config.py`) implemented a
flat-table `b1_frq` TOML schema that was never wired to any experiment: no
catalog module, shipped example, or doc used it, and its only production-code
caller was its own test suite. `B1InhomogeneityMixin`
(`pw90`/`b1_frq`/`b1_distribution`) is the one live B1 configuration path and
already covers the same concept.

## Changes

- Delete `B1FieldConfig`, `default_distribution_config()`, and
  `_default_distribution()` from `b1_config.py`; prune now-unused imports.
  `parse_distribution_config` and the distribution-union machinery that
  `B1InhomogeneityMixin` depends on are unchanged.
- `tests/configuration/test_b1_config.py`: drop the 6 dead
  `B1FieldConfig`-specific tests, keep all `B1InhomogeneityMixin`/dcest tests.
- `tests/nmr/test_distributions.py`: rewrite ~24 tests to exercise
  `parse_distribution_config(...).get_distribution(nominal)` directly instead
  of the dead class; drop 5 tests whose behavior no longer exists
  (nested-schema rejection, value/pw90 XOR, value>0 bound,
  gaussian-by-default — the live default is "no inhomogeneity").
- Add a CHANGELOG Infrastructure entry.

## Compatibility

None. Nothing in production code, the CLI, TOML schemas, or shipped examples
referenced `B1FieldConfig`.

## Validation

- `uv run pytest -q` — 325 passed
- `uv run ty check` — all checks passed
- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — all files formatted
- `git diff --check` — clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>