### PR TITLE
Remove obsolete ParameterStore aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   never wired to any experiment. `B1InhomogeneityMixin` remains the single B1
   configuration path, and the distribution-union parsing it depends on is
   unchanged.
+- Removed the obsolete `ParameterStore` compatibility aliases
+  (`add_parameters`, `add_parameters_mf`, `sort_parameters`,
+  `set_param_values`, `set_param_defaults`, `fix_all_parameters`,
+  `reset_parameters`) left over from the `AnalysisSession` migration. Internal
+  callers now use the canonical short method names
+  (`add_multiple`/`add_multiple_mf`, `sort`, `set_values`, `set_defaults`,
+  `fix_all`, `reset`); parameter semantics and fit/simulate behavior are
+  unchanged.
 
 ## [2026.06.1] - 2026-06-26
 

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -60,7 +60,7 @@ def run_sim(
     path = args.output
     plot = args.plot == "normal"
 
-    session.parameters.fix_all_parameters()
+    session.parameters.fix_all()
 
     execute_simulation(experiments, path, plot=plot, session=session)
 
@@ -95,7 +95,7 @@ def run(
     # Read initial values of fitting/fixed parameters
     print_reading_defaults()
     defaults = read_defaults(args.parameters)
-    session.parameters.set_param_defaults(defaults)
+    session.parameters.set_defaults(defaults)
 
     if args.commands == "simulate":
         run_sim(args, experiments, session)

--- a/src/chemex/experiments/builder.py
+++ b/src/chemex/experiments/builder.py
@@ -127,5 +127,5 @@ def build_experiments(
             _print_notice(notice)
         experiments.add(result.experiment)
 
-    parameter_store.sort_parameters()
+    parameter_store.sort()
     return experiments

--- a/src/chemex/optimize/gridding.py
+++ b/src/chemex/optimize/gridding.py
@@ -159,7 +159,7 @@ def set_params_from_grid(
     for grid_result in grids_1d:
         id_, values = next(iter(grid_result.grid.items()))
         par_values[id_] = values[grid_result.chisqr.argmin()]
-    parameter_store.set_param_values(par_values)
+    parameter_store.set_values(par_values)
 
 
 def make_grids_nd(

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -588,12 +588,6 @@ class ParameterStore:
         """
         self._database_mf.add_multiple(parameters)
 
-    def add_parameters(self, parameters: Parameters) -> None:
-        self.add_multiple(parameters)
-
-    def add_parameters_mf(self, parameters: Parameters) -> None:
-        self.add_multiple_mf(parameters)
-
     def get_parameters(self, param_ids: Iterable[str]) -> Parameters:
         """Retrieve parameters from the active catalog by IDs.
 
@@ -634,9 +628,6 @@ class ParameterStore:
         """Sort parameters in the active catalog."""
         self.database.sort()
 
-    def sort_parameters(self) -> None:
-        self.sort()
-
     def update_from_parameters(self, parameters: ParametersLF) -> None:
         """Update the active catalog from lmfit Parameters.
 
@@ -654,9 +645,6 @@ class ParameterStore:
 
         """
         return self.database.set_values(par_values)
-
-    def set_param_values(self, par_values: dict[str, float]) -> None:
-        self.set_values(par_values)
 
     def set_defaults(self, defaults: DefaultListType) -> None:
         """Set defaults for parameters in both catalogs.
@@ -677,9 +665,6 @@ class ParameterStore:
 
         self.database.check_params()
 
-    def set_param_defaults(self, defaults: DefaultListType) -> None:
-        self.set_defaults(defaults)
-
     def set_vary(self, section_names: Sequence[str], vary: bool) -> Counter[str]:
         """Set variability of parameters in the active catalog by section name.
 
@@ -696,9 +681,6 @@ class ParameterStore:
     def fix_all(self) -> None:
         """Fix all parameters in the active catalog, preventing them from varying."""
         self.database.fix_all()
-
-    def fix_all_parameters(self) -> None:
-        self.fix_all()
 
     def set_expressions(self, expression_list: Sequence[str]) -> Counter[str]:
         """Apply expressions to parameters in the active catalog.
@@ -735,9 +717,6 @@ class ParameterStore:
         """Clear all parameter catalogs used by the current process."""
         self._database.clear()
         self._database_mf.clear()
-
-    def reset_parameters(self) -> None:
-        self.reset()
 
 
 def create_parameter_store(model_reader: ModelReader) -> ParameterStore:

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -58,7 +58,7 @@ class AnalysisSession:
     def reset(self) -> None:
         """Clear cached runtime state before starting a new analysis."""
         self.parameter_factory.clear_cache()
-        self.parameters.reset_parameters()
+        self.parameters.reset()
         self.model.reset()
 
     def set_model(self, name: str) -> None:

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -42,16 +42,16 @@ class StubParameters:
         self.sort_calls = 0
         self.status_calls: list[Method] = []
 
-    def reset_parameters(self) -> None:
+    def reset(self) -> None:
         self.reset_calls += 1
 
-    def set_param_defaults(self, defaults: object) -> None:
+    def set_defaults(self, defaults: object) -> None:
         self.defaults_calls.append(defaults)
 
-    def fix_all_parameters(self) -> None:
+    def fix_all(self) -> None:
         self.fix_all_calls += 1
 
-    def sort_parameters(self) -> None:
+    def sort(self) -> None:
         self.sort_calls += 1
 
     def set_parameter_status(self, method: Method) -> None:


### PR DESCRIPTION
## Summary

- remove seven obsolete compatibility aliases from `ParameterStore`;
- migrate internal callers to the canonical short method names;
- update the `StubParameters` test double accordingly;
- document the cleanup under the unreleased Infrastructure section.

## Motivation

The aliases were retained temporarily during the AnalysisSession/runtime-state
migration to avoid changing every caller in the same pull request. The migration
is now complete, and the duplicate names add interface noise without providing
independent behavior.

The canonical short methods remain unchanged:

- `add_multiple`
- `add_multiple_mf`
- `sort`
- `set_values`
- `set_defaults`
- `fix_all`
- `reset`

## Behaviour and compatibility

This is an internal interface cleanup.

- parameter semantics are unchanged;
- model-free and regular catalog routing are unchanged;
- fit and simulation behavior are unchanged;
- no CLI, TOML, output, or documented Python API changes;
- direct users of the undocumented internal aliases would need to use the
  canonical short method names.

## Validation

- targeted tests — 37 passed;
- full suite — 325 passed;
- `uv run ty check` — passed;
- `uv run ruff check .` — passed;
- `uv run ruff format --check .` — passed;
- `git diff --check` — passed.