### PR TITLE
Introduce revisioned analysis values, snapshots, and legacy adapter

### DIFF
--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -102,7 +102,7 @@ def run(
     print_reading_defaults()
     defaults = read_defaults(args.parameters)
     session.parameters.set_defaults(defaults)
-    session.parameter_factory.try_seal_configuration()
+    session.try_build_analysis_values()
 
     if args.commands == "simulate":
         run_sim(args, experiments, session)

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -564,7 +564,7 @@ class ParameterStore:
     _database_mf: ParameterCatalog
     _defaults_applied: bool = field(default=False, init=False, repr=False)
     _configuration_locked: bool = field(default=False, init=False, repr=False)
-    _legacy_values_adapter: LegacyValuesAdapter | None = field(
+    _legacy_values_adapter: "LegacyValuesAdapter | None" = field(
         default=None,
         init=False,
         repr=False,
@@ -589,7 +589,7 @@ class ParameterStore:
         """Reject later definition/default mutations while values remain mutable."""
         self._configuration_locked = True
 
-    def attach_legacy_values_adapter(self, adapter: LegacyValuesAdapter) -> None:
+    def attach_legacy_values_adapter(self, adapter: "LegacyValuesAdapter") -> None:
         """Attach the session's one-way legacy-to-native values edge."""
         self._legacy_values_adapter = adapter
 

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -11,7 +11,7 @@ import sys
 from collections import Counter, defaultdict
 from collections.abc import Hashable, Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 from lmfit import Parameters as ParametersLF
@@ -30,6 +30,9 @@ from chemex.parameters.name import ParamName
 from chemex.parameters.setting import Parameters, ParamSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
+
+if TYPE_CHECKING:
+    from chemex.parameters.legacy_adapter import LegacyValuesAdapter
 
 _PARAM_NAME = r"\[(.+?)\]"
 _FLOAT = r"[-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?"
@@ -561,6 +564,11 @@ class ParameterStore:
     _database_mf: ParameterCatalog
     _defaults_applied: bool = field(default=False, init=False, repr=False)
     _configuration_locked: bool = field(default=False, init=False, repr=False)
+    _legacy_values_adapter: LegacyValuesAdapter | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
 
     @property
     def database(self) -> ParameterCatalog:
@@ -580,6 +588,10 @@ class ParameterStore:
     def lock_configuration(self) -> None:
         """Reject later definition/default mutations while values remain mutable."""
         self._configuration_locked = True
+
+    def attach_legacy_values_adapter(self, adapter: LegacyValuesAdapter) -> None:
+        """Attach the session's one-way legacy-to-native values edge."""
+        self._legacy_values_adapter = adapter
 
     def _ensure_configuration_open(self) -> None:
         if self._configuration_locked:
@@ -656,6 +668,11 @@ class ParameterStore:
 
         """
         self.database.update_from_lmfit_params(parameters)
+        if self._legacy_values_adapter is not None:
+            try:
+                self._legacy_values_adapter.try_commit(parameters)
+            except Exception as error:  # noqa: BLE001 - legacy authority boundary
+                self._legacy_values_adapter.disable(error)
 
     def set_values(self, par_values: dict[str, float]) -> None:
         """Set the values of specific parameters in the active catalog.
@@ -664,7 +681,12 @@ class ParameterStore:
             par_values (dict[str, float]): Parameter values to set.
 
         """
-        return self.database.set_values(par_values)
+        self.database.set_values(par_values)
+        if self._legacy_values_adapter is not None:
+            try:
+                self._legacy_values_adapter.try_commit_values(par_values)
+            except Exception as error:  # noqa: BLE001 - legacy authority boundary
+                self._legacy_values_adapter.disable(error)
 
     def set_defaults(self, defaults: DefaultListType) -> None:
         """Set defaults for parameters in both catalogs.

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -103,6 +103,11 @@ class ParameterFactory:
         """Return the failure that disabled the non-authoritative native candidate."""
         return self._native_construction_error
 
+    def disable_native_candidate(self, error: Exception) -> None:
+        """Record the first native failure without disturbing legacy construction."""
+        if self._native_construction_error is None:
+            self._native_construction_error = error
+
     def _build_settings(
         self,
         basis: Basis,

--- a/src/chemex/parameters/legacy_adapter.py
+++ b/src/chemex/parameters/legacy_adapter.py
@@ -1,0 +1,61 @@
+"""The single one-way adapter from legacy lmfit values to native central values."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from lmfit import Parameters as LmfitParameters
+
+from chemex.parameters.values import AnalysisValues
+
+
+class LegacyValuesAdapter:
+    """Mirror accepted legacy mutations without affecting legacy authority."""
+
+    def __init__(self, analysis_values: AnalysisValues) -> None:
+        self._analysis_values = analysis_values
+        self._failure: Exception | None = None
+
+    @property
+    def failure(self) -> Exception | None:
+        """Return the first failure that disabled native value mirroring."""
+        return self._failure
+
+    def try_commit(self, parameters: LmfitParameters) -> bool:
+        """Best-effort commit of one complete lmfit parameter scope."""
+        if self._failure is not None or not self._analysis_values.is_initialized:
+            return False
+        try:
+            scope = tuple(parameters)
+            candidate = {
+                param_id: float(parameters[param_id].value) for param_id in scope
+            }
+        except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
+            self._failure = error
+            return False
+        return self.try_commit_values(candidate)
+
+    def try_commit_values(self, candidate: Mapping[str, float]) -> bool:
+        """Best-effort commit of one native mapping from a legacy mutation."""
+        if self._failure is not None or not self._analysis_values.is_initialized:
+            return False
+        try:
+            expected = self._analysis_values.snapshot()
+            self._analysis_values.commit(
+                candidate,
+                expected=expected,
+                scope=tuple(candidate),
+            )
+        except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
+            self._failure = error
+            return False
+        return True
+
+    def disable(self, error: Exception) -> None:
+        """Disable mirroring after an earlier native candidate failure."""
+        if self._failure is None:
+            self._failure = error
+
+    def reset(self) -> None:
+        """Clear failure state for a full session rebuild."""
+        self._failure = None

--- a/src/chemex/parameters/values.py
+++ b/src/chemex/parameters/values.py
@@ -1,0 +1,285 @@
+"""Revisioned ChemEx-native central values for one analysis session."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from numbers import Real
+from threading import RLock
+from types import MappingProxyType
+
+from chemex.parameters.sealed import SealedConfiguration
+
+
+class AnalysisValuesCommitError(ValueError):
+    """Base error for a rejected atomic central-value commit."""
+
+
+class IncompatibleAnalysisValuesError(AnalysisValuesCommitError):
+    """Raised when a freshness snapshot belongs to another analysis state."""
+
+
+class StaleAnalysisValuesError(AnalysisValuesCommitError):
+    """Raised when the analysis-wide revision has advanced."""
+
+
+class InvalidAnalysisValuesCommitError(AnalysisValuesCommitError):
+    """Raised when commit scope or candidate central values are invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisValuesSnapshot(Mapping[str, float]):
+    """Immutable central values and the identities needed for freshness checks."""
+
+    model_identity: str
+    definitions_identity: str
+    configuration_identity: str
+    revision: int
+    _items: tuple[tuple[str, float], ...]
+    _index: Mapping[str, float] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        items = tuple((str(param_id), float(value)) for param_id, value in self._items)
+        index = MappingProxyType(dict(items))
+        if len(index) != len(items):
+            msg = "Analysis values snapshot contains duplicate parameter IDs"
+            raise ValueError(msg)
+        if isinstance(self.revision, bool) or self.revision < 0:
+            msg = "Analysis values snapshot revision must be non-negative"
+            raise ValueError(msg)
+        if any(not math.isfinite(value) for _param_id, value in items):
+            msg = "Analysis values snapshot contains a non-finite value"
+            raise ValueError(msg)
+        object.__setattr__(self, "_items", items)
+        object.__setattr__(self, "_index", index)
+
+    def __iter__(self) -> Iterator[str]:
+        return (param_id for param_id, _value in self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __getitem__(self, key: str) -> float:
+        return self._index[key]
+
+    def to_json(self) -> str:
+        """Serialize with stable field order and exact binary64 value tokens."""
+        payload = {
+            "schema_version": 1,
+            "model_identity": self.model_identity,
+            "definitions_identity": self.definitions_identity,
+            "configuration_identity": self.configuration_identity,
+            "revision": self.revision,
+            "values": [
+                {"id": param_id, "value": float(value).hex()}
+                for param_id, value in self._items
+            ],
+        }
+        return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, encoded: str) -> AnalysisValuesSnapshot:
+        """Restore a snapshot from its deterministic JSON representation."""
+        payload = json.loads(encoded)
+        if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+            msg = "Unsupported analysis values snapshot schema"
+            raise ValueError(msg)
+        values = payload.get("values")
+        if not isinstance(values, list):
+            msg = "Analysis values snapshot values must be a list"
+            raise TypeError(msg)
+        try:
+            items = tuple(
+                (entry["id"], float.fromhex(entry["value"])) for entry in values
+            )
+            model_identity = payload["model_identity"]
+            definitions_identity = payload["definitions_identity"]
+            configuration_identity = payload["configuration_identity"]
+            revision = payload["revision"]
+        except (KeyError, TypeError, ValueError) as error:
+            msg = "Invalid analysis values snapshot payload"
+            raise ValueError(msg) from error
+        if (
+            not all(
+                isinstance(identity, str)
+                for identity in (
+                    model_identity,
+                    definitions_identity,
+                    configuration_identity,
+                )
+            )
+            or isinstance(revision, bool)
+            or not isinstance(revision, int)
+        ):
+            msg = "Invalid analysis values snapshot identity or revision"
+            raise ValueError(msg)
+        return cls(
+            model_identity=model_identity,
+            definitions_identity=definitions_identity,
+            configuration_identity=configuration_identity,
+            revision=revision,
+            _items=items,
+        )
+
+
+class AnalysisValues:
+    """Session-owned mutable central values with one analysis-wide revision."""
+
+    def __init__(self) -> None:
+        self._model_identity = ""
+        self._definitions_identity = ""
+        self._configuration_identity = ""
+        self._items: tuple[tuple[str, float], ...] = ()
+        self._bounds: Mapping[str, tuple[float, float]] = MappingProxyType({})
+        self._revision: int | None = None
+        self._lock = RLock()
+
+    @property
+    def is_initialized(self) -> bool:
+        """Whether sealed configuration has initialized central values."""
+        with self._lock:
+            return self._revision is not None
+
+    def initialize(
+        self,
+        model_identity: str,
+        configuration: SealedConfiguration,
+    ) -> None:
+        """Initialize revision zero from immutable configured effective values."""
+        with self._lock:
+            if self._revision is not None:
+                msg = "Analysis values are already initialized"
+                raise RuntimeError(msg)
+
+            items: list[tuple[str, float]] = []
+            for config in configuration:
+                value = config.effective_value
+                if value is None or not math.isfinite(value):
+                    msg = (
+                        f"Invalid initial analysis value for {config.param_id!r}: "
+                        f"{value!r}"
+                    )
+                    raise ValueError(msg)
+                items.append((config.param_id, float(value)))
+
+            self._model_identity = str(model_identity)
+            self._definitions_identity = configuration.definitions_identity
+            self._configuration_identity = configuration.identity
+            self._items = tuple(items)
+            self._bounds = MappingProxyType(
+                {
+                    config.param_id: (config.lower_bound, config.upper_bound)
+                    for config in configuration
+                }
+            )
+            self._revision = 0
+
+    def snapshot(self) -> AnalysisValuesSnapshot:
+        """Return an immutable point-in-time copy of all configured values."""
+        with self._lock:
+            return self._snapshot_unlocked()
+
+    def _snapshot_unlocked(self) -> AnalysisValuesSnapshot:
+        if self._revision is None:
+            msg = "Analysis values are not initialized"
+            raise RuntimeError(msg)
+        return AnalysisValuesSnapshot(
+            model_identity=self._model_identity,
+            definitions_identity=self._definitions_identity,
+            configuration_identity=self._configuration_identity,
+            revision=self._revision,
+            _items=self._items,
+        )
+
+    def commit(
+        self,
+        candidate: Mapping[str, float],
+        *,
+        expected: AnalysisValuesSnapshot,
+        scope: tuple[str, ...],
+    ) -> AnalysisValuesSnapshot:
+        """Atomically commit a complete finite candidate for an explicit scope."""
+        with self._lock:
+            return self._commit_unlocked(candidate, expected=expected, scope=scope)
+
+    def _commit_unlocked(
+        self,
+        candidate: Mapping[str, float],
+        *,
+        expected: AnalysisValuesSnapshot,
+        scope: tuple[str, ...],
+    ) -> AnalysisValuesSnapshot:
+        current = self._snapshot_unlocked()
+        current_identity = (
+            current.model_identity,
+            current.definitions_identity,
+            current.configuration_identity,
+        )
+        expected_identity = (
+            expected.model_identity,
+            expected.definitions_identity,
+            expected.configuration_identity,
+        )
+        if expected_identity != current_identity:
+            msg = "Analysis values snapshot has incompatible model or configuration"
+            raise IncompatibleAnalysisValuesError(msg)
+        if expected.revision != current.revision:
+            msg = (
+                f"Analysis values revision is stale: expected {expected.revision}, "
+                f"current {current.revision}"
+            )
+            raise StaleAnalysisValuesError(msg)
+        if expected._items != current._items:
+            msg = "Analysis values snapshot does not match the current revision"
+            raise IncompatibleAnalysisValuesError(msg)
+
+        scope_ids = tuple(scope)
+        scope_set = set(scope_ids)
+        candidate_ids = set(candidate)
+        configured_ids = set(current)
+        if (
+            not scope_ids
+            or len(scope_set) != len(scope_ids)
+            or scope_set - configured_ids
+            or candidate_ids != scope_set
+        ):
+            msg = (
+                "Invalid analysis values commit scope: "
+                f"scope={scope_ids!r}, candidate_ids={tuple(candidate)!r}"
+            )
+            raise InvalidAnalysisValuesCommitError(msg)
+
+        replacements: dict[str, float] = {}
+        for param_id in scope_ids:
+            value = candidate[param_id]
+            if isinstance(value, bool) or not isinstance(value, Real):
+                msg = f"Invalid central value for {param_id!r}: {value!r}"
+                raise InvalidAnalysisValuesCommitError(msg)
+            numeric_value = float(value)
+            lower_bound, upper_bound = self._bounds[param_id]
+            if (
+                not math.isfinite(numeric_value)
+                or not lower_bound <= numeric_value <= upper_bound
+            ):
+                msg = f"Invalid central value for {param_id!r}: {value!r}"
+                raise InvalidAnalysisValuesCommitError(msg)
+            replacements[param_id] = numeric_value
+
+        self._items = tuple(
+            (param_id, replacements.get(param_id, value))
+            for param_id, value in self._items
+        )
+        self._revision = current.revision + 1
+        return self._snapshot_unlocked()
+
+    def reset(self) -> None:
+        """Return to the uninitialized state for a full analysis rebuild."""
+        with self._lock:
+            self._model_identity = ""
+            self._definitions_identity = ""
+            self._configuration_identity = ""
+            self._items = ()
+            self._bounds = MappingProxyType({})
+            self._revision = None

--- a/src/chemex/parameters/values.py
+++ b/src/chemex/parameters/values.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from numbers import Real
 from threading import RLock
 from types import MappingProxyType
+from uuid import uuid4
 
 from chemex.parameters.sealed import SealedConfiguration
 
@@ -33,6 +34,7 @@ class InvalidAnalysisValuesCommitError(AnalysisValuesCommitError):
 class AnalysisValuesSnapshot(Mapping[str, float]):
     """Immutable central values and the identities needed for freshness checks."""
 
+    occurrence_identity: str
     model_identity: str
     definitions_identity: str
     configuration_identity: str
@@ -68,6 +70,7 @@ class AnalysisValuesSnapshot(Mapping[str, float]):
         """Serialize with stable field order and exact binary64 value tokens."""
         payload = {
             "schema_version": 1,
+            "occurrence_identity": self.occurrence_identity,
             "model_identity": self.model_identity,
             "definitions_identity": self.definitions_identity,
             "configuration_identity": self.configuration_identity,
@@ -94,6 +97,7 @@ class AnalysisValuesSnapshot(Mapping[str, float]):
             items = tuple(
                 (entry["id"], float.fromhex(entry["value"])) for entry in values
             )
+            occurrence_identity = payload["occurrence_identity"]
             model_identity = payload["model_identity"]
             definitions_identity = payload["definitions_identity"]
             configuration_identity = payload["configuration_identity"]
@@ -105,6 +109,7 @@ class AnalysisValuesSnapshot(Mapping[str, float]):
             not all(
                 isinstance(identity, str)
                 for identity in (
+                    occurrence_identity,
                     model_identity,
                     definitions_identity,
                     configuration_identity,
@@ -116,6 +121,7 @@ class AnalysisValuesSnapshot(Mapping[str, float]):
             msg = "Invalid analysis values snapshot identity or revision"
             raise ValueError(msg)
         return cls(
+            occurrence_identity=occurrence_identity,
             model_identity=model_identity,
             definitions_identity=definitions_identity,
             configuration_identity=configuration_identity,
@@ -128,6 +134,7 @@ class AnalysisValues:
     """Session-owned mutable central values with one analysis-wide revision."""
 
     def __init__(self) -> None:
+        self._occurrence_identity = ""
         self._model_identity = ""
         self._definitions_identity = ""
         self._configuration_identity = ""
@@ -164,6 +171,7 @@ class AnalysisValues:
                     raise ValueError(msg)
                 items.append((config.param_id, float(value)))
 
+            self._occurrence_identity = uuid4().hex
             self._model_identity = str(model_identity)
             self._definitions_identity = configuration.definitions_identity
             self._configuration_identity = configuration.identity
@@ -186,6 +194,7 @@ class AnalysisValues:
             msg = "Analysis values are not initialized"
             raise RuntimeError(msg)
         return AnalysisValuesSnapshot(
+            occurrence_identity=self._occurrence_identity,
             model_identity=self._model_identity,
             definitions_identity=self._definitions_identity,
             configuration_identity=self._configuration_identity,
@@ -212,6 +221,9 @@ class AnalysisValues:
         scope: tuple[str, ...],
     ) -> AnalysisValuesSnapshot:
         current = self._snapshot_unlocked()
+        if expected.occurrence_identity != current.occurrence_identity:
+            msg = "Analysis values snapshot belongs to another analysis occurrence"
+            raise IncompatibleAnalysisValuesError(msg)
         current_identity = (
             current.model_identity,
             current.definitions_identity,
@@ -277,6 +289,7 @@ class AnalysisValues:
     def reset(self) -> None:
         """Return to the uninitialized state for a full analysis rebuild."""
         with self._lock:
+            self._occurrence_identity = ""
             self._model_identity = ""
             self._definitions_identity = ""
             self._configuration_identity = ""

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -11,6 +11,8 @@ from chemex.parameters.database import (
     create_parameter_store,
 )
 from chemex.parameters.factory import ParameterFactory
+from chemex.parameters.legacy_adapter import LegacyValuesAdapter
+from chemex.parameters.values import AnalysisValues
 from chemex.runtime.execution import ExecutionSettings
 
 _PLUGIN_STATE = {"registered": False}
@@ -34,12 +36,19 @@ class AnalysisSession:
         model: ModelController | None = None,
         parameters: ParameterStore | None = None,
         parameter_factory: ParameterFactory | None = None,
+        analysis_values: AnalysisValues | None = None,
         execution: ExecutionSettings | None = None,
     ) -> None:
         self.model = ModelState() if model is None else model
+        self.analysis_values = (
+            AnalysisValues() if analysis_values is None else analysis_values
+        )
+        self.legacy_values_adapter = LegacyValuesAdapter(self.analysis_values)
         self.parameters = (
             create_parameter_store(self.model) if parameters is None else parameters
         )
+        if isinstance(self.parameters, ParameterStore):
+            self.parameters.attach_legacy_values_adapter(self.legacy_values_adapter)
         self.parameter_factory = (
             ParameterFactory(self.parameters)
             if parameter_factory is None
@@ -59,7 +68,32 @@ class AnalysisSession:
         """Clear cached runtime state before starting a new analysis."""
         self.parameter_factory.reset()
         self.parameters.reset()
+        self.analysis_values.reset()
+        self.legacy_values_adapter.reset()
         self.model.reset()
+
+    def try_build_analysis_values(self) -> bool:
+        """Seal configuration and initialize the non-authoritative native values."""
+        if not self.parameter_factory.try_seal_configuration():
+            return False
+        configuration = self.parameter_factory.sealed_configuration
+        if configuration is None:
+            error = RuntimeError("Sealed parameter configuration is unavailable")
+            self.parameter_factory.disable_native_candidate(error)
+            self.legacy_values_adapter.disable(error)
+            return False
+        spec = self.model.spec
+        model_identity = (
+            f"{spec.name}|states={spec.states}|model_free={spec.model_free}|"
+            f"temp_coef={spec.temp_coef}|residue_specific={spec.residue_specific}"
+        )
+        try:
+            self.analysis_values.initialize(model_identity, configuration)
+        except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
+            self.parameter_factory.disable_native_candidate(error)
+            self.legacy_values_adapter.disable(error)
+            return False
+        return True
 
     def set_model(self, name: str) -> None:
         """Set the active kinetics model for the current session."""

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -87,9 +87,14 @@ class StubSession:
         self.model_names: list[str] = []
         self.parameter_factory = StubParameterFactory()
         self.execution = ExecutionSettings()
+        self.build_analysis_values_calls = 0
 
     def set_model(self, name: str) -> None:
         self.model_names.append(name)
+
+    def try_build_analysis_values(self) -> bool:
+        self.build_analysis_values_calls += 1
+        return self.parameter_factory.try_seal_configuration()
 
 
 class WriterParameterStore:
@@ -226,6 +231,9 @@ def test_analysis_sessions_own_distinct_runtime_state() -> None:
     np.testing.assert_equal(
         int(session_a.parameter_factory is session_b.parameter_factory),
         0,
+    )
+    np.testing.assert_equal(
+        int(session_a.analysis_values is session_b.analysis_values), 0
     )
     np.testing.assert_equal(basis_a.model.states, "abc")
     np.testing.assert_equal(basis_b.model.states, "ab")
@@ -372,6 +380,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     np.testing.assert_equal(recorded_env["VECLIB_MAXIMUM_THREADS"], "2")
     np.testing.assert_equal(session.parameters.defaults_calls, [defaults])
     np.testing.assert_equal(session.parameter_factory.seal_configuration_calls, 1)
+    np.testing.assert_equal(session.build_analysis_values_calls, 1)
     np.testing.assert_equal(experiments.filtered, 1)
     np.testing.assert_equal(recorded["build"][2], session)
     np.testing.assert_equal(recorded["run_methods"][4], session.execution)
@@ -403,6 +412,7 @@ def test_run_continues_when_native_configuration_is_unavailable(
 
     assert fit_ran == [True]
     assert session.parameter_factory.seal_configuration_calls == 1
+    assert session.build_analysis_values_calls == 1
 
 
 def test_run_uses_explicit_session_for_simulation_flow(
@@ -439,6 +449,7 @@ def test_run_uses_explicit_session_for_simulation_flow(
     np.testing.assert_equal(session.model_names, ["2st"])
     np.testing.assert_equal(session.parameters.defaults_calls, [defaults])
     np.testing.assert_equal(session.parameter_factory.seal_configuration_calls, 1)
+    np.testing.assert_equal(session.build_analysis_values_calls, 1)
     np.testing.assert_equal(session.parameters.fix_all_calls, 1)
     np.testing.assert_equal(recorded["build"][2], session)
 

--- a/tests/test_analysis_values.py
+++ b/tests/test_analysis_values.py
@@ -123,7 +123,9 @@ def test_snapshot_is_immutable_and_has_a_deterministic_json_round_trip() -> None
     restored = AnalysisValuesSnapshot.from_json(encoded)
 
     assert restored == snapshot
+    assert restored.occurrence_identity == snapshot.occurrence_identity
     assert restored.to_json() == encoded
+    assert '"occurrence_identity"' in encoded
     assert '"revision":0' in encoded
     assert '"value":"0x1.47ae147ae147bp-4"' in encoded
     with pytest.raises(dataclasses.FrozenInstanceError):
@@ -346,10 +348,49 @@ def test_session_reset_rebuilds_values_at_revision_zero() -> None:
 
     rebuilt = _build_shipped_session(session).analysis_values.snapshot()
     assert rebuilt.revision == 0
+    assert rebuilt.occurrence_identity != initial.occurrence_identity
     assert rebuilt.model_identity == initial.model_identity
     assert rebuilt.definitions_identity == initial.definitions_identity
     assert rebuilt.configuration_identity == initial.configuration_identity
     assert rebuilt["__PB"] == initial["__PB"]
+
+
+def test_snapshot_from_before_session_reset_is_rejected_after_rebuild() -> None:
+    session = _build_shipped_session()
+    previous_occurrence = session.analysis_values.snapshot()
+
+    session.reset()
+    rebuilt = _build_shipped_session(session).analysis_values.snapshot()
+
+    with pytest.raises(IncompatibleAnalysisValuesError):
+        session.analysis_values.commit(
+            {"__PB": 0.12},
+            expected=previous_occurrence,
+            scope=("__PB",),
+        )
+
+    assert session.analysis_values.snapshot() == rebuilt
+
+
+def test_snapshot_from_another_identical_session_is_rejected() -> None:
+    session_a = _build_shipped_session()
+    session_b = _build_shipped_session()
+    snapshot_a = session_a.analysis_values.snapshot()
+    snapshot_b = session_b.analysis_values.snapshot()
+
+    assert snapshot_a.occurrence_identity != snapshot_b.occurrence_identity
+    assert snapshot_a.model_identity == snapshot_b.model_identity
+    assert snapshot_a.definitions_identity == snapshot_b.definitions_identity
+    assert snapshot_a.configuration_identity == snapshot_b.configuration_identity
+
+    with pytest.raises(IncompatibleAnalysisValuesError):
+        session_b.analysis_values.commit(
+            {"__PB": 0.12},
+            expected=snapshot_a,
+            scope=("__PB",),
+        )
+
+    assert session_b.analysis_values.snapshot() == snapshot_b
 
 
 def test_model_change_is_rejected_after_analysis_values_are_initialized() -> None:

--- a/tests/test_analysis_values.py
+++ b/tests/test_analysis_values.py
@@ -1,0 +1,439 @@
+"""Behavioral tests for session-owned revisioned analysis values.
+
+The primary seam is the native AnalysisValues snapshot/commit API. Integration
+tests below exercise the real session construction and legacy adapter paths.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from argparse import Namespace
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+from typing import cast
+
+import pytest
+from lmfit import Parameters as LmfitParameters
+
+from chemex import chemex as chemex_module
+from chemex.configuration.methods import Selection
+from chemex.configuration.parameters import read_defaults
+from chemex.experiments.builder import build_experiments
+from chemex.parameters.legacy_adapter import LegacyValuesAdapter
+from chemex.parameters.sealed import ParamConfig, SealedConfiguration
+from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.values import (
+    AnalysisValues,
+    AnalysisValuesCommitError,
+    AnalysisValuesSnapshot,
+    IncompatibleAnalysisValuesError,
+    InvalidAnalysisValuesCommitError,
+    StaleAnalysisValuesError,
+)
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parent.parent
+SHIPPED_EXPERIMENT = (
+    ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+)
+SHIPPED_PARAMETERS = (
+    ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
+)
+SHIPPED_METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+def _configuration() -> SealedConfiguration:
+    configs = (
+        ParamConfig("__PB", 0.08, 0.0, 1.0),
+        ParamConfig("__KEX_AB", 400.0, 0.0, 10_000.0),
+    )
+    return SealedConfiguration(
+        _configs=configs,
+        _index={config.param_id: index for index, config in enumerate(configs)},
+        definitions_identity="definitions-v1",
+    )
+
+
+def _build_shipped_session(
+    session: AnalysisSession | None = None,
+) -> AnalysisSession:
+    session = AnalysisSession.create() if session is None else session
+    session.set_model("2st")
+    build_experiments(
+        [SHIPPED_EXPERIMENT],
+        Selection(include=None, exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([SHIPPED_PARAMETERS]))
+    assert session.try_build_analysis_values()
+    return session
+
+
+def _shipped_args(command: str, output: Path) -> Namespace:
+    args = Namespace(
+        commands=command,
+        model="2st",
+        include=[SpinSystem.from_name("G2N-HN")],
+        exclude=None,
+        experiments=[SHIPPED_EXPERIMENT],
+        parameters=[SHIPPED_PARAMETERS],
+        method=[SHIPPED_METHOD] if command == "fit" else None,
+        output=output,
+        plot="nothing",
+    )
+    if command == "fit":
+        args.workers = 1
+        args.native_threads = 1
+    return args
+
+
+def _authoritative_output_contents(output: Path) -> dict[Path, bytes]:
+    return {
+        path.relative_to(output): path.read_bytes()
+        for path in output.rglob("*")
+        if path.is_file()
+        and (
+            path.relative_to(output).parts[0] in {"Data", "Parameters"}
+            or path.relative_to(output) == Path("statistics.toml")
+        )
+    }
+
+
+def test_values_initialize_from_configuration_in_deterministic_order() -> None:
+    values = AnalysisValues()
+
+    values.initialize("2st", _configuration())
+    snapshot = values.snapshot()
+
+    assert snapshot.revision == 0
+    assert snapshot.model_identity == "2st"
+    assert snapshot.definitions_identity == "definitions-v1"
+    assert snapshot.configuration_identity == _configuration().identity
+    assert tuple(snapshot.items()) == (("__PB", 0.08), ("__KEX_AB", 400.0))
+
+
+def test_snapshot_is_immutable_and_has_a_deterministic_json_round_trip() -> None:
+    values = AnalysisValues()
+    values.initialize("2st", _configuration())
+    snapshot = values.snapshot()
+
+    encoded = snapshot.to_json()
+    restored = AnalysisValuesSnapshot.from_json(encoded)
+
+    assert restored == snapshot
+    assert restored.to_json() == encoded
+    assert '"revision":0' in encoded
+    assert '"value":"0x1.47ae147ae147bp-4"' in encoded
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        snapshot.revision = 1  # ty: ignore[invalid-assignment]
+    with pytest.raises(TypeError):
+        snapshot["__PB"] = 0.2  # ty: ignore[invalid-assignment]
+
+
+def test_commit_updates_one_complete_scope_and_increments_one_global_revision() -> None:
+    values = AnalysisValues()
+    values.initialize("2st", _configuration())
+    initial = values.snapshot()
+    restored_initial = AnalysisValuesSnapshot.from_json(initial.to_json())
+
+    committed = values.commit(
+        {"__PB": 0.12},
+        expected=restored_initial,
+        scope=("__PB",),
+    )
+
+    assert committed.revision == 1
+    assert tuple(committed.items()) == (("__PB", 0.12), ("__KEX_AB", 400.0))
+    assert initial.revision == 0
+    assert initial["__PB"] == 0.08
+
+
+def test_stale_and_incompatible_commits_are_atomic() -> None:
+    values = AnalysisValues()
+    values.initialize("2st", _configuration())
+    initial = values.snapshot()
+    values.commit({"__PB": 0.12}, expected=initial, scope=("__PB",))
+    committed = values.snapshot()
+
+    with pytest.raises(StaleAnalysisValuesError):
+        values.commit({"__KEX_AB": 500.0}, expected=initial, scope=("__KEX_AB",))
+
+    incompatible = dataclasses.replace(committed, configuration_identity="other")
+    with pytest.raises(IncompatibleAnalysisValuesError):
+        values.commit({"__KEX_AB": 500.0}, expected=incompatible, scope=("__KEX_AB",))
+
+    assert values.snapshot() == committed
+
+
+def test_concurrent_disjoint_commits_use_one_conservative_global_revision() -> None:
+    values = AnalysisValues()
+    values.initialize("2st", _configuration())
+    initial = values.snapshot()
+    barrier = Barrier(2)
+
+    def commit(candidate: dict[str, float]) -> AnalysisValuesSnapshot | Exception:
+        barrier.wait()
+        try:
+            return values.commit(
+                candidate,
+                expected=initial,
+                scope=tuple(candidate),
+            )
+        except AnalysisValuesCommitError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = tuple(executor.map(commit, ({"__PB": 0.12}, {"__KEX_AB": 500.0})))
+
+    assert sum(isinstance(result, AnalysisValuesSnapshot) for result in results) == 1
+    assert sum(isinstance(result, StaleAnalysisValuesError) for result in results) == 1
+    assert values.snapshot().revision == 1
+
+
+@pytest.mark.parametrize(
+    ("candidate", "scope"),
+    [
+        ({}, ("__PB",)),
+        ({"__PB": 0.12, "__KEX_AB": 500.0}, ("__PB",)),
+        ({"__UNKNOWN": 1.0}, ("__UNKNOWN",)),
+        ({"__PB": "not-a-number"}, ("__PB",)),
+        ({"__PB": float("nan")}, ("__PB",)),
+        ({"__PB": float("inf")}, ("__PB",)),
+        ({"__PB": 1.01}, ("__PB",)),
+    ],
+)
+def test_invalid_or_incomplete_commits_leave_values_and_revision_unchanged(
+    candidate: Mapping[str, object],
+    scope: tuple[str, ...],
+) -> None:
+    values = AnalysisValues()
+    values.initialize("2st", _configuration())
+    initial = values.snapshot()
+
+    with pytest.raises(InvalidAnalysisValuesCommitError):
+        values.commit(
+            cast("Mapping[str, float]", candidate),
+            expected=initial,
+            scope=scope,
+        )
+
+    assert values.snapshot() == initial
+
+
+def test_real_shipped_configuration_initializes_session_values_from_legacy() -> None:
+    session = _build_shipped_session()
+    snapshot = session.analysis_values.snapshot()
+
+    assert snapshot.revision == 0
+    assert tuple(snapshot) == tuple(session.parameters.database._parameters)
+    assert all(
+        value == session.parameters.get_value(param_id)
+        for param_id, value in snapshot.items()
+    )
+
+
+def test_single_legacy_adapter_commits_lmfit_values_to_native_state() -> None:
+    values = AnalysisValues()
+    values.initialize("2st", _configuration())
+    parameters = LmfitParameters()
+    parameters.add("__PB", value=0.12)
+    adapter = LegacyValuesAdapter(values)
+
+    assert adapter.try_commit(parameters)
+
+    snapshot = values.snapshot()
+    assert snapshot.revision == 1
+    assert snapshot["__PB"] == 0.12
+    assert adapter.failure is None
+
+
+def test_legacy_adapter_ignores_normal_pre_initialization_mutation() -> None:
+    values = AnalysisValues()
+    parameters = LmfitParameters()
+    parameters.add("__PB", value=0.12)
+    adapter = LegacyValuesAdapter(values)
+
+    assert not adapter.try_commit(parameters)
+    assert adapter.failure is None
+
+    values.initialize("2st", _configuration())
+    assert adapter.try_commit(parameters)
+    assert values.snapshot()["__PB"] == 0.12
+
+
+def test_real_legacy_store_update_mirrors_through_the_single_adapter() -> None:
+    session = _build_shipped_session()
+    initial = session.analysis_values.snapshot()
+    parameters = session.parameters.build_lmfit_params(("__PB",))
+    parameters["__PB"].value = 0.12
+
+    session.parameters.update_from_parameters(parameters)
+
+    committed = session.analysis_values.snapshot()
+    assert session.parameters.get_value("__PB") == 0.12
+    assert committed["__PB"] == 0.12
+    assert committed.revision == initial.revision + 1
+
+
+def test_legacy_mapping_mutation_uses_the_same_values_adapter() -> None:
+    session = _build_shipped_session()
+    initial = session.analysis_values.snapshot()
+
+    session.parameters.set_values({"__PB": 0.13})
+
+    committed = session.analysis_values.snapshot()
+    assert session.parameters.get_value("__PB") == 0.13
+    assert committed["__PB"] == 0.13
+    assert committed.revision == initial.revision + 1
+
+
+def test_native_commit_failure_cannot_veto_legacy_authoritative_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _build_shipped_session()
+    initial = session.analysis_values.snapshot()
+    parameters = session.parameters.build_lmfit_params(("__PB",))
+    parameters["__PB"].value = 0.14
+
+    def fail_native_commit(*_args: object, **_kwargs: object) -> None:
+        msg = "native candidate failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(AnalysisValues, "commit", fail_native_commit)
+
+    session.parameters.update_from_parameters(parameters)
+
+    assert session.parameters.get_value("__PB") == 0.14
+    assert session.analysis_values.snapshot() == initial
+    assert isinstance(session.legacy_values_adapter.failure, RuntimeError)
+
+
+def test_adapter_failure_cannot_veto_legacy_authoritative_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _build_shipped_session()
+    initial = session.analysis_values.snapshot()
+    parameters = session.parameters.build_lmfit_params(("__PB",))
+    parameters["__PB"].value = 0.16
+
+    def fail_adapter(*_args: object, **_kwargs: object) -> bool:
+        msg = "legacy edge failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(LegacyValuesAdapter, "try_commit", fail_adapter)
+
+    session.parameters.update_from_parameters(parameters)
+
+    assert session.parameters.get_value("__PB") == 0.16
+    assert session.analysis_values.snapshot() == initial
+    assert isinstance(session.legacy_values_adapter.failure, RuntimeError)
+
+
+def test_session_reset_rebuilds_values_at_revision_zero() -> None:
+    session = _build_shipped_session()
+    initial = session.analysis_values.snapshot()
+    parameters = session.parameters.build_lmfit_params(("__PB",))
+    parameters["__PB"].value = 0.12
+    session.parameters.update_from_parameters(parameters)
+    assert session.analysis_values.snapshot().revision == 1
+
+    session.reset()
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        session.analysis_values.snapshot()
+
+    rebuilt = _build_shipped_session(session).analysis_values.snapshot()
+    assert rebuilt.revision == 0
+    assert rebuilt.model_identity == initial.model_identity
+    assert rebuilt.definitions_identity == initial.definitions_identity
+    assert rebuilt.configuration_identity == initial.configuration_identity
+    assert rebuilt["__PB"] == initial["__PB"]
+
+
+def test_model_change_is_rejected_after_analysis_values_are_initialized() -> None:
+    session = _build_shipped_session()
+    snapshot = session.analysis_values.snapshot()
+
+    with pytest.raises(RuntimeError, match="reset the analysis session"):
+        session.set_model("3st")
+
+    assert session.model.name == "2st"
+    assert session.analysis_values.snapshot() == snapshot
+
+
+def test_shipped_fit_remains_legacy_authoritative_and_mirrors_accepted_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate_output = tmp_path / "candidate-enabled"
+    legacy_only_output = tmp_path / "legacy-only"
+    session = AnalysisSession.create()
+
+    chemex_module.run(_shipped_args("fit", candidate_output), session=session)
+
+    snapshot = session.analysis_values.snapshot()
+    assert snapshot.revision == 1
+    assert all(
+        value == session.parameters.get_value(param_id)
+        for param_id, value in snapshot.items()
+    )
+    assert list((candidate_output / "Data").rglob("*.dat"))
+    assert list((candidate_output / "Parameters").rglob("*.toml"))
+
+    def disable_native_candidate(*_args: object, **_kwargs: object) -> None:
+        msg = "native candidate disabled for parity reference"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(AnalysisValues, "initialize", disable_native_candidate)
+    chemex_module.run(
+        _shipped_args("fit", legacy_only_output),
+        session=AnalysisSession.create(),
+    )
+
+    assert _authoritative_output_contents(candidate_output) == (
+        _authoritative_output_contents(legacy_only_output)
+    )
+
+
+def test_shipped_simulation_survives_native_initialization_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate_output = tmp_path / "candidate-enabled"
+    legacy_only_output = tmp_path / "legacy-only"
+    session = AnalysisSession.create()
+
+    chemex_module.run(_shipped_args("simulate", candidate_output), session=session)
+
+    snapshot = session.analysis_values.snapshot()
+    assert snapshot.revision == 0
+    assert all(
+        value == session.parameters.get_value(param_id)
+        for param_id, value in snapshot.items()
+    )
+
+    def fail_native_initialization(*_args: object, **_kwargs: object) -> None:
+        msg = "native initialization failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(AnalysisValues, "initialize", fail_native_initialization)
+
+    legacy_session = AnalysisSession.create()
+    chemex_module.run(
+        _shipped_args("simulate", legacy_only_output),
+        session=legacy_session,
+    )
+
+    assert list((legacy_only_output / "Data").rglob("*.dat"))
+    assert _authoritative_output_contents(candidate_output) == (
+        _authoritative_output_contents(legacy_only_output)
+    )
+    assert isinstance(
+        legacy_session.parameter_factory.native_construction_error,
+        RuntimeError,
+    )
+    assert isinstance(legacy_session.legacy_values_adapter.failure, RuntimeError)
+    with pytest.raises(RuntimeError, match="not initialized"):
+        legacy_session.analysis_values.snapshot()


### PR DESCRIPTION
Closes #583.

## Summary

Introduces the next ChemEx-native parameter-model checkpoint from #566/#569:

* session-owned revisioned Analysis Values initialized from the sealed #582 configuration;
* immutable deterministic snapshots with serialization support;
* stale-safe, identity-checked atomic central-value commits;
* reset/rebuild semantics for native value state;
* a single lmfit-shaped legacy-edge adapter;
* failure isolation so native candidate failures cannot veto legacy-authoritative execution;
* parity coverage against real shipped fit and simulation inputs.

The existing legacy fitting, simulation, residual, parameter-mutation, reporting, and output paths remain authoritative.

## Commit semantics

Native central-value updates:

* are based on a captured revision and compatible parameter/configuration identity;
* validate the full affected update before mutation;
* reject stale, incompatible, incomplete, unknown, or invalid updates atomically;
* leave values and revision unchanged on failure;
* increment the analysis-wide revision exactly once on success.

## Legacy boundary

lmfit-shaped objects are confined to the legacy adapter boundary. Native parameter-domain objects do not depend on lmfit types or semantics.

## Deliberately not included

This checkpoint does not introduce:

* FIT/FIX roles or constraint compilation (#584);
* resolved/derived value frames;
* optimization vectors, problems, or results;
* covariance, uncertainty, resampling, or MCMC evidence;
* optimizer/search metadata;
* `stderr` or `brute_step`;
* inferred units or reconstructed provenance;
* generic transaction, event-sourcing, or identity frameworks.

## Validation

* `uv run pytest -q` — 414 passed, 1 existing emcee autocorrelation warning
* `uv run ty check`
* `uv run ruff check .`
* `uv run ruff format --check .`
* `git diff --check`
* shipped one-profile HZNZ fit and simulation outputs matched native-disabled legacy occurrences byte-for-byte

The full local suite was run under Python 3.14; supported CI environments provide the additional platform/version coverage.
