### PR TITLE
Simplify fit and simulation session flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   (`add_multiple`/`add_multiple_mf`, `sort`, `set_values`, `set_defaults`,
   `fix_all`, `reset`); parameter semantics and fit/simulate behavior are
   unchanged.
+- Simplified the fit and simulation workflow: `AnalysisSession` is no longer
+  threaded through lower-level `optimize/*` helpers (`run_methods`,
+  `execute_post_fit`, `execute_simulation`, `execute_post_fit_groups`,
+  `run_grid`). Execution policy is now passed explicitly through
+  `ExecutionSettings` only where needed (`run_methods` through `_fit_groups` to
+  `_run_statistics`), and parameter access continues through
+  `Experiments.parameter_store`. This intentionally narrows these lower-level
+  function signatures for any direct caller; CLI, TOML, output, and scientific
+  behavior are unchanged.
 
 ## [2026.06.1] - 2026-06-26
 

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -47,7 +47,9 @@ def run_fit(
     write_run_info(args, experiments, argv=argv)
 
     print_start_fit()
-    run_methods(experiments, methods, args.output, args.plot, session=session)
+    run_methods(
+        experiments, methods, args.output, args.plot, execution=session.execution
+    )
 
 
 def run_sim(
@@ -62,7 +64,7 @@ def run_sim(
 
     session.parameters.fix_all()
 
-    execute_simulation(experiments, path, plot=plot, session=session)
+    execute_simulation(experiments, path, plot=plot)
 
 
 def run(
@@ -91,6 +93,10 @@ def run(
     if not experiments:
         print_no_data()
         sys.exit()
+
+    if experiments.parameter_store is not session.parameters:
+        msg = "Experiments parameter store does not match the active session"
+        raise ValueError(msg)
 
     # Read initial values of fitting/fixed parameters
     print_reading_defaults()

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -26,7 +26,7 @@ from chemex.optimize.minimizer import (
     minimize_with_report,
 )
 from chemex.optimize.resampling import run_resampling_statistics
-from chemex.runtime import AnalysisSession
+from chemex.runtime import ExecutionSettings
 
 
 def _run_statistics(
@@ -35,12 +35,11 @@ def _run_statistics(
     fitmethod: str,
     statistics: Statistics | None = None,
     *,
-    session: AnalysisSession | None = None,
+    execution: ExecutionSettings | None = None,
 ) -> None:
     if statistics is None:
         return
 
-    execution = session.execution if session is not None else None
     run_resampling_statistics(
         experiments,
         path,
@@ -76,7 +75,7 @@ def _fit_groups(
     fitmethod: str,
     statistics: Statistics | None,
     *,
-    session: AnalysisSession | None = None,
+    execution: ExecutionSettings | None = None,
 ) -> None:
     parameter_store = experiments.parameter_store
     groups = create_groups(experiments)
@@ -105,7 +104,6 @@ def _fit_groups(
             group.experiments,
             group_path,
             plot=plot_flg,
-            session=session,
         )
 
         # Run Monte Carlo and/or bootstrap analysis
@@ -114,11 +112,11 @@ def _fit_groups(
             group_path,
             fitmethod,
             statistics,
-            session=session,
+            execution=execution,
         )
 
     if len(groups) > 1:
-        execute_post_fit_groups(experiments, path, plot, session=session)
+        execute_post_fit_groups(experiments, path, plot)
 
 
 def run_methods(
@@ -127,7 +125,7 @@ def run_methods(
     path: Path,
     plot_level: str,
     *,
-    session: AnalysisSession | None = None,
+    execution: ExecutionSettings | None = None,
 ) -> None:
     parameter_store = experiments.parameter_store
 
@@ -161,7 +159,6 @@ def run_methods(
                     path_sect,
                     plot_level,
                     method.fitmethod,
-                    session=session,
                 )
             except KeyboardInterrupt:
                 print_calculation_stopped_error()
@@ -172,5 +169,5 @@ def run_methods(
                 plot_level,
                 method.fitmethod,
                 method.statistics,
-                session=session,
+                execution=execution,
             )

--- a/src/chemex/optimize/gridding.py
+++ b/src/chemex/optimize/gridding.py
@@ -25,7 +25,6 @@ from chemex.optimize.helper import (
 )
 from chemex.optimize.minimizer import minimize
 from chemex.parameters.database import ParameterStore
-from chemex.runtime import AnalysisSession
 from chemex.typing import Array
 
 
@@ -259,8 +258,6 @@ def run_grid(
     path: Path,
     plot: str,
     fitmethod: str,
-    *,
-    session: AnalysisSession | None = None,
 ) -> None:
     print_running_grid()
 
@@ -284,6 +281,6 @@ def run_grid(
     plot_grid_2d(grids_2d, path / "Grid", parameter_store=parameter_store)
 
     if len(groups) > 1:
-        execute_post_fit_groups(experiments, path, plot, session=session)
+        execute_post_fit_groups(experiments, path, plot)
     else:
-        execute_post_fit(experiments, path, plot=plot != "nothing", session=session)
+        execute_post_fit(experiments, path, plot=plot != "nothing")

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -17,16 +17,6 @@ from chemex.messages import (
 )
 from chemex.parameters.database import ParameterStore
 from chemex.printers.parameters import write_parameters
-from chemex.runtime import AnalysisSession
-
-
-def _validate_session_parameter_store(
-    experiments: Experiments,
-    session: AnalysisSession | None,
-) -> None:
-    if session is not None and experiments.parameter_store is not session.parameters:
-        msg = "Experiments parameter store does not match the active session"
-        raise ValueError(msg)
 
 
 def calculate_statistics(
@@ -81,10 +71,8 @@ def _write_statistics(
 def _write_files(
     experiments: Experiments,
     path: Path,
-    session: AnalysisSession | None = None,
 ) -> None:
     """Write the results of the fit to output files."""
-    _validate_session_parameter_store(experiments, session)
     print_writing_results(path)
     path.mkdir(parents=True, exist_ok=True)
     write_parameters(experiments, path, parameter_store=experiments.parameter_store)
@@ -132,9 +120,8 @@ def execute_post_fit(
     path: Path,
     *,
     plot: bool = False,
-    session: AnalysisSession | None = None,
 ) -> None:
-    _write_files(experiments, path, session=session)
+    _write_files(experiments, path)
     if plot:
         _write_plots(experiments, path)
 
@@ -144,9 +131,7 @@ def execute_simulation(
     path: Path,
     *,
     plot: bool = False,
-    session: AnalysisSession | None = None,
 ) -> None:
-    _validate_session_parameter_store(experiments, session)
     experiments.prepare_for_simulation()
     _write_simulation_files(experiments, path)
     if plot:
@@ -157,8 +142,6 @@ def execute_post_fit_groups(
     experiments: Experiments,
     path: Path,
     plot: str,
-    *,
-    session: AnalysisSession | None = None,
 ) -> None:
     print_group_name("All groups")
     params_lf = experiments.parameter_store.build_lmfit_params(experiments.param_ids)
@@ -168,7 +151,6 @@ def execute_post_fit_groups(
         experiments,
         path / "All",
         plot=(plot != "nothing"),
-        session=session,
     )
 
 

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -311,9 +311,15 @@ def test_run_uses_explicit_session_for_fit_flow(
         path: Path,
         plot_level: str,
         *,
-        session: StubSession | None = None,
+        execution: ExecutionSettings | None = None,
     ) -> None:
-        recorded["run_methods"] = (experiments_arg, methods, path, plot_level, session)
+        recorded["run_methods"] = (
+            experiments_arg,
+            methods,
+            path,
+            plot_level,
+            execution,
+        )
 
     monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
     monkeypatch.setattr(chemex_module, "read_defaults", lambda _filenames: defaults)
@@ -339,7 +345,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     np.testing.assert_equal(session.parameters.defaults_calls, [defaults])
     np.testing.assert_equal(experiments.filtered, 1)
     np.testing.assert_equal(recorded["build"][2], session)
-    np.testing.assert_equal(recorded["run_methods"][4], session)
+    np.testing.assert_equal(recorded["run_methods"][4], session.execution)
     assert recorded["run_info"] is True
 
 
@@ -365,9 +371,8 @@ def test_run_uses_explicit_session_for_simulation_flow(
         path: Path,
         *,
         plot: bool = False,
-        session: StubSession | None = None,
     ) -> None:
-        recorded["simulation"] = (experiments_arg, path, plot, session)
+        recorded["simulation"] = (experiments_arg, path, plot)
 
     monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
     monkeypatch.setattr(chemex_module, "read_defaults", lambda _filenames: defaults)
@@ -379,7 +384,37 @@ def test_run_uses_explicit_session_for_simulation_flow(
     np.testing.assert_equal(session.parameters.defaults_calls, [defaults])
     np.testing.assert_equal(session.parameters.fix_all_calls, 1)
     np.testing.assert_equal(recorded["build"][2], session)
-    np.testing.assert_equal(recorded["simulation"][3], session)
+
+
+def test_run_rejects_experiments_built_under_a_different_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = StubSession()
+    mismatched_store = StubParameters()
+    experiments = FakeExperiments(parameter_store=mismatched_store)
+
+    def fake_build_experiments(
+        filenames: list[Path] | None,
+        selection: Selection,
+        *,
+        session: StubSession | None = None,
+    ) -> FakeExperiments:
+        return experiments
+
+    def fail_run_methods(*_args, **_kwargs) -> None:
+        pytest.fail("run_methods should not run for a mismatched parameter store")
+
+    def fail_execute_simulation(*_args, **_kwargs) -> None:
+        pytest.fail(
+            "execute_simulation should not run for a mismatched parameter store"
+        )
+
+    monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
+    monkeypatch.setattr(chemex_module, "run_methods", fail_run_methods)
+    monkeypatch.setattr(chemex_module, "execute_simulation", fail_execute_simulation)
+
+    with pytest.raises(ValueError, match="does not match the active session"):
+        chemex_module.run(make_args("fit"), session=session)
 
 
 def test_main_bootstraps_plugins_for_non_run_commands(
@@ -440,7 +475,7 @@ def test_main_dispatches_analysis_commands(monkeypatch: pytest.MonkeyPatch) -> N
     np.testing.assert_equal(calls, ["logo", "plugins", "run"])
 
 
-def test_run_methods_passes_session_to_fit_groups(
+def test_run_methods_passes_execution_to_fit_groups(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = StubSession()
@@ -454,7 +489,7 @@ def test_run_methods_passes_session_to_fit_groups(
         fitmethod: str,
         statistics: object,
         *,
-        session: StubSession | None = None,
+        execution: ExecutionSettings | None = None,
     ) -> None:
         recorded["fit_groups"] = (
             experiments_arg,
@@ -462,7 +497,7 @@ def test_run_methods_passes_session_to_fit_groups(
             plot,
             fitmethod,
             statistics,
-            session,
+            execution,
         )
 
     monkeypatch.setattr(fitting_module, "_fit_groups", fake_fit_groups)
@@ -472,12 +507,12 @@ def test_run_methods_passes_session_to_fit_groups(
         {"": Method()},
         Path("Output"),
         "normal",
-        session=session,
+        execution=session.execution,
     )
 
     np.testing.assert_equal(len(experiments.selections), 1)
     np.testing.assert_equal(len(session.parameters.status_calls), 1)
-    np.testing.assert_equal(recorded["fit_groups"][5], session)
+    np.testing.assert_equal(recorded["fit_groups"][5], session.execution)
 
 
 def test_run_methods_skips_fit_when_selection_removes_all_profiles(
@@ -501,7 +536,7 @@ def test_run_methods_skips_fit_when_selection_removes_all_profiles(
         {"": Method(include=["1H"])},
         Path("Output"),
         "normal",
-        session=session,
+        execution=session.execution,
     )
 
     np.testing.assert_equal(calls, ["no_data"])
@@ -641,11 +676,10 @@ def test_run_statistics_dispatches_mcmc_without_resampling(
     tmp_path: Path,
 ) -> None:
     recorded: dict[str, object] = {}
-    session = StubSession()
-    session.parameters = StatisticsParameterStore()
+    execution = ExecutionSettings(workers=4)
     experiments = SimpleNamespace(
         param_ids=["__PB"],
-        parameter_store=session.parameters,
+        parameter_store=StatisticsParameterStore(),
     )
 
     def fail_generate_exp_for_statistics(*_args, **_kwargs) -> None:
@@ -677,14 +711,14 @@ def test_run_statistics_dispatches_mcmc_without_resampling(
         tmp_path,
         "leastsq",
         fitting_module.Statistics(mcmc=100),
-        session=session,
+        execution=execution,
     )
 
     np.testing.assert_equal(recorded["experiments"], experiments)
     assert "__PB" in recorded["params"]
     assert recorded["settings"].steps == 100
     np.testing.assert_equal(recorded["path"], tmp_path)
-    np.testing.assert_equal(recorded["execution"], session.execution)
+    np.testing.assert_equal(recorded["execution"], execution)
 
 
 def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None:
@@ -723,16 +757,14 @@ def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None
     assert "1.00000e+00" in correlations
 
 
-def test_execute_post_fit_writes_parameters_from_session_store(
+def test_execute_post_fit_writes_parameters_from_experiments_store(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     param = ParamSetting(ParamName("PB"), value=0.15, vary=False)
-    session = StubSession()
-    session.parameters = WriterParameterStore({param.id_: param})
     experiments = SimpleNamespace(
         param_ids=[param.id_],
-        parameter_store=session.parameters,
+        parameter_store=WriterParameterStore({param.id_: param}),
         write=lambda _path: None,
     )
     monkeypatch.setattr(helper_module, "print_writing_results", lambda _path: None)
@@ -742,7 +774,7 @@ def test_execute_post_fit_writes_parameters_from_session_store(
         lambda *_args, **_kwargs: None,
     )
 
-    helper_module.execute_post_fit(experiments, tmp_path, session=session)
+    helper_module.execute_post_fit(experiments, tmp_path)
 
     np.testing.assert_equal(int((tmp_path / "Parameters" / "fixed.toml").exists()), 1)
 

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -283,7 +283,7 @@ def test_run_fit_creates_run_info(
     chemex_module.run_fit(
         args,
         experiments,
-        SimpleNamespace(),
+        SimpleNamespace(execution=None),
         argv=["chemex", "fit"],
     )
 


### PR DESCRIPTION
## Summary

- centralize the experiment/session parameter-store consistency check in
  `chemex.run()`;
- remove `AnalysisSession` threading from lower-level optimization helpers;
- pass `ExecutionSettings` explicitly only through the statistics path;
- keep parameter access owned by `Experiments.parameter_store`;
- update focused tests and document the internal contract narrowing.

## Motivation

The explicit-runtime-state migration left `AnalysisSession` threaded through
several lower-level optimization functions even where those functions only
relayed it further. The same cleanup had already been completed in
`optimize/grouping.py`.

This change finishes that cleanup without introducing a new context object or
binding `Experiments` to `AnalysisSession`.

## Behaviour and compatibility

- supported CLI orchestration still rejects mismatched experiment/session
  parameter stores, now once and earlier in `chemex.run()`;
- `execution=None` retains the existing default/sequential behavior;
- parameter semantics, model-free routing, fit behavior, simulation behavior,
  output, CLI, and TOML interfaces are unchanged;
- lower-level direct callers must no longer pass `session=` to the narrowed
  `optimize/*` functions and should pass `ExecutionSettings` only where needed.

## Validation

- targeted tests — 26 passed;
- full suite — 326 passed;
- `uv run ty check` — passed;
- `uv run ruff check .` — passed;
- `uv run ruff format --check .` — passed;
- `git diff --check` — passed.