### PR TITLE
Refactor pulse cache invalidation

### DIFF
--- a/src/chemex/nmr/_engine/engine.py
+++ b/src/chemex/nmr/_engine/engine.py
@@ -60,6 +60,12 @@ class ISLiouvillianEngine:
             (self.size, self.size),
             dtype=self._matrix_dtype,
         )
+        # Generations track how many times the shared free-evolution Liouvillian
+        # and each spin's B1 terms have changed, so pulse caches can detect
+        # staleness by comparison instead of being told to invalidate.
+        self._free_generation = 0
+        self._b1_i_generation = 0
+        self._b1_s_generation = 0
         self.h_frq = 0.0 if conditions.h_larmor_frq is None else conditions.h_larmor_frq
         self._readout = LiouvillianReadout(self.basis.vectors)
         self._q_order_i = _Q_ORDER_I.get(self.basis.extension, 1.0)
@@ -95,6 +101,7 @@ class ISLiouvillianEngine:
             ),
             start=self._zero_liouvillian,
         )
+        self._free_generation += 1
 
     def _matrix_or_zero(self, name: str) -> Array:
         return self._matrices.get(name, self._zero_liouvillian)
@@ -138,6 +145,7 @@ class ISLiouvillianEngine:
     def carrier_i(self, value: float) -> None:
         self.state.carrier_i = float(value)
         self._l_carrier_i = self._scaled_liouvillian_term("carrier_i", value)
+        self._free_generation += 1
 
     @property
     def carrier_s(self) -> float:
@@ -147,6 +155,7 @@ class ISLiouvillianEngine:
     def carrier_s(self, value: float) -> None:
         self.state.carrier_s = float(value)
         self._l_carrier_s = self._scaled_liouvillian_term("carrier_s", value)
+        self._free_generation += 1
 
     @property
     def offset_i(self) -> float:
@@ -160,6 +169,7 @@ class ISLiouvillianEngine:
             value,
             factor=float(np.sign(self.ppm_i)),
         )
+        self._free_generation += 1
 
     @property
     def offset_s(self) -> float:
@@ -173,6 +183,7 @@ class ISLiouvillianEngine:
             value,
             factor=float(np.sign(self.ppm_s)),
         )
+        self._free_generation += 1
 
     def _set_b1_i_profile(self, profile: B1Profile) -> None:
         self.state.b1_i_profile = profile
@@ -181,6 +192,7 @@ class ISLiouvillianEngine:
             matrix_x=self._matrix_or_zero("b1x_i"),
             matrix_y=self._matrix_or_zero("b1y_i"),
         )
+        self._b1_i_generation += 1
 
     def set_b1_i_inhomogeneity(
         self,
@@ -236,6 +248,7 @@ class ISLiouvillianEngine:
         self.state.b1_s = float(value)
         self.l_b1x_s = self._scaled_liouvillian_term("b1x_s", value)
         self.l_b1y_s = self._scaled_liouvillian_term("b1y_s", value)
+        self._b1_s_generation += 1
 
     @property
     def jeff_i(self) -> Distribution:
@@ -248,6 +261,7 @@ class ISLiouvillianEngine:
             distribution,
             matrix=self._matrix_or_zero("jeff_i"),
         )
+        self._free_generation += 1
 
     @property
     def gradient_dephasing(self) -> float:
@@ -276,6 +290,21 @@ class ISLiouvillianEngine:
     @property
     def weights(self) -> Array:
         return self._b1_i_state.axis.weights * self._jeff_i_state.axis.weights
+
+    def pulse_generation(self, spin: str) -> tuple[int, int]:
+        """Return a value that changes whenever spin's base pulses go stale.
+
+        Combines the shared free-evolution generation with the spin-specific
+        B1 generation, so callers only need to compare this tuple for
+        equality instead of knowing which underlying state affects which
+        spin's pulses.
+        """
+        if spin == "i":
+            return (self._free_generation, self._b1_i_generation)
+        if spin == "s":
+            return (self._free_generation, self._b1_s_generation)
+        msg = f"Unknown spin {spin!r}"
+        raise ValueError(msg)
 
     @property
     def detection(self) -> str:

--- a/src/chemex/nmr/_pulses/kernel.py
+++ b/src/chemex/nmr/_pulses/kernel.py
@@ -32,6 +32,20 @@ class PulseKernel:
         phases = self._phases[spin]
         return np.array([phases[i] @ propagator @ phases[-i] for i in range(4)])
 
+    def pulse_generation(self, spin: str) -> tuple[int, int]:
+        return self._engine.pulse_generation(spin)
+
+    @staticmethod
+    def _phase_mixed_term(
+        l_x: Array,
+        l_y: Array,
+        phase: float,
+        scale: float = 1.0,
+    ) -> Array:
+        """Combine a spin's x/y B1 Liouvillian terms for an RF pulse phase."""
+        rad = phase * np.pi * 0.5
+        return scale * np.cos(rad) * l_x + scale * np.sin(rad) * l_y
+
     def delays(self, times: float | Iterable[float]) -> Array:
         return calculate_propagators(self._engine.l_free, times)
 
@@ -42,11 +56,11 @@ class PulseKernel:
         scale: float = 1.0,
     ) -> Array:
         dephased = self._engine.b1_i_dist.dephasing
-        rad = phase * np.pi * 0.5
-        liouv = (
-            self._engine.l_free
-            + scale * np.cos(rad) * self._engine.l_b1x_i
-            + scale * np.sin(rad) * self._engine.l_b1y_i
+        liouv = self._engine.l_free + self._phase_mixed_term(
+            self._engine.l_b1x_i,
+            self._engine.l_b1y_i,
+            phase,
+            scale,
         )
         return calculate_propagators(liouv, times, dephasing=dephased)
 
@@ -56,11 +70,11 @@ class PulseKernel:
         phase: float,
         scale: float = 1.0,
     ) -> Array:
-        rad = phase * np.pi * 0.5
-        liouv = (
-            self._engine.l_free
-            + scale * np.cos(rad) * self._engine.l_b1x_s
-            + scale * np.sin(rad) * self._engine.l_b1y_s
+        liouv = self._engine.l_free + self._phase_mixed_term(
+            self._engine.l_b1x_s,
+            self._engine.l_b1y_s,
+            phase,
+            scale,
         )
         return calculate_propagators(liouv, times)
 
@@ -73,10 +87,12 @@ class PulseKernel:
         dephased = self._engine.b1_i_dist.dephasing
         liouv = (
             self._engine.l_free
-            + np.cos(phase_i * np.pi * 0.5) * self._engine.l_b1x_i
-            + np.sin(phase_i * np.pi * 0.5) * self._engine.l_b1y_i
-            + np.cos(phase_s * np.pi * 0.5) * self._engine.l_b1x_s
-            + np.sin(phase_s * np.pi * 0.5) * self._engine.l_b1y_s
+            + self._phase_mixed_term(
+                self._engine.l_b1x_i, self._engine.l_b1y_i, phase_i
+            )
+            + self._phase_mixed_term(
+                self._engine.l_b1x_s, self._engine.l_b1y_s, phase_s
+            )
         )
         return calculate_propagators(liouv, times, dephasing=dephased)
 

--- a/src/chemex/nmr/_pulses/library.py
+++ b/src/chemex/nmr/_pulses/library.py
@@ -11,14 +11,10 @@ from chemex.typing import Array
 @dataclass(slots=True)
 class _BasePulseCache:
     pw90: float = 0.0
-    dirty: bool = True
-
-    def invalidate(self) -> None:
-        self.dirty = True
+    built_generation: tuple[int, int] | None = None
 
     def set_b1(self, value: float) -> None:
         self.pw90 = 1.0 / (4.0 * value) if value else 0.0
-        self.dirty = True
 
 
 @dataclass(slots=True)
@@ -30,11 +26,13 @@ class _ISpinPulseCache(_BasePulseCache):
     def pulse_widths(self) -> Array:
         return np.array([1.0, 2.0, 8.0 / 3.0]) * self.pw90
 
-    def store(self, *, p90: Array, p180: Array, p240: Array) -> None:
+    def store(
+        self, *, p90: Array, p180: Array, p240: Array, generation: tuple[int, int]
+    ) -> None:
         self.p90 = p90
         self.p180 = p180
         self.p240 = p240
-        self.dirty = False
+        self.built_generation = generation
 
 
 @dataclass(slots=True)
@@ -44,9 +42,9 @@ class _SSpinPulseCache(_BasePulseCache):
     def pulse_widths(self) -> Array:
         return np.array([2.0]) * self.pw90
 
-    def store(self, *, p180: Array) -> None:
+    def store(self, *, p180: Array, generation: tuple[int, int]) -> None:
         self.p180 = p180
-        self.dirty = False
+        self.built_generation = generation
 
 
 class PulseLibrary:
@@ -57,16 +55,6 @@ class PulseLibrary:
         self._i_pulses = _ISpinPulseCache()
         self._s_pulses = _SSpinPulseCache()
 
-    def invalidate(self, *spins: str) -> None:
-        for spin in spins or ("i", "s"):
-            if spin == "i":
-                self._i_pulses.invalidate()
-            elif spin == "s":
-                self._s_pulses.invalidate()
-            else:
-                msg = f"Unknown spin cache {spin!r}"
-                raise ValueError(msg)
-
     def set_b1_i(self, value: float) -> None:
         self._i_pulses.set_b1(value)
 
@@ -74,10 +62,11 @@ class PulseLibrary:
         self._s_pulses.set_b1(value)
 
     def _ensure_base_pulses_i(self) -> None:
-        if self._i_pulses.dirty:
+        generation = self._kernel.pulse_generation("i")
+        if self._i_pulses.built_generation != generation:
             base = self._kernel.pulse_i(self._i_pulses.pulse_widths(), 0.0)
             p90, p180, p240 = self._kernel.add_phases(base, "i").swapaxes(0, 1)
-            self._i_pulses.store(p90=p90, p180=p180, p240=p240)
+            self._i_pulses.store(p90=p90, p180=p180, p240=p240, generation=generation)
 
     @property
     def p90_i(self) -> Array:
@@ -111,7 +100,8 @@ class PulseLibrary:
         return self.p90_i[[1, 2, 3, 0]] @ self.p240_i @ self.p90_i[[1, 2, 3, 0]]
 
     def _ensure_base_pulses_s(self) -> None:
-        if self._s_pulses.dirty:
+        generation = self._kernel.pulse_generation("s")
+        if self._s_pulses.built_generation != generation:
             # S-spin caching only has a single base pulse width, so there is no
             # width axis to preserve here. Keep the broadcast distribution axes
             # intact and add only the phase axis.
@@ -119,7 +109,7 @@ class PulseLibrary:
                 self._kernel.pulse_s(self._s_pulses.pulse_widths(), 0.0),
                 "s",
             )
-            self._s_pulses.store(p180=p180)
+            self._s_pulses.store(p180=p180, generation=generation)
 
     @property
     def p180_s(self) -> Array:

--- a/src/chemex/nmr/spectrometer.py
+++ b/src/chemex/nmr/spectrometer.py
@@ -35,19 +35,6 @@ class Spectrometer:
     ) -> Self:
         return cls(ISLiouvillianEngine(spin_system, basis, conditions))
 
-    def _invalidate_base_pulses(self, *spins: str) -> None:
-        self._pulse_library.invalidate(*spins)
-
-    def _set_engine_attr(
-        self,
-        name: str,
-        value: float | str | Distribution,
-        *,
-        invalidate: tuple[str, ...] = ("i", "s"),
-    ) -> None:
-        setattr(self._engine, name, value)
-        self._invalidate_base_pulses(*invalidate)
-
     def __init__(self, engine: ISLiouvillianEngine) -> None:
         self._engine = engine
         self._pulse_kernel = PulseKernel(engine)
@@ -68,7 +55,6 @@ class Spectrometer:
 
     def update(self, par_values: dict[str, float]) -> None:
         self._engine.update(par_values)
-        self._invalidate_base_pulses()
 
     @property
     def par_values(self) -> dict[str, float]:
@@ -96,7 +82,7 @@ class Spectrometer:
 
     @carrier_i.setter
     def carrier_i(self, value: float) -> None:
-        self._set_engine_attr("carrier_i", value)
+        self._engine.carrier_i = value
 
     @property
     def carrier_s(self) -> float:
@@ -104,7 +90,7 @@ class Spectrometer:
 
     @carrier_s.setter
     def carrier_s(self, value: float) -> None:
-        self._set_engine_attr("carrier_s", value)
+        self._engine.carrier_s = value
 
     @property
     def offset_i(self) -> float:
@@ -112,7 +98,7 @@ class Spectrometer:
 
     @offset_i.setter
     def offset_i(self, value: float) -> None:
-        self._set_engine_attr("offset_i", value)
+        self._engine.offset_i = value
 
     @property
     def offset_s(self) -> float:
@@ -120,7 +106,7 @@ class Spectrometer:
 
     @offset_s.setter
     def offset_s(self, value: float) -> None:
-        self._set_engine_attr("offset_s", value)
+        self._engine.offset_s = value
 
     @property
     def b1_i(self) -> float:
@@ -130,7 +116,6 @@ class Spectrometer:
     def b1_i(self, value: float) -> None:
         self._pulse_library.set_b1_i(value)
         self._engine.b1_i = value
-        self._invalidate_base_pulses("i")
 
     def set_b1_i_inhomogeneity(
         self,
@@ -139,7 +124,6 @@ class Spectrometer:
     ) -> None:
         self._pulse_library.set_b1_i(nominal)
         self._engine.set_b1_i_inhomogeneity(nominal, distribution)
-        self._invalidate_base_pulses("i")
 
     def set_b1_i_distribution(
         self,
@@ -153,7 +137,6 @@ class Spectrometer:
             )
         self._pulse_library.set_b1_i(nominal)
         self._engine.set_b1_i_distribution(distribution, nominal=nominal)
-        self._invalidate_base_pulses("i")
 
     @property
     def b1_s(self) -> float:
@@ -163,7 +146,6 @@ class Spectrometer:
     def b1_s(self, value: float) -> None:
         self._pulse_library.set_b1_s(value)
         self._engine.b1_s = value
-        self._invalidate_base_pulses("s")
 
     @property
     def jeff_i(self) -> Distribution:
@@ -171,7 +153,7 @@ class Spectrometer:
 
     @jeff_i.setter
     def jeff_i(self, value: Distribution) -> None:
-        self._set_engine_attr("jeff_i", value)
+        self._engine.jeff_i = value
 
     def get_equilibrium(self) -> Array:
         return self._engine.get_equilibrium()
@@ -205,7 +187,7 @@ class Spectrometer:
 
     @gradient_dephasing.setter
     def gradient_dephasing(self, value: float) -> None:
-        self._set_engine_attr("gradient_dephasing", value)
+        self._engine.gradient_dephasing = value
 
     def delays(self, times: float | Iterable[float]) -> Array:
         return self._pulse_kernel.delays(times)


### PR DESCRIPTION
## Summary

- move pulse-cache staleness tracking into `ISLiouvillianEngine`
  using generation counters;
- let `PulseLibrary` rebuild cached base pulses by comparing engine
  generations;
- remove the explicit invalidation coordination previously owned by
  `Spectrometer`;
- consolidate duplicated phase-mixing algebra in `PulseKernel`.

## Motivation

Pulse-relevant Liouvillian state and cache invalidation were updated in
separate places. This made it possible for a future state mutation to omit
the corresponding invalidation call.

The refactor places generation updates beside the engine mutations they
describe. `PulseLibrary` now determines whether its cached representation
is current by querying that state.

## Behaviour and compatibility

This is an internal, behaviour-preserving refactor.

- no scientific or numerical behaviour is intentionally changed;
- shared free-evolution changes still invalidate both I- and S-spin
  pulse caches;
- I-spin and S-spin B1 changes remain independently scoped;
- no CLI, TOML, output, parameter, or supported Python API changes;
- no changelog entry is needed because there is no user-visible change.

## Validation

- `uv run pytest -q` — 325 passed;
- `uv run ty check` — passed;
- `uv run ruff check .` — passed;
- `uv run ruff format --check .` — passed;
- `git diff --check` — passed.