### PR TITLE
Compile parameter roles and constraints into resolved value frames

### DIFF
--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -48,7 +48,12 @@ def run_fit(
 
     print_start_fit()
     run_methods(
-        experiments, methods, args.output, args.plot, execution=session.execution
+        experiments,
+        methods,
+        args.output,
+        args.plot,
+        execution=session.execution,
+        preview_parameterization=session.try_compile_parameterization,
     )
 
 

--- a/src/chemex/models/model.py
+++ b/src/chemex/models/model.py
@@ -17,6 +17,14 @@ class ModelSpec:
     temp_coef: bool = False
     residue_specific: bool = False
 
+    @property
+    def identity(self) -> str:
+        """Return the exact semantic identity of the selected model variant."""
+        return (
+            f"{self.name}|states={self.states}|model_free={self.model_free}|"
+            f"temp_coef={self.temp_coef}|residue_specific={self.residue_specific}"
+        )
+
     @staticmethod
     def validate_model_name(name: str) -> str:
         from chemex.models.factory import model_factory
@@ -89,3 +97,7 @@ class ModelState:
     @property
     def residue_specific(self) -> bool:
         return self._spec.residue_specific
+
+    @property
+    def identity(self) -> str:
+        return self._spec.identity

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -1,8 +1,9 @@
 """The fitting module contains the code for fitting the experimental data."""
 
+from collections.abc import Callable
 from pathlib import Path
 
-from chemex.configuration.methods import Methods, Statistics
+from chemex.configuration.methods import Method, Methods, Statistics
 from chemex.containers.experiments import Experiments
 from chemex.messages import (
     print_calculation_stopped_error,
@@ -126,6 +127,7 @@ def run_methods(
     plot_level: str,
     *,
     execution: ExecutionSettings | None = None,
+    preview_parameterization: Callable[[Method, set[str]], object] | None = None,
 ) -> None:
     parameter_store = experiments.parameter_store
 
@@ -141,6 +143,9 @@ def run_methods(
             continue
 
         print_fitmethod(method.fitmethod)
+
+        if preview_parameterization is not None:
+            preview_parameterization(method, experiments.param_ids)
 
         # Update the parameter "vary" and "expr" status
         parameter_store.set_parameter_status(method)

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -63,6 +63,9 @@ class ModelReader(Protocol):
     @property
     def model_free(self) -> bool: ...
 
+    @property
+    def identity(self) -> str: ...
+
 
 class ParameterIndex:
     """Maintains an index of parameter names for efficient searching and retrieval.

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -80,7 +80,7 @@ class ParameterFactory:
     parameter_store: ParameterStore
     _settings_cache: dict[
         tuple[str, bool, bool, bool, Basis, Conditions],
-        tuple[LocalSettings, LocalSettings],
+        tuple[LocalSettings, LocalSettings, frozenset[str]],
     ] = field(default_factory=dict)
     _definition_contributions: dict[str, list[DefinitionContribution]] = field(
         default_factory=dict,
@@ -130,7 +130,7 @@ class ParameterFactory:
         self,
         basis: Basis,
         conditions: Conditions,
-    ) -> tuple[LocalSettings, LocalSettings]:
+    ) -> tuple[LocalSettings, LocalSettings, frozenset[str]]:
         key = (
             basis.model.name,
             basis.model.model_free,
@@ -147,7 +147,11 @@ class ParameterFactory:
             settings_kinetics = model_factory.create_for_model(basis.model, conditions)
             settings = settings_kinetics | settings_spins
             settings_mf = settings_kinetics | settings_spins_mf
-            self._settings_cache[key] = (settings, settings_mf)
+            self._settings_cache[key] = (
+                settings,
+                settings_mf,
+                frozenset(settings_kinetics),
+            )
         return self._settings_cache[key]
 
     def _collect_definitions(
@@ -179,6 +183,7 @@ class ParameterFactory:
         parameters: Parameters,
         *,
         contributor: str,
+        model_owned_ids: frozenset[str],
     ) -> None:
         for param_id, parameter in parameters.items():
             contribution = ParameterDeclarationContribution(
@@ -186,6 +191,7 @@ class ParameterFactory:
                 supports_estimation=parameter.vary,
                 model_expression=parameter.expr,
                 contributor=contributor,
+                model_owned=param_id in model_owned_ids and bool(parameter.expr),
             )
             self._declaration_contributions.setdefault(param_id, []).append(
                 contribution
@@ -203,7 +209,7 @@ class ParameterFactory:
             msg = "Parameter definitions are already sealed; contributions are closed"
             raise RuntimeError(msg)
 
-        settings, settings_mf = self._build_settings(
+        settings, settings_mf, kinetic_names = self._build_settings(
             basis,
             config.conditions,
         )
@@ -234,6 +240,14 @@ class ParameterFactory:
             native_parameters = (
                 parameters_mf if self.parameter_store.model.model_free else parameters
             )
+            native_name_map = (
+                name_map_mf if self.parameter_store.model.model_free else name_map
+            )
+            model_owned_ids = frozenset(
+                native_name_map[name]
+                for name in kinetic_names
+                if name in native_name_map
+            )
             try:
                 self._collect_definitions(
                     native_parameters,
@@ -242,6 +256,7 @@ class ParameterFactory:
                 self._collect_declarations(
                     native_parameters,
                     contributor=construction_context,
+                    model_owned_ids=model_owned_ids,
                 )
             except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
                 self._native_construction_error = error
@@ -297,6 +312,7 @@ class ParameterFactory:
         self._sealed_configuration = configuration
         self._sealed_parameter_model = SealedParameterModel(
             model_name=self.parameter_store.model.name,
+            model_identity=self.parameter_store.model.identity,
             definitions=self._sealed_definitions,
             configuration=configuration,
             declarations=declarations,

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -8,6 +8,11 @@ from chemex.configuration.conditions import Conditions
 from chemex.models.factory import model_factory
 from chemex.nmr.basis import Basis
 from chemex.parameters.database import ParameterStore
+from chemex.parameters.parameterization import (
+    ParameterDeclarationContribution,
+    SealedParameterModel,
+    seal_parameter_declarations,
+)
 from chemex.parameters.sealed import (
     DefinitionContribution,
     ParamDefinition,
@@ -80,8 +85,16 @@ class ParameterFactory:
     _definition_contributions: dict[str, list[DefinitionContribution]] = field(
         default_factory=dict,
     )
+    _declaration_contributions: dict[
+        str,
+        list[ParameterDeclarationContribution],
+    ] = field(default_factory=dict)
     _sealed_definitions: SealedDefinitions | None = field(default=None, repr=False)
     _sealed_configuration: SealedConfiguration | None = field(default=None, repr=False)
+    _sealed_parameter_model: SealedParameterModel | None = field(
+        default=None,
+        repr=False,
+    )
     _native_construction_error: Exception | None = field(
         default=None,
         init=False,
@@ -97,6 +110,11 @@ class ParameterFactory:
     def sealed_configuration(self) -> SealedConfiguration | None:
         """Return immutable per-analysis configuration once it has been sealed."""
         return self._sealed_configuration
+
+    @property
+    def sealed_parameter_model(self) -> SealedParameterModel | None:
+        """Return the complete immutable native parameter model once sealed."""
+        return self._sealed_parameter_model
 
     @property
     def native_construction_error(self) -> Exception | None:
@@ -156,6 +174,23 @@ class ParameterFactory:
             )
             self._definition_contributions.setdefault(param_id, []).append(contribution)
 
+    def _collect_declarations(
+        self,
+        parameters: Parameters,
+        *,
+        contributor: str,
+    ) -> None:
+        for param_id, parameter in parameters.items():
+            contribution = ParameterDeclarationContribution(
+                param_id=param_id,
+                supports_estimation=parameter.vary,
+                model_expression=parameter.expr,
+                contributor=contributor,
+            )
+            self._declaration_contributions.setdefault(param_id, []).append(
+                contribution
+            )
+
     def create_parameters(
         self,
         config: ConfigConditionsType,
@@ -192,6 +227,9 @@ class ParameterFactory:
         )
         if contributor is not None:
             construction_context = f"{contributor}; {construction_context}"
+        _set_to_fit(parameters, name_map, config.to_be_fitted.rates)
+        _set_to_fit(parameters_mf, name_map_mf, config.to_be_fitted.model_free)
+
         if self._native_construction_error is None:
             native_parameters = (
                 parameters_mf if self.parameter_store.model.model_free else parameters
@@ -201,11 +239,12 @@ class ParameterFactory:
                     native_parameters,
                     contributor=construction_context,
                 )
+                self._collect_declarations(
+                    native_parameters,
+                    contributor=construction_context,
+                )
             except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
                 self._native_construction_error = error
-
-        _set_to_fit(parameters, name_map, config.to_be_fitted.rates)
-        _set_to_fit(parameters_mf, name_map_mf, config.to_be_fitted.model_free)
 
         self.parameter_store.add_multiple(parameters)
         self.parameter_store.add_multiple_mf(parameters_mf)
@@ -250,8 +289,18 @@ class ParameterFactory:
             self._sealed_definitions,
             self.parameter_store.database._parameters,
         )
+        declarations = seal_parameter_declarations(
+            self._sealed_definitions,
+            self._declaration_contributions,
+        )
         self.parameter_store.lock_configuration()
         self._sealed_configuration = configuration
+        self._sealed_parameter_model = SealedParameterModel(
+            model_name=self.parameter_store.model.name,
+            definitions=self._sealed_definitions,
+            configuration=configuration,
+            declarations=declarations,
+        )
 
     def try_seal_definitions(self) -> bool:
         """Seal definitions without allowing the native candidate to veto legacy."""
@@ -295,8 +344,10 @@ class ParameterFactory:
     def _clear_state(self) -> None:
         self._settings_cache.clear()
         self._definition_contributions.clear()
+        self._declaration_contributions.clear()
         self._sealed_definitions = None
         self._sealed_configuration = None
+        self._sealed_parameter_model = None
         self._native_construction_error = None
 
 

--- a/src/chemex/parameters/name.py
+++ b/src/chemex/parameters/name.py
@@ -138,3 +138,11 @@ class ParamName:
 
     def __str__(self) -> str:
         return f"[{self.section_res}]"
+
+
+def matches_parameter_index_selector(
+    selector: ParamName,
+    candidate: ParamName,
+) -> bool:
+    """Match with the exact search-key semantics used by ``ParameterIndex``."""
+    return selector.search_keys <= candidate.search_keys

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -9,13 +9,18 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import inspect
+import io
 import json
 import math
 import operator
+import re
+import tokenize
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from numbers import Real
+from pathlib import Path
 from types import MappingProxyType
 from typing import ClassVar, Literal, cast
 from uuid import uuid4
@@ -25,7 +30,7 @@ import numpy as np
 from chemex.configuration.conditions import Conditions
 from chemex.configuration.methods import Method
 from chemex.nmr.rates import rate_functions
-from chemex.parameters.name import ParamName
+from chemex.parameters.name import ParamName, matches_parameter_index_selector
 from chemex.parameters.sealed import (
     ParamDefinition,
     SealedConfiguration,
@@ -34,6 +39,9 @@ from chemex.parameters.sealed import (
 from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.parameters.values import AnalysisValuesSnapshot
+
+_PUBLIC_DECIMAL = re.compile(r"(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?\Z")
+_PUBLIC_OPERATORS = frozenset({"+", "-", "*", "/", "(", ")"})
 
 
 class ParameterRole(StrEnum):
@@ -103,6 +111,10 @@ class UnsupportedConstraintExpressionError(ParameterizationError):
     code = "unsupported_expression"
 
 
+class ModelDerivationOverrideError(ParameterizationError):
+    code = "model_derivation_override"
+
+
 @dataclass(frozen=True, slots=True)
 class ParameterDeclarationContribution:
     """One construction contribution to a parameter's scientific baseline."""
@@ -111,6 +123,7 @@ class ParameterDeclarationContribution:
     supports_estimation: bool
     model_expression: str
     contributor: str
+    model_owned: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +133,7 @@ class ParameterDeclaration:
     param_id: str
     supports_estimation: bool
     model_expression: str = ""
+    model_owned: bool = False
 
 
 def _fingerprint(kind: str, records: object) -> str:
@@ -161,6 +175,7 @@ class SealedParameterDeclarations(Mapping[str, ParameterDeclaration]):
                         item.param_id,
                         item.supports_estimation,
                         item.model_expression,
+                        item.model_owned,
                     )
                     for item in items
                 ),
@@ -204,17 +219,17 @@ def seal_parameter_declarations(
                 expressions=tuple(expressions),
             )
         supports_estimation = any(item.supports_estimation for item in contributed)
-        if supports_estimation:
-            expression = ""
-        elif expressions:
-            expression = expressions[0]
-        else:
-            expression = ""
+        expression = expressions[0] if expressions else ""
+        model_owned = any(
+            item.model_owned and item.model_expression.strip() == expression
+            for item in contributed
+        )
         items.append(
             ParameterDeclaration(
                 definition.param_id,
                 supports_estimation,
                 expression,
+                model_owned,
             )
         )
     return SealedParameterDeclarations(tuple(items))
@@ -225,6 +240,7 @@ class SealedParameterModel:
     """One immutable aggregate referencing the #582 sealed artifacts."""
 
     model_name: str
+    model_identity: str
     definitions: SealedDefinitions
     configuration: SealedConfiguration
     declarations: SealedParameterDeclarations
@@ -248,6 +264,7 @@ class SealedParameterModel:
                 "sealed-parameter-model",
                 (
                     self.model_name,
+                    self.model_identity,
                     self.definitions.identity,
                     self.configuration.identity,
                     self.declarations.identity,
@@ -304,25 +321,159 @@ class CompiledConstraint:
     expression_text: str
 
 
+_SCIENTIFIC_FUNCTION_SEMANTICS_VERSION = 1
+
+
+def _semantic_value_record(value: object) -> object:
+    """Encode deterministic callable state without process-local identities."""
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, np.generic):
+        return _semantic_value_record(value.item())
+    if isinstance(value, int):
+        return ("integer", str(value))
+    if isinstance(value, float):
+        return ("float", value.hex())
+    if isinstance(value, np.ndarray):
+        array = np.ascontiguousarray(value)
+        return (
+            "ndarray",
+            array.dtype.str,
+            tuple(array.shape),
+            hashlib.sha256(array.tobytes()).hexdigest(),
+        )
+    if isinstance(value, Mapping):
+        if not all(isinstance(key, str) for key in value):
+            raise IncompatibleParameterizationInputError(
+                "Scientific function state must use string mapping keys",
+            )
+        return tuple(
+            (key, _semantic_value_record(item)) for key, item in sorted(value.items())
+        )
+    if isinstance(value, (tuple, list)):
+        return tuple(_semantic_value_record(item) for item in value)
+    if isinstance(value, type):
+        return (
+            "type",
+            value.__module__,
+            value.__qualname__,
+            *_source_record(value),
+        )
+    raise IncompatibleParameterizationInputError(
+        "Scientific function has unsupported mutable implementation state",
+        state_type=type(value).__qualname__,
+    )
+
+
+def _source_record(
+    implementation: type[object] | Callable[..., object],
+) -> tuple[str, str]:
+    try:
+        source = inspect.getsource(implementation).encode()
+        source_file = inspect.getsourcefile(implementation)
+    except (OSError, TypeError) as error:
+        raise IncompatibleParameterizationInputError(
+            "Scientific function implementation source is unavailable",
+            implementation=type(implementation).__qualname__,
+        ) from error
+    module_digest = ""
+    if source_file is not None:
+        try:
+            module_digest = hashlib.sha256(Path(source_file).read_bytes()).hexdigest()
+        except OSError as error:
+            raise IncompatibleParameterizationInputError(
+                "Scientific function module source is unavailable",
+                source_file=source_file,
+            ) from error
+    return hashlib.sha256(source).hexdigest(), module_digest
+
+
+def _class_runtime_record(implementation_type: type[object]) -> object:
+    """Record runtime class data and Python methods used by callable instances."""
+    owners: list[object] = []
+    for owner in reversed(implementation_type.__mro__):
+        data: list[tuple[str, object]] = []
+        methods: list[tuple[str, object]] = []
+        for name, value in sorted(vars(owner).items()):
+            method = (
+                value.__func__
+                if isinstance(value, (classmethod, staticmethod))
+                else value
+            )
+            if inspect.isfunction(method):
+                methods.append((name, _scientific_function_record(method)))
+            elif not name.startswith("__") and not callable(value):
+                data.append((name, _semantic_value_record(value)))
+        if data or methods:
+            owners.append(
+                (owner.__module__, owner.__qualname__, tuple(data), tuple(methods))
+            )
+    return tuple(owners)
+
+
+def _scientific_function_record(function: Callable[..., object]) -> object:
+    if function is max:
+        return (
+            _SCIENTIFIC_FUNCTION_SEMANTICS_VERSION,
+            "chemex-scalar-maximum",
+        )
+    unwrapped = inspect.unwrap(function)
+    if inspect.isfunction(unwrapped):
+        closure = tuple(
+            _semantic_value_record(cell.cell_contents)
+            for cell in (unwrapped.__closure__ or ())
+        )
+        return (
+            _SCIENTIFIC_FUNCTION_SEMANTICS_VERSION,
+            "function",
+            unwrapped.__module__,
+            unwrapped.__qualname__,
+            *_source_record(unwrapped),
+            _semantic_value_record(unwrapped.__defaults__),
+            _semantic_value_record(unwrapped.__kwdefaults__),
+            closure,
+        )
+    if callable(function):
+        implementation_type = type(function)
+        return (
+            _SCIENTIFIC_FUNCTION_SEMANTICS_VERSION,
+            "callable-instance",
+            implementation_type.__module__,
+            implementation_type.__qualname__,
+            *_source_record(implementation_type),
+            _class_runtime_record(implementation_type),
+            _semantic_value_record(vars(function)),
+        )
+    raise IncompatibleParameterizationInputError(
+        "Scientific function registry entry is not callable",
+        function_type=type(function).__qualname__,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ScientificFunctionBinder:
     """Immutable trusted binding of the existing model-owned scalar functions."""
 
     model_name: str
     _functions: Mapping[str, Callable[..., object]]
+    _implementation_records: Mapping[str, object] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         functions = MappingProxyType(dict(sorted(self._functions.items())))
         object.__setattr__(self, "_functions", functions)
-        records = tuple(
-            (
-                name,
-                getattr(function, "__module__", type(function).__module__),
-                getattr(function, "__qualname__", type(function).__qualname__),
-            )
-            for name, function in functions.items()
+        implementation_records = MappingProxyType(
+            {
+                name: _scientific_function_record(function)
+                for name, function in functions.items()
+            }
         )
+        object.__setattr__(self, "_implementation_records", implementation_records)
+        records = tuple(implementation_records.items())
         object.__setattr__(self, "identity", _fingerprint("function-binder", records))
 
     def __contains__(self, function_id: object) -> bool:
@@ -330,6 +481,23 @@ class ScientificFunctionBinder:
 
     def __getitem__(self, function_id: str) -> Callable[..., object]:
         return self._functions[function_id]
+
+    def validate_implementations(self) -> None:
+        """Reject mutation of a callable after its implementation was bound."""
+        for function_id, function in self._functions.items():
+            expected = self._implementation_records[function_id]
+            try:
+                actual = _scientific_function_record(function)
+            except ParameterizationError as error:
+                raise ConstraintProgramMismatchError(
+                    "A bound scientific function no longer has its compiled semantics",
+                    function_id=function_id,
+                ) from error
+            if actual != expected:
+                raise ConstraintProgramMismatchError(
+                    "A bound scientific function changed after program compilation",
+                    function_id=function_id,
+                )
 
     @classmethod
     def for_model(cls, model_name: str) -> ScientificFunctionBinder:
@@ -546,6 +714,7 @@ class ActiveParameterization:
 
     def resolve(self, frame: IndependentValueFrame) -> ResolvedParameterValues:
         _validate_frame(self, frame)
+        self.binder.validate_implementations()
         values = {
             param_id: _finite_scalar(value, param_id=param_id)
             for param_id, value in frame._items
@@ -597,7 +766,7 @@ def _match_selector(
     matches = tuple(
         definition.param_id
         for definition in definitions
-        if selector.match(_definition_name(definition))
+        if matches_parameter_index_selector(selector, _definition_name(definition))
     )
     if not matches:
         raise NoParameterMatchError(
@@ -659,8 +828,44 @@ def _split_constraint(text: str) -> tuple[str, str]:
     return selectors[0][2], right.strip()
 
 
+def _validate_public_numeric_tokens(
+    source: str,
+    references: Mapping[str, str],
+    expression: str,
+) -> None:
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+        for token in tokens:
+            if token.type in {
+                tokenize.NEWLINE,
+                tokenize.NL,
+                tokenize.ENDMARKER,
+                tokenize.ENCODING,
+            }:
+                continue
+            if token.type == tokenize.NUMBER and _PUBLIC_DECIMAL.fullmatch(
+                token.string
+            ):
+                continue
+            if token.type == tokenize.NAME and token.string in references:
+                continue
+            if token.type == tokenize.OP and token.string in _PUBLIC_OPERATORS:
+                continue
+            raise UnsupportedConstraintExpressionError(
+                "Method expression contains syntax outside ChemEx numeric grammar",
+                expression=expression,
+                token=token.string,
+            )
+    except (IndentationError, tokenize.TokenError) as error:
+        raise UnsupportedConstraintExpressionError(
+            "Constraint is not a valid scalar expression",
+            expression=expression,
+        ) from error
+
+
 def _validate_public_expression_syntax(text: str) -> None:
     source, references = _replace_selectors(text)
+    _validate_public_numeric_tokens(source, references, text)
     try:
         parsed = ast.parse(source, mode="eval")
     except (SyntaxError, ValueError) as error:
@@ -753,7 +958,7 @@ def _role_for(
         else ParameterRole.FIX
     )
     expression = declaration.model_expression
-    source = "model"
+    source = "model" if declaration.model_owned else "baseline"
     for rule in rules:
         if param_id not in rule.matches:
             continue
@@ -761,6 +966,27 @@ def _role_for(
         expression = rule.expression_text
         source = f"method-rule:{rule.ordinal}"
     return role, expression, source
+
+
+def _validate_model_derivation_authority(
+    rules: Sequence[_RoleRule],
+    declarations: SealedParameterDeclarations,
+) -> None:
+    for rule in rules:
+        derived_matches = tuple(
+            param_id
+            for param_id in rule.matches
+            if declarations[param_id].model_expression
+            and declarations[param_id].model_owned
+        )
+        if derived_matches:
+            raise ModelDerivationOverrideError(
+                "Method rule cannot override a model-owned derivation",
+                selector=rule.selector,
+                role=rule.role.value,
+                ordinal=rule.ordinal,
+                param_ids=derived_matches,
+            )
 
 
 def _replace_selectors(right: str) -> tuple[str, Mapping[str, str]]:
@@ -822,7 +1048,7 @@ def _resolve_reference(
     candidates = tuple(
         definition
         for definition in definitions
-        if selector.match(_definition_name(definition))
+        if matches_parameter_index_selector(selector, _definition_name(definition))
     )
     if not candidates:
         raise NoParameterMatchError(
@@ -885,7 +1111,13 @@ def _compile_literal(node: ast.Constant, target_id: str) -> LiteralExpression:
             "Only finite numeric scalar literals are supported",
             target_id=target_id,
         )
-    value = float(node.value)
+    try:
+        value = float(node.value)
+    except OverflowError as error:
+        raise NonFiniteParameterValueError(
+            "Constraint literal exceeds the supported finite scalar range",
+            target_id=target_id,
+        ) from error
     if not math.isfinite(value):
         raise NonFiniteParameterValueError(
             "Constraint literal is non-finite",
@@ -973,6 +1205,12 @@ def _compile_function(
             target_id=context.target_id,
             function_id=function_id,
         )
+    if node.func.id != "max" or len(node.args) != 2:
+        raise UnsupportedConstraintExpressionError(
+            "Only the two-argument scalar maximum may be used without a component",
+            target_id=context.target_id,
+            function_id=node.func.id,
+        )
     return FunctionExpression(
         node.func.id,
         tuple(_compile_ast(argument, context) for argument in node.args),
@@ -988,7 +1226,19 @@ def _compile_function_component(
             "Only model-owned scientific-function components may be selected",
             target_id=context.target_id,
         )
-    compiled_call = _compile_function(node.value, context)
+    call = node.value
+    if (
+        not isinstance(call.func, ast.Name)
+        or call.keywords
+        or call.func.id == "max"
+        or call.func.id not in context.binder
+    ):
+        function_id = call.func.id if isinstance(call.func, ast.Name) else ""
+        raise UnsupportedConstraintExpressionError(
+            "Model expression requests an unsupported component function",
+            target_id=context.target_id,
+            function_id=function_id,
+        )
     component_node = node.slice
     if not isinstance(component_node, ast.Constant) or not isinstance(
         component_node.value,
@@ -999,8 +1249,8 @@ def _compile_function_component(
             target_id=context.target_id,
         )
     return FunctionExpression(
-        compiled_call.function_id,
-        compiled_call.arguments,
+        call.func.id,
+        tuple(_compile_ast(argument, context) for argument in call.args),
         component_node.value,
     )
 
@@ -1197,10 +1447,15 @@ def _validate_parameterization_inputs(
     required_ids: Sequence[str] | set[str],
 ) -> set[str]:
     expected = (
+        parameter_model.model_identity,
         parameter_model.definitions.identity,
         parameter_model.configuration.identity,
     )
-    actual = (snapshot.definitions_identity, snapshot.configuration_identity)
+    actual = (
+        snapshot.model_identity,
+        snapshot.definitions_identity,
+        snapshot.configuration_identity,
+    )
     if actual != expected:
         raise IncompatibleParameterizationInputError(
             "Analysis Values snapshot does not belong to the sealed parameter model",
@@ -1250,7 +1505,7 @@ def _compile_active_scope(
                 definitions=definitions,
                 binder=binder,
                 target_id=param_id,
-                model_owned=source == "model",
+                model_owned=source in {"model", "baseline"},
             )
             dependencies = _dependencies(expression)
             compiled[param_id] = CompiledConstraint(
@@ -1304,6 +1559,7 @@ def compile_active_parameterization(
 
     definitions = parameter_model.definitions
     rules = _build_rules(method, definitions)
+    _validate_model_derivation_authority(rules, parameter_model.declarations)
     binder = ScientificFunctionBinder.for_model(parameter_model.model_name)
     definition_order = {
         definition.param_id: position for position, definition in enumerate(definitions)
@@ -1338,7 +1594,7 @@ def compile_active_parameterization(
     constraints = tuple(compiled[param_id] for param_id in derived_ids)
     program = ConstraintProgram(
         parameter_model_identity=parameter_model.identity,
-        model_identity=snapshot.model_identity,
+        model_identity=parameter_model.model_identity,
         definitions_identity=snapshot.definitions_identity,
         configuration_identity=snapshot.configuration_identity,
         function_binder_identity=binder.identity,
@@ -1359,7 +1615,6 @@ def compile_active_parameterization(
 
 def build_initial_analysis_values(
     parameter_model: SealedParameterModel,
-    model_identity: str,
 ) -> Mapping[str, float]:
     """Natively fill missing model-derived revision-zero configuration values."""
     configuration = parameter_model.configuration
@@ -1374,7 +1629,7 @@ def build_initial_analysis_values(
             )
     bootstrap_snapshot = AnalysisValuesSnapshot(
         occurrence_identity=f"bootstrap:{uuid4().hex}",
-        model_identity=model_identity,
+        model_identity=parameter_model.model_identity,
         definitions_identity=parameter_model.definitions.identity,
         configuration_identity=configuration.identity,
         revision=0,
@@ -1443,7 +1698,13 @@ def _finite_scalar(value: object, *, param_id: str) -> float:
             param_id=param_id,
             value=value,
         )
-    scalar = float(value)
+    try:
+        scalar = float(value)
+    except OverflowError as error:
+        raise NonFiniteParameterValueError(
+            "Constraint value exceeds the supported finite scalar range",
+            param_id=param_id,
+        ) from error
     if not math.isfinite(scalar):
         raise NonFiniteParameterValueError(
             "Constraint value is non-finite",
@@ -1513,7 +1774,7 @@ def _evaluate_binary(
 def _evaluate_function(
     expression: FunctionExpression,
     context: _EvaluationContext,
-) -> object:
+) -> float:
     arguments = tuple(
         _evaluate_node(argument, context) for argument in expression.arguments
     )
@@ -1538,7 +1799,7 @@ def _evaluate_function(
             position=context.position,
         ) from error
     if expression.component is None:
-        return result
+        return _finite_scalar(result, param_id=context.target_id)
     if not isinstance(result, Mapping) or expression.component not in result:
         raise ConstraintDomainError(
             "Scientific constraint function did not return its declared component",
@@ -1548,7 +1809,10 @@ def _evaluate_function(
             arguments=arguments,
             position=context.position,
         )
-    return cast("Mapping[str, object]", result)[expression.component]
+    return _finite_scalar(
+        cast("Mapping[str, object]", result)[expression.component],
+        param_id=context.target_id,
+    )
 
 
 def _evaluate_node(

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -1,0 +1,1592 @@
+"""Immutable native parameter roles, constraints, and resolved scalar values.
+
+This module is a non-authoritative migration seam.  It compiles the currently
+supported method declarations beside the legacy lmfit path and never mutates
+parameter definitions, configuration, or committed Analysis Values.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import math
+import operator
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from numbers import Real
+from types import MappingProxyType
+from typing import ClassVar, Literal, cast
+from uuid import uuid4
+
+import numpy as np
+
+from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Method
+from chemex.nmr.rates import rate_functions
+from chemex.parameters.name import ParamName
+from chemex.parameters.sealed import (
+    ParamDefinition,
+    SealedConfiguration,
+    SealedDefinitions,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.values import AnalysisValuesSnapshot
+
+
+class ParameterRole(StrEnum):
+    """One method-scoped role for an active parameter."""
+
+    FIT = "fit"
+    FIX = "fix"
+    DERIVED = "derived"
+
+
+class ParameterizationError(ValueError):
+    """Base class for stable native compilation and resolution failures."""
+
+    code: ClassVar[str] = "parameterization_error"
+
+    def __init__(self, detail: str, **context: object) -> None:
+        self.detail = detail
+        self.context = MappingProxyType(dict(sorted(context.items())))
+        rendered = ", ".join(
+            f"{name}={value!r}" for name, value in self.context.items()
+        )
+        suffix = f" ({rendered})" if rendered else ""
+        super().__init__(f"{self.code}: {detail}{suffix}")
+
+
+class NoParameterMatchError(ParameterizationError):
+    code = "no_match"
+
+
+class AmbiguousParameterReferenceError(ParameterizationError):
+    code = "ambiguity"
+
+
+class ConstraintSelfReferenceError(ParameterizationError):
+    code = "self_reference"
+
+
+class ConstraintCycleError(ParameterizationError):
+    code = "cycle"
+
+
+class ConstraintDomainError(ParameterizationError):
+    code = "domain_error"
+
+
+class ConstraintEvaluationError(ParameterizationError):
+    code = "evaluation_error"
+
+
+class NonFiniteParameterValueError(ParameterizationError):
+    code = "non_finite"
+
+
+class IncompleteParameterDependenciesError(ParameterizationError):
+    code = "incomplete_dependencies"
+
+
+class IncompatibleParameterizationInputError(ParameterizationError):
+    code = "incompatible_input"
+
+
+class ConstraintProgramMismatchError(ParameterizationError):
+    code = "program_mismatch"
+
+
+class UnsupportedConstraintExpressionError(ParameterizationError):
+    code = "unsupported_expression"
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterDeclarationContribution:
+    """One construction contribution to a parameter's scientific baseline."""
+
+    param_id: str
+    supports_estimation: bool
+    model_expression: str
+    contributor: str
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterDeclaration:
+    """Sealed scientific inputs used to build each method-local baseline."""
+
+    param_id: str
+    supports_estimation: bool
+    model_expression: str = ""
+
+
+def _fingerprint(kind: str, records: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "schema": 1, "records": records},
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class SealedParameterDeclarations(Mapping[str, ParameterDeclaration]):
+    """Canonical immutable baseline roles and model-owned derivations."""
+
+    _items: tuple[ParameterDeclaration, ...]
+    _index: Mapping[str, ParameterDeclaration] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        items = tuple(self._items)
+        index = MappingProxyType({item.param_id: item for item in items})
+        if len(index) != len(items):
+            msg = "Sealed parameter declarations contain duplicate IDs"
+            raise ValueError(msg)
+        object.__setattr__(self, "_items", items)
+        object.__setattr__(self, "_index", index)
+        object.__setattr__(
+            self,
+            "identity",
+            _fingerprint(
+                "parameter-declarations",
+                tuple(
+                    (
+                        item.param_id,
+                        item.supports_estimation,
+                        item.model_expression,
+                    )
+                    for item in items
+                ),
+            ),
+        )
+
+    def __iter__(self) -> Iterator[str]:
+        return (item.param_id for item in self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __getitem__(self, key: str) -> ParameterDeclaration:
+        return self._index[key]
+
+
+def seal_parameter_declarations(
+    definitions: SealedDefinitions,
+    contributions: Mapping[str, Sequence[ParameterDeclarationContribution]],
+) -> SealedParameterDeclarations:
+    """Seal additive estimation support and model derivations in definition order."""
+    items: list[ParameterDeclaration] = []
+    for definition in definitions:
+        contributed = tuple(contributions.get(definition.param_id, ()))
+        if not contributed:
+            raise IncompleteParameterDependenciesError(
+                "No scientific baseline was contributed for a sealed parameter",
+                param_id=definition.param_id,
+            )
+        expressions = sorted(
+            {
+                item.model_expression.strip()
+                for item in contributed
+                if item.model_expression
+            }
+        )
+        if len(expressions) > 1:
+            raise IncompatibleParameterizationInputError(
+                "Contributors disagree on a model-owned expression",
+                param_id=definition.param_id,
+                expressions=tuple(expressions),
+            )
+        supports_estimation = any(item.supports_estimation for item in contributed)
+        if supports_estimation:
+            expression = ""
+        elif expressions:
+            expression = expressions[0]
+        else:
+            expression = ""
+        items.append(
+            ParameterDeclaration(
+                definition.param_id,
+                supports_estimation,
+                expression,
+            )
+        )
+    return SealedParameterDeclarations(tuple(items))
+
+
+@dataclass(frozen=True, slots=True)
+class SealedParameterModel:
+    """One immutable aggregate referencing the #582 sealed artifacts."""
+
+    model_name: str
+    definitions: SealedDefinitions
+    configuration: SealedConfiguration
+    declarations: SealedParameterDeclarations
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        definition_ids = tuple(item.param_id for item in self.definitions)
+        if self.configuration.definitions_identity != self.definitions.identity:
+            msg = "Sealed configuration does not belong to the definitions"
+            raise ValueError(msg)
+        if tuple(item.param_id for item in self.configuration) != definition_ids:
+            msg = "Sealed configuration ordering does not match definitions"
+            raise ValueError(msg)
+        if tuple(self.declarations) != definition_ids:
+            msg = "Sealed declarations ordering does not match definitions"
+            raise ValueError(msg)
+        object.__setattr__(
+            self,
+            "identity",
+            _fingerprint(
+                "sealed-parameter-model",
+                (
+                    self.model_name,
+                    self.definitions.identity,
+                    self.configuration.identity,
+                    self.declarations.identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LiteralExpression:
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceExpression:
+    param_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class UnaryExpression:
+    operator: Literal["positive", "negative"]
+    operand: ScalarExpression
+
+
+@dataclass(frozen=True, slots=True)
+class BinaryExpression:
+    operator: Literal["add", "subtract", "multiply", "divide"]
+    left: ScalarExpression
+    right: ScalarExpression
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionExpression:
+    function_id: str
+    arguments: tuple[ScalarExpression, ...]
+    component: str | None = None
+
+
+type ScalarExpression = (
+    LiteralExpression
+    | ReferenceExpression
+    | UnaryExpression
+    | BinaryExpression
+    | FunctionExpression
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledConstraint:
+    target_id: str
+    expression: ScalarExpression
+    dependencies: tuple[str, ...]
+    source: str
+    expression_text: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScientificFunctionBinder:
+    """Immutable trusted binding of the existing model-owned scalar functions."""
+
+    model_name: str
+    _functions: Mapping[str, Callable[..., object]]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        functions = MappingProxyType(dict(sorted(self._functions.items())))
+        object.__setattr__(self, "_functions", functions)
+        records = tuple(
+            (
+                name,
+                getattr(function, "__module__", type(function).__module__),
+                getattr(function, "__qualname__", type(function).__qualname__),
+            )
+            for name, function in functions.items()
+        )
+        object.__setattr__(self, "identity", _fingerprint("function-binder", records))
+
+    def __contains__(self, function_id: object) -> bool:
+        return function_id in self._functions
+
+    def __getitem__(self, function_id: str) -> Callable[..., object]:
+        return self._functions[function_id]
+
+    @classmethod
+    def for_model(cls, model_name: str) -> ScientificFunctionBinder:
+        functions: dict[str, Callable[..., object]] = {
+            name: cast("Callable[..., object]", function)
+            for name, function in (
+                rate_functions | user_function_registry.get(model_name)
+            ).items()
+        }
+        functions["max"] = max
+        return cls(model_name, functions)
+
+
+@dataclass(frozen=True, slots=True)
+class IndependentValueFrame:
+    """One complete ordered independent-value input for a compiled program."""
+
+    parameterization_identity: str
+    program_fingerprint: str
+    occurrence_identity: str
+    revision: int
+    _items: tuple[tuple[str, float], ...]
+
+    def __post_init__(self) -> None:
+        items = tuple(self._items)
+        if len({param_id for param_id, _value in items}) != len(items):
+            msg = "Independent-value frame contains duplicate parameter IDs"
+            raise ValueError(msg)
+        object.__setattr__(self, "_items", items)
+
+    def with_updates(self, updates: Mapping[str, float]) -> IndependentValueFrame:
+        unknown = set(updates) - {param_id for param_id, _value in self._items}
+        if unknown:
+            raise IncompatibleParameterizationInputError(
+                "Independent-value updates contain unknown IDs",
+                unknown_ids=tuple(sorted(unknown)),
+            )
+        return type(self)(
+            parameterization_identity=self.parameterization_identity,
+            program_fingerprint=self.program_fingerprint,
+            occurrence_identity=self.occurrence_identity,
+            revision=self.revision,
+            _items=tuple(
+                (param_id, updates.get(param_id, value))
+                for param_id, value in self._items
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedParameterValues(Mapping[str, float]):
+    """Immutable complete independent and derived scalar values for active scope."""
+
+    parameterization_identity: str
+    program_fingerprint: str
+    occurrence_identity: str
+    revision: int
+    _items: tuple[tuple[str, float], ...]
+    _index: Mapping[str, float] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        items = tuple(self._items)
+        index = MappingProxyType(dict(items))
+        if len(index) != len(items):
+            msg = "Resolved parameter values contain duplicate IDs"
+            raise ValueError(msg)
+        object.__setattr__(self, "_items", items)
+        object.__setattr__(self, "_index", index)
+
+    def __iter__(self) -> Iterator[str]:
+        return (param_id for param_id, _value in self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __getitem__(self, key: str) -> float:
+        return self._index[key]
+
+
+@dataclass(frozen=True, slots=True)
+class ConstraintProgram:
+    """Immutable restricted value program over one deterministic active scope."""
+
+    parameter_model_identity: str
+    model_identity: str
+    definitions_identity: str
+    configuration_identity: str
+    function_binder_identity: str
+    scope_ids: tuple[str, ...]
+    independent_ids: tuple[str, ...]
+    derived_ids: tuple[str, ...]
+    constraints: tuple[CompiledConstraint, ...]
+    evaluation_order: tuple[str, ...]
+    fingerprint: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        records = (
+            self.parameter_model_identity,
+            self.model_identity,
+            self.definitions_identity,
+            self.configuration_identity,
+            self.function_binder_identity,
+            self.scope_ids,
+            self.independent_ids,
+            self.derived_ids,
+            tuple(
+                (
+                    item.target_id,
+                    _expression_record(item.expression),
+                    item.dependencies,
+                )
+                for item in self.constraints
+            ),
+            self.evaluation_order,
+        )
+        object.__setattr__(
+            self, "fingerprint", _fingerprint("constraint-program", records)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveParameterization:
+    """Fresh method-scoped roles plus a restricted immutable value program."""
+
+    program: ConstraintProgram
+    binder: ScientificFunctionBinder = field(repr=False, compare=False)
+    occurrence_identity: str
+    source_revision: int
+    _roles: tuple[tuple[str, ParameterRole], ...]
+    identity: str = field(init=False)
+    _role_index: Mapping[str, ParameterRole] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        roles = tuple(self._roles)
+        role_index = MappingProxyType(dict(roles))
+        if tuple(role_index) != self.program.scope_ids:
+            msg = "Parameter roles do not match the constraint-program scope"
+            raise ValueError(msg)
+        object.__setattr__(self, "_roles", roles)
+        object.__setattr__(self, "_role_index", role_index)
+        object.__setattr__(
+            self,
+            "identity",
+            _fingerprint(
+                "active-parameterization",
+                (
+                    self.program.fingerprint,
+                    self.occurrence_identity,
+                    self.source_revision,
+                    tuple((param_id, role.value) for param_id, role in roles),
+                ),
+            ),
+        )
+
+    @property
+    def independent_ids(self) -> tuple[str, ...]:
+        return self.program.independent_ids
+
+    @property
+    def derived_ids(self) -> tuple[str, ...]:
+        return self.program.derived_ids
+
+    @property
+    def scope_ids(self) -> tuple[str, ...]:
+        return self.program.scope_ids
+
+    def role(self, param_id: str) -> ParameterRole:
+        return self._role_index[param_id]
+
+    def frame_from_snapshot(
+        self,
+        snapshot: AnalysisValuesSnapshot,
+    ) -> IndependentValueFrame:
+        expected = (
+            self.occurrence_identity,
+            self.source_revision,
+            self.program.model_identity,
+            self.program.definitions_identity,
+            self.program.configuration_identity,
+        )
+        actual = (
+            snapshot.occurrence_identity,
+            snapshot.revision,
+            snapshot.model_identity,
+            snapshot.definitions_identity,
+            snapshot.configuration_identity,
+        )
+        if actual != expected:
+            raise IncompatibleParameterizationInputError(
+                "Analysis Values snapshot is incompatible with the parameterization",
+                expected=expected,
+                actual=actual,
+            )
+        try:
+            items = tuple(
+                (param_id, snapshot[param_id]) for param_id in self.independent_ids
+            )
+        except KeyError as error:
+            raise IncompleteParameterDependenciesError(
+                "Analysis Values snapshot lacks an independent parameter",
+                param_id=str(error.args[0]),
+            ) from error
+        return IndependentValueFrame(
+            parameterization_identity=self.identity,
+            program_fingerprint=self.program.fingerprint,
+            occurrence_identity=self.occurrence_identity,
+            revision=self.source_revision,
+            _items=items,
+        )
+
+    def resolve(self, frame: IndependentValueFrame) -> ResolvedParameterValues:
+        _validate_frame(self, frame)
+        values = {
+            param_id: _finite_scalar(value, param_id=param_id)
+            for param_id, value in frame._items
+        }
+        constraints = {item.target_id: item for item in self.program.constraints}
+        for position, target_id in enumerate(self.program.evaluation_order):
+            constraint = constraints[target_id]
+            values[target_id] = _evaluate_expression(
+                constraint.expression,
+                values,
+                self.binder,
+                target_id=target_id,
+                position=position,
+            )
+        return ResolvedParameterValues(
+            parameterization_identity=self.identity,
+            program_fingerprint=self.program.fingerprint,
+            occurrence_identity=self.occurrence_identity,
+            revision=self.source_revision,
+            _items=tuple((param_id, values[param_id]) for param_id in self.scope_ids),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _RoleRule:
+    role: ParameterRole
+    selector: str
+    expression_text: str
+    matches: tuple[str, ...]
+    ordinal: int
+
+
+def _definition_name(definition: ParamDefinition) -> ParamName:
+    return ParamName(
+        definition.name,
+        SpinSystem.from_name(definition.spin_system_name),
+        Conditions.model_construct(None, **dict(definition.condition_entries)),
+    )
+
+
+def _match_selector(
+    selector_text: str,
+    definitions: SealedDefinitions,
+    *,
+    role: ParameterRole,
+    ordinal: int,
+) -> tuple[str, ...]:
+    selector = ParamName.from_section(selector_text)
+    matches = tuple(
+        definition.param_id
+        for definition in definitions
+        if selector.match(_definition_name(definition))
+    )
+    if not matches:
+        raise NoParameterMatchError(
+            "No sealed parameter matches a method selector",
+            selector=selector_text,
+            role=role.value,
+            ordinal=ordinal,
+        )
+    return matches
+
+
+def _scan_selectors(text: str) -> tuple[tuple[int, int, str], ...]:
+    selectors: list[tuple[int, int, str]] = []
+    position = 0
+    while position < len(text):
+        if text[position] != "[":
+            position += 1
+            continue
+        start = position
+        depth = 1
+        position += 1
+        while position < len(text) and depth:
+            if text[position] == "[":
+                depth += 1
+            elif text[position] == "]":
+                depth -= 1
+            position += 1
+        if depth:
+            raise UnsupportedConstraintExpressionError(
+                "Unclosed parameter selector",
+                expression=text,
+            )
+        selectors.append((start, position, text[start + 1 : position - 1]))
+    return tuple(selectors)
+
+
+def _split_constraint(text: str) -> tuple[str, str]:
+    if text.count("=") != 1:
+        raise UnsupportedConstraintExpressionError(
+            "A method constraint must contain exactly one '='",
+            expression=text,
+        )
+    left, right = text.split("=", maxsplit=1)
+    selectors = _scan_selectors(left)
+    if (
+        len(selectors) != 1
+        or left[: selectors[0][0]].strip()
+        or left[selectors[0][1] :].strip()
+    ):
+        raise UnsupportedConstraintExpressionError(
+            "Constraint left side must be one bracketed selector",
+            expression=text,
+        )
+    if not right.strip():
+        raise UnsupportedConstraintExpressionError(
+            "Constraint right side cannot be empty",
+            expression=text,
+        )
+    return selectors[0][2], right.strip()
+
+
+def _validate_public_expression_syntax(text: str) -> None:
+    source, references = _replace_selectors(text)
+    try:
+        parsed = ast.parse(source, mode="eval")
+    except (SyntaxError, ValueError) as error:
+        raise UnsupportedConstraintExpressionError(
+            "Constraint is not a valid scalar expression",
+            expression=text,
+        ) from error
+
+    def validate(node: ast.AST) -> None:
+        if isinstance(node, ast.Constant):
+            _compile_literal(node, "method-syntax")
+            return
+        if isinstance(node, ast.Name) and node.id in references:
+            return
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+            validate(node.operand)
+            return
+        if isinstance(node, ast.BinOp) and isinstance(
+            node.op,
+            (ast.Add, ast.Sub, ast.Mult, ast.Div),
+        ):
+            validate(node.left)
+            validate(node.right)
+            return
+        raise UnsupportedConstraintExpressionError(
+            "Method expression contains unsupported scalar syntax",
+            expression=text,
+            syntax=type(node).__name__,
+        )
+
+    validate(parsed.body)
+
+
+def _build_rules(
+    method: Method, definitions: SealedDefinitions
+) -> tuple[_RoleRule, ...]:
+    rules: list[_RoleRule] = []
+    ordinal = 0
+    for text in method.constraints:
+        selector, expression = _split_constraint(text)
+        _validate_public_expression_syntax(expression)
+        rules.append(
+            _RoleRule(
+                ParameterRole.DERIVED,
+                selector,
+                expression,
+                _match_selector(
+                    selector,
+                    definitions,
+                    role=ParameterRole.DERIVED,
+                    ordinal=ordinal,
+                ),
+                ordinal,
+            )
+        )
+        ordinal += 1
+    for role, selectors in (
+        (ParameterRole.FIX, method.fix),
+        (ParameterRole.FIT, method.fit),
+    ):
+        for selector in selectors:
+            rules.append(
+                _RoleRule(
+                    role,
+                    selector,
+                    "",
+                    _match_selector(
+                        selector,
+                        definitions,
+                        role=role,
+                        ordinal=ordinal,
+                    ),
+                    ordinal,
+                )
+            )
+            ordinal += 1
+    return tuple(rules)
+
+
+def _role_for(
+    param_id: str,
+    declaration: ParameterDeclaration,
+    rules: Sequence[_RoleRule],
+) -> tuple[ParameterRole, str, str]:
+    role = (
+        ParameterRole.DERIVED
+        if declaration.model_expression
+        else ParameterRole.FIT
+        if declaration.supports_estimation
+        else ParameterRole.FIX
+    )
+    expression = declaration.model_expression
+    source = "model"
+    for rule in rules:
+        if param_id not in rule.matches:
+            continue
+        role = rule.role
+        expression = rule.expression_text
+        source = f"method-rule:{rule.ordinal}"
+    return role, expression, source
+
+
+def _replace_selectors(right: str) -> tuple[str, Mapping[str, str]]:
+    selectors = _scan_selectors(right)
+    replacements: dict[str, str] = {}
+    parts: list[str] = []
+    position = 0
+    for index, (start, end, selector) in enumerate(selectors):
+        placeholder = f"__selector_{index}"
+        parts.extend((right[position:start], placeholder))
+        replacements[placeholder] = selector
+        position = end
+    parts.append(right[position:])
+    return "".join(parts), MappingProxyType(replacements)
+
+
+def _compatible_context(
+    candidate: ParamDefinition,
+    target: ParamDefinition,
+    selector: ParamName,
+) -> tuple[frozenset[str], int] | None:
+    matched: set[str] = set()
+    extras = 0
+    candidate_spin = SpinSystem.from_name(candidate.spin_system_name)
+    target_spin = SpinSystem.from_name(target.spin_system_name)
+    if candidate_spin and not selector.spin_system:
+        if target_spin and (
+            candidate_spin == target_spin
+            or candidate_spin.match(target_spin)
+            or target_spin.match(candidate_spin)
+        ):
+            matched.add("spin_system")
+        elif target_spin:
+            return None
+        else:
+            extras += 1
+
+    selector_conditions = selector.conditions.model_dump()
+    target_conditions = dict(target.condition_entries)
+    for name, value in candidate.condition_entries:
+        if selector_conditions.get(name) is not None:
+            continue
+        target_value = target_conditions.get(name)
+        if target_value is None:
+            extras += 1
+        elif target_value == value:
+            matched.add(name)
+        else:
+            return None
+    return frozenset(matched), extras
+
+
+def _resolve_reference(
+    selector_text: str,
+    target_id: str,
+    definitions: SealedDefinitions,
+) -> str:
+    selector = ParamName.from_section(selector_text)
+    candidates = tuple(
+        definition
+        for definition in definitions
+        if selector.match(_definition_name(definition))
+    )
+    if not candidates:
+        raise NoParameterMatchError(
+            "No sealed parameter matches a constraint reference",
+            selector=selector_text,
+            target_id=target_id,
+        )
+    non_self = tuple(item for item in candidates if item.param_id != target_id)
+    if not non_self:
+        raise ConstraintSelfReferenceError(
+            "Constraint reference resolves only to its target",
+            selector=selector_text,
+            target_id=target_id,
+        )
+    target = definitions[target_id]
+    ranked = tuple(
+        (candidate, context)
+        for candidate in non_self
+        if (context := _compatible_context(candidate, target, selector)) is not None
+    )
+    if not ranked:
+        raise NoParameterMatchError(
+            "No context-compatible parameter matches a constraint reference",
+            selector=selector_text,
+            target_id=target_id,
+        )
+    minimum_extras = min(context[1] for _candidate, context in ranked)
+    eligible = tuple(
+        (candidate, context[0])
+        for candidate, context in ranked
+        if context[1] == minimum_extras
+    )
+    maximal = tuple(
+        candidate
+        for candidate, fields in eligible
+        if not any(fields < other_fields for _other, other_fields in eligible)
+    )
+    if len(maximal) != 1:
+        raise AmbiguousParameterReferenceError(
+            "Constraint reference has multiple equally specific matches",
+            selector=selector_text,
+            target_id=target_id,
+            candidate_ids=tuple(item.param_id for item in maximal),
+        )
+    return maximal[0].param_id
+
+
+@dataclass(frozen=True, slots=True)
+class _ExpressionCompileContext:
+    references: Mapping[str, str]
+    definitions: SealedDefinitions
+    binder: ScientificFunctionBinder
+    target_id: str
+    model_owned: bool
+
+
+def _compile_literal(node: ast.Constant, target_id: str) -> LiteralExpression:
+    if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+        raise UnsupportedConstraintExpressionError(
+            "Only finite numeric scalar literals are supported",
+            target_id=target_id,
+        )
+    value = float(node.value)
+    if not math.isfinite(value):
+        raise NonFiniteParameterValueError(
+            "Constraint literal is non-finite",
+            target_id=target_id,
+            value=value,
+        )
+    return LiteralExpression(0.0 if value == 0.0 else value)
+
+
+def _compile_reference(
+    node: ast.Name,
+    context: _ExpressionCompileContext,
+) -> ReferenceExpression:
+    if node.id in context.references:
+        param_id = _resolve_reference(
+            context.references[node.id],
+            context.target_id,
+            context.definitions,
+        )
+    elif context.model_owned and node.id.startswith("__"):
+        param_id = node.id
+        if param_id not in context.definitions:
+            raise IncompleteParameterDependenciesError(
+                "Model expression references an unknown sealed parameter",
+                target_id=context.target_id,
+                dependency_id=param_id,
+            )
+        if param_id == context.target_id:
+            raise ConstraintSelfReferenceError(
+                "Model expression directly references its target",
+                target_id=context.target_id,
+            )
+    else:
+        raise UnsupportedConstraintExpressionError(
+            "Bare names are not supported in scalar constraints",
+            target_id=context.target_id,
+            name=node.id,
+        )
+    return ReferenceExpression(param_id)
+
+
+def _compile_unary(
+    node: ast.UnaryOp,
+    context: _ExpressionCompileContext,
+) -> UnaryExpression:
+    unary: Literal["positive", "negative"] = (
+        "positive" if isinstance(node.op, ast.UAdd) else "negative"
+    )
+    return UnaryExpression(unary, _compile_ast(node.operand, context))
+
+
+def _compile_binary(
+    node: ast.BinOp,
+    context: _ExpressionCompileContext,
+) -> BinaryExpression:
+    operators: dict[
+        type[ast.operator],
+        Literal["add", "subtract", "multiply", "divide"],
+    ] = {
+        ast.Add: "add",
+        ast.Sub: "subtract",
+        ast.Mult: "multiply",
+        ast.Div: "divide",
+    }
+    return BinaryExpression(
+        operators[type(node.op)],
+        _compile_ast(node.left, context),
+        _compile_ast(node.right, context),
+    )
+
+
+def _compile_function(
+    node: ast.Call,
+    context: _ExpressionCompileContext,
+) -> FunctionExpression:
+    if (
+        not context.model_owned
+        or not isinstance(node.func, ast.Name)
+        or node.keywords
+        or node.func.id not in context.binder
+    ):
+        function_id = node.func.id if isinstance(node.func, ast.Name) else ""
+        raise UnsupportedConstraintExpressionError(
+            "Model expression requests an unsupported scientific function",
+            target_id=context.target_id,
+            function_id=function_id,
+        )
+    return FunctionExpression(
+        node.func.id,
+        tuple(_compile_ast(argument, context) for argument in node.args),
+    )
+
+
+def _compile_function_component(
+    node: ast.Subscript,
+    context: _ExpressionCompileContext,
+) -> FunctionExpression:
+    if not context.model_owned or not isinstance(node.value, ast.Call):
+        raise UnsupportedConstraintExpressionError(
+            "Only model-owned scientific-function components may be selected",
+            target_id=context.target_id,
+        )
+    compiled_call = _compile_function(node.value, context)
+    component_node = node.slice
+    if not isinstance(component_node, ast.Constant) or not isinstance(
+        component_node.value,
+        str,
+    ):
+        raise UnsupportedConstraintExpressionError(
+            "Scientific-function component must be a literal string",
+            target_id=context.target_id,
+        )
+    return FunctionExpression(
+        compiled_call.function_id,
+        compiled_call.arguments,
+        component_node.value,
+    )
+
+
+def _compile_ast(
+    node: ast.AST,
+    context: _ExpressionCompileContext,
+) -> ScalarExpression:
+    if isinstance(node, ast.Constant):
+        return _compile_literal(node, context.target_id)
+    if isinstance(node, ast.Name):
+        return _compile_reference(node, context)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        return _compile_unary(node, context)
+    if isinstance(node, ast.BinOp) and isinstance(
+        node.op,
+        (ast.Add, ast.Sub, ast.Mult, ast.Div),
+    ):
+        return _compile_binary(node, context)
+    if isinstance(node, ast.Call):
+        return _compile_function(node, context)
+    if isinstance(node, ast.Subscript):
+        return _compile_function_component(node, context)
+    raise UnsupportedConstraintExpressionError(
+        "Expression contains syntax outside ChemEx scalar constraint semantics",
+        target_id=context.target_id,
+        syntax=type(node).__name__,
+    )
+
+
+def _parse_expression(
+    text: str,
+    *,
+    definitions: SealedDefinitions,
+    binder: ScientificFunctionBinder,
+    target_id: str,
+    model_owned: bool,
+) -> ScalarExpression:
+    source = text
+    references: Mapping[str, str] = MappingProxyType({})
+    if not model_owned:
+        source, references = _replace_selectors(text)
+    try:
+        parsed = ast.parse(source, mode="eval")
+    except (SyntaxError, ValueError) as error:
+        raise UnsupportedConstraintExpressionError(
+            "Constraint is not a valid scalar expression",
+            target_id=target_id,
+            expression=text,
+        ) from error
+    return _compile_ast(
+        parsed.body,
+        _ExpressionCompileContext(
+            references,
+            definitions,
+            binder,
+            target_id,
+            model_owned,
+        ),
+    )
+
+
+def _dependencies(expression: ScalarExpression) -> tuple[str, ...]:
+    ordered: dict[str, None] = {}
+
+    def visit(node: ScalarExpression) -> None:
+        if isinstance(node, ReferenceExpression):
+            ordered.setdefault(node.param_id, None)
+        elif isinstance(node, UnaryExpression):
+            visit(node.operand)
+        elif isinstance(node, BinaryExpression):
+            visit(node.left)
+            visit(node.right)
+        elif isinstance(node, FunctionExpression):
+            for argument in node.arguments:
+                visit(argument)
+
+    visit(expression)
+    return tuple(ordered)
+
+
+def _expression_record(expression: ScalarExpression) -> object:
+    if isinstance(expression, LiteralExpression):
+        return ("literal", float(expression.value).hex())
+    if isinstance(expression, ReferenceExpression):
+        return ("reference", expression.param_id)
+    if isinstance(expression, UnaryExpression):
+        return ("unary", expression.operator, _expression_record(expression.operand))
+    if isinstance(expression, BinaryExpression):
+        return (
+            "binary",
+            expression.operator,
+            _expression_record(expression.left),
+            _expression_record(expression.right),
+        )
+    return (
+        "function",
+        expression.function_id,
+        expression.component,
+        tuple(_expression_record(item) for item in expression.arguments),
+    )
+
+
+def _topological_order(
+    derived_ids: tuple[str, ...],
+    constraints: Mapping[str, CompiledConstraint],
+    order: Mapping[str, int],
+) -> tuple[str, ...]:
+    derived = set(derived_ids)
+    incoming = {
+        param_id: sum(
+            dependency in derived for dependency in constraints[param_id].dependencies
+        )
+        for param_id in derived_ids
+    }
+    outgoing: dict[str, list[str]] = {param_id: [] for param_id in derived_ids}
+    for target_id in derived_ids:
+        for dependency in constraints[target_id].dependencies:
+            if dependency in derived:
+                outgoing[dependency].append(target_id)
+    ready = sorted(
+        (param_id for param_id, count in incoming.items() if count == 0),
+        key=order.__getitem__,
+    )
+    result: list[str] = []
+    while ready:
+        param_id = ready.pop(0)
+        result.append(param_id)
+        for dependent in sorted(outgoing[param_id], key=order.__getitem__):
+            incoming[dependent] -= 1
+            if incoming[dependent] == 0:
+                ready.append(dependent)
+                ready.sort(key=order.__getitem__)
+    if len(result) != len(derived_ids):
+        cycle_ids = _find_constraint_cycle(derived_ids, constraints, order)
+        raise ConstraintCycleError(
+            "Constraint dependency graph contains a cycle",
+            param_ids=cycle_ids,
+            constraints=tuple(
+                (
+                    param_id,
+                    constraints[param_id].source,
+                    constraints[param_id].expression_text,
+                )
+                for param_id in cycle_ids
+            ),
+        )
+    return tuple(result)
+
+
+def _find_constraint_cycle(
+    derived_ids: tuple[str, ...],
+    constraints: Mapping[str, CompiledConstraint],
+    order: Mapping[str, int],
+) -> tuple[str, ...]:
+    """Return the first exact dependency cycle in stable definition order."""
+    derived = set(derived_ids)
+    state: dict[str, int] = dict.fromkeys(derived_ids, 0)
+    stack: list[str] = []
+    positions: dict[str, int] = {}
+
+    def visit(param_id: str) -> tuple[str, ...] | None:
+        state[param_id] = 1
+        positions[param_id] = len(stack)
+        stack.append(param_id)
+        dependencies = sorted(
+            (
+                dependency
+                for dependency in constraints[param_id].dependencies
+                if dependency in derived
+            ),
+            key=order.__getitem__,
+        )
+        for dependency in dependencies:
+            if state[dependency] == 0:
+                if cycle := visit(dependency):
+                    return cycle
+            elif state[dependency] == 1:
+                return tuple(stack[positions[dependency] :])
+        stack.pop()
+        positions.pop(param_id)
+        state[param_id] = 2
+        return None
+
+    for param_id in derived_ids:
+        if state[param_id] == 0 and (cycle := visit(param_id)):
+            return cycle
+    raise AssertionError("Unresolved constraint graph did not contain a cycle")
+
+
+def _validate_parameterization_inputs(
+    parameter_model: SealedParameterModel,
+    snapshot: AnalysisValuesSnapshot,
+    required_ids: Sequence[str] | set[str],
+) -> set[str]:
+    expected = (
+        parameter_model.definitions.identity,
+        parameter_model.configuration.identity,
+    )
+    actual = (snapshot.definitions_identity, snapshot.configuration_identity)
+    if actual != expected:
+        raise IncompatibleParameterizationInputError(
+            "Analysis Values snapshot does not belong to the sealed parameter model",
+            expected=expected,
+            actual=actual,
+        )
+    required = set(required_ids)
+    unknown_required = required - set(parameter_model.declarations)
+    if unknown_required:
+        raise IncompleteParameterDependenciesError(
+            "Required scope contains unknown sealed parameter IDs",
+            param_ids=tuple(sorted(unknown_required)),
+        )
+    if not required:
+        raise IncompleteParameterDependenciesError("Required parameter scope is empty")
+    return required
+
+
+def _compile_active_scope(
+    parameter_model: SealedParameterModel,
+    rules: Sequence[_RoleRule],
+    binder: ScientificFunctionBinder,
+    required: set[str],
+) -> tuple[
+    set[str],
+    dict[str, tuple[ParameterRole, str, str]],
+    dict[str, CompiledConstraint],
+]:
+    definitions = parameter_model.definitions
+    active = set(required)
+    role_data: dict[str, tuple[ParameterRole, str, str]] = {}
+    compiled: dict[str, CompiledConstraint] = {}
+    pending = True
+    while pending:
+        pending = False
+        for definition in definitions:
+            param_id = definition.param_id
+            if param_id not in active or param_id in role_data:
+                continue
+            declaration = parameter_model.declarations[param_id]
+            role, expression_text, source = _role_for(param_id, declaration, rules)
+            role_data[param_id] = (role, expression_text, source)
+            if role is not ParameterRole.DERIVED:
+                continue
+            expression = _parse_expression(
+                expression_text,
+                definitions=definitions,
+                binder=binder,
+                target_id=param_id,
+                model_owned=source == "model",
+            )
+            dependencies = _dependencies(expression)
+            compiled[param_id] = CompiledConstraint(
+                param_id,
+                expression,
+                dependencies,
+                source,
+                expression_text,
+            )
+            for dependency in dependencies:
+                if dependency not in parameter_model.declarations:
+                    raise IncompleteParameterDependenciesError(
+                        "Constraint dependency is absent from the sealed model",
+                        target_id=param_id,
+                        dependency_id=dependency,
+                    )
+                if dependency not in active:
+                    active.add(dependency)
+                    pending = True
+    return active, role_data, compiled
+
+
+def _validate_rules_in_active_scope(
+    rules: Sequence[_RoleRule],
+    active: set[str],
+) -> None:
+    inactive_rules = tuple(rule for rule in rules if not (set(rule.matches) & active))
+    if not inactive_rules:
+        return
+    rule = inactive_rules[0]
+    raise NoParameterMatchError(
+        "Method selector has no match in the active dependency scope",
+        selector=rule.selector,
+        role=rule.role.value,
+        ordinal=rule.ordinal,
+    )
+
+
+def compile_active_parameterization(
+    parameter_model: SealedParameterModel,
+    snapshot: AnalysisValuesSnapshot,
+    method: Method,
+    required_ids: Sequence[str] | set[str],
+) -> ActiveParameterization:
+    """Compile one fresh method-scoped role and constraint program."""
+    required = _validate_parameterization_inputs(
+        parameter_model,
+        snapshot,
+        required_ids,
+    )
+
+    definitions = parameter_model.definitions
+    rules = _build_rules(method, definitions)
+    binder = ScientificFunctionBinder.for_model(parameter_model.model_name)
+    definition_order = {
+        definition.param_id: position for position, definition in enumerate(definitions)
+    }
+    active, role_data, compiled = _compile_active_scope(
+        parameter_model,
+        rules,
+        binder,
+        required,
+    )
+    _validate_rules_in_active_scope(rules, active)
+
+    scope_ids = tuple(
+        definition.param_id
+        for definition in definitions
+        if definition.param_id in active
+    )
+    roles = tuple((param_id, role_data[param_id][0]) for param_id in scope_ids)
+    independent_ids = tuple(
+        param_id
+        for param_id, role in roles
+        if role in (ParameterRole.FIT, ParameterRole.FIX)
+    )
+    derived_ids = tuple(
+        param_id for param_id, role in roles if role is ParameterRole.DERIVED
+    )
+    evaluation_order = _topological_order(
+        derived_ids,
+        compiled,
+        definition_order,
+    )
+    constraints = tuple(compiled[param_id] for param_id in derived_ids)
+    program = ConstraintProgram(
+        parameter_model_identity=parameter_model.identity,
+        model_identity=snapshot.model_identity,
+        definitions_identity=snapshot.definitions_identity,
+        configuration_identity=snapshot.configuration_identity,
+        function_binder_identity=binder.identity,
+        scope_ids=scope_ids,
+        independent_ids=independent_ids,
+        derived_ids=derived_ids,
+        constraints=constraints,
+        evaluation_order=evaluation_order,
+    )
+    return ActiveParameterization(
+        program=program,
+        binder=binder,
+        occurrence_identity=snapshot.occurrence_identity,
+        source_revision=snapshot.revision,
+        _roles=roles,
+    )
+
+
+def build_initial_analysis_values(
+    parameter_model: SealedParameterModel,
+    model_identity: str,
+) -> Mapping[str, float]:
+    """Natively fill missing model-derived revision-zero configuration values."""
+    configuration = parameter_model.configuration
+    missing_ids = tuple(
+        config.param_id for config in configuration if config.effective_value is None
+    )
+    for param_id in missing_ids:
+        if not parameter_model.declarations[param_id].model_expression:
+            raise IncompleteParameterDependenciesError(
+                "A configured parameter lacks both a value and model derivation",
+                param_id=param_id,
+            )
+    bootstrap_snapshot = AnalysisValuesSnapshot(
+        occurrence_identity=f"bootstrap:{uuid4().hex}",
+        model_identity=model_identity,
+        definitions_identity=parameter_model.definitions.identity,
+        configuration_identity=configuration.identity,
+        revision=0,
+        _items=tuple(
+            (config.param_id, config.effective_value)
+            for config in configuration
+            if config.effective_value is not None
+        ),
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        bootstrap_snapshot,
+        Method(),
+        set(parameter_model.declarations),
+    )
+    resolved = parameterization.resolve(
+        parameterization.frame_from_snapshot(bootstrap_snapshot)
+    )
+    return MappingProxyType(
+        {
+            config.param_id: (
+                resolved[config.param_id]
+                if config.effective_value is None
+                else config.effective_value
+            )
+            for config in configuration
+        }
+    )
+
+
+def _validate_frame(
+    parameterization: ActiveParameterization,
+    frame: IndependentValueFrame,
+) -> None:
+    if frame.program_fingerprint != parameterization.program.fingerprint:
+        raise ConstraintProgramMismatchError(
+            "Independent-value frame names a different constraint program",
+            expected=parameterization.program.fingerprint,
+            actual=frame.program_fingerprint,
+        )
+    if (
+        frame.parameterization_identity != parameterization.identity
+        or frame.occurrence_identity != parameterization.occurrence_identity
+        or frame.revision != parameterization.source_revision
+    ):
+        raise IncompatibleParameterizationInputError(
+            "Independent-value frame belongs to another parameterization occurrence",
+            expected_identity=parameterization.identity,
+            actual_identity=frame.parameterization_identity,
+            expected_occurrence=parameterization.occurrence_identity,
+            actual_occurrence=frame.occurrence_identity,
+        )
+    frame_ids = tuple(param_id for param_id, _value in frame._items)
+    if frame_ids != parameterization.independent_ids:
+        raise IncompleteParameterDependenciesError(
+            "Independent-value frame is incomplete or incorrectly ordered",
+            expected_ids=parameterization.independent_ids,
+            actual_ids=frame_ids,
+        )
+
+
+def _finite_scalar(value: object, *, param_id: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ConstraintEvaluationError(
+            "Constraint value is not a real scalar",
+            param_id=param_id,
+            value=value,
+        )
+    scalar = float(value)
+    if not math.isfinite(scalar):
+        raise NonFiniteParameterValueError(
+            "Constraint value is non-finite",
+            param_id=param_id,
+            value=scalar,
+        )
+    return 0.0 if scalar == 0.0 else scalar
+
+
+@dataclass(frozen=True, slots=True)
+class _EvaluationContext:
+    values: Mapping[str, float]
+    binder: ScientificFunctionBinder
+    target_id: str
+    position: int
+
+
+def _evaluate_reference(
+    expression: ReferenceExpression,
+    context: _EvaluationContext,
+) -> float:
+    try:
+        return context.values[expression.param_id]
+    except KeyError as error:
+        raise IncompleteParameterDependenciesError(
+            "A dependency was unavailable during constraint evaluation",
+            target_id=context.target_id,
+            dependency_id=expression.param_id,
+            position=context.position,
+        ) from error
+
+
+def _evaluate_binary(
+    expression: BinaryExpression,
+    context: _EvaluationContext,
+) -> float:
+    left = cast("float", _evaluate_node(expression.left, context))
+    right = cast("float", _evaluate_node(expression.right, context))
+    operations: dict[str, Callable[[float, float], float]] = {
+        "add": operator.add,
+        "subtract": operator.sub,
+        "multiply": operator.mul,
+        "divide": operator.truediv,
+    }
+    try:
+        return operations[expression.operator](left, right)
+    except (ArithmeticError, ValueError) as error:
+        raise ConstraintDomainError(
+            "Arithmetic constraint operation is outside its domain",
+            target_id=context.target_id,
+            operator=expression.operator,
+            left=left,
+            right=right,
+            position=context.position,
+        ) from error
+    except TypeError as error:
+        raise ConstraintEvaluationError(
+            "Arithmetic constraint operands are not compatible scalars",
+            target_id=context.target_id,
+            operator=expression.operator,
+            left=left,
+            right=right,
+            position=context.position,
+        ) from error
+
+
+def _evaluate_function(
+    expression: FunctionExpression,
+    context: _EvaluationContext,
+) -> object:
+    arguments = tuple(
+        _evaluate_node(argument, context) for argument in expression.arguments
+    )
+    try:
+        result = context.binder[expression.function_id](*arguments)
+    except (ArithmeticError, FloatingPointError, ValueError) as error:
+        raise ConstraintDomainError(
+            "Scientific constraint function failed its value domain",
+            target_id=context.target_id,
+            function_id=expression.function_id,
+            component=expression.component,
+            arguments=arguments,
+            position=context.position,
+        ) from error
+    except Exception as error:
+        raise ConstraintEvaluationError(
+            "Scientific constraint function could not be evaluated",
+            target_id=context.target_id,
+            function_id=expression.function_id,
+            component=expression.component,
+            arguments=arguments,
+            position=context.position,
+        ) from error
+    if expression.component is None:
+        return result
+    if not isinstance(result, Mapping) or expression.component not in result:
+        raise ConstraintDomainError(
+            "Scientific constraint function did not return its declared component",
+            target_id=context.target_id,
+            function_id=expression.function_id,
+            component=expression.component,
+            arguments=arguments,
+            position=context.position,
+        )
+    return cast("Mapping[str, object]", result)[expression.component]
+
+
+def _evaluate_node(
+    expression: ScalarExpression,
+    context: _EvaluationContext,
+) -> object:
+    if isinstance(expression, LiteralExpression):
+        return expression.value
+    if isinstance(expression, ReferenceExpression):
+        return _evaluate_reference(expression, context)
+    if isinstance(expression, UnaryExpression):
+        operand = cast("float", _evaluate_node(expression.operand, context))
+        try:
+            return +operand if expression.operator == "positive" else -operand
+        except TypeError as error:
+            raise ConstraintEvaluationError(
+                "Unary constraint operand is not a compatible scalar",
+                target_id=context.target_id,
+                operator=expression.operator,
+                operand=operand,
+                position=context.position,
+            ) from error
+    if isinstance(expression, BinaryExpression):
+        return _evaluate_binary(expression, context)
+    return _evaluate_function(expression, context)
+
+
+def _evaluate_expression(
+    expression: ScalarExpression,
+    values: Mapping[str, float],
+    binder: ScientificFunctionBinder,
+    *,
+    target_id: str,
+    position: int,
+) -> float:
+    with np.errstate(all="raise"):
+        result = _evaluate_node(
+            expression,
+            _EvaluationContext(values, binder, target_id, position),
+        )
+    return _finite_scalar(result, param_id=target_id)

--- a/src/chemex/parameters/values.py
+++ b/src/chemex/parameters/values.py
@@ -153,6 +153,8 @@ class AnalysisValues:
         self,
         model_identity: str,
         configuration: SealedConfiguration,
+        *,
+        _native_initial_values: Mapping[str, float] | None = None,
     ) -> None:
         """Initialize revision zero from immutable configured effective values."""
         with self._lock:
@@ -160,10 +162,36 @@ class AnalysisValues:
                 msg = "Analysis values are already initialized"
                 raise RuntimeError(msg)
 
+            configured_ids = tuple(config.param_id for config in configuration)
+            if (
+                _native_initial_values is not None
+                and tuple(_native_initial_values) != configured_ids
+            ):
+                msg = "Native initial values do not exactly cover configuration IDs"
+                raise ValueError(msg)
+
             items: list[tuple[str, float]] = []
             for config in configuration:
-                value = config.effective_value
-                if value is None or not math.isfinite(value):
+                value = (
+                    config.effective_value
+                    if _native_initial_values is None
+                    else _native_initial_values[config.param_id]
+                )
+                if (
+                    config.effective_value is not None
+                    and value != config.effective_value
+                ):
+                    msg = (
+                        "Native initialization changed configured value for "
+                        f"{config.param_id!r}"
+                    )
+                    raise ValueError(msg)
+                if (
+                    value is None
+                    or isinstance(value, bool)
+                    or not isinstance(value, Real)
+                    or not math.isfinite(value)
+                ):
                     msg = (
                         f"Invalid initial analysis value for {config.param_id!r}: "
                         f"{value!r}"

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -15,7 +15,6 @@ from chemex.parameters.factory import ParameterFactory
 from chemex.parameters.legacy_adapter import LegacyValuesAdapter
 from chemex.parameters.parameterization import (
     ActiveParameterization,
-    ResolvedParameterValues,
     build_initial_analysis_values,
     compile_active_parameterization,
 )
@@ -62,9 +61,6 @@ class AnalysisSession:
             else parameter_factory
         )
         self.execution = ExecutionSettings() if execution is None else execution
-        self.last_parameterization: ActiveParameterization | None = None
-        self.last_resolved_parameter_values: ResolvedParameterValues | None = None
-        self.last_parameterization_failure: Exception | None = None
 
     @classmethod
     def create(cls) -> AnalysisSession:
@@ -80,9 +76,6 @@ class AnalysisSession:
         self.parameters.reset()
         self.analysis_values.reset()
         self.legacy_values_adapter.reset()
-        self.last_parameterization = None
-        self.last_resolved_parameter_values = None
-        self.last_parameterization_failure = None
         self.model.reset()
 
     def try_build_analysis_values(self) -> bool:
@@ -96,14 +89,10 @@ class AnalysisSession:
             self.parameter_factory.disable_native_candidate(error)
             self.legacy_values_adapter.disable(error)
             return False
-        spec = self.model.spec
-        model_identity = (
-            f"{spec.name}|states={spec.states}|model_free={spec.model_free}|"
-            f"temp_coef={spec.temp_coef}|residue_specific={spec.residue_specific}"
-        )
+        model_identity = self.model.spec.identity
         try:
             initial_values = (
-                build_initial_analysis_values(parameter_model, model_identity)
+                build_initial_analysis_values(parameter_model)
                 if any(item.effective_value is None for item in configuration)
                 else None
             )
@@ -150,15 +139,9 @@ class AnalysisSession:
         try:
             candidate = self.compile_parameterization(method, required_ids)
             frame = candidate.frame_from_snapshot(self.analysis_values.snapshot())
-            resolved = candidate.resolve(frame)
-        except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
-            self.last_parameterization = None
-            self.last_resolved_parameter_values = None
-            self.last_parameterization_failure = error
+            candidate.resolve(frame)
+        except Exception:  # noqa: BLE001 - checkpoint-1 isolation boundary
             return None
-        self.last_parameterization = candidate
-        self.last_resolved_parameter_values = resolved
-        self.last_parameterization_failure = None
         return candidate
 
 

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from chemex.configuration.methods import Method
 from chemex.experiments.loader import register_experiments
 from chemex.models.loader import register_kinetic_settings
 from chemex.models.model import ModelSpec, ModelState
@@ -12,6 +13,12 @@ from chemex.parameters.database import (
 )
 from chemex.parameters.factory import ParameterFactory
 from chemex.parameters.legacy_adapter import LegacyValuesAdapter
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    ResolvedParameterValues,
+    build_initial_analysis_values,
+    compile_active_parameterization,
+)
 from chemex.parameters.values import AnalysisValues
 from chemex.runtime.execution import ExecutionSettings
 
@@ -55,6 +62,9 @@ class AnalysisSession:
             else parameter_factory
         )
         self.execution = ExecutionSettings() if execution is None else execution
+        self.last_parameterization: ActiveParameterization | None = None
+        self.last_resolved_parameter_values: ResolvedParameterValues | None = None
+        self.last_parameterization_failure: Exception | None = None
 
     @classmethod
     def create(cls) -> AnalysisSession:
@@ -70,6 +80,9 @@ class AnalysisSession:
         self.parameters.reset()
         self.analysis_values.reset()
         self.legacy_values_adapter.reset()
+        self.last_parameterization = None
+        self.last_resolved_parameter_values = None
+        self.last_parameterization_failure = None
         self.model.reset()
 
     def try_build_analysis_values(self) -> bool:
@@ -77,8 +90,9 @@ class AnalysisSession:
         if not self.parameter_factory.try_seal_configuration():
             return False
         configuration = self.parameter_factory.sealed_configuration
-        if configuration is None:
-            error = RuntimeError("Sealed parameter configuration is unavailable")
+        parameter_model = self.parameter_factory.sealed_parameter_model
+        if configuration is None or parameter_model is None:
+            error = RuntimeError("Sealed native parameter model is unavailable")
             self.parameter_factory.disable_native_candidate(error)
             self.legacy_values_adapter.disable(error)
             return False
@@ -88,7 +102,16 @@ class AnalysisSession:
             f"temp_coef={spec.temp_coef}|residue_specific={spec.residue_specific}"
         )
         try:
-            self.analysis_values.initialize(model_identity, configuration)
+            initial_values = (
+                build_initial_analysis_values(parameter_model, model_identity)
+                if any(item.effective_value is None for item in configuration)
+                else None
+            )
+            self.analysis_values.initialize(
+                model_identity,
+                configuration,
+                _native_initial_values=initial_values,
+            )
         except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
             self.parameter_factory.disable_native_candidate(error)
             self.legacy_values_adapter.disable(error)
@@ -100,6 +123,43 @@ class AnalysisSession:
         ensure_plugins_registered()
         self.parameter_factory.clear_cache()
         self.model.set_model(name)
+
+    def compile_parameterization(
+        self,
+        method: Method,
+        required_ids: set[str],
+    ) -> ActiveParameterization:
+        """Compile one native preview without changing authoritative state."""
+        parameter_model = self.parameter_factory.sealed_parameter_model
+        if parameter_model is None:
+            msg = "The sealed native parameter model is unavailable"
+            raise RuntimeError(msg)
+        return compile_active_parameterization(
+            parameter_model,
+            self.analysis_values.snapshot(),
+            method,
+            required_ids,
+        )
+
+    def try_compile_parameterization(
+        self,
+        method: Method,
+        required_ids: set[str],
+    ) -> ActiveParameterization | None:
+        """Best-effort native preview that cannot veto the legacy occurrence."""
+        try:
+            candidate = self.compile_parameterization(method, required_ids)
+            frame = candidate.frame_from_snapshot(self.analysis_values.snapshot())
+            resolved = candidate.resolve(frame)
+        except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
+            self.last_parameterization = None
+            self.last_resolved_parameter_values = None
+            self.last_parameterization_failure = error
+            return None
+        self.last_parameterization = candidate
+        self.last_resolved_parameter_values = resolved
+        self.last_parameterization_failure = None
+        return candidate
 
 
 def ensure_plugins_registered() -> None:

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -96,6 +96,13 @@ class StubSession:
         self.build_analysis_values_calls += 1
         return self.parameter_factory.try_seal_configuration()
 
+    def try_compile_parameterization(
+        self,
+        _method: object,
+        _required_ids: set[str],
+    ) -> None:
+        return None
+
 
 class WriterParameterStore:
     def __init__(self, parameters: dict[str, ParamSetting]) -> None:
@@ -348,6 +355,7 @@ def test_run_uses_explicit_session_for_fit_flow(
         plot_level: str,
         *,
         execution: ExecutionSettings | None = None,
+        preview_parameterization: object | None = None,
     ) -> None:
         recorded["run_methods"] = (
             experiments_arg,
@@ -355,6 +363,7 @@ def test_run_uses_explicit_session_for_fit_flow(
             path,
             plot_level,
             execution,
+            preview_parameterization,
         )
 
     monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
@@ -384,6 +393,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     np.testing.assert_equal(experiments.filtered, 1)
     np.testing.assert_equal(recorded["build"][2], session)
     np.testing.assert_equal(recorded["run_methods"][4], session.execution)
+    assert recorded["run_methods"][5] == session.try_compile_parameterization
     assert recorded["run_info"] is True
 
 

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -18,6 +18,9 @@ from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
 from chemex.experiments.builder import build_experiments
 from chemex.models.factory import model_factory
+from chemex.nmr.rates import rate_functions
+from chemex.parameters.database import ParameterIndex
+from chemex.parameters.name import ParamName
 from chemex.parameters.parameterization import (
     AmbiguousParameterReferenceError,
     ConstraintCycleError,
@@ -27,14 +30,17 @@ from chemex.parameters.parameterization import (
     ConstraintSelfReferenceError,
     IncompatibleParameterizationInputError,
     IncompleteParameterDependenciesError,
+    ModelDerivationOverrideError,
     NonFiniteParameterValueError,
     NoParameterMatchError,
     ParameterDeclaration,
+    ParameterDeclarationContribution,
     ParameterRole,
     SealedParameterDeclarations,
     SealedParameterModel,
     UnsupportedConstraintExpressionError,
     compile_active_parameterization,
+    seal_parameter_declarations,
 )
 from chemex.parameters.sealed import (
     ParamConfig,
@@ -78,6 +84,83 @@ def _build_dcest_session() -> tuple[AnalysisSession, set[str]]:
     return session, experiments.param_ids
 
 
+def _build_mf_session() -> tuple[AnalysisSession, set[str]]:
+    session = AnalysisSession.create()
+    session.set_model("2st.mf")
+    experiments = build_experiments(
+        [MF_EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G23N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([MF_PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    return session, experiments.param_ids
+
+
+def _build_fit_session() -> tuple[AnalysisSession, set[str]]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [FIT_EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([FIT_PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    return session, experiments.param_ids
+
+
+def _legacy_roles_and_values(
+    session: AnalysisSession,
+    method: Method,
+    required_ids: set[str],
+) -> tuple[dict[str, ParameterRole], dict[str, float]]:
+    session.parameters.set_parameter_status(method)
+    parameters = session.parameters.build_lmfit_params(required_ids)
+    roles = {
+        param_id: (
+            ParameterRole.DERIVED
+            if parameter.expr is not None
+            else ParameterRole.FIT
+            if parameter.vary
+            else ParameterRole.FIX
+        )
+        for param_id, parameter in parameters.items()
+    }
+    return roles, parameters.valuesdict()
+
+
+def _assert_complete_shipped_parity(
+    native_session: AnalysisSession,
+    legacy_session: AnalysisSession,
+    method: Method,
+    required_ids: set[str],
+) -> None:
+    snapshot = native_session.analysis_values.snapshot()
+    parameterization = native_session.compile_parameterization(
+        method,
+        required_ids,
+    )
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+    legacy_roles, legacy_values = _legacy_roles_and_values(
+        legacy_session,
+        method,
+        required_ids,
+    )
+
+    assert parameterization.scope_ids == tuple(legacy_roles)
+    assert {
+        param_id: parameterization.role(param_id)
+        for param_id in parameterization.scope_ids
+    } == legacy_roles
+    assert dict(resolved) == pytest.approx(legacy_values, rel=1e-13, abs=1e-13)
+    assert native_session.analysis_values.snapshot() == snapshot
+
+
 def _native_fixture(
     declarations: tuple[ParameterDeclaration, ...],
     *,
@@ -116,6 +199,7 @@ def _native_fixture(
     sealed_declarations = SealedParameterDeclarations(declarations)
     parameter_model = SealedParameterModel(
         model_name,
+        f"{model_name}|test",
         sealed_definitions,
         configuration,
         sealed_declarations,
@@ -143,8 +227,7 @@ def test_shipped_method_compiles_roles_and_resolves_without_mutation() -> None:
 
     parameterization = session.try_compile_parameterization(method, required_ids)
     assert parameterization is not None
-    resolved = session.last_resolved_parameter_values
-    assert resolved is not None
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(before))
 
     definitions = session.parameter_factory.sealed_definitions
     assert definitions is not None
@@ -172,6 +255,97 @@ def test_shipped_method_compiles_roles_and_resolves_without_mutation() -> None:
     assert step2 is not None
     assert step2.role(d2o) is ParameterRole.FIX
     assert session.analysis_values.snapshot() == before
+
+
+def test_shipped_dcest_constraint_roles_and_values_match_legacy_completely() -> None:
+    native_session, required_ids = _build_dcest_session()
+    legacy_session, legacy_required_ids = _build_dcest_session()
+    assert legacy_required_ids == required_ids
+    method = read_methods([DCEST_METHOD])["STEP1"]
+
+    _assert_complete_shipped_parity(
+        native_session,
+        legacy_session,
+        method,
+        required_ids,
+    )
+
+
+def test_shipped_fix_roles_and_values_match_legacy_completely() -> None:
+    native_session, required_ids = _build_fit_session()
+    legacy_session, legacy_required_ids = _build_fit_session()
+    assert legacy_required_ids == required_ids
+    method = read_methods([FIT_METHOD])["DEFAULT"]
+
+    _assert_complete_shipped_parity(
+        native_session,
+        legacy_session,
+        method,
+        required_ids,
+    )
+
+
+@pytest.mark.parametrize(
+    "method",
+    (
+        Method(fit=("PA",)),
+        Method(fix=("PA",)),
+        Method(constraints=("[PA] = 0.5",)),
+    ),
+    ids=("fit", "fix", "constraint"),
+)
+def test_shipped_2st_hd_population_derivation_cannot_be_overridden(
+    method: Method,
+) -> None:
+    session, required_ids = _build_dcest_session()
+    definitions = session.parameter_factory.sealed_definitions
+    assert definitions is not None
+    pa_id = next(item.param_id for item in definitions if item.name == "PA")
+    baseline = session.compile_parameterization(Method(), required_ids)
+
+    assert baseline.role(pa_id) is ParameterRole.DERIVED
+
+    with pytest.raises(ModelDerivationOverrideError) as raised:
+        session.compile_parameterization(method, required_ids)
+
+    assert raised.value.code == "model_derivation_override"
+    assert raised.value.context["param_ids"] == (pa_id,)
+
+
+def test_sealing_retains_model_derivation_when_estimation_is_supported() -> None:
+    definition = ParamDefinition(
+        "__PA",
+        "PA",
+        "",
+        (),
+        1.0,
+        -float("inf"),
+        float("inf"),
+    )
+    definitions = SealedDefinitions((definition,), {definition.param_id: 0})
+    declarations = seal_parameter_declarations(
+        definitions,
+        {
+            definition.param_id: (
+                ParameterDeclarationContribution(
+                    definition.param_id,
+                    False,
+                    "1.0 - __PB",
+                    "model",
+                    True,
+                ),
+                ParameterDeclarationContribution(
+                    definition.param_id,
+                    True,
+                    "",
+                    "experiment",
+                ),
+            )
+        },
+    )
+
+    assert declarations[definition.param_id].supports_estimation
+    assert declarations[definition.param_id].model_expression == "1.0 - __PB"
 
 
 def test_constraint_chain_is_deterministic_and_freshly_reresolves() -> None:
@@ -282,19 +456,11 @@ def test_shadowed_constraint_still_receives_public_syntax_validation() -> None:
 
 
 def test_real_model_free_scientific_expression_matches_legacy_resolution() -> None:
-    session = AnalysisSession.create()
-    session.set_model("2st.mf")
-    experiments = build_experiments(
-        [MF_EXPERIMENT],
-        Selection(include=[SpinSystem.from_name("G23N-HN")], exclude=None),
-        session=session,
-    )
-    session.parameters.set_defaults(read_defaults([MF_PARAMETERS]))
-    assert session.try_build_analysis_values(), repr(
-        session.parameter_factory.native_construction_error
-    )
-    snapshot = session.analysis_values.snapshot()
-    configuration = session.parameter_factory.sealed_configuration
+    native_session, required_ids = _build_mf_session()
+    legacy_session, legacy_required_ids = _build_mf_session()
+    assert legacy_required_ids == required_ids
+    snapshot = native_session.analysis_values.snapshot()
+    configuration = native_session.parameter_factory.sealed_configuration
     assert configuration is not None
     assert tuple(snapshot) == tuple(item.param_id for item in configuration)
     assert all(
@@ -306,26 +472,23 @@ def test_real_model_free_scientific_expression_matches_legacy_resolution() -> No
     assert not snapshot.occurrence_identity.startswith("bootstrap:")
 
     method = read_methods([MF_METHOD])["DEFAULT"]
-    parameterization = session.compile_parameterization(method, experiments.param_ids)
-    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
-    legacy = session.parameters.build_lmfit_params(experiments.param_ids).valuesdict()
-    definitions = session.parameter_factory.sealed_definitions
+    parameterization = native_session.compile_parameterization(method, required_ids)
+    definitions = native_session.parameter_factory.sealed_definitions
     assert definitions is not None
-    derived_rate_ids = tuple(
-        item.param_id
-        for item in definitions
-        if item.param_id in parameterization.derived_ids and item.name.startswith("R2")
-    )
-
-    assert derived_rate_ids
     pb = next(item.param_id for item in definitions if item.name == "PB")
     kex_ab = next(item.param_id for item in definitions if item.name == "KEX_AB")
     assert parameterization.role(pb) is ParameterRole.FIX
     assert parameterization.role(kex_ab) is ParameterRole.FIX
-    for param_id in derived_rate_ids:
-        assert resolved[param_id] == pytest.approx(
-            legacy[param_id], rel=1e-13, abs=1e-13
-        )
+    assert any(
+        item.param_id in parameterization.derived_ids and item.name.startswith("R2")
+        for item in definitions
+    )
+    _assert_complete_shipped_parity(
+        native_session,
+        legacy_session,
+        method,
+        required_ids,
+    )
 
 
 @pytest.mark.parametrize("model_name", ("2st_binding", "2st_eyring"))
@@ -387,6 +550,104 @@ def test_supported_arithmetic_has_explicit_precedence_and_unary_semantics() -> N
     assert resolved["__B"] == -2.0
 
 
+@pytest.mark.parametrize(
+    ("literal", "expected"),
+    (
+        ("10", 10.0),
+        ("10.25", 10.25),
+        (".25", 0.25),
+        ("10.", 10.0),
+        ("1.25e-2", 0.0125),
+        ("2E+3", 2000.0),
+    ),
+)
+def test_public_constraints_accept_legacy_decimal_numeric_syntax(
+    literal: str,
+    expected: float,
+) -> None:
+    parameter_model, snapshot = _native_fixture(
+        (ParameterDeclaration("__A", False),),
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(constraints=(f"[A] = {literal}",)),
+        {"__A"},
+    )
+
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert resolved["__A"] == expected
+
+
+@pytest.mark.parametrize("literal", ("0x10", "0b10", "0o10", "1_0", "1j"))
+def test_public_constraints_reject_python_only_numeric_literals(literal: str) -> None:
+    parameter_model, snapshot = _native_fixture(
+        (ParameterDeclaration("__A", False),),
+    )
+
+    with pytest.raises(UnsupportedConstraintExpressionError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(constraints=(f"[A] = {literal}",)),
+            {"__A"},
+        )
+
+    assert raised.value.code == "unsupported_expression"
+
+
+def test_oversized_public_literal_is_a_typed_non_finite_failure() -> None:
+    parameter_model, snapshot = _native_fixture(
+        (ParameterDeclaration("__A", False),),
+    )
+
+    with pytest.raises(NonFiniteParameterValueError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(constraints=(f"[A] = {'9' * 400}",)),
+            {"__A"},
+        )
+
+    assert raised.value.code == "non_finite"
+
+
+def test_oversized_independent_frame_value_is_a_typed_non_finite_failure() -> None:
+    parameter_model, snapshot = _native_fixture(
+        (ParameterDeclaration("__A", False),),
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__A"},
+    )
+    frame = parameterization.frame_from_snapshot(snapshot)
+
+    with pytest.raises(NonFiniteParameterValueError) as raised:
+        parameterization.resolve(frame.with_updates({"__A": 10**400}))
+
+    assert raised.value.code == "non_finite"
+
+
+def test_foreign_model_snapshot_is_rejected_before_program_compilation() -> None:
+    parameter_model, snapshot = _native_fixture(
+        (ParameterDeclaration("__A", False),),
+    )
+
+    with pytest.raises(IncompatibleParameterizationInputError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            dataclasses.replace(snapshot, model_identity="foreign-model"),
+            Method(),
+            {"__A"},
+        )
+
+    assert raised.value.code == "incompatible_input"
+    assert raised.value.context["actual"][0] == "foreign-model"
+
+
 def test_no_match_failure_has_stable_type_code_and_context() -> None:
     parameter_model, snapshot = _native_fixture((ParameterDeclaration("__A", False),))
 
@@ -400,6 +661,45 @@ def test_no_match_failure_has_stable_type_code_and_context() -> None:
 
     assert raised.value.code == "no_match"
     assert raised.value.context["selector"] == "missing"
+
+
+@pytest.mark.parametrize(
+    ("method", "required_ids"),
+    (
+        (Method(fit=("R2",)), {"__R2_A"}),
+        (Method(fix=("R2",)), {"__R2_A"}),
+        (Method(constraints=("[R2] = 1.0",)), {"__R2_A"}),
+        (Method(constraints=("[B] = [R2]",)), {"__B"}),
+    ),
+    ids=("fit-target", "fix-target", "constraint-target", "constraint-reference"),
+)
+def test_parameter_selectors_use_legacy_exact_name_matching(
+    method: Method,
+    required_ids: set[str],
+) -> None:
+    definitions = (
+        ParamDefinition("__R2_A", "R2_A", "", (), 1.0, -10.0, 10.0),
+        ParamDefinition("__B", "B", "", (), 1.0, -10.0, 10.0),
+    )
+    declarations = tuple(
+        ParameterDeclaration(item.param_id, False) for item in definitions
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        definitions=definitions,
+    )
+    legacy_index = ParameterIndex()
+    legacy_index.add(ParamName.from_section("R2_A"))
+
+    assert legacy_index.get_matching_ids(ParamName.from_section("R2")) == set()
+
+    with pytest.raises(NoParameterMatchError):
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            method,
+            required_ids,
+        )
 
 
 def test_contextually_incomparable_reference_is_ambiguity() -> None:
@@ -499,7 +799,7 @@ def test_arithmetic_domain_failure_does_not_return_partial_values() -> None:
 def test_scientific_function_evaluation_failure_is_typed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def explode(_value: float) -> float:
+    def explode(_value: float) -> dict[str, float]:
         msg = "backend exploded"
         raise RuntimeError(msg)
 
@@ -510,7 +810,7 @@ def test_scientific_function_evaluation_failure_is_typed(
     )
     declarations = (
         ParameterDeclaration("__A", False),
-        ParameterDeclaration("__B", False, "explode(__A)"),
+        ParameterDeclaration("__B", False, 'explode(__A)["result"]'),
     )
     parameter_model, snapshot = _native_fixture(
         declarations,
@@ -528,6 +828,139 @@ def test_scientific_function_evaluation_failure_is_typed(
 
     assert raised.value.code == "evaluation_error"
     assert raised.value.context["function_id"] == "explode"
+
+
+def test_scientific_function_identity_tracks_same_metadata_implementation_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def implementation_one(value: float) -> dict[str, float]:
+        return {"result": value * 2.0}
+
+    def implementation_two(value: float) -> dict[str, float]:
+        return {"result": value * 3.0}
+
+    for implementation in (implementation_one, implementation_two):
+        monkeypatch.setattr(implementation, "__name__", "same_metadata")
+        monkeypatch.setattr(implementation, "__qualname__", "same_metadata")
+
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration(
+            "__B",
+            False,
+            'same_metadata(__A)["result"]',
+        ),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 2.0, "__B": 0.0},
+        model_name="test_model",
+    )
+    monkeypatch.setitem(
+        user_function_registry.user_function_registry,
+        "test_model",
+        {"same_metadata": implementation_one},
+    )
+    first = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__B"},
+    )
+    first_frame = first.frame_from_snapshot(snapshot)
+
+    monkeypatch.setitem(
+        user_function_registry.user_function_registry,
+        "test_model",
+        {"same_metadata": implementation_two},
+    )
+    second = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__B"},
+    )
+
+    assert first.binder.identity != second.binder.identity
+    assert first.program.fingerprint != second.program.fingerprint
+    assert first.resolve(first_frame)["__B"] == 4.0
+    with pytest.raises(ConstraintProgramMismatchError):
+        second.resolve(first_frame)
+
+
+def test_mutated_bound_scientific_function_cannot_change_compiled_program(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MutableScientificFunction:
+        def __init__(self) -> None:
+            self.scale = 2.0
+
+        def __call__(self, value: float) -> dict[str, float]:
+            return {"result": value * self.scale}
+
+    function = MutableScientificFunction()
+    monkeypatch.setitem(
+        user_function_registry.user_function_registry,
+        "test_model",
+        {"mutable": function},
+    )
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False, 'mutable(__A)["result"]'),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 2.0, "__B": 0.0},
+        model_name="test_model",
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__B"},
+    )
+    frame = parameterization.frame_from_snapshot(snapshot)
+    assert parameterization.resolve(frame)["__B"] == 4.0
+
+    function.scale = 3.0
+
+    with pytest.raises(ConstraintProgramMismatchError) as raised:
+        parameterization.resolve(frame)
+
+    assert raised.value.code == "program_mismatch"
+    assert raised.value.context["function_id"] == "mutable"
+
+
+def test_mutated_shipped_rate_class_state_cannot_change_compiled_program(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    declarations = (
+        ParameterDeclaration("__H", False),
+        ParameterDeclaration("__TAUC", False),
+        ParameterDeclaration("__S2", False),
+        ParameterDeclaration("__R2", False, 'nh(__H, __TAUC, __S2)["r2_i"]'),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__H": 800.0, "__TAUC": 5.0, "__S2": 0.9, "__R2": 0.0},
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__R2"},
+    )
+    frame = parameterization.frame_from_snapshot(snapshot)
+    parameterization.resolve(frame)
+    rate_type = type(rate_functions["nh"])
+
+    monkeypatch.setattr(rate_type, "gi", rate_type.gi * 1.01)
+
+    with pytest.raises(ConstraintProgramMismatchError) as raised:
+        parameterization.resolve(frame)
+
+    assert raised.value.code == "program_mismatch"
+    assert raised.value.context["function_id"] == "nh"
 
 
 def test_malformed_scientific_function_component_is_typed(
@@ -564,8 +997,7 @@ def test_malformed_scientific_function_component_is_typed(
         parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
 
     assert raised.value.code == "evaluation_error"
-    assert raised.value.context["target_id"] == "__B"
-    assert raised.value.context["operator"] == "add"
+    assert raised.value.context["param_id"] == "__B"
 
 
 def test_non_finite_derived_value_has_its_own_failure_category() -> None:
@@ -651,8 +1083,11 @@ def test_native_compilation_failure_cannot_veto_real_legacy_fit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = AnalysisSession.create()
+    preview_calls = 0
 
     def fail_preview(*_args: object, **_kwargs: object) -> None:
+        nonlocal preview_calls
+        preview_calls += 1
         msg = "native preview failed"
         raise RuntimeError(msg)
 
@@ -675,6 +1110,4 @@ def test_native_compilation_failure_cannot_veto_real_legacy_fit(
 
     assert list((tmp_path / "Data").rglob("*.dat"))
     assert list((tmp_path / "Parameters").rglob("*.toml"))
-    assert isinstance(session.last_parameterization_failure, RuntimeError)
-    assert session.last_parameterization is None
-    assert session.last_resolved_parameter_values is None
+    assert preview_calls > 0

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -1,0 +1,680 @@
+"""Behavioral tests for native method-scoped parameterization (#584).
+
+The primary seam is compilation from the sealed parameter model, a current
+Analysis Values snapshot, a method declaration, and the selected profile scope.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from chemex import chemex as chemex_module
+from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.parameters import read_defaults
+from chemex.experiments.builder import build_experiments
+from chemex.models.factory import model_factory
+from chemex.parameters.parameterization import (
+    AmbiguousParameterReferenceError,
+    ConstraintCycleError,
+    ConstraintDomainError,
+    ConstraintEvaluationError,
+    ConstraintProgramMismatchError,
+    ConstraintSelfReferenceError,
+    IncompatibleParameterizationInputError,
+    IncompleteParameterDependenciesError,
+    NonFiniteParameterValueError,
+    NoParameterMatchError,
+    ParameterDeclaration,
+    ParameterRole,
+    SealedParameterDeclarations,
+    SealedParameterModel,
+    UnsupportedConstraintExpressionError,
+    compile_active_parameterization,
+)
+from chemex.parameters.sealed import (
+    ParamConfig,
+    ParamDefinition,
+    SealedConfiguration,
+    SealedDefinitions,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parent.parent
+DCEST_EXPERIMENT = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Experiments/3hz.toml"
+DCEST_PARAMETERS = (
+    ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Parameters/parameters.toml"
+)
+DCEST_METHOD = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Methods/method.toml"
+MF_EXPERIMENT = ROOT / "examples/Experiments/CEST_15N_TR/Experiments/trosy.toml"
+MF_PARAMETERS = ROOT / "examples/Experiments/CEST_15N_TR/Parameters/parameters.toml"
+MF_METHOD = ROOT / "examples/Experiments/CEST_15N_TR/Methods/method.toml"
+FIT_EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+FIT_PARAMETERS = (
+    ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
+)
+FIT_METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+def _build_dcest_session() -> tuple[AnalysisSession, set[str]]:
+    session = AnalysisSession.create()
+    session.set_model("2st_hd")
+    experiments = build_experiments(
+        [DCEST_EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("1N")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([DCEST_PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    return session, experiments.param_ids
+
+
+def _native_fixture(
+    declarations: tuple[ParameterDeclaration, ...],
+    *,
+    values: dict[str, float] | None = None,
+    definitions: tuple[ParamDefinition, ...] | None = None,
+    model_name: str = "2st",
+    occurrence_identity: str = "occurrence-a",
+) -> tuple[SealedParameterModel, AnalysisValuesSnapshot]:
+    if definitions is None:
+        definitions = tuple(
+            ParamDefinition(
+                item.param_id,
+                item.param_id.removeprefix("__"),
+                "",
+                (),
+                1.0,
+                -float("inf"),
+                float("inf"),
+            )
+            for item in declarations
+        )
+    sealed_definitions = SealedDefinitions(
+        definitions,
+        {item.param_id: index for index, item in enumerate(definitions)},
+    )
+    current = values or {item.param_id: 1.0 for item in declarations}
+    configs = tuple(
+        ParamConfig(item.param_id, current[item.param_id], -float("inf"), float("inf"))
+        for item in declarations
+    )
+    configuration = SealedConfiguration(
+        configs,
+        {item.param_id: index for index, item in enumerate(configs)},
+        definitions_identity=sealed_definitions.identity,
+    )
+    sealed_declarations = SealedParameterDeclarations(declarations)
+    parameter_model = SealedParameterModel(
+        model_name,
+        sealed_definitions,
+        configuration,
+        sealed_declarations,
+    )
+    snapshot = AnalysisValuesSnapshot(
+        occurrence_identity=occurrence_identity,
+        model_identity=f"{model_name}|test",
+        definitions_identity=sealed_definitions.identity,
+        configuration_identity=configuration.identity,
+        revision=0,
+        _items=tuple(current.items()),
+    )
+    return parameter_model, snapshot
+
+
+def test_shipped_method_compiles_roles_and_resolves_without_mutation() -> None:
+    session, required_ids = _build_dcest_session()
+    methods = read_methods([DCEST_METHOD])
+    method = methods["STEP1"]
+    before = session.analysis_values.snapshot()
+    legacy_expressions = {
+        param_id: parameter.expr
+        for param_id, parameter in session.parameters.database._parameters.items()
+    }
+
+    parameterization = session.try_compile_parameterization(method, required_ids)
+    assert parameterization is not None
+    resolved = session.last_resolved_parameter_values
+    assert resolved is not None
+
+    definitions = session.parameter_factory.sealed_definitions
+    assert definitions is not None
+    r1_a = next(
+        item.param_id
+        for item in definitions
+        if item.name == "R1_A" and item.spin_system_name == "1N"
+    )
+    r1_b = next(
+        item.param_id
+        for item in definitions
+        if item.name == "R1_B" and item.spin_system_name == "1N"
+    )
+    d2o = next(item.param_id for item in definitions if item.name == "D2O")
+
+    assert parameterization.role(r1_b) is ParameterRole.DERIVED
+    assert parameterization.role(d2o) is ParameterRole.FIT
+    assert resolved[r1_b] == pytest.approx(0.5 * resolved[r1_a])
+    assert session.analysis_values.snapshot() == before
+    assert (
+        session.parameters.database._parameters[r1_b].expr == legacy_expressions[r1_b]
+    )
+
+    step2 = session.try_compile_parameterization(methods["STEP2"], required_ids)
+    assert step2 is not None
+    assert step2.role(d2o) is ParameterRole.FIX
+    assert session.analysis_values.snapshot() == before
+
+
+def test_constraint_chain_is_deterministic_and_freshly_reresolves() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False),
+        ParameterDeclaration("__C", False),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 3.0, "__B": 20.0, "__C": 30.0},
+    )
+    method = Method(
+        constraints=("[B] = [A] * 2", "[C] = [B] + 1"),
+        fit=("A",),
+    )
+
+    first = compile_active_parameterization(parameter_model, snapshot, method, {"__C"})
+    second = compile_active_parameterization(parameter_model, snapshot, method, {"__C"})
+    frame = first.frame_from_snapshot(snapshot)
+
+    assert first.program.fingerprint == second.program.fingerprint
+    assert first.scope_ids == ("__A", "__B", "__C")
+    assert first.program.evaluation_order == ("__B", "__C")
+    assert first.resolve(frame)["__C"] == pytest.approx(7.0)
+    assert first.resolve(frame.with_updates({"__A": 4.0}))["__C"] == pytest.approx(9.0)
+    assert snapshot["__B"] == 20.0
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        first.source_revision = 1  # ty: ignore[invalid-assignment]
+
+
+def test_legacy_constraints_fix_fit_precedence_uses_final_fit_role() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 3.0, "__B": 20.0},
+    )
+    method = Method(
+        constraints=("[B] = [A] * 2",),
+        fix=("B",),
+        fit=("B",),
+    )
+
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        method,
+        {"__B"},
+    )
+
+    assert parameterization.role("__B") is ParameterRole.FIT
+    assert parameterization.scope_ids == ("__B",)
+    assert parameterization.derived_ids == ()
+    assert (
+        parameterization.resolve(parameterization.frame_from_snapshot(snapshot))["__B"]
+        == 20.0
+    )
+
+
+def test_later_constraint_declaration_wins_for_the_same_target() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 3.0, "__B": 20.0},
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(
+            constraints=(
+                "[B] = [A] * 2",
+                "[B] = [A] * 3",
+            )
+        ),
+        {"__B"},
+    )
+
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert resolved["__B"] == 9.0
+    with pytest.raises(TypeError):
+        resolved["__B"] = 7.0  # ty: ignore[invalid-assignment]
+
+
+def test_shadowed_constraint_still_receives_public_syntax_validation() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False),
+    )
+    parameter_model, snapshot = _native_fixture(declarations)
+
+    with pytest.raises(UnsupportedConstraintExpressionError):
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(
+                constraints=("[B] = max([A], 1)",),
+                fit=("B",),
+            ),
+            {"__B"},
+        )
+
+
+def test_real_model_free_scientific_expression_matches_legacy_resolution() -> None:
+    session = AnalysisSession.create()
+    session.set_model("2st.mf")
+    experiments = build_experiments(
+        [MF_EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G23N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([MF_PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    snapshot = session.analysis_values.snapshot()
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    assert tuple(snapshot) == tuple(item.param_id for item in configuration)
+    assert all(
+        snapshot[item.param_id] == item.effective_value
+        for item in configuration
+        if item.effective_value is not None
+    )
+    assert any(item.effective_value is None for item in configuration)
+    assert not snapshot.occurrence_identity.startswith("bootstrap:")
+
+    method = read_methods([MF_METHOD])["DEFAULT"]
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+    legacy = session.parameters.build_lmfit_params(experiments.param_ids).valuesdict()
+    definitions = session.parameter_factory.sealed_definitions
+    assert definitions is not None
+    derived_rate_ids = tuple(
+        item.param_id
+        for item in definitions
+        if item.param_id in parameterization.derived_ids and item.name.startswith("R2")
+    )
+
+    assert derived_rate_ids
+    pb = next(item.param_id for item in definitions if item.name == "PB")
+    kex_ab = next(item.param_id for item in definitions if item.name == "KEX_AB")
+    assert parameterization.role(pb) is ParameterRole.FIX
+    assert parameterization.role(kex_ab) is ParameterRole.FIX
+    for param_id in derived_rate_ids:
+        assert resolved[param_id] == pytest.approx(
+            legacy[param_id], rel=1e-13, abs=1e-13
+        )
+
+
+@pytest.mark.parametrize("model_name", ("2st_binding", "2st_eyring"))
+def test_registered_scientific_model_expression_compiles_through_restricted_language(
+    model_name: str,
+) -> None:
+    AnalysisSession.create()
+    conditions = Conditions(
+        h_larmor_frq=800.0,
+        temperature=25.0,
+        p_total=1e-3,
+        l_total=2e-3,
+        d2o=0.1,
+    )
+    settings = model_factory.create(model_name, conditions)
+    name_map = {name: f"__{name.upper()}" for name in settings}
+    declarations = tuple(
+        ParameterDeclaration(
+            name_map[name],
+            setting.vary,
+            "" if setting.vary else setting.expr.format_map(name_map),
+        )
+        for name, setting in settings.items()
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        model_name=model_name,
+    )
+
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        set(name_map.values()),
+    )
+
+    assert parameterization.scope_ids == tuple(name_map.values())
+
+
+def test_supported_arithmetic_has_explicit_precedence_and_unary_semantics() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 6.0, "__B": 0.0},
+    )
+    method = Method(constraints=("[B] = -([A] - 2) / +2",))
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        method,
+        {"__B"},
+    )
+
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert resolved["__B"] == -2.0
+
+
+def test_no_match_failure_has_stable_type_code_and_context() -> None:
+    parameter_model, snapshot = _native_fixture((ParameterDeclaration("__A", False),))
+
+    with pytest.raises(NoParameterMatchError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(fit=("MISSING",)),
+            {"__A"},
+        )
+
+    assert raised.value.code == "no_match"
+    assert raised.value.context["selector"] == "missing"
+
+
+def test_contextually_incomparable_reference_is_ambiguity() -> None:
+    definitions = (
+        ParamDefinition("__A_SPIN", "A", "G1N-HN", (), 1.0, -10.0, 10.0),
+        ParamDefinition(
+            "__A_FIELD", "A", "", (("h_larmor_frq", 800.0),), 1.0, -10.0, 10.0
+        ),
+        ParamDefinition(
+            "__T", "T", "G1N-HN", (("h_larmor_frq", 800.0),), 1.0, -10.0, 10.0
+        ),
+    )
+    declarations = tuple(
+        ParameterDeclaration(item.param_id, False) for item in definitions
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        definitions=definitions,
+    )
+
+    with pytest.raises(AmbiguousParameterReferenceError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(constraints=("[T] = [A]",)),
+            {"__T"},
+        )
+
+    assert raised.value.code == "ambiguity"
+    assert raised.value.context["candidate_ids"] == ("__A_SPIN", "__A_FIELD")
+
+
+def test_direct_self_reference_is_rejected_before_evaluation() -> None:
+    parameter_model, snapshot = _native_fixture((ParameterDeclaration("__A", False),))
+
+    with pytest.raises(ConstraintSelfReferenceError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(constraints=("[A] = [A]",)),
+            {"__A"},
+        )
+
+    assert raised.value.code == "self_reference"
+    assert raised.value.context["target_id"] == "__A"
+
+
+def test_indirect_constraint_cycle_reports_exact_ids_and_provenance() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False),
+        ParameterDeclaration("__C", False),
+    )
+    parameter_model, snapshot = _native_fixture(declarations)
+
+    with pytest.raises(ConstraintCycleError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(
+                constraints=("[A] = [B]", "[B] = [A]", "[C] = [A]"),
+            ),
+            {"__C"},
+        )
+
+    assert raised.value.code == "cycle"
+    assert raised.value.context["param_ids"] == ("__A", "__B")
+    assert raised.value.context["constraints"] == (
+        ("__A", "method-rule:0", "[b]"),
+        ("__B", "method-rule:1", "[a]"),
+    )
+
+
+def test_arithmetic_domain_failure_does_not_return_partial_values() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 0.0, "__B": 10.0},
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(constraints=("[B] = 1 / [A]",)),
+        {"__B"},
+    )
+
+    with pytest.raises(ConstraintDomainError) as raised:
+        parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert raised.value.code == "domain_error"
+    assert raised.value.context["target_id"] == "__B"
+
+
+def test_scientific_function_evaluation_failure_is_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def explode(_value: float) -> float:
+        msg = "backend exploded"
+        raise RuntimeError(msg)
+
+    monkeypatch.setitem(
+        user_function_registry.user_function_registry,
+        "test_model",
+        {"explode": explode},
+    )
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False, "explode(__A)"),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        model_name="test_model",
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__B"},
+    )
+
+    with pytest.raises(ConstraintEvaluationError) as raised:
+        parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert raised.value.code == "evaluation_error"
+    assert raised.value.context["function_id"] == "explode"
+
+
+def test_malformed_scientific_function_component_is_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def malformed(_value: float) -> dict[str, object]:
+        return {"result": [1.0]}
+
+    monkeypatch.setitem(
+        user_function_registry.user_function_registry,
+        "test_model",
+        {"malformed": malformed},
+    )
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration(
+            "__B",
+            False,
+            'malformed(__A)["result"] + 1',
+        ),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        model_name="test_model",
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__B"},
+    )
+
+    with pytest.raises(ConstraintEvaluationError) as raised:
+        parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert raised.value.code == "evaluation_error"
+    assert raised.value.context["target_id"] == "__B"
+    assert raised.value.context["operator"] == "add"
+
+
+def test_non_finite_derived_value_has_its_own_failure_category() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 1e308, "__B": 0.0},
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(constraints=("[B] = [A] * [A]",)),
+        {"__B"},
+    )
+
+    with pytest.raises(NonFiniteParameterValueError) as raised:
+        parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert raised.value.code == "non_finite"
+    assert raised.value.context["param_id"] == "__B"
+
+
+def test_unknown_model_dependency_is_incomplete_dependency_failure() -> None:
+    declarations = (ParameterDeclaration("__A", False, "__MISSING + 1"),)
+    parameter_model, snapshot = _native_fixture(declarations)
+
+    with pytest.raises(IncompleteParameterDependenciesError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(),
+            {"__A"},
+        )
+
+    assert raised.value.code == "incomplete_dependencies"
+    assert raised.value.context["dependency_id"] == "__MISSING"
+
+
+def test_other_occurrence_snapshot_is_incompatible_even_for_same_model() -> None:
+    parameter_model, snapshot = _native_fixture((ParameterDeclaration("__A", False),))
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__A"},
+    )
+    other_occurrence = dataclasses.replace(
+        snapshot,
+        occurrence_identity="occurrence-b",
+    )
+
+    with pytest.raises(IncompatibleParameterizationInputError) as raised:
+        parameterization.frame_from_snapshot(other_occurrence)
+
+    assert raised.value.code == "incompatible_input"
+
+
+def test_incomplete_and_program_mismatched_frames_are_distinct_failures() -> None:
+    parameter_model, snapshot = _native_fixture((ParameterDeclaration("__A", False),))
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__A"},
+    )
+    frame = parameterization.frame_from_snapshot(snapshot)
+
+    with pytest.raises(IncompleteParameterDependenciesError):
+        parameterization.resolve(dataclasses.replace(frame, _items=()))
+    with pytest.raises(ConstraintProgramMismatchError) as raised:
+        parameterization.resolve(
+            dataclasses.replace(frame, program_fingerprint="different-program")
+        )
+
+    assert raised.value.code == "program_mismatch"
+
+
+def test_native_compilation_failure_cannot_veto_real_legacy_fit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = AnalysisSession.create()
+
+    def fail_preview(*_args: object, **_kwargs: object) -> None:
+        msg = "native preview failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(session, "compile_parameterization", fail_preview)
+    args = Namespace(
+        commands="fit",
+        model="2st",
+        include=[SpinSystem.from_name("G2N-HN")],
+        exclude=None,
+        experiments=[FIT_EXPERIMENT],
+        parameters=[FIT_PARAMETERS],
+        method=[FIT_METHOD],
+        output=tmp_path,
+        plot="nothing",
+        workers=1,
+        native_threads=1,
+    )
+
+    chemex_module.run(args, session=session)
+
+    assert list((tmp_path / "Data").rglob("*.dat"))
+    assert list((tmp_path / "Parameters").rglob("*.toml"))
+    assert isinstance(session.last_parameterization_failure, RuntimeError)
+    assert session.last_parameterization is None
+    assert session.last_resolved_parameter_values is None

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -283,7 +283,10 @@ def test_run_fit_creates_run_info(
     chemex_module.run_fit(
         args,
         experiments,
-        SimpleNamespace(execution=None),
+        SimpleNamespace(
+            execution=None,
+            try_compile_parameterization=lambda *_args: None,
+        ),
         argv=["chemex", "fit"],
     )
 


### PR DESCRIPTION
Closes #584.

## Summary

Introduces the next ChemEx-native parameter-model checkpoint from #566/#569:

* immutable method-scoped active parameterizations;
* deterministic compilation of existing `FIT`, `FIX`, and `CONSTRAINTS` declarations;
* a restricted native constraint program using stable ChemEx parameter IDs;
* immutable independent-value frames and resolved scalar snapshots;
* deterministic dependency closure and constraint evaluation;
* stable typed failures for invalid selectors, graphs, inputs, and evaluations;
* best-effort native preview isolated from the legacy-authoritative execution path.

The existing legacy fitting, simulation, residual, mutation, reporting, and output paths remain authoritative.

## Constraint semantics

Public method constraints support:

* finite scalar literals;
* bracketed ChemEx selectors;
* parentheses;
* unary `+` / `-`;
* binary `+`, `-`, `*`, `/`.

Model-owned scientific expressions additionally use the existing ChemEx model/rate function bindings required by current models.

There is no arbitrary Python evaluator or generic lmfit-compatible expression API.

Existing declaration precedence is preserved:

`CONSTRAINTS → FIX → FIT`, with later declarations winning according to current ChemEx behavior.

## Parameter-model boundaries

* roles and constraints remain method-scoped;
* definitions and immutable configuration are not mutated;
* Analysis Values retain only committed central values and #583 revision/occurrence semantics;
* resolved frames are immutable and cannot mutate Analysis Values;
* stable parameter IDs and deterministic ordering are preserved;
* native compilation/evaluation failures cannot veto an otherwise valid legacy-authoritative occurrence.

## Deliberately not included

This checkpoint does not introduce:

* native optimizer vectors or solver migration;
* accepted numerical-result/commit orchestration;
* covariance, uncertainty, resampling, or MCMC evidence;
* grouped-fit redesign;
* a generic expression language;
* mutable parallel parameter catalogs;
* generic transaction, graph, or identity frameworks.

## Validation

* Python 3.13: 437 passed
* Python 3.14: 437 passed
* `uv run ty check`
* `uv run ruff check .`
* `uv run ruff format --check .`
* `git diff --check`
* `uv build`
* representative shipped DCEST and model-free CEST inputs exercised directly
* native model-free derived relaxation rates agree with legacy lmfit resolution to `rtol=1e-13`, `atol=1e-13`

One existing emcee autocorrelation warning remains.
