### PR TITLE
Seal canonical parameter definitions and configuration

### DIFF
--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -102,6 +102,7 @@ def run(
     print_reading_defaults()
     defaults = read_defaults(args.parameters)
     session.parameters.set_defaults(defaults)
+    session.parameter_factory.seal_configuration()
 
     if args.commands == "simulate":
         run_sim(args, experiments, session)

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -102,7 +102,7 @@ def run(
     print_reading_defaults()
     defaults = read_defaults(args.parameters)
     session.parameters.set_defaults(defaults)
-    session.parameter_factory.seal_configuration()
+    session.parameter_factory.try_seal_configuration()
 
     if args.commands == "simulate":
         run_sim(args, experiments, session)

--- a/src/chemex/experiments/builder.py
+++ b/src/chemex/experiments/builder.py
@@ -89,6 +89,7 @@ def build_experiments(
     parameter_store = session.parameters
 
     if not filenames:
+        session.parameter_factory.seal_definitions()
         return Experiments(parameter_store=parameter_store)
 
     print_loading_experiments()
@@ -128,4 +129,5 @@ def build_experiments(
         experiments.add(result.experiment)
 
     parameter_store.sort()
+    session.parameter_factory.seal_definitions()
     return experiments

--- a/src/chemex/experiments/builder.py
+++ b/src/chemex/experiments/builder.py
@@ -89,7 +89,7 @@ def build_experiments(
     parameter_store = session.parameters
 
     if not filenames:
-        session.parameter_factory.seal_definitions()
+        session.parameter_factory.try_seal_definitions()
         return Experiments(parameter_store=parameter_store)
 
     print_loading_experiments()
@@ -129,5 +129,5 @@ def build_experiments(
         experiments.add(result.experiment)
 
     parameter_store.sort()
-    session.parameter_factory.seal_definitions()
+    session.parameter_factory.try_seal_definitions()
     return experiments

--- a/src/chemex/experiments/experiment_types.py
+++ b/src/chemex/experiments/experiment_types.py
@@ -601,6 +601,9 @@ def _build[ConfigT: GenericConfig](
             config,
             basis=calculation.spectrometer.basis,
             spin_system=calculation.spectrometer.spin_system,
+            contributor=(
+                f"experiment={source.filename!s}, type={experiment_type_.name!r}"
+            ),
         )
         profiles.append(
             Profile(

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -559,6 +559,8 @@ class ParameterStore:
     model: ModelReader
     _database: ParameterCatalog
     _database_mf: ParameterCatalog
+    _defaults_applied: bool = field(default=False, init=False, repr=False)
+    _configuration_locked: bool = field(default=False, init=False, repr=False)
 
     @property
     def database(self) -> ParameterCatalog:
@@ -570,6 +572,20 @@ class ParameterStore:
         """
         return self._database_mf if self.model.model_free else self._database
 
+    @property
+    def defaults_applied(self) -> bool:
+        """Whether default and ordinary model-free initialization completed."""
+        return self._defaults_applied
+
+    def lock_configuration(self) -> None:
+        """Reject later definition/default mutations while values remain mutable."""
+        self._configuration_locked = True
+
+    def _ensure_configuration_open(self) -> None:
+        if self._configuration_locked:
+            msg = "Parameter configuration is sealed"
+            raise RuntimeError(msg)
+
     def add_multiple(self, parameters: Parameters) -> None:
         """Add multiple parameters to the primary catalog.
 
@@ -577,7 +593,9 @@ class ParameterStore:
             parameters (Parameters): Parameters to be added.
 
         """
+        self._ensure_configuration_open()
         self._database.add_multiple(parameters)
+        self._defaults_applied = False
 
     def add_multiple_mf(self, parameters: Parameters) -> None:
         """Add multiple parameters to the model-free catalog.
@@ -586,7 +604,9 @@ class ParameterStore:
             parameters (Parameters): Parameters to be added.
 
         """
+        self._ensure_configuration_open()
         self._database_mf.add_multiple(parameters)
+        self._defaults_applied = False
 
     def get_parameters(self, param_ids: Iterable[str]) -> Parameters:
         """Retrieve parameters from the active catalog by IDs.
@@ -653,9 +673,15 @@ class ParameterStore:
             defaults (DefaultListType): Default settings to apply.
 
         """
+        self._ensure_configuration_open()
+        if self._defaults_applied:
+            msg = "Parameter defaults have already been applied"
+            raise RuntimeError(msg)
+        self._defaults_applied = False
         self._database_mf.set_defaults(defaults)
 
         if self.model.model_free:
+            self._defaults_applied = True
             return
 
         params_mf = self._database_mf.build_lmfit_params(model_name=self.model.name)
@@ -664,6 +690,7 @@ class ParameterStore:
         self.database.set_defaults(defaults)
 
         self.database.check_params()
+        self._defaults_applied = True
 
     def set_vary(self, section_names: Sequence[str], vary: bool) -> Counter[str]:
         """Set variability of parameters in the active catalog by section name.
@@ -717,6 +744,8 @@ class ParameterStore:
         """Clear all parameter catalogs used by the current process."""
         self._database.clear()
         self._database_mf.clear()
+        self._defaults_applied = False
+        self._configuration_locked = False
 
 
 def create_parameter_store(model_reader: ModelReader) -> ParameterStore:

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -82,6 +82,11 @@ class ParameterFactory:
     )
     _sealed_definitions: SealedDefinitions | None = field(default=None, repr=False)
     _sealed_configuration: SealedConfiguration | None = field(default=None, repr=False)
+    _native_construction_error: Exception | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
 
     @property
     def sealed_definitions(self) -> SealedDefinitions | None:
@@ -92,6 +97,11 @@ class ParameterFactory:
     def sealed_configuration(self) -> SealedConfiguration | None:
         """Return immutable per-analysis configuration once it has been sealed."""
         return self._sealed_configuration
+
+    @property
+    def native_construction_error(self) -> Exception | None:
+        """Return the failure that disabled the non-authoritative native candidate."""
+        return self._native_construction_error
 
     def _build_settings(
         self,
@@ -177,10 +187,17 @@ class ParameterFactory:
         )
         if contributor is not None:
             construction_context = f"{contributor}; {construction_context}"
-        if self.parameter_store.model.model_free:
-            self._collect_definitions(parameters_mf, contributor=construction_context)
-        else:
-            self._collect_definitions(parameters, contributor=construction_context)
+        if self._native_construction_error is None:
+            native_parameters = (
+                parameters_mf if self.parameter_store.model.model_free else parameters
+            )
+            try:
+                self._collect_definitions(
+                    native_parameters,
+                    contributor=construction_context,
+                )
+            except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
+                self._native_construction_error = error
 
         _set_to_fit(parameters, name_map, config.to_be_fitted.rates)
         _set_to_fit(parameters_mf, name_map_mf, config.to_be_fitted.model_free)
@@ -231,8 +248,34 @@ class ParameterFactory:
         self.parameter_store.lock_configuration()
         self._sealed_configuration = configuration
 
+    def try_seal_definitions(self) -> bool:
+        """Seal definitions without allowing the native candidate to veto legacy."""
+        if self._native_construction_error is not None:
+            return False
+        try:
+            self.seal_definitions()
+        except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
+            self._native_construction_error = error
+            return False
+        return True
+
+    def try_seal_configuration(self) -> bool:
+        """Seal configuration without allowing the native candidate to veto legacy."""
+        if self._native_construction_error is not None:
+            return False
+        try:
+            self.seal_configuration()
+        except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
+            self._native_construction_error = error
+            return False
+        return True
+
     def clear_cache(self) -> None:
-        if self._definition_contributions or self._sealed_definitions is not None:
+        if (
+            self._definition_contributions
+            or self._sealed_definitions is not None
+            or self._native_construction_error is not None
+        ):
             msg = (
                 "Parameter construction has started; reset the analysis session "
                 "before changing its model"
@@ -249,6 +292,7 @@ class ParameterFactory:
         self._definition_contributions.clear()
         self._sealed_definitions = None
         self._sealed_configuration = None
+        self._native_construction_error = None
 
 
 def create_parameters(

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -8,6 +8,15 @@ from chemex.configuration.conditions import Conditions
 from chemex.models.factory import model_factory
 from chemex.nmr.basis import Basis
 from chemex.parameters.database import ParameterStore
+from chemex.parameters.sealed import (
+    DefinitionContribution,
+    ParamDefinition,
+    SealedConfiguration,
+    SealedDefinitions,
+    build_sealed_configuration,
+    canonicalize_definitions,
+    extract_condition_entries,
+)
 from chemex.parameters.setting import LocalSettings, Parameters, ParamSetting
 from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.spins import build_spin_param_settings
@@ -68,6 +77,21 @@ class ParameterFactory:
         tuple[str, bool, bool, bool, Basis, Conditions],
         tuple[LocalSettings, LocalSettings],
     ] = field(default_factory=dict)
+    _definition_contributions: dict[str, list[DefinitionContribution]] = field(
+        default_factory=dict,
+    )
+    _sealed_definitions: SealedDefinitions | None = field(default=None, repr=False)
+    _sealed_configuration: SealedConfiguration | None = field(default=None, repr=False)
+
+    @property
+    def sealed_definitions(self) -> SealedDefinitions | None:
+        """Return the immutable definitions once construction has sealed them."""
+        return self._sealed_definitions
+
+    @property
+    def sealed_configuration(self) -> SealedConfiguration | None:
+        """Return immutable per-analysis configuration once it has been sealed."""
+        return self._sealed_configuration
 
     def _build_settings(
         self,
@@ -93,13 +117,42 @@ class ParameterFactory:
             self._settings_cache[key] = (settings, settings_mf)
         return self._settings_cache[key]
 
+    def _collect_definitions(
+        self,
+        parameters: Parameters,
+        *,
+        contributor: str,
+    ) -> None:
+        """Extract ParamDefinition contributions from parameters before legacy merge."""
+        for param_id, param_setting in parameters.items():
+            contribution = DefinitionContribution(
+                definition=ParamDefinition(
+                    param_id=param_id,
+                    name=param_setting.param_name.name,
+                    spin_system_name=str(param_setting.param_name.spin_system),
+                    condition_entries=extract_condition_entries(
+                        param_setting.param_name.conditions,
+                    ),
+                    default_value=param_setting.value,
+                    lower_bound=param_setting.min,
+                    upper_bound=param_setting.max,
+                ),
+                contributor=contributor,
+            )
+            self._definition_contributions.setdefault(param_id, []).append(contribution)
+
     def create_parameters(
         self,
         config: ConfigConditionsType,
         *,
         basis: Basis,
         spin_system: SpinSystem,
+        contributor: str | None = None,
     ) -> dict[str, str]:
+        if self._sealed_definitions is not None:
+            msg = "Parameter definitions are already sealed; contributions are closed"
+            raise RuntimeError(msg)
+
         settings, settings_mf = self._build_settings(
             basis,
             config.conditions,
@@ -117,6 +170,18 @@ class ParameterFactory:
             config.conditions,
         )
 
+        conditions = extract_condition_entries(config.conditions)
+        construction_context = (
+            f"model={self.parameter_store.model.name!r}, basis={basis.type!r}, "
+            f"profile={str(spin_system)!r}, conditions={conditions!r}"
+        )
+        if contributor is not None:
+            construction_context = f"{contributor}; {construction_context}"
+        if self.parameter_store.model.model_free:
+            self._collect_definitions(parameters_mf, contributor=construction_context)
+        else:
+            self._collect_definitions(parameters, contributor=construction_context)
+
         _set_to_fit(parameters, name_map, config.to_be_fitted.rates)
         _set_to_fit(parameters_mf, name_map_mf, config.to_be_fitted.model_free)
 
@@ -127,8 +192,63 @@ class ParameterFactory:
 
         return {local_name: name_map[local_name] for local_name in selection}
 
+    def seal_definitions(self) -> None:
+        """Canonicalize accumulated definitions into an immutable sealed collection.
+
+        Must be called after all experiments have contributed their parameters.
+        Equivalent duplicate contributions are collapsed; conflicting fields
+        raise DefinitionConflictError.
+
+        """
+        if self._sealed_definitions is not None:
+            msg = "Parameter definitions are already sealed"
+            raise RuntimeError(msg)
+        self._sealed_definitions = canonicalize_definitions(
+            self._definition_contributions,
+        )
+
+    def seal_configuration(self) -> None:
+        """Build sealed configuration from post-defaults legacy catalog state.
+
+        Must be called after set_defaults() has completed. Requires
+        seal_definitions() to have been called first.
+
+        """
+        if self._sealed_definitions is None:
+            msg = "seal_definitions() must be called before seal_configuration()"
+            raise RuntimeError(msg)
+        if self._sealed_configuration is not None:
+            msg = "Parameter configuration is already sealed"
+            raise RuntimeError(msg)
+        if not self.parameter_store.defaults_applied:
+            msg = "Parameter defaults must be applied before configuration sealing"
+            raise RuntimeError(msg)
+
+        configuration = build_sealed_configuration(
+            self._sealed_definitions,
+            self.parameter_store.database._parameters,
+        )
+        self.parameter_store.lock_configuration()
+        self._sealed_configuration = configuration
+
     def clear_cache(self) -> None:
+        if self._definition_contributions or self._sealed_definitions is not None:
+            msg = (
+                "Parameter construction has started; reset the analysis session "
+                "before changing its model"
+            )
+            raise RuntimeError(msg)
+        self._clear_state()
+
+    def reset(self) -> None:
+        """Clear all construction state as part of a full analysis reset."""
+        self._clear_state()
+
+    def _clear_state(self) -> None:
         self._settings_cache.clear()
+        self._definition_contributions.clear()
+        self._sealed_definitions = None
+        self._sealed_configuration = None
 
 
 def create_parameters(
@@ -137,9 +257,11 @@ def create_parameters(
     basis: Basis,
     spin_system: SpinSystem,
     parameter_factory: ParameterFactory,
+    contributor: str | None = None,
 ) -> dict[str, str]:
     return parameter_factory.create_parameters(
         config,
         basis=basis,
         spin_system=spin_system,
+        contributor=contributor,
     )

--- a/src/chemex/parameters/sealed.py
+++ b/src/chemex/parameters/sealed.py
@@ -1,0 +1,402 @@
+"""Canonical immutable parameter definitions and per-analysis configuration.
+
+These ChemEx-native objects are constructed beside the legacy mutable catalog.
+The legacy execution path remains authoritative at this migration checkpoint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import overload
+
+from chemex.configuration.conditions import Conditions
+from chemex.parameters.setting import ParamSetting
+from chemex.parameters.spin_system import SpinSystem
+
+_CONDITION_FIELDS = ("d2o", "h_larmor_frq", "l_total", "p_total", "temperature")
+_CONDITION_ORDER = ("temperature", "h_larmor_frq", "p_total", "l_total", "d2o")
+_DEFINITION_FIELDS = (
+    "name",
+    "spin_system_name",
+    "condition_entries",
+    "default_value",
+    "lower_bound",
+    "upper_bound",
+)
+
+
+def extract_condition_entries(
+    conditions: Conditions,
+) -> tuple[tuple[str, float], ...]:
+    """Extract scoped numeric condition fields into an immutable tuple."""
+    return tuple(
+        (field_name, value)
+        for field_name in _CONDITION_FIELDS
+        if (value := getattr(conditions, field_name, None)) is not None
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ParamDefinition:
+    """Immutable scientific identity and physical metadata of a parameter."""
+
+    param_id: str
+    name: str
+    spin_system_name: str
+    condition_entries: tuple[tuple[str, float], ...]
+    default_value: float | None
+    lower_bound: float
+    upper_bound: float
+
+    def __post_init__(self) -> None:
+        entries = tuple(
+            (str(name), float(value)) for name, value in self.condition_entries
+        )
+        object.__setattr__(self, "condition_entries", entries)
+
+
+@dataclass(frozen=True, slots=True)
+class DefinitionContribution:
+    """One definition plus stable context identifying its construction source."""
+
+    definition: ParamDefinition
+    contributor: str
+
+
+@dataclass(frozen=True, slots=True)
+class DefinitionFieldConflict:
+    """All contributed values for one disagreeing definition field."""
+
+    field: str
+    values: tuple[object, ...]
+
+
+class DefinitionConflictError(ValueError):
+    """Raised when contributions for one stable ID disagree."""
+
+    def __init__(
+        self,
+        param_id: str,
+        conflicts: Sequence[DefinitionFieldConflict],
+        contributors: Sequence[str],
+    ) -> None:
+        self.param_id = param_id
+        self.conflicts = tuple(conflicts)
+        self.conflicting_fields = tuple(conflict.field for conflict in self.conflicts)
+        self.contributors = tuple(contributors)
+        # Retain the first-field convenience attributes used by early #582 callers.
+        self.field = self.conflicts[0].field
+        self.values = self.conflicts[0].values
+        fields = "; ".join(
+            f"{conflict.field}={conflict.values!r}" for conflict in self.conflicts
+        )
+        sources = ", ".join(repr(contributor) for contributor in self.contributors)
+        super().__init__(
+            f"Conflicting definitions for parameter {param_id!r}: {fields}; "
+            f"contributors=({sources})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ParamConfig:
+    """Immutable per-analysis effective state after construction precedence."""
+
+    param_id: str
+    effective_value: float | None
+    lower_bound: float
+    upper_bound: float
+
+
+def _float_token(value: float | None) -> str | None:
+    return None if value is None else float(value).hex()
+
+
+def _fingerprint(kind: str, records: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "schema": 1, "records": records},
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _definition_identity(definitions: Sequence[ParamDefinition]) -> str:
+    records = [
+        (
+            definition.param_id,
+            definition.name,
+            definition.spin_system_name,
+            tuple(
+                (name, _float_token(value))
+                for name, value in definition.condition_entries
+            ),
+            _float_token(definition.default_value),
+            _float_token(definition.lower_bound),
+            _float_token(definition.upper_bound),
+        )
+        for definition in definitions
+    ]
+    return _fingerprint("parameter-definitions", records)
+
+
+def _configuration_identity(configs: Sequence[ParamConfig]) -> str:
+    records = [
+        (
+            config.param_id,
+            _float_token(config.effective_value),
+            _float_token(config.lower_bound),
+            _float_token(config.upper_bound),
+        )
+        for config in configs
+    ]
+    return _fingerprint("parameter-configuration", records)
+
+
+@dataclass(frozen=True, slots=True)
+class SealedDefinitions:
+    """Deeply immutable, canonically ordered parameter definitions."""
+
+    _definitions: tuple[ParamDefinition, ...]
+    _index: Mapping[str, int]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        definitions = tuple(self._definitions)
+        index_data = {
+            definition.param_id: position
+            for position, definition in enumerate(definitions)
+        }
+        if len(index_data) != len(definitions):
+            msg = "Sealed definitions contain duplicate parameter IDs"
+            raise ValueError(msg)
+        index = MappingProxyType(index_data)
+        object.__setattr__(self, "_definitions", definitions)
+        object.__setattr__(self, "_index", index)
+        object.__setattr__(self, "identity", _definition_identity(definitions))
+
+    def __len__(self) -> int:
+        return len(self._definitions)
+
+    def __iter__(self) -> Iterator[ParamDefinition]:
+        return iter(self._definitions)
+
+    def __contains__(self, param_id: object) -> bool:
+        return param_id in self._index
+
+    @overload
+    def __getitem__(self, key: str) -> ParamDefinition: ...
+
+    @overload
+    def __getitem__(self, key: int) -> ParamDefinition: ...
+
+    def __getitem__(self, key: str | int) -> ParamDefinition:
+        if isinstance(key, int):
+            return self._definitions[key]
+        return self._definitions[self._index[key]]
+
+
+@dataclass(frozen=True, slots=True)
+class SealedConfiguration:
+    """Deeply immutable configuration in definition order."""
+
+    _configs: tuple[ParamConfig, ...]
+    _index: Mapping[str, int]
+    definitions_identity: str = ""
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        configs = tuple(self._configs)
+        index_data = {
+            config.param_id: position for position, config in enumerate(configs)
+        }
+        if len(index_data) != len(configs):
+            msg = "Sealed configuration contains duplicate parameter IDs"
+            raise ValueError(msg)
+        index = MappingProxyType(index_data)
+        object.__setattr__(self, "_configs", configs)
+        object.__setattr__(self, "_index", index)
+        object.__setattr__(
+            self,
+            "identity",
+            _fingerprint(
+                "parameter-configuration",
+                (self.definitions_identity, _configuration_identity(configs)),
+            ),
+        )
+
+    def __len__(self) -> int:
+        return len(self._configs)
+
+    def __iter__(self) -> Iterator[ParamConfig]:
+        return iter(self._configs)
+
+    def __contains__(self, param_id: object) -> bool:
+        return param_id in self._index
+
+    @overload
+    def __getitem__(self, key: str) -> ParamConfig: ...
+
+    @overload
+    def __getitem__(self, key: int) -> ParamConfig: ...
+
+    def __getitem__(self, key: str | int) -> ParamConfig:
+        if isinstance(key, int):
+            return self._configs[key]
+        return self._configs[self._index[key]]
+
+
+type ContributionLike = (
+    DefinitionContribution | ParamDefinition | tuple[ParamDefinition, str]
+)
+
+
+def _coerce_contribution(contribution: ContributionLike) -> DefinitionContribution:
+    if isinstance(contribution, DefinitionContribution):
+        return contribution
+    if isinstance(contribution, ParamDefinition):
+        return DefinitionContribution(contribution, "unspecified contributor")
+    definition, contributor = contribution
+    return DefinitionContribution(definition, contributor)
+
+
+def _equal(left: object, right: object) -> bool:
+    if (
+        isinstance(left, float)
+        and isinstance(right, float)
+        and math.isnan(left)
+        and math.isnan(right)
+    ):
+        return True
+    return left == right
+
+
+def _spin_sort_key(name: str) -> tuple[tuple[object, ...], ...]:
+    spin_system = SpinSystem.from_name(name)
+    return tuple(
+        (
+            spin.atom.nucleus.name,
+            spin.group.number,
+            spin.group.symbol,
+            spin.group.suffix,
+            spin.atom.name,
+        )
+        for spin in spin_system.spins.values()
+    )
+
+
+def _conditions_sort_key(
+    entries: Sequence[tuple[str, float]],
+) -> tuple[tuple[int, float], ...]:
+    values = dict(entries)
+    return tuple(
+        (1, values[field_name]) if field_name in values else (0, 0.0)
+        for field_name in _CONDITION_ORDER
+    )
+
+
+def _definition_sort_key(definition: ParamDefinition) -> tuple[object, ...]:
+    return (
+        definition.name,
+        _spin_sort_key(definition.spin_system_name),
+        _conditions_sort_key(definition.condition_entries),
+        definition.param_id,
+    )
+
+
+def canonicalize_definitions(
+    contributions: Mapping[str, Sequence[ContributionLike]],
+) -> SealedDefinitions:
+    """Validate contributions and return one canonical definition per stable ID."""
+    canonical: list[ParamDefinition] = []
+    for param_id, raw_contributions in contributions.items():
+        normalized = tuple(
+            sorted(
+                (_coerce_contribution(item) for item in raw_contributions),
+                key=lambda item: (item.contributor, repr(item.definition)),
+            )
+        )
+        if not normalized:
+            continue
+        if any(item.definition.param_id != param_id for item in normalized):
+            msg = f"Contribution key {param_id!r} does not match its parameter ID"
+            raise ValueError(msg)
+
+        reference = normalized[0].definition
+        conflicts = tuple(
+            DefinitionFieldConflict(
+                field_name,
+                tuple(getattr(item.definition, field_name) for item in normalized),
+            )
+            for field_name in _DEFINITION_FIELDS
+            if any(
+                not _equal(
+                    getattr(reference, field_name),
+                    getattr(item.definition, field_name),
+                )
+                for item in normalized[1:]
+            )
+        )
+        if conflicts:
+            raise DefinitionConflictError(
+                param_id,
+                conflicts,
+                tuple(item.contributor for item in normalized),
+            )
+        canonical.append(reference)
+
+    definitions = tuple(sorted(canonical, key=_definition_sort_key))
+    index = {
+        definition.param_id: position for position, definition in enumerate(definitions)
+    }
+    return SealedDefinitions(_definitions=definitions, _index=index)
+
+
+class ConfigurationMismatchError(ValueError):
+    """Raised when definitions and the active legacy catalog do not match."""
+
+    def __init__(self, missing: Sequence[str], unexpected: Sequence[str]) -> None:
+        self.missing = tuple(missing)
+        self.unexpected = tuple(unexpected)
+        super().__init__(
+            "Parameter configuration does not match sealed definitions: "
+            f"missing={self.missing!r}, unexpected={self.unexpected!r}"
+        )
+
+
+def build_sealed_configuration(
+    definitions: SealedDefinitions,
+    legacy_parameters: Mapping[str, ParamSetting],
+) -> SealedConfiguration:
+    """Build configuration from the fully initialized active legacy catalog."""
+    definition_ids = {definition.param_id for definition in definitions}
+    legacy_ids = set(legacy_parameters)
+    if definition_ids != legacy_ids:
+        raise ConfigurationMismatchError(
+            sorted(definition_ids - legacy_ids),
+            sorted(legacy_ids - definition_ids),
+        )
+
+    configs: list[ParamConfig] = []
+    for definition in definitions:
+        parameter = legacy_parameters[definition.param_id]
+        configs.append(
+            ParamConfig(
+                param_id=definition.param_id,
+                effective_value=parameter.value,
+                lower_bound=parameter.min,
+                upper_bound=parameter.max,
+            )
+        )
+
+    configs_tuple = tuple(configs)
+    index = {config.param_id: position for position, config in enumerate(configs_tuple)}
+    return SealedConfiguration(
+        _configs=configs_tuple,
+        _index=index,
+        definitions_identity=definitions.identity,
+    )

--- a/src/chemex/parameters/sealed.py
+++ b/src/chemex/parameters/sealed.py
@@ -15,11 +15,11 @@ from types import MappingProxyType
 from typing import overload
 
 from chemex.configuration.conditions import Conditions
+from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
 from chemex.parameters.spin_system import SpinSystem
 
 _CONDITION_FIELDS = ("d2o", "h_larmor_frq", "l_total", "p_total", "temperature")
-_CONDITION_ORDER = ("temperature", "h_larmor_frq", "p_total", "l_total", "d2o")
 _DEFINITION_FIELDS = (
     "name",
     "spin_system_name",
@@ -275,37 +275,87 @@ def _equal(left: object, right: object) -> bool:
     return left == right
 
 
-def _spin_sort_key(name: str) -> tuple[tuple[object, ...], ...]:
-    spin_system = SpinSystem.from_name(name)
-    return tuple(
-        (
-            spin.atom.nucleus.name,
-            spin.group.number,
-            spin.group.symbol,
-            spin.group.suffix,
-            spin.atom.name,
-        )
-        for spin in spin_system.spins.values()
-    )
-
-
-def _conditions_sort_key(
-    entries: Sequence[tuple[str, float]],
-) -> tuple[tuple[int, float], ...]:
-    values = dict(entries)
-    return tuple(
-        (1, values[field_name]) if field_name in values else (0, 0.0)
-        for field_name in _CONDITION_ORDER
-    )
-
-
-def _definition_sort_key(definition: ParamDefinition) -> tuple[object, ...]:
-    return (
+def _definition_sort_key(definition: ParamDefinition) -> ParamName:
+    """Reproduce the legacy-authoritative ``ParamName`` ordering exactly."""
+    return ParamName(
         definition.name,
-        _spin_sort_key(definition.spin_system_name),
-        _conditions_sort_key(definition.condition_entries),
-        definition.param_id,
+        SpinSystem.from_name(definition.spin_system_name),
+        Conditions.model_construct(None, **dict(definition.condition_entries)),
     )
+
+
+class InvalidConstructionError(ValueError):
+    """Base error for invalid initial values or physical bounds."""
+
+    artifact = "parameter state"
+
+    def __init__(
+        self,
+        param_id: str,
+        field: str,
+        value: object,
+        detail: str,
+    ) -> None:
+        self.param_id = param_id
+        self.field = field
+        self.value = value
+        self.detail = detail
+        super().__init__(
+            f"Invalid {self.artifact} for parameter {param_id!r}: "
+            f"{field}={value!r}; {detail}"
+        )
+
+
+class InvalidDefinitionError(InvalidConstructionError):
+    """Raised when a definition default or physical bound cannot be sealed."""
+
+    artifact = "definition"
+
+
+class InvalidConfigurationError(InvalidConstructionError):
+    """Raised when an effective value or physical bound cannot be sealed."""
+
+    artifact = "configuration"
+
+
+def _validate_initial_state(
+    param_id: str,
+    value: float | None,
+    lower_bound: float,
+    upper_bound: float,
+    *,
+    value_field: str,
+    error_type: type[InvalidConstructionError],
+) -> None:
+    for field_name, field_value in (
+        (value_field, value),
+        ("lower_bound", lower_bound),
+        ("upper_bound", upper_bound),
+    ):
+        if field_value is not None and math.isnan(field_value):
+            raise error_type(
+                param_id,
+                field_name,
+                field_value,
+                "NaN is not a valid configured value",
+            )
+    if lower_bound > upper_bound:
+        raise error_type(
+            param_id,
+            "lower_bound",
+            lower_bound,
+            f"must not exceed upper_bound={upper_bound!r}",
+        )
+    if value is not None and not lower_bound <= value <= upper_bound:
+        raise error_type(
+            param_id,
+            value_field,
+            value,
+            (
+                "must be within configured physical bounds "
+                f"[{lower_bound!r}, {upper_bound!r}]"
+            ),
+        )
 
 
 def canonicalize_definitions(
@@ -347,6 +397,14 @@ def canonicalize_definitions(
                 conflicts,
                 tuple(item.contributor for item in normalized),
             )
+        _validate_initial_state(
+            param_id,
+            reference.default_value,
+            reference.lower_bound,
+            reference.upper_bound,
+            value_field="default_value",
+            error_type=InvalidDefinitionError,
+        )
         canonical.append(reference)
 
     definitions = tuple(sorted(canonical, key=_definition_sort_key))
@@ -384,6 +442,14 @@ def build_sealed_configuration(
     configs: list[ParamConfig] = []
     for definition in definitions:
         parameter = legacy_parameters[definition.param_id]
+        _validate_initial_state(
+            definition.param_id,
+            parameter.value,
+            parameter.min,
+            parameter.max,
+            value_field="effective_value",
+            error_type=InvalidConfigurationError,
+        )
         configs.append(
             ParamConfig(
                 param_id=definition.param_id,

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -57,7 +57,7 @@ class AnalysisSession:
 
     def reset(self) -> None:
         """Clear cached runtime state before starting a new analysis."""
-        self.parameter_factory.clear_cache()
+        self.parameter_factory.reset()
         self.parameters.reset()
         self.model.reset()
 

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -63,6 +63,7 @@ class StubParameterFactory:
         self.clear_calls = 0
         self.seal_definition_calls = 0
         self.seal_configuration_calls = 0
+        self.native_sealing_succeeds = True
 
     def clear_cache(self) -> None:
         self.clear_calls += 1
@@ -70,11 +71,13 @@ class StubParameterFactory:
     def reset(self) -> None:
         self.clear_calls += 1
 
-    def seal_definitions(self) -> None:
+    def try_seal_definitions(self) -> bool:
         self.seal_definition_calls += 1
+        return self.native_sealing_succeeds
 
-    def seal_configuration(self) -> None:
+    def try_seal_configuration(self) -> bool:
         self.seal_configuration_calls += 1
+        return self.native_sealing_succeeds
 
 
 class StubSession:
@@ -373,6 +376,33 @@ def test_run_uses_explicit_session_for_fit_flow(
     np.testing.assert_equal(recorded["build"][2], session)
     np.testing.assert_equal(recorded["run_methods"][4], session.execution)
     assert recorded["run_info"] is True
+
+
+def test_run_continues_when_native_configuration_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = StubSession()
+    session.parameter_factory.native_sealing_succeeds = False
+    experiments = FakeExperiments(parameter_store=session.parameters)
+    fit_ran: list[bool] = []
+
+    monkeypatch.setattr(
+        chemex_module,
+        "build_experiments",
+        lambda *_args, **_kwargs: experiments,
+    )
+    monkeypatch.setattr(chemex_module, "read_defaults", lambda _filenames: object())
+    monkeypatch.setattr(
+        chemex_module,
+        "run_methods",
+        lambda *_args, **_kwargs: fit_ran.append(True),
+    )
+    monkeypatch.setattr(chemex_module, "write_run_info", lambda *_args, **_kwargs: None)
+
+    chemex_module.run(make_args("fit"), session=session)
+
+    assert fit_ran == [True]
+    assert session.parameter_factory.seal_configuration_calls == 1
 
 
 def test_run_uses_explicit_session_for_simulation_flow(

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -61,9 +61,20 @@ class StubParameters:
 class StubParameterFactory:
     def __init__(self) -> None:
         self.clear_calls = 0
+        self.seal_definition_calls = 0
+        self.seal_configuration_calls = 0
 
     def clear_cache(self) -> None:
         self.clear_calls += 1
+
+    def reset(self) -> None:
+        self.clear_calls += 1
+
+    def seal_definitions(self) -> None:
+        self.seal_definition_calls += 1
+
+    def seal_configuration(self) -> None:
+        self.seal_configuration_calls += 1
 
 
 class StubSession:
@@ -285,6 +296,20 @@ def test_build_experiments_uses_session_parameter_store(
     np.testing.assert_equal(opened, [Path("a.toml"), Path("b.toml")])
     assert all(call["parameters"] is session.parameter_factory for call in build_calls)
     assert all(call["model"] is session.model.spec for call in build_calls)
+    np.testing.assert_equal(session.parameter_factory.seal_definition_calls, 1)
+
+
+def test_build_experiments_seals_empty_definition_set() -> None:
+    session = StubSession()
+
+    experiments = builder_module.build_experiments(
+        None,
+        Selection(include=None, exclude=None),
+        session=session,
+    )
+
+    assert not experiments
+    np.testing.assert_equal(session.parameter_factory.seal_definition_calls, 1)
 
 
 def test_run_uses_explicit_session_for_fit_flow(
@@ -343,6 +368,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     np.testing.assert_equal(recorded_env["OMP_NUM_THREADS"], "2")
     np.testing.assert_equal(recorded_env["VECLIB_MAXIMUM_THREADS"], "2")
     np.testing.assert_equal(session.parameters.defaults_calls, [defaults])
+    np.testing.assert_equal(session.parameter_factory.seal_configuration_calls, 1)
     np.testing.assert_equal(experiments.filtered, 1)
     np.testing.assert_equal(recorded["build"][2], session)
     np.testing.assert_equal(recorded["run_methods"][4], session.execution)
@@ -382,6 +408,7 @@ def test_run_uses_explicit_session_for_simulation_flow(
 
     np.testing.assert_equal(session.model_names, ["2st"])
     np.testing.assert_equal(session.parameters.defaults_calls, [defaults])
+    np.testing.assert_equal(session.parameter_factory.seal_configuration_calls, 1)
     np.testing.assert_equal(session.parameters.fix_all_calls, 1)
     np.testing.assert_equal(recorded["build"][2], session)
 

--- a/tests/test_sealed_parameters.py
+++ b/tests/test_sealed_parameters.py
@@ -1,0 +1,834 @@
+"""Tests for sealed canonical parameter definitions and configuration (#582).
+
+Primary seam: real construction path through AnalysisSession, ParameterFactory,
+and shipped experiment inputs. Verified against the legacy-authoritative catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, fields
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Selection
+from chemex.configuration.parameters import DefaultSetting, read_defaults
+from chemex.experiments.builder import build_experiments
+from chemex.nmr.basis import Basis
+from chemex.parameters.name import ParamName
+from chemex.parameters.sealed import (
+    ConfigurationMismatchError,
+    DefinitionConflictError,
+    ParamConfig,
+    ParamDefinition,
+    SealedDefinitions,
+    build_sealed_configuration,
+    extract_condition_entries,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parents[1]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cpmg_config(
+    h_larmor_frq: float = 800.0,
+    profiles: dict[str, str] | None = None,
+) -> SimpleNamespace:
+    """Minimal config object mimicking ExperimentConfiguration for CPMG 15N IP."""
+    if profiles is None:
+        profiles = {}
+    conditions = Conditions(h_larmor_frq=h_larmor_frq, label=("2h",))
+    return SimpleNamespace(
+        conditions=conditions,
+        to_be_fitted=SimpleNamespace(rates=["r2"], model_free=[]),
+    )
+
+
+def _build_ordinary_session_with_two_residues() -> tuple[
+    AnalysisSession, dict[str, str], dict[str, str]
+]:
+    """Build a 2st ordinary session with two spin systems through the real path."""
+    session = AnalysisSession.create()
+    session.set_model("2st")
+
+    config = _make_cpmg_config()
+    basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+    spin_a = SpinSystem.from_name("G23N-HN")
+    spin_b = SpinSystem.from_name("A45N-HN")
+
+    ids_a = session.parameter_factory.create_parameters(
+        config,
+        basis=basis,
+        spin_system=spin_a,
+    )
+    ids_b = session.parameter_factory.create_parameters(
+        config,
+        basis=basis,
+        spin_system=spin_b,
+    )
+
+    return session, ids_a, ids_b
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Ordinary analysis — definitions match legacy catalog
+# ---------------------------------------------------------------------------
+
+
+class TestOrdinaryDefinitionsMatchLegacy:
+    """Verify that ordinary-mode sealed definitions match the legacy catalog."""
+
+    def test_sealed_definitions_are_produced(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        assert session.parameter_factory.sealed_definitions is not None
+
+    def test_definition_param_ids_match_legacy_catalog(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+        legacy_params = session.parameters.database._parameters
+
+        definition_ids = {d.param_id for d in definitions}
+        legacy_ids = set(legacy_params.keys())
+
+        assert definition_ids == legacy_ids
+
+    def test_definition_fields_match_legacy_param_settings(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+        legacy_params = session.parameters.database._parameters
+
+        for defn in definitions:
+            legacy = legacy_params[defn.param_id]
+            assert defn.name == legacy.param_name.name, (
+                f"{defn.param_id}: name mismatch"
+            )
+            assert defn.spin_system_name == str(legacy.param_name.spin_system), (
+                f"{defn.param_id}: spin_system mismatch"
+            )
+            assert defn.default_value == legacy.value or (
+                defn.default_value is None and legacy.value is None
+            ), (
+                f"{defn.param_id}: default_value mismatch {defn.default_value} vs {legacy.value}"
+            )
+
+    def test_definition_bounds_match_legacy(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+        legacy_params = session.parameters.database._parameters
+
+        for defn in definitions:
+            legacy = legacy_params[defn.param_id]
+            np.testing.assert_equal(defn.lower_bound, legacy.min)
+            np.testing.assert_equal(defn.upper_bound, legacy.max)
+
+    def test_native_type_fields_are_scoped_to_definition_and_configuration(
+        self,
+    ) -> None:
+        assert [item.name for item in fields(ParamDefinition)] == [
+            "param_id",
+            "name",
+            "spin_system_name",
+            "condition_entries",
+            "default_value",
+            "lower_bound",
+            "upper_bound",
+        ]
+        assert [item.name for item in fields(ParamConfig)] == [
+            "param_id",
+            "effective_value",
+            "lower_bound",
+            "upper_bound",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Model-free analysis — complete definition set
+# ---------------------------------------------------------------------------
+
+
+class TestModelFreeDefinitionsComplete:
+    """Model-free definitions include MF quantities and rate identities."""
+
+    def test_model_free_definitions_match_active_catalog(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st.mf")
+
+        config = SimpleNamespace(
+            conditions=Conditions(h_larmor_frq=800.0, label=("2h",)),
+            to_be_fitted=SimpleNamespace(rates=[], model_free=["tauc", "s2"]),
+        )
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+        spin = SpinSystem.from_name("G23N-HN")
+
+        session.parameter_factory.create_parameters(
+            config,
+            basis=basis,
+            spin_system=spin,
+        )
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+        # In model-free mode, database property dispatches to _database_mf
+        legacy_mf_params = session.parameters.database._parameters
+
+        definition_ids = {d.param_id for d in definitions}
+        legacy_ids = set(legacy_mf_params.keys())
+
+        assert definition_ids == legacy_ids
+
+    def test_model_free_definitions_include_tauc_and_s2(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st.mf")
+
+        config = SimpleNamespace(
+            conditions=Conditions(h_larmor_frq=800.0, label=("2h",)),
+            to_be_fitted=SimpleNamespace(rates=[], model_free=["tauc", "s2"]),
+        )
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+        spin = SpinSystem.from_name("G23N-HN")
+
+        session.parameter_factory.create_parameters(
+            config,
+            basis=basis,
+            spin_system=spin,
+        )
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+        names = {d.name for d in definitions}
+
+        assert "TAUC_A" in names
+        assert "S2_A" in names
+
+    def test_model_free_definitions_include_rate_identities(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st.mf")
+
+        config = SimpleNamespace(
+            conditions=Conditions(h_larmor_frq=800.0, label=("2h",)),
+            to_be_fitted=SimpleNamespace(rates=[], model_free=["tauc", "s2"]),
+        )
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+        spin = SpinSystem.from_name("G23N-HN")
+
+        session.parameter_factory.create_parameters(
+            config,
+            basis=basis,
+            spin_system=spin,
+        )
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+        names = {d.name for d in definitions}
+
+        # Rate identities should be present even in model-free mode
+        r2_names = {n for n in names if n.startswith("R2")}
+        assert len(r2_names) > 0, "Rate identities missing from model-free definitions"
+
+    def test_ordinary_mode_excludes_model_free_only_quantities(self) -> None:
+        """Model-free auxiliary quantities (TAUC, S2, KHH) that exist only in
+        parameters_mf must not appear in ordinary canonical definitions."""
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+        definition_ids = {d.param_id for d in definitions}
+
+        # These should match the ordinary catalog, not the model-free catalog
+        ordinary_ids = set(session.parameters._database._parameters.keys())
+        mf_only_ids = (
+            set(session.parameters._database_mf._parameters.keys()) - ordinary_ids
+        )
+
+        assert not (definition_ids & mf_only_ids), (
+            f"Ordinary definitions contain model-free-only IDs: "
+            f"{definition_ids & mf_only_ids}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Equivalent duplicate contributions are deduplicated
+# ---------------------------------------------------------------------------
+
+
+class TestEquivalentDuplicateDeduplication:
+    """Multiple spin systems contributing the same global parameter."""
+
+    def test_global_params_deduplicated(self) -> None:
+        session, ids_a, ids_b = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+
+        # kex_ab is global — contributed by both spin systems
+        kex_ids = [d.param_id for d in definitions if d.name == "KEX_AB"]
+        assert len(kex_ids) == 1, f"Expected 1 KEX_AB definition, got {len(kex_ids)}"
+
+    def test_residue_specific_params_not_deduplicated(self) -> None:
+        session, ids_a, ids_b = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        definitions = session.parameter_factory.sealed_definitions
+
+        # Chemical shifts are residue-specific
+        cs_defs = [d for d in definitions if d.name == "CS_A"]
+        assert len(cs_defs) >= 2, f"Expected ≥2 CS_A definitions, got {len(cs_defs)}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Conflicting contributions raise DefinitionConflictError
+# ---------------------------------------------------------------------------
+
+
+class TestConflictingContributions:
+    """Conflicting definition fields for the same param_id must be rejected."""
+
+    def test_conflicting_default_value_raises(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st")
+
+        # Create a definition contribution manually
+        defn_a = ParamDefinition(
+            param_id="__KEX_AB_T_25_0C",
+            name="KEX_AB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=200.0,
+            lower_bound=0.0,
+            upper_bound=float("inf"),
+        )
+        defn_b = ParamDefinition(
+            param_id="__KEX_AB_T_25_0C",
+            name="KEX_AB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=500.0,  # CONFLICT
+            lower_bound=0.0,
+            upper_bound=float("inf"),
+        )
+
+        session.parameter_factory._definition_contributions["__KEX_AB_T_25_0C"] = [
+            defn_a,
+            defn_b,
+        ]
+
+        with pytest.raises(DefinitionConflictError) as exc_info:
+            session.parameter_factory.seal_definitions()
+
+        assert exc_info.value.param_id == "__KEX_AB_T_25_0C"
+        assert exc_info.value.field == "default_value"
+
+    def test_conflicting_bounds_raises(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st")
+
+        defn_a = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        defn_b = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.05,
+            lower_bound=-1.0,  # CONFLICT
+            upper_bound=1.0,
+        )
+
+        session.parameter_factory._definition_contributions["__PB"] = [defn_a, defn_b]
+
+        with pytest.raises(DefinitionConflictError) as exc_info:
+            session.parameter_factory.seal_definitions()
+
+        assert exc_info.value.param_id == "__PB"
+        assert exc_info.value.field == "lower_bound"
+
+    def test_reports_every_conflicting_field_and_all_contributors(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st")
+        defn_a = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        defn_b = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.10,
+            lower_bound=-1.0,
+            upper_bound=1.0,
+        )
+        session.parameter_factory._definition_contributions["__PB"] = [
+            (defn_a, "experiment-a"),  # type: ignore[list-item]
+            (defn_b, "experiment-b"),  # type: ignore[list-item]
+        ]
+
+        with pytest.raises(DefinitionConflictError) as exc_info:
+            session.parameter_factory.seal_definitions()
+
+        assert exc_info.value.conflicting_fields == (
+            "default_value",
+            "lower_bound",
+        )
+        assert exc_info.value.contributors == ("experiment-a", "experiment-b")
+        assert "experiment-a" in str(exc_info.value)
+        assert "experiment-b" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Deep public immutability
+# ---------------------------------------------------------------------------
+
+
+class TestDeepImmutability:
+    """All sealed objects must be structurally immutable through public API."""
+
+    def test_param_definition_fields_frozen(self) -> None:
+        defn = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(("temperature", 25.0),),
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        with pytest.raises(FrozenInstanceError):
+            defn.default_value = 0.1  # type: ignore[misc]
+
+    def test_param_definition_condition_entries_immutable(self) -> None:
+        defn = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(("temperature", 25.0),),
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        with pytest.raises(TypeError):
+            defn.condition_entries[0] = ("h_larmor_frq", 600.0)  # type: ignore[index]
+
+    def test_mutable_constructor_inputs_are_copied(self) -> None:
+        entries = [["temperature", 25.0]]
+        defn = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=entries,  # type: ignore[arg-type]
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        index = {"__PB": 0}
+        definitions = SealedDefinitions(_definitions=(defn,), _index=index)
+
+        entries[0][1] = 30.0
+        index["__FAKE"] = 0
+
+        assert defn.condition_entries == (("temperature", 25.0),)
+        assert "__FAKE" not in definitions
+
+    def test_param_config_fields_frozen(self) -> None:
+        cfg = ParamConfig(
+            param_id="__PB",
+            effective_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        with pytest.raises(FrozenInstanceError):
+            cfg.effective_value = 0.1  # type: ignore[misc]
+
+    def test_sealed_definitions_cannot_be_mutated(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        definitions = session.parameter_factory.sealed_definitions
+
+        with pytest.raises((FrozenInstanceError, TypeError, AttributeError)):
+            definitions._definitions = ()  # type: ignore[misc]
+
+    def test_sealed_configuration_cannot_be_mutated(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        session.parameters.set_defaults([])
+        session.parameter_factory.seal_configuration()
+        config = session.parameter_factory.sealed_configuration
+
+        with pytest.raises((FrozenInstanceError, TypeError, AttributeError)):
+            config._configs = ()  # type: ignore[misc]
+
+    def test_lookup_indexes_cannot_be_mutated(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        definitions = session.parameter_factory.sealed_definitions
+
+        with pytest.raises(TypeError):
+            definitions._index["__FAKE"] = 0  # type: ignore[index]
+
+        session.parameters.set_defaults([])
+        session.parameter_factory.seal_configuration()
+        configuration = session.parameter_factory.sealed_configuration
+
+        with pytest.raises(TypeError):
+            configuration._index["__FAKE"] = 0  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Canonical ordering is deterministic
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalOrdering:
+    """Ordering must be deterministic regardless of contribution order."""
+
+    def test_ordering_independent_of_spin_system_order(self) -> None:
+        # Build with G23N first, A45N second
+        session_ab, _, _ = _build_ordinary_session_with_two_residues()
+        session_ab.parameter_factory.seal_definitions()
+        ids_ab = [d.param_id for d in session_ab.parameter_factory.sealed_definitions]
+
+        # Build with A45N first, G23N second (reversed order)
+        session_ba = AnalysisSession.create()
+        session_ba.set_model("2st")
+        config = _make_cpmg_config()
+        basis = Basis(type="ixy", spin_system="nh", model=session_ba.model.spec)
+        spin_a = SpinSystem.from_name("A45N-HN")
+        spin_b = SpinSystem.from_name("G23N-HN")
+
+        session_ba.parameter_factory.create_parameters(
+            config,
+            basis=basis,
+            spin_system=spin_a,
+        )
+        session_ba.parameter_factory.create_parameters(
+            config,
+            basis=basis,
+            spin_system=spin_b,
+        )
+        session_ba.parameter_factory.seal_definitions()
+        ids_ba = [d.param_id for d in session_ba.parameter_factory.sealed_definitions]
+
+        assert ids_ab == ids_ba
+
+    def test_residues_and_conditions_use_semantic_numeric_order(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st")
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+        for field, residue in (
+            (1000.0, "G10N-HN"),
+            (800.0, "A2N-HN"),
+        ):
+            session.parameter_factory.create_parameters(
+                _make_cpmg_config(h_larmor_frq=field),
+                basis=basis,
+                spin_system=SpinSystem.from_name(residue),
+            )
+        session.parameter_factory.seal_definitions()
+        definitions = session.parameter_factory.sealed_definitions
+
+        cs_residues = [
+            defn.spin_system_name for defn in definitions if defn.name == "CS_A"
+        ]
+        r2_fields = [
+            dict(defn.condition_entries)["h_larmor_frq"]
+            for defn in definitions
+            if defn.name == "R2_A"
+        ]
+
+        assert cs_residues == ["A2N", "G10N"]
+        assert r2_fields == [800.0, 1000.0]
+
+
+class TestSealingLifecycle:
+    def test_model_cannot_change_after_definition_construction(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        definitions_identity = session.parameter_factory.sealed_definitions.identity
+
+        with pytest.raises(RuntimeError, match="reset the analysis session"):
+            session.set_model("3st")
+
+        assert session.model.name == "2st"
+        assert (
+            session.parameter_factory.sealed_definitions.identity
+            == definitions_identity
+        )
+
+    def test_contributions_are_rejected_after_definition_sealing(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        config = _make_cpmg_config()
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+
+        with pytest.raises(RuntimeError, match="definitions.*sealed"):
+            session.parameter_factory.create_parameters(
+                config,
+                basis=basis,
+                spin_system=SpinSystem.from_name("L67N-HN"),
+            )
+
+    def test_definition_sealing_cannot_be_repeated(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        with pytest.raises(RuntimeError, match="definitions.*sealed"):
+            session.parameter_factory.seal_definitions()
+
+    def test_configuration_requires_defaults_initialization(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        with pytest.raises(RuntimeError, match="defaults"):
+            session.parameter_factory.seal_configuration()
+
+    def test_configuration_sealing_cannot_be_repeated(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        session.parameters.set_defaults([])
+        session.parameter_factory.seal_configuration()
+
+        with pytest.raises(RuntimeError, match="configuration.*sealed"):
+            session.parameter_factory.seal_configuration()
+
+    def test_defaults_cannot_be_applied_repeatedly(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        session.parameters.set_defaults([])
+
+        with pytest.raises(RuntimeError, match="defaults.*already.*applied"):
+            session.parameters.set_defaults([])
+
+    def test_defaults_cannot_change_after_configuration_sealing(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        session.parameters.set_defaults([])
+        session.parameter_factory.seal_configuration()
+        identity = session.parameter_factory.sealed_configuration.identity
+
+        with pytest.raises(RuntimeError, match="configuration.*sealed"):
+            session.parameters.set_defaults(
+                [(ParamName.from_section("PB"), DefaultSetting(0.20))]
+            )
+
+        assert session.parameter_factory.sealed_configuration.identity == identity
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Configuration matches post-defaults legacy state
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurationMatchesLegacy:
+    """SealedConfiguration must match the legacy catalog after set_defaults()."""
+
+    def test_configuration_matches_legacy_catalog(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+
+        # Apply defaults (empty in this case)
+        session.parameters.set_defaults([])
+        session.parameter_factory.seal_configuration()
+
+        config = session.parameter_factory.sealed_configuration
+        legacy_params = session.parameters.database._parameters
+
+        for cfg in config:
+            legacy = legacy_params[cfg.param_id]
+            assert cfg.effective_value == legacy.value or (
+                cfg.effective_value is None and legacy.value is None
+            ), f"{cfg.param_id}: value mismatch"
+            np.testing.assert_equal(cfg.lower_bound, legacy.min)
+            np.testing.assert_equal(cfg.upper_bound, legacy.max)
+
+    def test_configuration_param_ids_match_definitions(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        session.parameters.set_defaults([])
+        session.parameter_factory.seal_configuration()
+
+        def_ids = {d.param_id for d in session.parameter_factory.sealed_definitions}
+        cfg_ids = {c.param_id for c in session.parameter_factory.sealed_configuration}
+
+        assert def_ids == cfg_ids
+
+    def test_missing_definition_configuration_is_rejected(self) -> None:
+        definition = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        definitions = SealedDefinitions(
+            _definitions=(definition,),
+            _index={"__PB": 0},
+        )
+
+        with pytest.raises(ConfigurationMismatchError) as exc_info:
+            build_sealed_configuration(definitions, {})
+
+        assert exc_info.value.missing == ("__PB",)
+
+    def test_configuration_captures_effective_overrides(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        defaults = [
+            (
+                ParamName.from_section("PB"),
+                DefaultSetting(0.08, min=0.01, max=0.20),
+            ),
+        ]
+        session.parameters.set_defaults(defaults)
+        session.parameter_factory.seal_configuration()
+
+        config = session.parameter_factory.sealed_configuration
+        pb_id = next(defn.param_id for defn in config if defn.param_id == "__PB")
+        pb = config[pb_id]
+
+        assert pb.effective_value == 0.08
+        assert pb.lower_bound == 0.01
+        assert pb.upper_bound == 0.20
+
+    def test_definitions_and_configuration_have_deterministic_identities(self) -> None:
+        session_a, _, _ = _build_ordinary_session_with_two_residues()
+        session_a.parameter_factory.seal_definitions()
+        session_a.parameters.set_defaults([])
+        session_a.parameter_factory.seal_configuration()
+
+        session_b = AnalysisSession.create()
+        session_b.set_model("2st")
+        config = _make_cpmg_config()
+        basis = Basis(type="ixy", spin_system="nh", model=session_b.model.spec)
+        for residue in ("A45N-HN", "G23N-HN"):
+            session_b.parameter_factory.create_parameters(
+                config,
+                basis=basis,
+                spin_system=SpinSystem.from_name(residue),
+            )
+        session_b.parameter_factory.seal_definitions()
+        session_b.parameters.set_defaults([])
+        session_b.parameter_factory.seal_configuration()
+
+        assert session_a.parameter_factory.sealed_definitions.identity == (
+            session_b.parameter_factory.sealed_definitions.identity
+        )
+        assert session_a.parameter_factory.sealed_configuration.identity == (
+            session_b.parameter_factory.sealed_configuration.identity
+        )
+        assert (
+            session_a.parameter_factory.sealed_configuration.definitions_identity
+            == session_a.parameter_factory.sealed_definitions.identity
+        )
+
+
+class TestShippedInputParity:
+    @pytest.mark.parametrize(
+        ("model", "experiment", "parameters"),
+        [
+            (
+                "2st",
+                "examples/Experiments/CPMG_15N_IP/Experiments/500mhz.toml",
+                "examples/Experiments/CPMG_15N_IP/Parameters/parameters.toml",
+            ),
+            (
+                "2st.mf",
+                "examples/Experiments/CEST_15N_TR/Experiments/trosy.toml",
+                "examples/Experiments/CEST_15N_TR/Parameters/parameters.toml",
+            ),
+        ],
+    )
+    def test_real_inputs_match_active_legacy_catalog(
+        self,
+        model: str,
+        experiment: str,
+        parameters: str,
+    ) -> None:
+        session = AnalysisSession.create()
+        session.set_model(model)
+        build_experiments(
+            [ROOT / experiment],
+            Selection(include=None, exclude=None),
+            session=session,
+        )
+        session.parameters.set_defaults(read_defaults([ROOT / parameters]))
+        session.parameter_factory.seal_configuration()
+
+        definitions = session.parameter_factory.sealed_definitions
+        configuration = session.parameter_factory.sealed_configuration
+        legacy = session.parameters.database._parameters
+
+        assert [defn.param_id for defn in definitions] == list(legacy)
+        assert [item.param_id for item in configuration] == list(legacy)
+        assert all(
+            str(ROOT / experiment) in contribution.contributor
+            for contributions in session.parameter_factory._definition_contributions.values()
+            for contribution in contributions
+        )
+        for defn, item in zip(definitions, configuration, strict=True):
+            setting = legacy[defn.param_id]
+            assert item.effective_value == setting.value
+            assert item.lower_bound == setting.min
+            assert item.upper_bound == setting.max
+
+
+# ---------------------------------------------------------------------------
+# Test: extract_condition_entries helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractConditionEntries:
+    """Verify the condition extraction helper produces sorted immutable tuples."""
+
+    def test_extracts_set_fields(self) -> None:
+        conditions = Conditions(h_larmor_frq=800.0, temperature=25.0)
+        entries = extract_condition_entries(conditions)
+
+        assert entries == (("h_larmor_frq", 800.0), ("temperature", 25.0))
+
+    def test_omits_none_fields(self) -> None:
+        conditions = Conditions(temperature=25.0)
+        entries = extract_condition_entries(conditions)
+
+        assert entries == (("temperature", 25.0),)
+
+    def test_empty_conditions(self) -> None:
+        conditions = Conditions()
+        entries = extract_condition_entries(conditions)
+
+        assert entries == ()
+
+    def test_result_is_deeply_immutable(self) -> None:
+        conditions = Conditions(h_larmor_frq=800.0, temperature=25.0)
+        entries = extract_condition_entries(conditions)
+
+        assert isinstance(entries, tuple)
+        assert all(isinstance(e, tuple) for e in entries)

--- a/tests/test_sealed_parameters.py
+++ b/tests/test_sealed_parameters.py
@@ -22,12 +22,15 @@ from chemex.parameters.name import ParamName
 from chemex.parameters.sealed import (
     ConfigurationMismatchError,
     DefinitionConflictError,
+    InvalidConfigurationError,
+    InvalidDefinitionError,
     ParamConfig,
     ParamDefinition,
     SealedDefinitions,
     build_sealed_configuration,
     extract_condition_entries,
 )
+from chemex.parameters.setting import ParamSetting
 from chemex.parameters.spin_system import SpinSystem
 from chemex.runtime import AnalysisSession
 
@@ -291,6 +294,78 @@ class TestEquivalentDuplicateDeduplication:
 
 
 # ---------------------------------------------------------------------------
+# Definition defaults and physical bounds are valid before sealing
+# ---------------------------------------------------------------------------
+
+
+class TestDefinitionValidation:
+    @pytest.mark.parametrize(
+        ("field", "default_value", "lower_bound", "upper_bound"),
+        [
+            ("default_value", np.nan, 0.0, 1.0),
+            ("lower_bound", 0.5, np.nan, 1.0),
+            ("upper_bound", 0.5, 0.0, np.nan),
+            ("lower_bound", 0.5, 0.8, 0.2),
+            ("default_value", -0.1, 0.0, 1.0),
+            ("default_value", 1.1, 0.0, 1.0),
+        ],
+    )
+    def test_invalid_definition_cannot_be_sealed(
+        self,
+        field: str,
+        default_value: float,
+        lower_bound: float,
+        upper_bound: float,
+    ) -> None:
+        session = AnalysisSession.create()
+        definition = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=default_value,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+        )
+        session.parameter_factory._definition_contributions["__PB"] = [definition]
+
+        with pytest.raises(InvalidDefinitionError) as exc_info:
+            session.parameter_factory.seal_definitions()
+
+        assert exc_info.value.field == field
+        assert session.parameter_factory.sealed_definitions is None
+
+    @pytest.mark.parametrize(
+        ("lower_bound", "upper_bound"),
+        [
+            (-np.inf, np.inf),
+            (0.0, np.inf),
+            (-np.inf, 0.0),
+        ],
+    )
+    def test_definition_accepts_supported_infinite_bounds(
+        self,
+        lower_bound: float,
+        upper_bound: float,
+    ) -> None:
+        session = AnalysisSession.create()
+        definition = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.0,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+        )
+        session.parameter_factory._definition_contributions["__PB"] = [definition]
+
+        session.parameter_factory.seal_definitions()
+
+        assert session.parameter_factory.sealed_definitions["__PB"] == definition
+
+
+# ---------------------------------------------------------------------------
 # Test 4: Conflicting contributions raise DefinitionConflictError
 # ---------------------------------------------------------------------------
 
@@ -400,6 +475,73 @@ class TestConflictingContributions:
         assert exc_info.value.contributors == ("experiment-a", "experiment-b")
         assert "experiment-a" in str(exc_info.value)
         assert "experiment-b" in str(exc_info.value)
+
+    def test_real_construction_detects_conflict_before_legacy_collapse(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st_binding")
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+        spin_system = SpinSystem.from_name("A2N-HN")
+
+        for contributor, p_total in (
+            ("experiment-a", 1.0001e-3),
+            ("experiment-b", 1.0002e-3),
+        ):
+            config = SimpleNamespace(
+                conditions=Conditions(p_total=p_total, l_total=2.0e-3),
+                to_be_fitted=SimpleNamespace(rates=[], model_free=[]),
+            )
+            session.parameter_factory.create_parameters(
+                config,
+                basis=basis,
+                spin_system=spin_system,
+                contributor=contributor,
+            )
+
+        assert session.parameter_factory.try_seal_definitions() is False
+        error = session.parameter_factory.native_construction_error
+        assert isinstance(error, DefinitionConflictError)
+        assert error.conflicting_fields == ("condition_entries",)
+        assert {source.split(";", maxsplit=1)[0] for source in error.contributors} == {
+            "experiment-a",
+            "experiment-b",
+        }
+        assert error.param_id in session.parameters.database._parameters
+
+    def test_definition_collection_failure_preserves_legacy_parameters(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st")
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+
+        def fail_native_collection(*_args: object, **_kwargs: object) -> None:
+            msg = "native definition collection failed"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            session.parameter_factory,
+            "_collect_definitions",
+            fail_native_collection,
+        )
+
+        name_map = session.parameter_factory.create_parameters(
+            _make_cpmg_config(),
+            basis=basis,
+            spin_system=SpinSystem.from_name("A2N-HN"),
+        )
+
+        assert name_map
+        legacy_parameters = session.parameters.get_parameters(name_map.values())
+        assert set(name_map.values()) <= set(legacy_parameters)
+        assert session.parameter_factory.try_seal_definitions() is False
+        assert isinstance(
+            session.parameter_factory.native_construction_error,
+            RuntimeError,
+        )
+        with pytest.raises(RuntimeError, match="reset the analysis session"):
+            session.set_model("3st")
+        assert session.model.name == "2st"
 
 
 # ---------------------------------------------------------------------------
@@ -537,33 +679,57 @@ class TestCanonicalOrdering:
 
         assert ids_ab == ids_ba
 
-    def test_residues_and_conditions_use_semantic_numeric_order(self) -> None:
+    def test_residue_order_matches_legacy_for_multi_digit_numbers(self) -> None:
         session = AnalysisSession.create()
         session.set_model("2st")
         basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
-        for field, residue in (
-            (1000.0, "G10N-HN"),
-            (800.0, "A2N-HN"),
-        ):
+        for residue in ("A10N-HN", "A2N-HN"):
             session.parameter_factory.create_parameters(
-                _make_cpmg_config(h_larmor_frq=field),
+                _make_cpmg_config(),
                 basis=basis,
                 spin_system=SpinSystem.from_name(residue),
             )
+        session.parameters.sort()
         session.parameter_factory.seal_definitions()
         definitions = session.parameter_factory.sealed_definitions
 
         cs_residues = [
             defn.spin_system_name for defn in definitions if defn.name == "CS_A"
         ]
-        r2_fields = [
-            dict(defn.condition_entries)["h_larmor_frq"]
-            for defn in definitions
-            if defn.name == "R2_A"
+
+        assert cs_residues == ["A2N", "A10N"]
+        assert [defn.param_id for defn in definitions if defn.name == "CS_A"] == [
+            param_id
+            for param_id, setting in session.parameters.database._parameters.items()
+            if setting.param_name.name == "CS_A"
         ]
 
-        assert cs_residues == ["A2N", "G10N"]
-        assert r2_fields == [800.0, 1000.0]
+    def test_condition_order_matches_legacy_for_different_digit_widths(self) -> None:
+        session = AnalysisSession.create()
+        session.set_model("2st")
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+        spin_system = SpinSystem.from_name("A2N-HN")
+        for field in (800.0, 1000.0):
+            session.parameter_factory.create_parameters(
+                _make_cpmg_config(h_larmor_frq=field),
+                basis=basis,
+                spin_system=spin_system,
+            )
+        session.parameters.sort()
+        session.parameter_factory.seal_definitions()
+        definitions = session.parameter_factory.sealed_definitions
+
+        r2_ids = [defn.param_id for defn in definitions if defn.name == "R2_A"]
+
+        assert r2_ids == [
+            "__R2_A_A2N_1000_0MHZ",
+            "__R2_A_A2N_800_0MHZ",
+        ]
+        assert r2_ids == [
+            param_id
+            for param_id, setting in session.parameters.database._parameters.items()
+            if setting.param_name.name == "R2_A"
+        ]
 
 
 class TestSealingLifecycle:
@@ -639,6 +805,40 @@ class TestSealingLifecycle:
 
         assert session.parameter_factory.sealed_configuration.identity == identity
 
+    def test_reset_clears_and_reconstructs_sealed_parameter_state(self) -> None:
+        session, _, _ = _build_ordinary_session_with_two_residues()
+        session.parameter_factory.seal_definitions()
+        session.parameters.set_defaults([])
+        session.parameter_factory.seal_configuration()
+        definitions_identity = session.parameter_factory.sealed_definitions.identity
+        configuration_identity = session.parameter_factory.sealed_configuration.identity
+
+        session.reset()
+
+        assert session.parameter_factory.sealed_definitions is None
+        assert session.parameter_factory.sealed_configuration is None
+        assert session.parameter_factory.native_construction_error is None
+
+        session.set_model("2st")
+        config = _make_cpmg_config()
+        basis = Basis(type="ixy", spin_system="nh", model=session.model.spec)
+        for residue in ("G23N-HN", "A45N-HN"):
+            session.parameter_factory.create_parameters(
+                config,
+                basis=basis,
+                spin_system=SpinSystem.from_name(residue),
+            )
+        session.parameter_factory.seal_definitions()
+        session.parameters.set_defaults([])
+        session.parameter_factory.seal_configuration()
+
+        assert session.parameter_factory.sealed_definitions.identity == (
+            definitions_identity
+        )
+        assert session.parameter_factory.sealed_configuration.identity == (
+            configuration_identity
+        )
+
 
 # ---------------------------------------------------------------------------
 # Test 7: Configuration matches post-defaults legacy state
@@ -697,6 +897,146 @@ class TestConfigurationMatchesLegacy:
             build_sealed_configuration(definitions, {})
 
         assert exc_info.value.missing == ("__PB",)
+
+    def test_configuration_rejects_reversed_bounds(self) -> None:
+        definition = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        definitions = SealedDefinitions(
+            _definitions=(definition,),
+            _index={"__PB": 0},
+        )
+        parameter = ParamSetting(
+            ParamName("PB"),
+            value=0.5,
+            min=0.8,
+            max=0.2,
+        )
+
+        with pytest.raises(InvalidConfigurationError, match="lower_bound"):
+            build_sealed_configuration(definitions, {"__PB": parameter})
+
+    @pytest.mark.parametrize(
+        ("field", "value", "lower_bound", "upper_bound"),
+        [
+            ("effective_value", np.nan, 0.0, 1.0),
+            ("lower_bound", 0.5, np.nan, 1.0),
+            ("upper_bound", 0.5, 0.0, np.nan),
+        ],
+    )
+    def test_configuration_rejects_nan_values_and_bounds(
+        self,
+        field: str,
+        value: float,
+        lower_bound: float,
+        upper_bound: float,
+    ) -> None:
+        definition = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        definitions = SealedDefinitions(
+            _definitions=(definition,),
+            _index={"__PB": 0},
+        )
+        parameter = ParamSetting(
+            ParamName("PB"),
+            value=value,
+            min=lower_bound,
+            max=upper_bound,
+        )
+
+        with pytest.raises(InvalidConfigurationError) as exc_info:
+            build_sealed_configuration(definitions, {"__PB": parameter})
+
+        assert exc_info.value.field == field
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    def test_configuration_rejects_initial_value_outside_bounds(
+        self,
+        value: float,
+    ) -> None:
+        definition = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.05,
+            lower_bound=0.0,
+            upper_bound=1.0,
+        )
+        definitions = SealedDefinitions(
+            _definitions=(definition,),
+            _index={"__PB": 0},
+        )
+        parameter = ParamSetting(
+            ParamName("PB"),
+            value=value,
+            min=0.0,
+            max=1.0,
+        )
+
+        with pytest.raises(
+            InvalidConfigurationError,
+            match="effective_value",
+        ):
+            build_sealed_configuration(definitions, {"__PB": parameter})
+
+    @pytest.mark.parametrize(
+        ("lower_bound", "upper_bound"),
+        [
+            (-np.inf, np.inf),
+            (0.0, np.inf),
+            (-np.inf, 0.0),
+        ],
+    )
+    def test_configuration_accepts_supported_infinite_bounds(
+        self,
+        lower_bound: float,
+        upper_bound: float,
+    ) -> None:
+        definition = ParamDefinition(
+            param_id="__PB",
+            name="PB",
+            spin_system_name="",
+            condition_entries=(),
+            default_value=0.0,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+        )
+        definitions = SealedDefinitions(
+            _definitions=(definition,),
+            _index={"__PB": 0},
+        )
+        parameter = ParamSetting(
+            ParamName("PB"),
+            value=0.0,
+            min=lower_bound,
+            max=upper_bound,
+        )
+
+        configuration = build_sealed_configuration(
+            definitions,
+            {"__PB": parameter},
+        )
+
+        assert configuration["__PB"] == ParamConfig(
+            param_id="__PB",
+            effective_value=0.0,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+        )
 
     def test_configuration_captures_effective_overrides(self) -> None:
         session, _, _ = _build_ordinary_session_with_two_residues()


### PR DESCRIPTION
Closes #582.

## Summary

Introduces the first ChemEx-native parameter-model checkpoint from #566/#569:

- immutable canonical parameter definitions;
- immutable per-analysis parameter configuration;
- deterministic semantic ordering;
- pre-merge duplicate-definition validation with contributor diagnostics;
- explicit definition/configuration sealing lifecycle;
- ordinary and model-free active-mode isolation;
- parity checks against the legacy-authoritative parameter catalog using shipped inputs.

The existing legacy parameter, fitting, residual, CLI, TOML, and output paths remain authoritative.

## Deliberately not included

This checkpoint does not introduce:

- revisioned values, snapshots, commits, serialization, or lmfit adapters (#583);
- FIT/FIX roles, active constraints, expressions, or resolved frames (#584);
- optimizer/search metadata such as `brute_step`;
- uncertainty state;
- inferred units or reconstructed provenance.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q` — 368 passed, 1 existing emcee warning
- `uv run ruff format --check .`
- `git diff --check`