### PR TITLE
Evaluate complete simulations through the native evaluation boundary

### DIFF
--- a/src/chemex/containers/profile.py
+++ b/src/chemex/containers/profile.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Protocol, Self, runtime_checkable
 
+import numpy as np
 from lmfit import Parameters as ParametersLF
 
 from chemex.containers.data import Data
-from chemex.evaluation import ProfileEvaluator
+from chemex.evaluation.profile import ProfileEvaluator
 from chemex.nmr.spectrometer import Spectrometer
 from chemex.parameters.spin_system import SpinSystem
 from chemex.printers.data import Printer
@@ -71,8 +73,15 @@ class Profile:
 
     def _get_parameter_values(self, params: ParametersLF) -> dict[str, float]:
         """Get the parameter values from the provided parameters."""
+        return self._local_parameter_values(
+            {param_id: params[param_id].value for param_id in self.param_ids}
+        )
+
+    def _local_parameter_values(
+        self, parameter_values: Mapping[str, float]
+    ) -> dict[str, float]:
         return {
-            local_name: params[param_id].value
+            local_name: parameter_values[param_id]
             for local_name, param_id in self.name_map.items()
         }
 
@@ -81,11 +90,28 @@ class Profile:
         parameter_values = self._get_parameter_values(params)
         self.spectrometer.update(parameter_values)
 
+    def calculate_unscaled(self, parameter_values: Mapping[str, float]) -> Array:
+        """Run only this profile's scientific calculation.
+
+        Scaling, residual construction, masking, and publication remain owned by
+        the caller.  This is intentionally the narrow calculation seam used by
+        the native qualification evaluator as well as the legacy adapter.
+        """
+        self.spectrometer.update(self._local_parameter_values(parameter_values))
+        # Existing pulse implementations are typed against Data but consume only
+        # metadata.  Give them a fresh zeroed carrier so kernels never see this
+        # profile's observations, errors, masks, or calculated arrays.
+        kernel_data = Data(
+            exp=np.zeros_like(self.data.exp),
+            err=np.zeros_like(self.data.err),
+            metadata=self.data.metadata,
+        )
+        return self.pulse_sequence.calculate(self.spectrometer, kernel_data)
+
     def calculate(self, params: ParametersLF) -> Array:
         """Calculate and return the Array."""
-        self.update_spectrometer(params)
-        self.data.calc_unscaled = self.pulse_sequence.calculate(
-            self.spectrometer, self.data
+        self.data.calc_unscaled = self.calculate_unscaled(
+            {param_id: params[param_id].value for param_id in self.param_ids}
         )
         if self.is_scaled:
             self.data.calc = self.data.scale * self.data.calc_unscaled

--- a/src/chemex/containers/profile.py
+++ b/src/chemex/containers/profile.py
@@ -104,7 +104,10 @@ class Profile:
         kernel_data = Data(
             exp=np.zeros_like(self.data.exp),
             err=np.zeros_like(self.data.err),
-            metadata=self.data.metadata,
+            # Kernel metadata is a per-call carrier, never an alias of the
+            # authoritative profile data.  Native evaluation owns all
+            # observations, uncertainties, masks, and residual semantics.
+            metadata=np.array(self.data.metadata, copy=True),
         )
         return self.pulse_sequence.calculate(self.spectrometer, kernel_data)
 

--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -1,0 +1,1209 @@
+"""Non-authoritative immutable native evaluation boundary (#585).
+
+This module deliberately has no optimizer or workflow entry point.  It is a
+qualification harness: callers build a frozen plan from already-selected
+ChemEx experiments, bind trusted local profile implementations, then evaluate
+one complete independent frame through a private single-owner workspace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from numbers import Real
+from threading import get_ident
+from typing import Any, Literal, cast
+
+import numpy as np
+
+from chemex.containers.experiments import Experiments
+from chemex.containers.profile import Profile
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    IndependentValueFrame,
+    ParameterizationError,
+    ResolvedParameterValues,
+)
+from chemex.typing import Array
+
+_SCHEMA_VERSION = 1
+_NORMALIZATION_VERSION = "weighted-zero-intercept-v1"
+_RESIDUAL_VERSION = "calculated-minus-experimental-weighted-masked-v1"
+_COMPATIBILITY_VERSION = "chemex-profile-kernel-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationFrame:
+    """The narrow #572 public independent-value input.
+
+    Lifecycle occurrence/revision validation happens before this projection is
+    made by ``from_lifecycle_frame``; evaluators never expose that metadata.
+    """
+
+    parameterization_identity: str
+    _items: tuple[tuple[str, float], ...]
+
+    def __post_init__(self) -> None:
+        items: list[tuple[str, float]] = []
+        for param_id, value in self._items:
+            if not isinstance(param_id, str):
+                raise TypeError("Evaluation-frame parameter IDs must be strings")
+            items.append((param_id, _finite_evaluation_scalar(value)))
+        if len({param_id for param_id, _value in items}) != len(items):
+            raise ValueError("Evaluation-frame parameter IDs must be unique")
+        object.__setattr__(self, "_items", tuple(items))
+
+    @classmethod
+    def from_lifecycle_frame(
+        cls,
+        parameterization: ActiveParameterization,
+        frame: IndependentValueFrame,
+    ) -> EvaluationFrame:
+        """Project a lifecycle-checked #584 frame into the public #572 input."""
+        if (
+            frame.parameterization_identity != parameterization.identity
+            or frame.program_fingerprint != parameterization.program.fingerprint
+            or frame.occurrence_identity != parameterization.occurrence_identity
+            or frame.revision != parameterization.source_revision
+        ):
+            raise ValueError("Lifecycle frame is incompatible with parameterization")
+        if tuple(param_id for param_id, _value in frame._items) != (
+            parameterization.independent_ids
+        ):
+            raise ValueError("Lifecycle frame has non-canonical independent ID order")
+        return cls(
+            parameterization.identity,
+            frame._items,
+        )
+
+
+def _finite_evaluation_scalar(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError("Evaluation-frame values must be real binary64 scalars")
+    try:
+        scalar = float(value)
+    except OverflowError as error:
+        raise ValueError("Evaluation-frame values must be finite") from error
+    if not math.isfinite(scalar):
+        raise ValueError("Evaluation-frame values must be finite")
+    return 0.0 if scalar == 0.0 else scalar
+
+
+def _canonical_float(value: float) -> str:
+    scalar = float(value)
+    if not math.isfinite(scalar):
+        raise ValueError("Native evaluation plans require finite scalar data")
+    return (0.0 if scalar == 0.0 else scalar).hex()
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"schema": _SCHEMA_VERSION, "kind": kind, "record": record},
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _semantic_value(value: object) -> object:
+    """Encode finite scientific values without repr or runtime identity."""
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, Real):
+        if isinstance(value, bool):
+            return value
+        return {"binary64": _canonical_float(float(value))}
+    if isinstance(value, np.ndarray):
+        raw_values = cast("Any", value).tolist()
+        return _semantic_value(raw_values)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _semantic_value(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [_semantic_value(item) for item in value]
+    raise TypeError(
+        f"Unsupported native scientific descriptor value: {type(value).__name__}"
+    )
+
+
+def _semantic_json(value: object) -> str:
+    return json.dumps(
+        _semantic_value(value), ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    )
+
+
+def _kernel_configuration(profile: Profile) -> str:
+    settings = getattr(profile.pulse_sequence, "settings", None)
+    if not hasattr(settings, "model_dump"):
+        raise ValueError("Native profile kernels must expose immutable settings")
+    return _semantic_json(settings.model_dump(mode="json"))
+
+
+def _observation_metadata(profile: Profile) -> str:
+    return _semantic_json(profile.data.metadata.tolist())
+
+
+def _spectrometer_configuration(profile: Profile) -> str:
+    return _semantic_json(profile.spectrometer.native_kernel_descriptor())
+
+
+def _readonly(values: Array) -> Array:
+    result = np.array(values, dtype=np.float64, copy=True)
+    result.flags.writeable = False
+    return result
+
+
+def _record_list(value: object, *, field_name: str) -> list[object]:
+    if not isinstance(value, list):
+        raise TypeError(f"Evaluation-plan {field_name} must be a list")
+    return cast("list[object]", value)
+
+
+def _record_int(value: object, *, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"Evaluation-plan {field_name} must be an integer")
+    return value
+
+
+def _record_float(value: object, *, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"Evaluation-plan {field_name} must be a scalar")
+    return _finite_evaluation_scalar(value)
+
+
+def _record_binary64(value: object, *, field_name: str) -> float:
+    if not isinstance(value, str):
+        raise TypeError(f"Evaluation-plan {field_name} must be a binary64 string")
+    try:
+        scalar = float.fromhex(value)
+    except ValueError as error:
+        raise ValueError(f"Evaluation-plan {field_name} is not binary64") from error
+    if _canonical_float(scalar) != value:
+        raise ValueError(f"Evaluation-plan {field_name} is not canonical binary64")
+    return scalar
+
+
+def _record_bool(value: object, *, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"Evaluation-plan {field_name} must be a boolean")
+    return value
+
+
+def _record_local_inputs(value: object) -> tuple[tuple[str, str], ...]:
+    items = _record_list(value, field_name="local_inputs")
+    pairs: list[tuple[str, str]] = []
+    for item in items:
+        pair = _record_list(item, field_name="local_input")
+        if len(pair) != 2:
+            raise TypeError("Evaluation-plan local inputs must be string pairs")
+        name, param_id = pair
+        if not isinstance(name, str) or not isinstance(param_id, str):
+            raise TypeError("Evaluation-plan local inputs must be string pairs")
+        pairs.append((name, param_id))
+    return tuple(pairs)
+
+
+def _profile_source_identity(profile: Profile) -> str:
+    """Fingerprint every scientific input that a trusted binding must retain."""
+    data = profile.data
+    return _identity(
+        "profile-source",
+        (
+            tuple(
+                (name, param_id) for name, param_id in sorted(profile.name_map.items())
+            ),
+            bool(profile.is_scaled),
+            type(profile.pulse_sequence).__module__,
+            type(profile.pulse_sequence).__qualname__,
+            _kernel_configuration(profile),
+            _spectrometer_configuration(profile),
+            tuple(_canonical_float(value) for value in np.ravel(data.exp)),
+            tuple(_canonical_float(value) for value in np.ravel(data.err)),
+            tuple(bool(value) for value in np.ravel(data.mask)),
+            _observation_metadata(profile),
+        ),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ProfilePlan:
+    """Frozen population and kernel contract for one ChemEx profile."""
+
+    identity: str
+    source_identity: str
+    experiment_ordinal: int
+    profile_ordinal: int
+    observation_offset: int
+    local_inputs: tuple[tuple[str, str], ...]
+    is_scaled: bool
+    experimental_values: tuple[float, ...]
+    uncertainties: tuple[float, ...]
+    mask: tuple[bool, ...]
+    kernel_identity: str
+    kernel_configuration: str
+    spectrometer_configuration: str
+    observation_metadata: str
+    output_shape: tuple[int, ...]
+
+    @property
+    def param_ids(self) -> tuple[str, ...]:
+        return tuple(sorted({param_id for _name, param_id in self.local_inputs}))
+
+    @property
+    def observation_count(self) -> int:
+        return len(self.experimental_values)
+
+    @property
+    def retained_observation_indices(self) -> tuple[int, ...]:
+        return tuple(index for index, included in enumerate(self.mask) if included)
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationPlan:
+    """Serializable immutable specification of one exact flat population."""
+
+    parameterization_identity: str
+    constraint_program_identity: str
+    profiles: tuple[ProfilePlan, ...]
+    normalization_version: str = _NORMALIZATION_VERSION
+    residual_version: str = _RESIDUAL_VERSION
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "evaluation-plan",
+                (
+                    self.parameterization_identity,
+                    self.constraint_program_identity,
+                    tuple(
+                        (
+                            item.identity,
+                            item.source_identity,
+                            item.experiment_ordinal,
+                            item.profile_ordinal,
+                            item.observation_offset,
+                            item.local_inputs,
+                            item.is_scaled,
+                            tuple(
+                                _canonical_float(value)
+                                for value in item.experimental_values
+                            ),
+                            tuple(
+                                _canonical_float(value) for value in item.uncertainties
+                            ),
+                            item.mask,
+                            item.kernel_identity,
+                            item.kernel_configuration,
+                            item.spectrometer_configuration,
+                            item.observation_metadata,
+                            item.output_shape,
+                        )
+                        for item in self.profiles
+                    ),
+                    self.normalization_version,
+                    self.residual_version,
+                ),
+            ),
+        )
+
+    @property
+    def observation_count(self) -> int:
+        return sum(item.observation_count for item in self.profiles)
+
+    @property
+    def retained_observation_count(self) -> int:
+        return sum(len(item.retained_observation_indices) for item in self.profiles)
+
+    def to_record(self) -> dict[str, object]:
+        """Return an executable-object-free serialization payload."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "parameterization_identity": self.parameterization_identity,
+            "constraint_program_identity": self.constraint_program_identity,
+            "normalization_version": self.normalization_version,
+            "residual_version": self.residual_version,
+            "profiles": [
+                {
+                    "identity": item.identity,
+                    "source_identity": item.source_identity,
+                    "experiment_ordinal": item.experiment_ordinal,
+                    "profile_ordinal": item.profile_ordinal,
+                    "observation_offset": item.observation_offset,
+                    "local_inputs": [list(value) for value in item.local_inputs],
+                    "is_scaled": item.is_scaled,
+                    "experimental_values": [
+                        _canonical_float(value) for value in item.experimental_values
+                    ],
+                    "uncertainties": [
+                        _canonical_float(value) for value in item.uncertainties
+                    ],
+                    "mask": list(item.mask),
+                    "kernel_identity": item.kernel_identity,
+                    "kernel_configuration": item.kernel_configuration,
+                    "spectrometer_configuration": item.spectrometer_configuration,
+                    "observation_metadata": item.observation_metadata,
+                    "output_shape": list(item.output_shape),
+                }
+                for item in self.profiles
+            ],
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> EvaluationPlan:
+        """Restore and verify a plan before it is rebound to local kernels."""
+        if record.get("schema_version") != _SCHEMA_VERSION:
+            raise ValueError("Unsupported native evaluation-plan schema")
+        raw_profiles = record.get("profiles")
+        if not isinstance(raw_profiles, list):
+            raise TypeError("Evaluation-plan profiles must be a list")
+        try:
+            profiles = tuple(
+                ProfilePlan(
+                    identity=str(cast("Mapping[str, object]", item)["identity"]),
+                    source_identity=str(
+                        cast("Mapping[str, object]", item)["source_identity"]
+                    ),
+                    experiment_ordinal=_record_int(
+                        cast("Mapping[str, object]", item)["experiment_ordinal"],
+                        field_name="experiment_ordinal",
+                    ),
+                    profile_ordinal=_record_int(
+                        cast("Mapping[str, object]", item)["profile_ordinal"],
+                        field_name="profile_ordinal",
+                    ),
+                    observation_offset=_record_int(
+                        cast("Mapping[str, object]", item)["observation_offset"],
+                        field_name="observation_offset",
+                    ),
+                    local_inputs=_record_local_inputs(
+                        cast("Mapping[str, object]", item)["local_inputs"]
+                    ),
+                    is_scaled=_record_bool(
+                        cast("Mapping[str, object]", item)["is_scaled"],
+                        field_name="is_scaled",
+                    ),
+                    experimental_values=tuple(
+                        _record_binary64(value, field_name="experimental_values")
+                        for value in _record_list(
+                            cast("Mapping[str, object]", item)["experimental_values"],
+                            field_name="experimental_values",
+                        )
+                    ),
+                    uncertainties=tuple(
+                        _record_binary64(value, field_name="uncertainties")
+                        for value in _record_list(
+                            cast("Mapping[str, object]", item)["uncertainties"],
+                            field_name="uncertainties",
+                        )
+                    ),
+                    mask=tuple(
+                        _record_bool(value, field_name="mask")
+                        for value in _record_list(
+                            cast("Mapping[str, object]", item)["mask"],
+                            field_name="mask",
+                        )
+                    ),
+                    kernel_identity=str(
+                        cast("Mapping[str, object]", item)["kernel_identity"]
+                    ),
+                    kernel_configuration=str(
+                        cast("Mapping[str, object]", item)["kernel_configuration"]
+                    ),
+                    spectrometer_configuration=str(
+                        cast("Mapping[str, object]", item)["spectrometer_configuration"]
+                    ),
+                    observation_metadata=str(
+                        cast("Mapping[str, object]", item)["observation_metadata"]
+                    ),
+                    output_shape=tuple(
+                        _record_int(value, field_name="output_shape")
+                        for value in _record_list(
+                            cast("Mapping[str, object]", item)["output_shape"],
+                            field_name="output_shape",
+                        )
+                    ),
+                )
+                for item in raw_profiles
+                if isinstance(item, Mapping)
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("Malformed native evaluation plan") from error
+        if len(profiles) != len(raw_profiles):
+            raise ValueError("Malformed native evaluation-profile record")
+        plan = cls(
+            parameterization_identity=str(record["parameterization_identity"]),
+            constraint_program_identity=str(record["constraint_program_identity"]),
+            profiles=profiles,
+            normalization_version=str(record["normalization_version"]),
+            residual_version=str(record["residual_version"]),
+        )
+        if record.get("identity") != plan.identity:
+            raise ValueError("Evaluation-plan fingerprint does not match its payload")
+        return plan
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileEvaluation:
+    """One complete immutable profile segment in canonical plan order."""
+
+    profile_identity: str
+    observation_offset: int
+    observation_count: int
+    residual_offset: int
+    residual_count: int
+    retained_observation_indices: tuple[int, ...]
+    normalization_factor: float
+    kernel_identity: str
+
+
+def _profile_evaluation_from_record(
+    record: object,
+    descriptor: ProfilePlan,
+) -> ProfileEvaluation:
+    if not isinstance(record, Mapping):
+        raise TypeError("Evaluation-result profile must be a mapping")
+    values = cast("Mapping[str, object]", record)
+    retained = tuple(
+        _record_int(value, field_name="retained observation index")
+        for value in _record_list(
+            values.get("retained_observation_indices"),
+            field_name="retained_observation_indices",
+        )
+    )
+    if (
+        values.get("profile_identity") != descriptor.identity
+        or values.get("kernel_identity") != descriptor.kernel_identity
+        or retained != descriptor.retained_observation_indices
+    ):
+        raise ValueError("Evaluation-result profile does not match frozen plan")
+    return ProfileEvaluation(
+        descriptor.identity,
+        _record_int(values.get("observation_offset"), field_name="observation_offset"),
+        _record_int(values.get("observation_count"), field_name="observation_count"),
+        _record_int(values.get("residual_offset"), field_name="residual_offset"),
+        _record_int(values.get("residual_count"), field_name="residual_count"),
+        retained,
+        _record_float(values.get("normalization_factor"), field_name="normalization"),
+        descriptor.kernel_identity,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationResult:
+    """The only successful native-evaluation outcome."""
+
+    plan_identity: str
+    parameterization_identity: str
+    evaluator_compatibility_identity: str
+    resolved_values: ResolvedParameterValues
+    unscaled_calculations: Array
+    normalized_calculations: Array
+    residuals: Array
+    profiles: tuple[ProfileEvaluation, ...]
+
+    @property
+    def identity(self) -> str:
+        """Deterministic identity of this complete immutable scientific outcome."""
+        return _identity(
+            "evaluation-result",
+            (
+                self.plan_identity,
+                self.parameterization_identity,
+                self.evaluator_compatibility_identity,
+                tuple(self.resolved_values.items()),
+                tuple(_canonical_float(value) for value in self.unscaled_calculations),
+                tuple(
+                    _canonical_float(value) for value in self.normalized_calculations
+                ),
+                tuple(_canonical_float(value) for value in self.residuals),
+                tuple(
+                    (
+                        item.profile_identity,
+                        item.observation_offset,
+                        item.observation_count,
+                        item.residual_offset,
+                        item.residual_count,
+                        item.retained_observation_indices,
+                        _canonical_float(item.normalization_factor),
+                        item.kernel_identity,
+                    )
+                    for item in self.profiles
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize immutable scientific evidence without runtime machinery."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "plan_identity": self.plan_identity,
+            "parameterization_identity": self.parameterization_identity,
+            "evaluator_compatibility_identity": self.evaluator_compatibility_identity,
+            "resolved": {
+                "program_fingerprint": self.resolved_values.program_fingerprint,
+                "occurrence_identity": self.resolved_values.occurrence_identity,
+                "revision": self.resolved_values.revision,
+                "items": list(self.resolved_values.items()),
+            },
+            "unscaled_calculations": self.unscaled_calculations.tolist(),
+            "normalized_calculations": self.normalized_calculations.tolist(),
+            "residuals": self.residuals.tolist(),
+            "profiles": [
+                {
+                    "profile_identity": item.profile_identity,
+                    "observation_offset": item.observation_offset,
+                    "observation_count": item.observation_count,
+                    "residual_offset": item.residual_offset,
+                    "residual_count": item.residual_count,
+                    "retained_observation_indices": list(
+                        item.retained_observation_indices
+                    ),
+                    "normalization_factor": item.normalization_factor,
+                    "kernel_identity": item.kernel_identity,
+                }
+                for item in self.profiles
+            ],
+        }
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        plan: EvaluationPlan,
+    ) -> EvaluationResult:
+        """Restore a result only when its population matches a frozen plan."""
+        if record.get("schema_version") != _SCHEMA_VERSION:
+            raise ValueError("Unsupported native evaluation-result schema")
+        if record.get("plan_identity") != plan.identity:
+            raise ValueError("Evaluation result belongs to another plan")
+        resolved_record = record.get("resolved")
+        if not isinstance(resolved_record, Mapping):
+            raise TypeError("Evaluation-result resolved values must be a mapping")
+        resolved_values = cast("Mapping[str, object]", resolved_record)
+        items = _record_list(resolved_values.get("items"), field_name="resolved.items")
+        resolved = ResolvedParameterValues(
+            parameterization_identity=str(record["parameterization_identity"]),
+            program_fingerprint=str(resolved_values["program_fingerprint"]),
+            occurrence_identity=str(resolved_values["occurrence_identity"]),
+            revision=_record_int(resolved_values["revision"], field_name="revision"),
+            _items=tuple(
+                (
+                    str(_record_list(item, field_name="resolved item")[0]),
+                    _record_float(
+                        _record_list(item, field_name="resolved item")[1],
+                        field_name="resolved value",
+                    ),
+                )
+                for item in items
+            ),
+        )
+        profiles_record = _record_list(record.get("profiles"), field_name="profiles")
+        if len(profiles_record) != len(plan.profiles):
+            raise ValueError("Evaluation result has the wrong profile population")
+        profiles = tuple(
+            _profile_evaluation_from_record(item, descriptor)
+            for item, descriptor in zip(profiles_record, plan.profiles, strict=True)
+        )
+        unscaled = _readonly(
+            np.asarray(
+                _record_list(
+                    record.get("unscaled_calculations"),
+                    field_name="unscaled calculations",
+                ),
+                dtype=np.float64,
+            )
+        )
+        normalized = _readonly(
+            np.asarray(
+                _record_list(
+                    record.get("normalized_calculations"),
+                    field_name="normalized calculations",
+                ),
+                dtype=np.float64,
+            )
+        )
+        residuals = _readonly(
+            np.asarray(
+                _record_list(record.get("residuals"), field_name="residuals"),
+                dtype=np.float64,
+            )
+        )
+        if (
+            unscaled.shape != (plan.observation_count,)
+            or normalized.shape != (plan.observation_count,)
+            or residuals.shape != (plan.retained_observation_count,)
+            or not np.all(np.isfinite(unscaled))
+            or not np.all(np.isfinite(normalized))
+            or not np.all(np.isfinite(residuals))
+        ):
+            raise ValueError("Malformed native evaluation-result arrays")
+        return cls(
+            plan.identity,
+            str(record["parameterization_identity"]),
+            str(record["evaluator_compatibility_identity"]),
+            resolved,
+            unscaled,
+            normalized,
+            residuals,
+            profiles,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationFailure:
+    """Atomic typed non-success outcome; no usable vectors accompany it."""
+
+    plan_identity: str
+    parameterization_identity: str
+    stage: Literal[
+        "frame", "resolution", "kernel", "normalization", "residual", "binding"
+    ]
+    category: str
+    validity: Literal[
+        "INVALID_REQUEST",
+        "INVALID_TRIAL",
+        "INVALID_PLAN_OR_BINDING",
+        "IMPLEMENTATION_FAILURE",
+    ]
+    profile_identity: str | None = None
+    message: str = ""
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize stable failure information without exception objects."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "plan_identity": self.plan_identity,
+            "parameterization_identity": self.parameterization_identity,
+            "stage": self.stage,
+            "category": self.category,
+            "validity": self.validity,
+            "profile_identity": self.profile_identity,
+            "message": self.message,
+        }
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        plan: EvaluationPlan,
+    ) -> EvaluationFailure:
+        """Restore a sanitized failure only for the matching frozen plan."""
+        if record.get("schema_version") != _SCHEMA_VERSION:
+            raise ValueError("Unsupported native evaluation-failure schema")
+        if record.get("plan_identity") != plan.identity:
+            raise ValueError("Evaluation failure belongs to another plan")
+        stage = str(record.get("stage"))
+        validity = str(record.get("validity"))
+        if stage not in {
+            "frame",
+            "resolution",
+            "kernel",
+            "normalization",
+            "residual",
+            "binding",
+        }:
+            raise ValueError("Unknown native evaluation-failure stage")
+        if validity not in {
+            "INVALID_REQUEST",
+            "INVALID_TRIAL",
+            "INVALID_PLAN_OR_BINDING",
+            "IMPLEMENTATION_FAILURE",
+        }:
+            raise ValueError("Unknown native evaluation-failure validity")
+        profile_identity = record.get("profile_identity")
+        if profile_identity is not None and profile_identity not in {
+            item.identity for item in plan.profiles
+        }:
+            raise ValueError("Evaluation failure names a profile outside its plan")
+        return cls(
+            plan.identity,
+            str(record["parameterization_identity"]),
+            stage,
+            str(record["category"]),
+            validity,
+            None if profile_identity is None else str(profile_identity),
+            str(record.get("message", "")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CacheStatistics:
+    hits: int
+    misses: int
+    entries: int
+
+
+@dataclass(frozen=True, slots=True)
+class _CachedProfile:
+    unscaled: Array
+    normalized: Array
+    residuals: Array
+    normalization_factor: float
+
+
+@dataclass(slots=True)
+class _Workspace:
+    templates: tuple[Profile, ...]
+    profiles: tuple[Profile, ...]
+    cache: OrderedDict[tuple[object, ...], _CachedProfile] = field(
+        default_factory=OrderedDict
+    )
+    hits: int = 0
+    misses: int = 0
+    poisoned: bool = False
+
+    def reset(self) -> None:
+        self.profiles = tuple(deepcopy(profile) for profile in self.templates)
+        self.cache.clear()
+
+
+def _build_plan(
+    experiments: Experiments,
+    parameterization: ActiveParameterization,
+) -> tuple[EvaluationPlan, tuple[tuple[int, int, Profile], ...]]:
+    profile_plans: list[ProfilePlan] = []
+    sources: list[tuple[int, int, Profile]] = []
+    offset = 0
+    for experiment_ordinal, experiment in enumerate(experiments):
+        for profile_ordinal, profile in enumerate(experiment.profiles):
+            exp = np.asarray(profile.data.exp, dtype=np.float64)
+            err = np.asarray(profile.data.err, dtype=np.float64)
+            mask = np.asarray(profile.data.mask, dtype=np.bool_)
+            if exp.ndim != 1 or err.shape != exp.shape or mask.shape != exp.shape:
+                raise ValueError(
+                    "Native evaluation requires one-dimensional symmetric data"
+                )
+            retained = mask
+            if not np.all(np.isfinite(exp[retained])) or not np.all(
+                np.isfinite(err[retained]) & (err[retained] > 0.0)
+            ):
+                raise ValueError(
+                    "Retained native observations require finite positive errors"
+                )
+            if profile.is_scaled and not np.any(retained):
+                raise ValueError(
+                    "A scaled native profile cannot retain zero observations"
+                )
+            source_identity = _profile_source_identity(profile)
+            kernel_identity = (
+                f"{type(profile.pulse_sequence).__module__}:"
+                f"{type(profile.pulse_sequence).__qualname__}:{_COMPATIBILITY_VERSION}"
+            )
+            identity = _identity(
+                "profile-plan",
+                (source_identity, experiment_ordinal, profile_ordinal, offset),
+            )
+            profile_plans.append(
+                ProfilePlan(
+                    identity=identity,
+                    source_identity=source_identity,
+                    experiment_ordinal=experiment_ordinal,
+                    profile_ordinal=profile_ordinal,
+                    observation_offset=offset,
+                    local_inputs=tuple(sorted(profile.name_map.items())),
+                    is_scaled=profile.is_scaled,
+                    experimental_values=tuple(float(value) for value in exp),
+                    uncertainties=tuple(float(value) for value in err),
+                    mask=tuple(bool(value) for value in mask),
+                    kernel_identity=kernel_identity,
+                    kernel_configuration=_kernel_configuration(profile),
+                    spectrometer_configuration=_spectrometer_configuration(profile),
+                    observation_metadata=_observation_metadata(profile),
+                    output_shape=tuple(exp.shape),
+                )
+            )
+            sources.append((experiment_ordinal, profile_ordinal, profile))
+            offset += exp.size
+    return (
+        EvaluationPlan(
+            parameterization_identity=parameterization.identity,
+            constraint_program_identity=parameterization.program.fingerprint,
+            profiles=tuple(profile_plans),
+        ),
+        tuple(sources),
+    )
+
+
+class EvaluationEngine:
+    """Binds one immutable plan to trusted local ChemEx profile kernels."""
+
+    def __init__(
+        self,
+        plan: EvaluationPlan,
+        parameterization: ActiveParameterization,
+        sources: Sequence[tuple[int, int, Profile]],
+    ) -> None:
+        if plan.parameterization_identity != parameterization.identity:
+            raise ValueError("Evaluation plan belongs to another parameterization")
+        if plan.constraint_program_identity != parameterization.program.fingerprint:
+            raise ValueError("Evaluation plan belongs to another constraint program")
+        if (
+            plan.normalization_version != _NORMALIZATION_VERSION
+            or plan.residual_version != _RESIDUAL_VERSION
+        ):
+            raise ValueError("Evaluation plan has incompatible execution semantics")
+        if len(plan.profiles) != len(sources):
+            raise ValueError("Trusted profile bindings do not match evaluation plan")
+        expected_offset = 0
+        for descriptor, (experiment_ordinal, profile_ordinal, source) in zip(
+            plan.profiles, sources, strict=True
+        ):
+            if (
+                descriptor.experiment_ordinal != experiment_ordinal
+                or descriptor.profile_ordinal != profile_ordinal
+                or descriptor.observation_offset != expected_offset
+                or descriptor.observation_count != source.data.exp.size
+                or descriptor.identity
+                != _identity(
+                    "profile-plan",
+                    (
+                        _profile_source_identity(source),
+                        experiment_ordinal,
+                        profile_ordinal,
+                        expected_offset,
+                    ),
+                )
+            ):
+                raise ValueError(
+                    "Trusted population structure does not match frozen plan"
+                )
+            if descriptor.source_identity != _profile_source_identity(source):
+                raise ValueError("Trusted profile binding does not match frozen plan")
+            kernel_identity = (
+                f"{type(source.pulse_sequence).__module__}:"
+                f"{type(source.pulse_sequence).__qualname__}:{_COMPATIBILITY_VERSION}"
+            )
+            if (
+                descriptor.kernel_identity != kernel_identity
+                or descriptor.kernel_configuration != _kernel_configuration(source)
+                or descriptor.spectrometer_configuration
+                != _spectrometer_configuration(source)
+                or descriptor.local_inputs != tuple(sorted(source.name_map.items()))
+                or descriptor.observation_metadata != _observation_metadata(source)
+                or descriptor.output_shape != tuple(source.data.exp.shape)
+            ):
+                raise ValueError("Trusted kernel descriptor does not match frozen plan")
+            expected_offset += descriptor.observation_count
+        self.plan = plan
+        self._parameterization = parameterization
+        # Copy construction-owned mutable machinery once.  Plans retain no
+        # source objects, and callers cannot alter a future workspace by
+        # mutating the legacy occurrence after it was bound.
+        self._sources = tuple(deepcopy(source) for _e, _p, source in sources)
+        self.compatibility_identity = _identity(
+            "evaluation-compatibility",
+            tuple(item.kernel_identity for item in plan.profiles),
+        )
+
+    @classmethod
+    def from_experiments(
+        cls,
+        experiments: Experiments,
+        parameterization: ActiveParameterization,
+    ) -> EvaluationEngine:
+        plan, sources = _build_plan(experiments, parameterization)
+        return cls(plan, parameterization, sources)
+
+    @classmethod
+    def bind(
+        cls,
+        plan: EvaluationPlan,
+        parameterization: ActiveParameterization,
+        experiments: Experiments,
+    ) -> EvaluationEngine:
+        """Trusted local rebinding path for a deserialized plan."""
+        sources = tuple(
+            (experiment_ordinal, profile_ordinal, profile)
+            for experiment_ordinal, experiment in enumerate(experiments)
+            for profile_ordinal, profile in enumerate(experiment.profiles)
+        )
+        return cls(plan, parameterization, sources)
+
+    def new_evaluator(self) -> BoundEvaluator:
+        """Create an empty single-owner workspace from trusted implementations."""
+        return BoundEvaluator(
+            self.plan,
+            self._parameterization,
+            self.compatibility_identity,
+            _Workspace(
+                self._sources,
+                tuple(deepcopy(profile) for profile in self._sources),
+            ),
+        )
+
+
+class BoundEvaluator:
+    """One non-reentrant evaluator with private reusable ChemEx workspaces."""
+
+    def __init__(
+        self,
+        plan: EvaluationPlan,
+        parameterization: ActiveParameterization,
+        compatibility_identity: str,
+        workspace: _Workspace,
+    ) -> None:
+        self.plan = plan
+        self._parameterization = parameterization
+        self.compatibility_identity = compatibility_identity
+        self._workspace = workspace
+        self._owner = get_ident()
+
+    @property
+    def cache_statistics(self) -> CacheStatistics:
+        return CacheStatistics(
+            self._workspace.hits,
+            self._workspace.misses,
+            len(self._workspace.cache),
+        )
+
+    def _failure(
+        self,
+        stage: Literal[
+            "frame", "resolution", "kernel", "normalization", "residual", "binding"
+        ],
+        category: str,
+        validity: Literal[
+            "INVALID_REQUEST",
+            "INVALID_TRIAL",
+            "INVALID_PLAN_OR_BINDING",
+            "IMPLEMENTATION_FAILURE",
+        ],
+        *,
+        profile_identity: str | None = None,
+        message: str = "",
+    ) -> EvaluationFailure:
+        if validity in {"INVALID_PLAN_OR_BINDING", "IMPLEMENTATION_FAILURE"}:
+            self._workspace.poisoned = True
+            self._workspace.cache.clear()
+        elif validity == "INVALID_TRIAL":
+            self._workspace.reset()
+        return EvaluationFailure(
+            self.plan.identity,
+            self._parameterization.identity,
+            stage,
+            category,
+            validity,
+            profile_identity,
+            message,
+        )
+
+    def _calculate_unscaled(
+        self,
+        descriptor: ProfilePlan,
+        profile: Profile,
+        resolved: ResolvedParameterValues,
+    ) -> Array | EvaluationFailure:
+        """Run and validate the narrow unscaled profile kernel."""
+        try:
+            unscaled = np.asarray(profile.calculate_unscaled(resolved))
+        except Exception as error:  # noqa: BLE001 - native kernel fault boundary
+            return self._failure(
+                "kernel",
+                "kernel_exception",
+                "IMPLEMENTATION_FAILURE",
+                profile_identity=descriptor.identity,
+                message=str(error),
+            )
+        if unscaled.shape != (descriptor.observation_count,):
+            return self._failure(
+                "kernel",
+                "unexpected_shape",
+                "IMPLEMENTATION_FAILURE",
+                profile_identity=descriptor.identity,
+            )
+        if not np.issubdtype(unscaled.dtype, np.floating):
+            return self._failure(
+                "kernel",
+                "unexpected_dtype",
+                "IMPLEMENTATION_FAILURE",
+                profile_identity=descriptor.identity,
+            )
+        unscaled_values = _readonly(unscaled)
+        if not np.all(np.isfinite(unscaled_values)):
+            return self._failure(
+                "kernel",
+                "non_finite_calculation",
+                "INVALID_TRIAL",
+                profile_identity=descriptor.identity,
+            )
+        return unscaled_values
+
+    def _normalize_profile(
+        self,
+        descriptor: ProfilePlan,
+        unscaled: Array,
+    ) -> _CachedProfile | EvaluationFailure:
+        """Apply the frozen #572 normalization and retained residual contract."""
+        exp = np.asarray(descriptor.experimental_values, dtype=np.float64)
+        err = np.asarray(descriptor.uncertainties, dtype=np.float64)
+        retained = np.asarray(descriptor.mask, dtype=np.bool_)
+        if descriptor.is_scaled:
+            selected_exp = exp[retained]
+            selected_calc = unscaled[retained]
+            selected_err = err[retained]
+            numerator = float(
+                np.dot(selected_exp / selected_err, selected_calc / selected_err)
+            )
+            denominator = float(
+                np.dot(selected_calc / selected_err, selected_calc / selected_err)
+            )
+            if (
+                not math.isfinite(numerator)
+                or not math.isfinite(denominator)
+                or denominator == 0.0
+            ):
+                return self._failure(
+                    "normalization",
+                    "invalid_normalization",
+                    "INVALID_TRIAL",
+                    profile_identity=descriptor.identity,
+                )
+            scale = numerator / denominator
+            if not math.isfinite(scale):
+                return self._failure(
+                    "normalization",
+                    "non_finite_normalization",
+                    "INVALID_TRIAL",
+                    profile_identity=descriptor.identity,
+                )
+        else:
+            scale = 1.0
+        normalized = _readonly(scale * unscaled)
+        residuals = _readonly((normalized[retained] - exp[retained]) / err[retained])
+        if not np.all(np.isfinite(normalized)) or not np.all(np.isfinite(residuals)):
+            return self._failure(
+                "residual",
+                "non_finite_residual",
+                "INVALID_TRIAL",
+                profile_identity=descriptor.identity,
+            )
+        return _CachedProfile(unscaled, normalized, residuals, scale)
+
+    def _cached_profile(
+        self,
+        descriptor: ProfilePlan,
+        profile: Profile,
+        resolved: ResolvedParameterValues,
+    ) -> _CachedProfile | EvaluationFailure:
+        key = (
+            descriptor.identity,
+            *(resolved[param_id] for param_id in descriptor.param_ids),
+        )
+        cached = self._workspace.cache.get(key)
+        if cached is not None:
+            self._workspace.cache.move_to_end(key)
+            self._workspace.hits += 1
+            return cached
+        self._workspace.misses += 1
+        unscaled = self._calculate_unscaled(descriptor, profile, resolved)
+        if isinstance(unscaled, EvaluationFailure):
+            return unscaled
+        cached = self._normalize_profile(descriptor, unscaled)
+        if isinstance(cached, EvaluationFailure):
+            return cached
+        self._workspace.cache[key] = cached
+        self._workspace.cache.move_to_end(key)
+        while len(self._workspace.cache) > 5:
+            self._workspace.cache.popitem(last=False)
+        return cached
+
+    def evaluate(
+        self,
+        frame: EvaluationFrame,
+    ) -> EvaluationResult | EvaluationFailure:
+        """Resolve once and atomically return a complete result or typed failure."""
+        if get_ident() != self._owner:
+            return self._failure(
+                "binding", "workspace_owner_violation", "INVALID_REQUEST"
+            )
+        if self._workspace.poisoned:
+            return self._failure(
+                "binding", "workspace_poisoned", "INVALID_PLAN_OR_BINDING"
+            )
+        try:
+            if frame.parameterization_identity != self._parameterization.identity:
+                return self._failure(
+                    "frame", "parameterization_mismatch", "INVALID_REQUEST"
+                )
+            if (
+                tuple(param_id for param_id, _value in frame._items)
+                != self._parameterization.independent_ids
+            ):
+                return self._failure(
+                    "frame", "independent_value_order", "INVALID_REQUEST"
+                )
+            lifecycle_frame = IndependentValueFrame(
+                self._parameterization.identity,
+                self._parameterization.program.fingerprint,
+                self._parameterization.occurrence_identity,
+                self._parameterization.source_revision,
+                frame._items,
+            )
+            resolved = self._parameterization.resolve(lifecycle_frame)
+        except ParameterizationError as error:
+            return self._failure(
+                "resolution", error.code, "INVALID_REQUEST", message=str(error)
+            )
+        except Exception as error:  # noqa: BLE001 - trusted-program boundary
+            return self._failure(
+                "resolution",
+                "unexpected_resolution_error",
+                "IMPLEMENTATION_FAILURE",
+                message=str(error),
+            )
+        unscaled_parts: list[Array] = []
+        normalized_parts: list[Array] = []
+        residual_parts: list[Array] = []
+        profiles: list[ProfileEvaluation] = []
+        residual_offset = 0
+        for descriptor, profile in zip(
+            self.plan.profiles, self._workspace.profiles, strict=True
+        ):
+            cached = self._cached_profile(descriptor, profile, resolved)
+            if isinstance(cached, EvaluationFailure):
+                return cached
+            retained = descriptor.retained_observation_indices
+            profiles.append(
+                ProfileEvaluation(
+                    descriptor.identity,
+                    descriptor.observation_offset,
+                    descriptor.observation_count,
+                    residual_offset,
+                    len(retained),
+                    retained,
+                    cached.normalization_factor,
+                    descriptor.kernel_identity,
+                )
+            )
+            residual_offset += len(retained)
+            unscaled_parts.append(cached.unscaled)
+            normalized_parts.append(cached.normalized)
+            residual_parts.append(cached.residuals)
+        return EvaluationResult(
+            self.plan.identity,
+            self._parameterization.identity,
+            self.compatibility_identity,
+            resolved,
+            _readonly(
+                np.concatenate(unscaled_parts) if unscaled_parts else np.empty(0)
+            ),
+            _readonly(
+                np.concatenate(normalized_parts) if normalized_parts else np.empty(0)
+            ),
+            _readonly(
+                np.concatenate(residual_parts) if residual_parts else np.empty(0)
+            ),
+            tuple(profiles),
+        )

--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 from collections import OrderedDict
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from numbers import Real
@@ -21,8 +22,10 @@ from typing import Any, Literal, cast
 
 import numpy as np
 
+from chemex.containers.data import Data
 from chemex.containers.experiments import Experiments
-from chemex.containers.profile import Profile
+from chemex.containers.profile import Profile, PulseSequence
+from chemex.nmr.spectrometer import Spectrometer
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     IndependentValueFrame,
@@ -32,9 +35,71 @@ from chemex.parameters.parameterization import (
 from chemex.typing import Array
 
 _SCHEMA_VERSION = 1
-_NORMALIZATION_VERSION = "weighted-zero-intercept-v1"
+_SCALAR_VERSION = "canonical-binary64-v1"
+_NORMALIZATION_VERSION = "weighted-zero-intercept-ordered-binary64-v2"
 _RESIDUAL_VERSION = "calculated-minus-experimental-weighted-masked-v1"
+_MASKING_VERSION = "retained-true-observations-v1"
+_ORDERING_VERSION = "experiment-profile-row-v1"
+_FAILURE_VERSION = "typed-failure-v1"
+_DIAGNOSTICS_VERSION = "no-contractual-diagnostics-v1"
 _COMPATIBILITY_VERSION = "chemex-profile-kernel-v1"
+type FailureStage = Literal[
+    "frame",
+    "resolution",
+    "projection",
+    "cache",
+    "kernel",
+    "normalization",
+    "residual",
+    "result",
+    "binding",
+]
+type FailureValidity = Literal[
+    "INVALID_REQUEST",
+    "INVALID_TRIAL",
+    "INVALID_PLAN_OR_BINDING",
+    "IMPLEMENTATION_FAILURE",
+]
+_FAILURE_TAXONOMY = {
+    "frame": {
+        "parameterization_mismatch": "INVALID_REQUEST",
+        "independent_value_order": "INVALID_REQUEST",
+    },
+    "resolution": {
+        "no_match": "INVALID_PLAN_OR_BINDING",
+        "ambiguity": "INVALID_PLAN_OR_BINDING",
+        "self_reference": "INVALID_PLAN_OR_BINDING",
+        "cycle": "INVALID_PLAN_OR_BINDING",
+        "domain_error": "INVALID_TRIAL",
+        "evaluation_error": "INVALID_TRIAL",
+        "non_finite": "INVALID_TRIAL",
+        "incomplete_dependencies": "INVALID_PLAN_OR_BINDING",
+        "incompatible_input": "INVALID_PLAN_OR_BINDING",
+        "program_mismatch": "INVALID_PLAN_OR_BINDING",
+        "unsupported_expression": "INVALID_PLAN_OR_BINDING",
+        "model_derivation_override": "INVALID_PLAN_OR_BINDING",
+        "unexpected_resolution_error": "IMPLEMENTATION_FAILURE",
+    },
+    "projection": {"missing_local_parameter": "INVALID_PLAN_OR_BINDING"},
+    "cache": {"cache_key_exception": "IMPLEMENTATION_FAILURE"},
+    "kernel": {
+        "kernel_exception": "IMPLEMENTATION_FAILURE",
+        "unexpected_container": "IMPLEMENTATION_FAILURE",
+        "unexpected_shape": "IMPLEMENTATION_FAILURE",
+        "unexpected_dtype": "IMPLEMENTATION_FAILURE",
+        "non_finite_calculation": "INVALID_TRIAL",
+    },
+    "normalization": {"invalid_normalization": "INVALID_TRIAL"},
+    "residual": {"non_finite_residual": "INVALID_TRIAL"},
+    "result": {"result_assembly_exception": "IMPLEMENTATION_FAILURE"},
+    "binding": {
+        "workspace_owner_violation": "INVALID_REQUEST",
+        "workspace_reentrant": "INVALID_REQUEST",
+        "workspace_process_violation": "INVALID_PLAN_OR_BINDING",
+        "workspace_poisoned": "INVALID_PLAN_OR_BINDING",
+        "unexpected_evaluation_error": "IMPLEMENTATION_FAILURE",
+    },
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,14 +141,55 @@ class EvaluationFrame:
             parameterization.independent_ids
         ):
             raise ValueError("Lifecycle frame has non-canonical independent ID order")
-        return cls(
-            parameterization.identity,
-            frame._items,
+        return cls(parameterization.evaluator_identity, frame._items)
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize only canonical evaluator-facing frame semantics."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "parameterization_identity": self.parameterization_identity,
+            "items": [
+                [param_id, _canonical_float(value)] for param_id, value in self._items
+            ],
+            "identity": self.identity,
+        }
+
+    @property
+    def identity(self) -> str:
+        return _identity(
+            "evaluation-frame",
+            (
+                self.parameterization_identity,
+                tuple((key, _canonical_float(value)) for key, value in self._items),
+            ),
         )
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> EvaluationFrame:
+        _record_exact_keys(
+            record,
+            {"schema_version", "parameterization_identity", "items", "identity"},
+            "Evaluation-frame",
+        )
+        if record.get("schema_version") != _SCHEMA_VERSION:
+            raise ValueError("Unsupported native evaluation-frame schema")
+        identity = record.get("parameterization_identity")
+        if not isinstance(identity, str):
+            raise TypeError(
+                "Evaluation-frame parameterization identity must be a string"
+            )
+        items = tuple(
+            _record_frame_item(item)
+            for item in _record_list(record.get("items"), field_name="frame items")
+        )
+        frame = cls(identity, items)
+        if record.get("identity") != frame.identity:
+            raise ValueError("Evaluation-frame fingerprint does not match its payload")
+        return frame
 
 
 def _finite_evaluation_scalar(value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
+    if isinstance(value, bool) or not isinstance(value, (float, np.float64)):
         raise TypeError("Evaluation-frame values must be real binary64 scalars")
     try:
         scalar = float(value)
@@ -156,9 +262,106 @@ def _spectrometer_configuration(profile: Profile) -> str:
 
 
 def _readonly(values: Array) -> Array:
-    result = np.array(values, dtype=np.float64, copy=True)
-    result.flags.writeable = False
-    return result
+    """Own immutable binary64 storage that cannot be made writable again."""
+    copied = np.ascontiguousarray(values, dtype=np.float64)
+    return np.frombuffer(copied.tobytes(), dtype=np.float64)
+
+
+def _weighted_reduction(
+    experimental: Array, calculation: Array, uncertainty: Array, *, square: bool
+) -> float:
+    """Left-to-right binary64 terms in canonical retained-observation order."""
+    total = 0.0
+    for exp, calc, err in zip(experimental, calculation, uncertainty, strict=True):
+        left = float(calc) / float(err)
+        right = left if square else float(exp) / float(err)
+        term = left * right
+        total = total + term
+        if (
+            not math.isfinite(left)
+            or not math.isfinite(right)
+            or not math.isfinite(total)
+        ):
+            return math.nan
+    return total
+
+
+def _normalization_factor(descriptor: ProfilePlan, unscaled: Array) -> float | None:
+    if not descriptor.is_scaled:
+        return 1.0
+    retained = np.asarray(descriptor.mask, dtype=np.bool_)
+    exp = np.asarray(descriptor.experimental_values, dtype=np.float64)[retained]
+    err = np.asarray(descriptor.uncertainties, dtype=np.float64)[retained]
+    calc = unscaled[retained]
+    numerator = _weighted_reduction(exp, calc, err, square=False)
+    denominator = _weighted_reduction(exp, calc, err, square=True)
+    if (
+        not math.isfinite(numerator)
+        or not math.isfinite(denominator)
+        or denominator == 0.0
+    ):
+        return None
+    scale = numerator / denominator
+    return scale if math.isfinite(scale) else None
+
+
+def _parameterization_failure_validity(
+    error: ParameterizationError,
+) -> Literal["INVALID_REQUEST", "INVALID_TRIAL", "INVALID_PLAN_OR_BINDING"]:
+    validity = _FAILURE_TAXONOMY["resolution"].get(error.code)
+    if validity is None:
+        raise RuntimeError("Undeclared parameterization failure")
+    return cast(
+        'Literal["INVALID_REQUEST", "INVALID_TRIAL", "INVALID_PLAN_OR_BINDING"]',
+        validity,
+    )
+
+
+def _validate_plan_runtime_versions(plan: EvaluationPlan) -> None:
+    if (
+        plan.normalization_version != _NORMALIZATION_VERSION
+        or plan.residual_version != _RESIDUAL_VERSION
+        or plan.scalar_version != _SCALAR_VERSION
+        or plan.masking_version != _MASKING_VERSION
+        or plan.ordering_version != _ORDERING_VERSION
+        or plan.failure_version != _FAILURE_VERSION
+        or plan.diagnostics_version != _DIAGNOSTICS_VERSION
+    ):
+        raise ValueError("Evaluation plan has incompatible execution semantics")
+
+
+def _record_failure_stage_validity(
+    record: Mapping[str, object],
+) -> tuple[FailureStage, FailureValidity]:
+    stage = _record_string(record.get("stage"), "failure stage")
+    validity = _record_string(record.get("validity"), "failure validity")
+    if stage not in _FAILURE_TAXONOMY:
+        raise ValueError("Unknown native evaluation-failure stage")
+    if validity not in {
+        "INVALID_REQUEST",
+        "INVALID_TRIAL",
+        "INVALID_PLAN_OR_BINDING",
+        "IMPLEMENTATION_FAILURE",
+    }:
+        raise ValueError("Unknown native evaluation-failure validity")
+    category = _record_string(record.get("category"), "failure category")
+    if _FAILURE_TAXONOMY[stage].get(category) != validity:
+        raise ValueError("Evaluation failure has incompatible stage and validity")
+    return cast(FailureStage, stage), validity
+
+
+def _record_exact_keys(
+    record: Mapping[str, object], expected: set[str], name: str
+) -> None:
+    if set(record) != expected:
+        raise ValueError(f"{name} record has unknown or missing fields")
+
+
+def _record_frame_item(value: object) -> tuple[str, float]:
+    pair = _record_list(value, field_name="frame item")
+    if len(pair) != 2 or not isinstance(pair[0], str):
+        raise TypeError("Evaluation-frame items must be [string, binary64] pairs")
+    return pair[0], _record_binary64(pair[1], field_name="frame value")
 
 
 def _record_list(value: object, *, field_name: str) -> list[object]:
@@ -195,6 +398,20 @@ def _record_bool(value: object, *, field_name: str) -> bool:
     if not isinstance(value, bool):
         raise TypeError(f"Evaluation-plan {field_name} must be a boolean")
     return value
+
+
+def _record_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"Evaluation record {field_name} must be a string")
+    return value
+
+
+def _record_string_sequence(value: object, field_name: str) -> tuple[str, ...]:
+    items = _record_list(value, field_name=field_name)
+    result = tuple(_record_string(item, field_name) for item in items)
+    if len(set(result)) != len(result):
+        raise ValueError(f"Evaluation record {field_name} must be unique")
+    return result
 
 
 def _record_local_inputs(value: object) -> tuple[tuple[str, str], ...]:
@@ -273,8 +490,14 @@ class EvaluationPlan:
     parameterization_identity: str
     constraint_program_identity: str
     profiles: tuple[ProfilePlan, ...]
+    resolved_ids: tuple[str, ...] = ()
+    scalar_version: str = _SCALAR_VERSION
     normalization_version: str = _NORMALIZATION_VERSION
     residual_version: str = _RESIDUAL_VERSION
+    masking_version: str = _MASKING_VERSION
+    ordering_version: str = _ORDERING_VERSION
+    failure_version: str = _FAILURE_VERSION
+    diagnostics_version: str = _DIAGNOSTICS_VERSION
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -286,6 +509,7 @@ class EvaluationPlan:
                 (
                     self.parameterization_identity,
                     self.constraint_program_identity,
+                    self.resolved_ids,
                     tuple(
                         (
                             item.identity,
@@ -313,6 +537,11 @@ class EvaluationPlan:
                     ),
                     self.normalization_version,
                     self.residual_version,
+                    self.scalar_version,
+                    self.masking_version,
+                    self.ordering_version,
+                    self.failure_version,
+                    self.diagnostics_version,
                 ),
             ),
         )
@@ -331,8 +560,14 @@ class EvaluationPlan:
             "schema_version": _SCHEMA_VERSION,
             "parameterization_identity": self.parameterization_identity,
             "constraint_program_identity": self.constraint_program_identity,
+            "resolved_ids": list(self.resolved_ids),
+            "scalar_version": self.scalar_version,
             "normalization_version": self.normalization_version,
             "residual_version": self.residual_version,
+            "masking_version": self.masking_version,
+            "ordering_version": self.ordering_version,
+            "failure_version": self.failure_version,
+            "diagnostics_version": self.diagnostics_version,
             "profiles": [
                 {
                     "identity": item.identity,
@@ -363,6 +598,25 @@ class EvaluationPlan:
     @classmethod
     def from_record(cls, record: Mapping[str, object]) -> EvaluationPlan:
         """Restore and verify a plan before it is rebound to local kernels."""
+        _record_exact_keys(
+            record,
+            {
+                "schema_version",
+                "parameterization_identity",
+                "constraint_program_identity",
+                "resolved_ids",
+                "scalar_version",
+                "normalization_version",
+                "residual_version",
+                "masking_version",
+                "ordering_version",
+                "failure_version",
+                "diagnostics_version",
+                "profiles",
+                "identity",
+            },
+            "Evaluation-plan",
+        )
         if record.get("schema_version") != _SCHEMA_VERSION:
             raise ValueError("Unsupported native evaluation-plan schema")
         raw_profiles = record.get("profiles")
@@ -442,12 +696,58 @@ class EvaluationPlan:
             raise ValueError("Malformed native evaluation plan") from error
         if len(profiles) != len(raw_profiles):
             raise ValueError("Malformed native evaluation-profile record")
+        expected_offset = 0
+        for descriptor in profiles:
+            if (
+                len(descriptor.uncertainties) != descriptor.observation_count
+                or len(descriptor.mask) != descriptor.observation_count
+                or descriptor.output_shape != (descriptor.observation_count,)
+                or descriptor.observation_offset != expected_offset
+                or descriptor.experiment_ordinal < 0
+                or descriptor.profile_ordinal < 0
+                or descriptor.identity
+                != _identity(
+                    "profile-plan",
+                    (
+                        descriptor.source_identity,
+                        descriptor.experiment_ordinal,
+                        descriptor.profile_ordinal,
+                        descriptor.observation_offset,
+                    ),
+                )
+            ):
+                raise ValueError("Malformed native evaluation-profile semantics")
+            expected_offset += descriptor.observation_count
         plan = cls(
-            parameterization_identity=str(record["parameterization_identity"]),
-            constraint_program_identity=str(record["constraint_program_identity"]),
+            parameterization_identity=_record_string(
+                record["parameterization_identity"], "parameterization identity"
+            ),
+            constraint_program_identity=_record_string(
+                record["constraint_program_identity"], "constraint program identity"
+            ),
             profiles=profiles,
-            normalization_version=str(record["normalization_version"]),
-            residual_version=str(record["residual_version"]),
+            resolved_ids=_record_string_sequence(
+                record["resolved_ids"], "resolved IDs"
+            ),
+            scalar_version=_record_string(record["scalar_version"], "scalar version"),
+            normalization_version=_record_string(
+                record["normalization_version"], "normalization version"
+            ),
+            residual_version=_record_string(
+                record["residual_version"], "residual version"
+            ),
+            masking_version=_record_string(
+                record["masking_version"], "masking version"
+            ),
+            ordering_version=_record_string(
+                record["ordering_version"], "ordering version"
+            ),
+            failure_version=_record_string(
+                record["failure_version"], "failure version"
+            ),
+            diagnostics_version=_record_string(
+                record["diagnostics_version"], "diagnostics version"
+            ),
         )
         if record.get("identity") != plan.identity:
             raise ValueError("Evaluation-plan fingerprint does not match its payload")
@@ -468,6 +768,37 @@ class ProfileEvaluation:
     kernel_identity: str
 
 
+@dataclass(frozen=True, slots=True)
+class ResolvedEvaluationValues(Mapping[str, float]):
+    """Evaluator-semantic resolved snapshot with no lifecycle authority."""
+
+    parameterization_identity: str
+    program_identity: str
+    _items: tuple[tuple[str, float], ...]
+    _index: Mapping[str, float] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        items = tuple(
+            (key, _finite_evaluation_scalar(value)) for key, value in self._items
+        )
+        if len({key for key, _value in items}) != len(items):
+            raise ValueError("Resolved evaluation values must have unique IDs")
+        object.__setattr__(self, "_items", items)
+        object.__setattr__(self, "_index", dict(items))
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._index)
+
+    def __len__(self) -> int:
+        return len(self._index)
+
+    def __getitem__(self, key: str) -> float:
+        return self._index[key]
+
+    def ordered_items(self) -> tuple[tuple[str, float], ...]:
+        return self._items
+
+
 def _profile_evaluation_from_record(
     record: object,
     descriptor: ProfilePlan,
@@ -475,6 +806,20 @@ def _profile_evaluation_from_record(
     if not isinstance(record, Mapping):
         raise TypeError("Evaluation-result profile must be a mapping")
     values = cast("Mapping[str, object]", record)
+    _record_exact_keys(
+        values,
+        {
+            "profile_identity",
+            "observation_offset",
+            "observation_count",
+            "residual_offset",
+            "residual_count",
+            "retained_observation_indices",
+            "normalization_factor",
+            "kernel_identity",
+        },
+        "Evaluation-result profile",
+    )
     retained = tuple(
         _record_int(value, field_name="retained observation index")
         for value in _record_list(
@@ -495,9 +840,58 @@ def _profile_evaluation_from_record(
         _record_int(values.get("residual_offset"), field_name="residual_offset"),
         _record_int(values.get("residual_count"), field_name="residual_count"),
         retained,
-        _record_float(values.get("normalization_factor"), field_name="normalization"),
+        _record_binary64(
+            values.get("normalization_factor"), field_name="normalization"
+        ),
         descriptor.kernel_identity,
     )
+
+
+def _compatibility_identity(plan: EvaluationPlan) -> str:
+    return _identity(
+        "evaluation-compatibility",
+        tuple(item.kernel_identity for item in plan.profiles),
+    )
+
+
+def _validate_result_relationships(
+    plan: EvaluationPlan,
+    unscaled: Array,
+    normalized: Array,
+    residuals: Array,
+    profiles: tuple[ProfileEvaluation, ...],
+) -> None:
+    residual_offset = 0
+    for descriptor, item in zip(plan.profiles, profiles, strict=True):
+        if (
+            item.observation_offset != descriptor.observation_offset
+            or item.observation_count != descriptor.observation_count
+            or item.residual_offset != residual_offset
+            or item.residual_count != len(descriptor.retained_observation_indices)
+        ):
+            raise ValueError("Evaluation result has inconsistent profile offsets")
+        start = item.observation_offset
+        stop = start + item.observation_count
+        retained = np.asarray(item.retained_observation_indices, dtype=np.intp)
+        expected_factor = _normalization_factor(descriptor, unscaled[start:stop])
+        if expected_factor is None or _canonical_float(
+            item.normalization_factor
+        ) != _canonical_float(expected_factor):
+            raise ValueError("Evaluation result has inconsistent normalization")
+        with np.errstate(all="raise"):
+            expected_normalized = item.normalization_factor * unscaled[start:stop]
+            expected_residuals = (
+                normalized[start:stop][retained]
+                - np.asarray(descriptor.experimental_values)[retained]
+            ) / np.asarray(descriptor.uncertainties)[retained]
+        if not np.array_equal(
+            normalized[start:stop], expected_normalized
+        ) or not np.array_equal(
+            residuals[residual_offset : residual_offset + item.residual_count],
+            expected_residuals,
+        ):
+            raise ValueError("Evaluation result arrays do not match profile semantics")
+        residual_offset += item.residual_count
 
 
 @dataclass(frozen=True, slots=True)
@@ -507,7 +901,7 @@ class EvaluationResult:
     plan_identity: str
     parameterization_identity: str
     evaluator_compatibility_identity: str
-    resolved_values: ResolvedParameterValues
+    resolved_values: ResolvedEvaluationValues
     unscaled_calculations: Array
     normalized_calculations: Array
     residuals: Array
@@ -522,7 +916,7 @@ class EvaluationResult:
                 self.plan_identity,
                 self.parameterization_identity,
                 self.evaluator_compatibility_identity,
-                tuple(self.resolved_values.items()),
+                self.resolved_values.ordered_items(),
                 tuple(_canonical_float(value) for value in self.unscaled_calculations),
                 tuple(
                     _canonical_float(value) for value in self.normalized_calculations
@@ -546,20 +940,25 @@ class EvaluationResult:
 
     def to_record(self) -> dict[str, object]:
         """Serialize immutable scientific evidence without runtime machinery."""
-        return {
+        record: dict[str, object] = {
             "schema_version": _SCHEMA_VERSION,
             "plan_identity": self.plan_identity,
             "parameterization_identity": self.parameterization_identity,
             "evaluator_compatibility_identity": self.evaluator_compatibility_identity,
             "resolved": {
-                "program_fingerprint": self.resolved_values.program_fingerprint,
-                "occurrence_identity": self.resolved_values.occurrence_identity,
-                "revision": self.resolved_values.revision,
-                "items": list(self.resolved_values.items()),
+                "program_identity": self.resolved_values.program_identity,
+                "items": [
+                    [param_id, _canonical_float(value)]
+                    for param_id, value in self.resolved_values.ordered_items()
+                ],
             },
-            "unscaled_calculations": self.unscaled_calculations.tolist(),
-            "normalized_calculations": self.normalized_calculations.tolist(),
-            "residuals": self.residuals.tolist(),
+            "unscaled_calculations": [
+                _canonical_float(value) for value in self.unscaled_calculations
+            ],
+            "normalized_calculations": [
+                _canonical_float(value) for value in self.normalized_calculations
+            ],
+            "residuals": [_canonical_float(value) for value in self.residuals],
             "profiles": [
                 {
                     "profile_identity": item.profile_identity,
@@ -570,12 +969,14 @@ class EvaluationResult:
                     "retained_observation_indices": list(
                         item.retained_observation_indices
                     ),
-                    "normalization_factor": item.normalization_factor,
+                    "normalization_factor": _canonical_float(item.normalization_factor),
                     "kernel_identity": item.kernel_identity,
                 }
                 for item in self.profiles
             ],
         }
+        record["identity"] = self.identity
+        return record
 
     @classmethod
     def from_record(
@@ -584,6 +985,22 @@ class EvaluationResult:
         plan: EvaluationPlan,
     ) -> EvaluationResult:
         """Restore a result only when its population matches a frozen plan."""
+        _record_exact_keys(
+            record,
+            {
+                "schema_version",
+                "plan_identity",
+                "parameterization_identity",
+                "evaluator_compatibility_identity",
+                "resolved",
+                "unscaled_calculations",
+                "normalized_calculations",
+                "residuals",
+                "profiles",
+                "identity",
+            },
+            "Evaluation-result",
+        )
         if record.get("schema_version") != _SCHEMA_VERSION:
             raise ValueError("Unsupported native evaluation-result schema")
         if record.get("plan_identity") != plan.identity:
@@ -592,23 +1009,27 @@ class EvaluationResult:
         if not isinstance(resolved_record, Mapping):
             raise TypeError("Evaluation-result resolved values must be a mapping")
         resolved_values = cast("Mapping[str, object]", resolved_record)
-        items = _record_list(resolved_values.get("items"), field_name="resolved.items")
-        resolved = ResolvedParameterValues(
-            parameterization_identity=str(record["parameterization_identity"]),
-            program_fingerprint=str(resolved_values["program_fingerprint"]),
-            occurrence_identity=str(resolved_values["occurrence_identity"]),
-            revision=_record_int(resolved_values["revision"], field_name="revision"),
-            _items=tuple(
-                (
-                    str(_record_list(item, field_name="resolved item")[0]),
-                    _record_float(
-                        _record_list(item, field_name="resolved item")[1],
-                        field_name="resolved value",
-                    ),
-                )
-                for item in items
-            ),
+        _record_exact_keys(
+            resolved_values, {"program_identity", "items"}, "Evaluation-result resolved"
         )
+        items = _record_list(resolved_values.get("items"), field_name="resolved.items")
+        parameterization_identity = _record_string(
+            record["parameterization_identity"], "parameterization identity"
+        )
+        resolved = ResolvedEvaluationValues(
+            parameterization_identity,
+            _record_string(
+                resolved_values["program_identity"], "resolved program identity"
+            ),
+            tuple(_record_frame_item(item) for item in items),
+        )
+        if (
+            parameterization_identity != plan.parameterization_identity
+            or resolved.program_identity != plan.constraint_program_identity
+            or tuple(key for key, _value in resolved.ordered_items())
+            != plan.resolved_ids
+        ):
+            raise ValueError("Evaluation result has incompatible resolved values")
         profiles_record = _record_list(record.get("profiles"), field_name="profiles")
         if len(profiles_record) != len(plan.profiles):
             raise ValueError("Evaluation result has the wrong profile population")
@@ -618,26 +1039,34 @@ class EvaluationResult:
         )
         unscaled = _readonly(
             np.asarray(
-                _record_list(
-                    record.get("unscaled_calculations"),
-                    field_name="unscaled calculations",
-                ),
-                dtype=np.float64,
+                [
+                    _record_binary64(value, field_name="unscaled calculation")
+                    for value in _record_list(
+                        record.get("unscaled_calculations"),
+                        field_name="unscaled calculations",
+                    )
+                ]
             )
         )
         normalized = _readonly(
             np.asarray(
-                _record_list(
-                    record.get("normalized_calculations"),
-                    field_name="normalized calculations",
-                ),
-                dtype=np.float64,
+                [
+                    _record_binary64(value, field_name="normalized calculation")
+                    for value in _record_list(
+                        record.get("normalized_calculations"),
+                        field_name="normalized calculations",
+                    )
+                ]
             )
         )
         residuals = _readonly(
             np.asarray(
-                _record_list(record.get("residuals"), field_name="residuals"),
-                dtype=np.float64,
+                [
+                    _record_binary64(value, field_name="residual")
+                    for value in _record_list(
+                        record.get("residuals"), field_name="residuals"
+                    )
+                ]
             )
         )
         if (
@@ -649,16 +1078,23 @@ class EvaluationResult:
             or not np.all(np.isfinite(residuals))
         ):
             raise ValueError("Malformed native evaluation-result arrays")
-        return cls(
+        expected_compatibility = _compatibility_identity(plan)
+        if record.get("evaluator_compatibility_identity") != expected_compatibility:
+            raise ValueError("Evaluation result has incompatible evaluator binding")
+        _validate_result_relationships(plan, unscaled, normalized, residuals, profiles)
+        result = cls(
             plan.identity,
-            str(record["parameterization_identity"]),
-            str(record["evaluator_compatibility_identity"]),
+            parameterization_identity,
+            expected_compatibility,
             resolved,
             unscaled,
             normalized,
             residuals,
             profiles,
         )
+        if record.get("identity") != result.identity:
+            raise ValueError("Evaluation-result fingerprint does not match its payload")
+        return result
 
 
 @dataclass(frozen=True, slots=True)
@@ -668,7 +1104,15 @@ class EvaluationFailure:
     plan_identity: str
     parameterization_identity: str
     stage: Literal[
-        "frame", "resolution", "kernel", "normalization", "residual", "binding"
+        "frame",
+        "resolution",
+        "projection",
+        "cache",
+        "kernel",
+        "normalization",
+        "residual",
+        "result",
+        "binding",
     ]
     category: str
     validity: Literal[
@@ -679,6 +1123,21 @@ class EvaluationFailure:
     ]
     profile_identity: str | None = None
     message: str = ""
+
+    @property
+    def identity(self) -> str:
+        return _identity(
+            "evaluation-failure",
+            (
+                self.plan_identity,
+                self.parameterization_identity,
+                self.stage,
+                self.category,
+                self.validity,
+                self.profile_identity,
+                self.message,
+            ),
+        )
 
     def to_record(self) -> dict[str, object]:
         """Serialize stable failure information without exception objects."""
@@ -691,6 +1150,7 @@ class EvaluationFailure:
             "validity": self.validity,
             "profile_identity": self.profile_identity,
             "message": self.message,
+            "identity": self.identity,
         }
 
     @classmethod
@@ -700,42 +1160,55 @@ class EvaluationFailure:
         plan: EvaluationPlan,
     ) -> EvaluationFailure:
         """Restore a sanitized failure only for the matching frozen plan."""
+        _record_exact_keys(
+            record,
+            {
+                "schema_version",
+                "plan_identity",
+                "parameterization_identity",
+                "stage",
+                "category",
+                "validity",
+                "profile_identity",
+                "message",
+                "identity",
+            },
+            "Evaluation-failure",
+        )
         if record.get("schema_version") != _SCHEMA_VERSION:
             raise ValueError("Unsupported native evaluation-failure schema")
         if record.get("plan_identity") != plan.identity:
             raise ValueError("Evaluation failure belongs to another plan")
-        stage = str(record.get("stage"))
-        validity = str(record.get("validity"))
-        if stage not in {
-            "frame",
-            "resolution",
-            "kernel",
-            "normalization",
-            "residual",
-            "binding",
-        }:
-            raise ValueError("Unknown native evaluation-failure stage")
-        if validity not in {
-            "INVALID_REQUEST",
-            "INVALID_TRIAL",
-            "INVALID_PLAN_OR_BINDING",
-            "IMPLEMENTATION_FAILURE",
-        }:
-            raise ValueError("Unknown native evaluation-failure validity")
+        if record.get("parameterization_identity") != plan.parameterization_identity:
+            raise ValueError("Evaluation failure belongs to another parameterization")
+        stage, validity = _record_failure_stage_validity(record)
         profile_identity = record.get("profile_identity")
         if profile_identity is not None and profile_identity not in {
             item.identity for item in plan.profiles
         }:
             raise ValueError("Evaluation failure names a profile outside its plan")
-        return cls(
+        category = _record_string(record.get("category"), "failure category")
+        message = _record_string(record.get("message"), "failure message")
+        if not category:
+            raise ValueError("Evaluation failure category cannot be empty")
+        if (stage in {"frame", "resolution", "result", "binding"}) != (
+            profile_identity is None
+        ):
+            raise ValueError("Evaluation failure has invalid profile location")
+        failure = cls(
             plan.identity,
-            str(record["parameterization_identity"]),
+            plan.parameterization_identity,
             stage,
-            str(record["category"]),
+            category,
             validity,
             None if profile_identity is None else str(profile_identity),
-            str(record.get("message", "")),
+            message,
         )
+        if record.get("identity") != failure.identity:
+            raise ValueError(
+                "Evaluation-failure fingerprint does not match its payload"
+            )
+        return failure
 
 
 @dataclass(frozen=True, slots=True)
@@ -753,10 +1226,60 @@ class _CachedProfile:
     normalization_factor: float
 
 
+@dataclass(frozen=True, slots=True)
+class _LocalParameterProjection(Mapping[str, float]):
+    """The only resolved values a native profile calculation can observe."""
+
+    _items: tuple[tuple[str, float], ...]
+    _values: Mapping[str, float] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "_values", dict(self._items))
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __getitem__(self, key: str) -> float:
+        return self._values[key]
+
+
+@dataclass(slots=True)
+class _NativeKernelCapability:
+    """Private adapter that exposes only local values and copied metadata."""
+
+    spectrometer: Spectrometer
+    pulse_sequence: PulseSequence
+    metadata: Array
+    output_size: int
+
+    @classmethod
+    def from_profile(cls, profile: Profile) -> _NativeKernelCapability:
+        return cls(
+            profile.spectrometer.new_native_workspace(),
+            deepcopy(profile.pulse_sequence),
+            np.array(profile.data.metadata, copy=True),
+            profile.data.exp.size,
+        )
+
+    def calculate(self, local_values: Mapping[str, float]) -> Array:
+        self.spectrometer.update(dict(local_values))
+        return self.pulse_sequence.calculate(
+            self.spectrometer,
+            Data(
+                exp=np.zeros(self.output_size, dtype=np.float64),
+                err=np.ones(self.output_size, dtype=np.float64),
+                metadata=np.array(self.metadata, copy=True),
+            ),
+        )
+
+
 @dataclass(slots=True)
 class _Workspace:
-    templates: tuple[Profile, ...]
-    profiles: tuple[Profile, ...]
+    templates: tuple[_NativeKernelCapability, ...]
+    profiles: tuple[_NativeKernelCapability, ...]
     cache: OrderedDict[tuple[object, ...], _CachedProfile] = field(
         default_factory=OrderedDict
     )
@@ -828,9 +1351,10 @@ def _build_plan(
             offset += exp.size
     return (
         EvaluationPlan(
-            parameterization_identity=parameterization.identity,
+            parameterization_identity=parameterization.evaluator_identity,
             constraint_program_identity=parameterization.program.fingerprint,
             profiles=tuple(profile_plans),
+            resolved_ids=parameterization.scope_ids,
         ),
         tuple(sources),
     )
@@ -845,15 +1369,11 @@ class EvaluationEngine:
         parameterization: ActiveParameterization,
         sources: Sequence[tuple[int, int, Profile]],
     ) -> None:
-        if plan.parameterization_identity != parameterization.identity:
+        if plan.parameterization_identity != parameterization.evaluator_identity:
             raise ValueError("Evaluation plan belongs to another parameterization")
         if plan.constraint_program_identity != parameterization.program.fingerprint:
             raise ValueError("Evaluation plan belongs to another constraint program")
-        if (
-            plan.normalization_version != _NORMALIZATION_VERSION
-            or plan.residual_version != _RESIDUAL_VERSION
-        ):
-            raise ValueError("Evaluation plan has incompatible execution semantics")
+        _validate_plan_runtime_versions(plan)
         if len(plan.profiles) != len(sources):
             raise ValueError("Trusted profile bindings do not match evaluation plan")
         expected_offset = 0
@@ -893,19 +1413,29 @@ class EvaluationEngine:
                 or descriptor.local_inputs != tuple(sorted(source.name_map.items()))
                 or descriptor.observation_metadata != _observation_metadata(source)
                 or descriptor.output_shape != tuple(source.data.exp.shape)
+                or descriptor.is_scaled != source.is_scaled
+                or descriptor.experimental_values
+                != tuple(float(value) for value in np.asarray(source.data.exp))
+                or descriptor.uncertainties
+                != tuple(float(value) for value in np.asarray(source.data.err))
+                or descriptor.mask
+                != tuple(bool(value) for value in np.asarray(source.data.mask))
             ):
                 raise ValueError("Trusted kernel descriptor does not match frozen plan")
+            if not set(descriptor.param_ids).issubset(parameterization.scope_ids):
+                raise ValueError(
+                    "Evaluation plan projects parameters outside its closure"
+                )
             expected_offset += descriptor.observation_count
+        if plan.resolved_ids != parameterization.scope_ids:
+            raise ValueError("Evaluation plan has incompatible resolved-value ordering")
         self.plan = plan
         self._parameterization = parameterization
         # Copy construction-owned mutable machinery once.  Plans retain no
         # source objects, and callers cannot alter a future workspace by
         # mutating the legacy occurrence after it was bound.
         self._sources = tuple(deepcopy(source) for _e, _p, source in sources)
-        self.compatibility_identity = _identity(
-            "evaluation-compatibility",
-            tuple(item.kernel_identity for item in plan.profiles),
-        )
+        self.compatibility_identity = _compatibility_identity(plan)
 
     @classmethod
     def from_experiments(
@@ -938,8 +1468,14 @@ class EvaluationEngine:
             self._parameterization,
             self.compatibility_identity,
             _Workspace(
-                self._sources,
-                tuple(deepcopy(profile) for profile in self._sources),
+                tuple(
+                    _NativeKernelCapability.from_profile(profile)
+                    for profile in self._sources
+                ),
+                tuple(
+                    _NativeKernelCapability.from_profile(profile)
+                    for profile in self._sources
+                ),
             ),
         )
 
@@ -959,6 +1495,8 @@ class BoundEvaluator:
         self.compatibility_identity = compatibility_identity
         self._workspace = workspace
         self._owner = get_ident()
+        self._owner_pid = os.getpid()
+        self._in_flight = False
 
     @property
     def cache_statistics(self) -> CacheStatistics:
@@ -971,7 +1509,15 @@ class BoundEvaluator:
     def _failure(
         self,
         stage: Literal[
-            "frame", "resolution", "kernel", "normalization", "residual", "binding"
+            "frame",
+            "resolution",
+            "projection",
+            "cache",
+            "kernel",
+            "normalization",
+            "residual",
+            "result",
+            "binding",
         ],
         category: str,
         validity: Literal[
@@ -984,6 +1530,8 @@ class BoundEvaluator:
         profile_identity: str | None = None,
         message: str = "",
     ) -> EvaluationFailure:
+        if _FAILURE_TAXONOMY[stage].get(category) != validity:
+            raise RuntimeError("Undeclared native evaluation failure")
         if validity in {"INVALID_PLAN_OR_BINDING", "IMPLEMENTATION_FAILURE"}:
             self._workspace.poisoned = True
             self._workspace.cache.clear()
@@ -991,7 +1539,7 @@ class BoundEvaluator:
             self._workspace.reset()
         return EvaluationFailure(
             self.plan.identity,
-            self._parameterization.identity,
+            self._parameterization.evaluator_identity,
             stage,
             category,
             validity,
@@ -1002,12 +1550,35 @@ class BoundEvaluator:
     def _calculate_unscaled(
         self,
         descriptor: ProfilePlan,
-        profile: Profile,
+        profile: _NativeKernelCapability,
         resolved: ResolvedParameterValues,
     ) -> Array | EvaluationFailure:
         """Run and validate the narrow unscaled profile kernel."""
         try:
-            unscaled = np.asarray(profile.calculate_unscaled(resolved))
+            local = _LocalParameterProjection(
+                tuple(
+                    (local_name, resolved[param_id])
+                    for local_name, param_id in descriptor.local_inputs
+                )
+            )
+        except KeyError as error:
+            return self._failure(
+                "projection",
+                "missing_local_parameter",
+                "INVALID_PLAN_OR_BINDING",
+                profile_identity=descriptor.identity,
+                message=str(error),
+            )
+        except Exception as error:  # noqa: BLE001 - projection integrity fence
+            return self._failure(
+                "projection",
+                "missing_local_parameter",
+                "INVALID_PLAN_OR_BINDING",
+                profile_identity=descriptor.identity,
+                message=str(error),
+            )
+        try:
+            unscaled = profile.calculate(local)
         except Exception as error:  # noqa: BLE001 - native kernel fault boundary
             return self._failure(
                 "kernel",
@@ -1016,6 +1587,13 @@ class BoundEvaluator:
                 profile_identity=descriptor.identity,
                 message=str(error),
             )
+        if not isinstance(unscaled, np.ndarray):
+            return self._failure(
+                "kernel",
+                "unexpected_container",
+                "IMPLEMENTATION_FAILURE",
+                profile_identity=descriptor.identity,
+            )
         if unscaled.shape != (descriptor.observation_count,):
             return self._failure(
                 "kernel",
@@ -1023,7 +1601,7 @@ class BoundEvaluator:
                 "IMPLEMENTATION_FAILURE",
                 profile_identity=descriptor.identity,
             )
-        if not np.issubdtype(unscaled.dtype, np.floating):
+        if unscaled.dtype != np.dtype(np.float64):
             return self._failure(
                 "kernel",
                 "unexpected_dtype",
@@ -1050,38 +1628,29 @@ class BoundEvaluator:
         err = np.asarray(descriptor.uncertainties, dtype=np.float64)
         retained = np.asarray(descriptor.mask, dtype=np.bool_)
         if descriptor.is_scaled:
-            selected_exp = exp[retained]
-            selected_calc = unscaled[retained]
-            selected_err = err[retained]
-            numerator = float(
-                np.dot(selected_exp / selected_err, selected_calc / selected_err)
-            )
-            denominator = float(
-                np.dot(selected_calc / selected_err, selected_calc / selected_err)
-            )
-            if (
-                not math.isfinite(numerator)
-                or not math.isfinite(denominator)
-                or denominator == 0.0
-            ):
+            scale = _normalization_factor(descriptor, unscaled)
+            if scale is None:
                 return self._failure(
                     "normalization",
                     "invalid_normalization",
                     "INVALID_TRIAL",
                     profile_identity=descriptor.identity,
                 )
-            scale = numerator / denominator
-            if not math.isfinite(scale):
-                return self._failure(
-                    "normalization",
-                    "non_finite_normalization",
-                    "INVALID_TRIAL",
-                    profile_identity=descriptor.identity,
-                )
         else:
             scale = 1.0
-        normalized = _readonly(scale * unscaled)
-        residuals = _readonly((normalized[retained] - exp[retained]) / err[retained])
+        try:
+            with np.errstate(all="raise"):
+                normalized = _readonly(scale * unscaled)
+                residuals = _readonly(
+                    (normalized[retained] - exp[retained]) / err[retained]
+                )
+        except FloatingPointError:
+            return self._failure(
+                "residual",
+                "non_finite_residual",
+                "INVALID_TRIAL",
+                profile_identity=descriptor.identity,
+            )
         if not np.all(np.isfinite(normalized)) or not np.all(np.isfinite(residuals)):
             return self._failure(
                 "residual",
@@ -1094,13 +1663,22 @@ class BoundEvaluator:
     def _cached_profile(
         self,
         descriptor: ProfilePlan,
-        profile: Profile,
+        profile: _NativeKernelCapability,
         resolved: ResolvedParameterValues,
     ) -> _CachedProfile | EvaluationFailure:
-        key = (
-            descriptor.identity,
-            *(resolved[param_id] for param_id in descriptor.param_ids),
-        )
+        try:
+            key = (
+                descriptor.identity,
+                *(resolved[param_id] for param_id in descriptor.param_ids),
+            )
+        except Exception as error:  # noqa: BLE001 - cache integrity fence
+            return self._failure(
+                "cache",
+                "cache_key_exception",
+                "IMPLEMENTATION_FAILURE",
+                profile_identity=descriptor.identity,
+                message=str(error),
+            )
         cached = self._workspace.cache.get(key)
         if cached is not None:
             self._workspace.cache.move_to_end(key)
@@ -1119,7 +1697,7 @@ class BoundEvaluator:
             self._workspace.cache.popitem(last=False)
         return cached
 
-    def evaluate(
+    def _evaluate_impl(
         self,
         frame: EvaluationFrame,
     ) -> EvaluationResult | EvaluationFailure:
@@ -1133,7 +1711,10 @@ class BoundEvaluator:
                 "binding", "workspace_poisoned", "INVALID_PLAN_OR_BINDING"
             )
         try:
-            if frame.parameterization_identity != self._parameterization.identity:
+            if (
+                frame.parameterization_identity
+                != self._parameterization.evaluator_identity
+            ):
                 return self._failure(
                     "frame", "parameterization_mismatch", "INVALID_REQUEST"
                 )
@@ -1154,7 +1735,10 @@ class BoundEvaluator:
             resolved = self._parameterization.resolve(lifecycle_frame)
         except ParameterizationError as error:
             return self._failure(
-                "resolution", error.code, "INVALID_REQUEST", message=str(error)
+                "resolution",
+                error.code,
+                _parameterization_failure_validity(error),
+                message=str(error),
             )
         except Exception as error:  # noqa: BLE001 - trusted-program boundary
             return self._failure(
@@ -1191,19 +1775,67 @@ class BoundEvaluator:
             unscaled_parts.append(cached.unscaled)
             normalized_parts.append(cached.normalized)
             residual_parts.append(cached.residuals)
-        return EvaluationResult(
-            self.plan.identity,
-            self._parameterization.identity,
-            self.compatibility_identity,
-            resolved,
-            _readonly(
-                np.concatenate(unscaled_parts) if unscaled_parts else np.empty(0)
-            ),
-            _readonly(
-                np.concatenate(normalized_parts) if normalized_parts else np.empty(0)
-            ),
-            _readonly(
-                np.concatenate(residual_parts) if residual_parts else np.empty(0)
-            ),
-            tuple(profiles),
-        )
+        try:
+            return EvaluationResult(
+                self.plan.identity,
+                self._parameterization.evaluator_identity,
+                self.compatibility_identity,
+                ResolvedEvaluationValues(
+                    self._parameterization.evaluator_identity,
+                    self._parameterization.program.fingerprint,
+                    resolved._items,
+                ),
+                _readonly(
+                    np.concatenate(unscaled_parts) if unscaled_parts else np.empty(0)
+                ),
+                _readonly(
+                    np.concatenate(normalized_parts)
+                    if normalized_parts
+                    else np.empty(0)
+                ),
+                _readonly(
+                    np.concatenate(residual_parts) if residual_parts else np.empty(0)
+                ),
+                tuple(profiles),
+            )
+        except Exception as error:  # noqa: BLE001 - result integrity fence
+            return self._failure(
+                "result",
+                "result_assembly_exception",
+                "IMPLEMENTATION_FAILURE",
+                message=str(error),
+            )
+
+    def evaluate(self, frame: EvaluationFrame) -> EvaluationResult | EvaluationFailure:
+        """Fence one complete call under the declared single-owner contract."""
+        if os.getpid() != self._owner_pid:
+            return self._failure(
+                "binding", "workspace_process_violation", "INVALID_PLAN_OR_BINDING"
+            )
+        if get_ident() != self._owner:
+            return self._failure(
+                "binding", "workspace_owner_violation", "INVALID_REQUEST"
+            )
+        if self._in_flight:
+            return self._failure("binding", "workspace_reentrant", "INVALID_REQUEST")
+        if self._workspace.poisoned:
+            return self._failure(
+                "binding", "workspace_poisoned", "INVALID_PLAN_OR_BINDING"
+            )
+        self._in_flight = True
+        try:
+            with np.errstate(all="raise"):
+                return self._evaluate_impl(frame)
+        except FloatingPointError as error:
+            return self._failure(
+                "residual", "non_finite_residual", "INVALID_TRIAL", message=str(error)
+            )
+        except Exception as error:  # noqa: BLE001 - complete native boundary
+            return self._failure(
+                "binding",
+                "unexpected_evaluation_error",
+                "IMPLEMENTATION_FAILURE",
+                message=str(error),
+            )
+        finally:
+            self._in_flight = False

--- a/src/chemex/experiments/experiment_types.py
+++ b/src/chemex/experiments/experiment_types.py
@@ -605,6 +605,7 @@ def _build[ConfigT: GenericConfig](
                 f"experiment={source.filename!s}, type={experiment_type_.name!r}"
             ),
         )
+        calculation.spectrometer.finalize_native_construction()
         profiles.append(
             Profile(
                 data,

--- a/src/chemex/experiments/experiment_types.py
+++ b/src/chemex/experiments/experiment_types.py
@@ -605,7 +605,7 @@ def _build[ConfigT: GenericConfig](
                 f"experiment={source.filename!s}, type={experiment_type_.name!r}"
             ),
         )
-        calculation.spectrometer.finalize_native_construction()
+        calculation.spectrometer.try_finalize_native_construction()
         profiles.append(
             Profile(
                 data,

--- a/src/chemex/nmr/spectrometer.py
+++ b/src/chemex/nmr/spectrometer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from types import MappingProxyType
 from typing import Self
 
 import numpy as np
@@ -26,6 +27,49 @@ calculate_propagators = _propagators.calculate_propagators
 
 
 class Spectrometer:
+    def native_kernel_descriptor(self) -> Mapping[str, object]:
+        """Return immutable public construction semantics for native evaluation.
+
+        This deliberately exposes a value record, rather than the internal
+        Liouvillian engine, for the native qualification boundary.
+        """
+        basis = self.basis
+
+        def distribution_record(distribution: Distribution) -> Mapping[str, object]:
+            return MappingProxyType(
+                {
+                    "values": tuple(float(value) for value in distribution.values),
+                    "weights": tuple(float(value) for value in distribution.weights),
+                    "dephasing": distribution.dephasing,
+                }
+            )
+
+        return MappingProxyType(
+            {
+                "basis_type": basis.type,
+                "basis_spin_system": basis.spin_system,
+                "basis_extension": basis.extension,
+                "model_name": basis.model.name,
+                "model_states": basis.model.states,
+                "model_free": basis.model.model_free,
+                "model_temp_coef": basis.model.temp_coef,
+                "model_residue_specific": basis.model.residue_specific,
+                "spin_system": str(self.spin_system),
+                "ppm_i": float(self.ppm_i),
+                "ppm_s": float(self.ppm_s),
+                "carrier_i": float(self.carrier_i),
+                "carrier_s": float(self.carrier_s),
+                "offset_i": float(self.offset_i),
+                "offset_s": float(self.offset_s),
+                "detection": self.detection,
+                "b1_i": float(self.b1_i),
+                "b1_i_distribution": distribution_record(self.b1_i_distribution),
+                "b1_s": float(self.b1_s),
+                "jeff_i": distribution_record(self.jeff_i),
+                "gradient_dephasing": float(self.gradient_dephasing),
+            }
+        )
+
     @classmethod
     def from_spin_system(
         cls,
@@ -116,6 +160,11 @@ class Spectrometer:
     def b1_i(self, value: float) -> None:
         self._pulse_library.set_b1_i(value)
         self._engine.b1_i = value
+
+    @property
+    def b1_i_distribution(self) -> Distribution:
+        """Return the immutable configured I-spin B1 distribution."""
+        return self._engine.b1_i_dist
 
     def set_b1_i_inhomogeneity(
         self,

--- a/src/chemex/nmr/spectrometer.py
+++ b/src/chemex/nmr/spectrometer.py
@@ -39,15 +39,45 @@ def _native_descriptor_view(record: dict[str, object]) -> Mapping[str, object]:
 class Spectrometer:
     def finalize_native_construction(self) -> None:
         """Freeze configured scientific construction state before pulse execution."""
-        if self._native_workspace_template is not None:
-            return
-        self._native_kernel_descriptor = self._build_native_kernel_descriptor()
-        self._native_workspace_template = deepcopy(self)
+        if self._native_construction_attempted:
+            if self._native_workspace_template is not None:
+                return
+            raise ValueError(self._native_construction_unavailable_message())
+        try:
+            descriptor = self._build_native_kernel_descriptor()
+            workspace_template = deepcopy(self)
+        except Exception as error:
+            self._native_kernel_descriptor = None
+            self._native_workspace_template = None
+            self._native_construction_diagnostic = f"{type(error).__name__}: {error}"
+            self._native_construction_attempted = True
+            raise
+        self._native_kernel_descriptor = descriptor
+        self._native_workspace_template = workspace_template
+        self._native_construction_diagnostic = None
+        self._native_construction_attempted = True
+
+    def try_finalize_native_construction(self) -> bool:
+        """Attempt a native snapshot without making legacy construction depend on it."""
+        try:
+            self.finalize_native_construction()
+        except Exception:  # noqa: BLE001 - isolate optional native qualification
+            return False
+        return True
+
+    @property
+    def native_construction_diagnostic(self) -> str | None:
+        """Explain why this one-time native snapshot is unavailable."""
+        return self._native_construction_diagnostic
+
+    def _native_construction_unavailable_message(self) -> str:
+        detail = self._native_construction_diagnostic or "not finalized"
+        return f"Native construction is unavailable: {detail}"
 
     def new_native_workspace(self) -> Self:
         """Return a private mutable execution spectrometer from frozen inputs."""
         if self._native_workspace_template is None:
-            raise ValueError("Spectrometer native construction was not finalized")
+            raise ValueError(self._native_construction_unavailable_message())
         return cast("Self", deepcopy(self._native_workspace_template))
 
     def native_kernel_descriptor(self) -> Mapping[str, object]:
@@ -57,7 +87,7 @@ class Spectrometer:
         Liouvillian engine, for the native qualification boundary.
         """
         if self._native_kernel_descriptor is None:
-            raise ValueError("Spectrometer native construction was not finalized")
+            raise ValueError(self._native_construction_unavailable_message())
         return _native_descriptor_view(self._native_kernel_descriptor)
 
     def _build_native_kernel_descriptor(self) -> dict[str, object]:
@@ -104,6 +134,8 @@ class Spectrometer:
         self._engine = engine
         self._native_kernel_descriptor: dict[str, object] | None = None
         self._native_workspace_template: Spectrometer | None = None
+        self._native_construction_attempted = False
+        self._native_construction_diagnostic: str | None = None
         self._pulse_kernel = PulseKernel(engine)
         self._pulse_library = PulseLibrary(self._pulse_kernel)
         self.analysis = SpectrometerAnalysis(self._engine)

--- a/src/chemex/nmr/spectrometer.py
+++ b/src/chemex/nmr/spectrometer.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
+from copy import deepcopy
 from types import MappingProxyType
-from typing import Self
+from typing import Self, cast
 
 import numpy as np
 
@@ -26,49 +27,69 @@ DictArray = dict[str, Array]
 calculate_propagators = _propagators.calculate_propagators
 
 
+def _native_descriptor_view(record: dict[str, object]) -> Mapping[str, object]:
+    return MappingProxyType(
+        {
+            key: MappingProxyType(value) if isinstance(value, dict) else value
+            for key, value in record.items()
+        }
+    )
+
+
 class Spectrometer:
+    def finalize_native_construction(self) -> None:
+        """Freeze configured scientific construction state before pulse execution."""
+        if self._native_workspace_template is not None:
+            return
+        self._native_kernel_descriptor = self._build_native_kernel_descriptor()
+        self._native_workspace_template = deepcopy(self)
+
+    def new_native_workspace(self) -> Self:
+        """Return a private mutable execution spectrometer from frozen inputs."""
+        if self._native_workspace_template is None:
+            raise ValueError("Spectrometer native construction was not finalized")
+        return cast("Self", deepcopy(self._native_workspace_template))
+
     def native_kernel_descriptor(self) -> Mapping[str, object]:
         """Return immutable public construction semantics for native evaluation.
 
         This deliberately exposes a value record, rather than the internal
         Liouvillian engine, for the native qualification boundary.
         """
+        if self._native_kernel_descriptor is None:
+            raise ValueError("Spectrometer native construction was not finalized")
+        return _native_descriptor_view(self._native_kernel_descriptor)
+
+    def _build_native_kernel_descriptor(self) -> dict[str, object]:
         basis = self.basis
 
-        def distribution_record(distribution: Distribution) -> Mapping[str, object]:
-            return MappingProxyType(
-                {
-                    "values": tuple(float(value) for value in distribution.values),
-                    "weights": tuple(float(value) for value in distribution.weights),
-                    "dephasing": distribution.dephasing,
-                }
-            )
-
-        return MappingProxyType(
-            {
-                "basis_type": basis.type,
-                "basis_spin_system": basis.spin_system,
-                "basis_extension": basis.extension,
-                "model_name": basis.model.name,
-                "model_states": basis.model.states,
-                "model_free": basis.model.model_free,
-                "model_temp_coef": basis.model.temp_coef,
-                "model_residue_specific": basis.model.residue_specific,
-                "spin_system": str(self.spin_system),
-                "ppm_i": float(self.ppm_i),
-                "ppm_s": float(self.ppm_s),
-                "carrier_i": float(self.carrier_i),
-                "carrier_s": float(self.carrier_s),
-                "offset_i": float(self.offset_i),
-                "offset_s": float(self.offset_s),
-                "detection": self.detection,
-                "b1_i": float(self.b1_i),
-                "b1_i_distribution": distribution_record(self.b1_i_distribution),
-                "b1_s": float(self.b1_s),
-                "jeff_i": distribution_record(self.jeff_i),
-                "gradient_dephasing": float(self.gradient_dephasing),
+        def distribution_record(distribution: Distribution) -> dict[str, object]:
+            return {
+                "values": tuple(float(value) for value in distribution.values),
+                "weights": tuple(float(value) for value in distribution.weights),
+                "dephasing": distribution.dephasing,
             }
-        )
+
+        return {
+            "basis_type": basis.type,
+            "basis_spin_system": basis.spin_system,
+            "basis_extension": basis.extension,
+            "model_name": basis.model.name,
+            "model_states": basis.model.states,
+            "model_free": basis.model.model_free,
+            "model_temp_coef": basis.model.temp_coef,
+            "model_residue_specific": basis.model.residue_specific,
+            "spin_system": str(self.spin_system),
+            "ppm_i": float(self.ppm_i),
+            "ppm_s": float(self.ppm_s),
+            "carrier_i": float(self.carrier_i),
+            "carrier_s": float(self.carrier_s),
+            "detection": self.detection,
+            "b1_i": float(self.b1_i),
+            "b1_i_distribution": distribution_record(self.b1_i_distribution),
+            "b1_s": float(self.b1_s),
+            "jeff_i": distribution_record(self.jeff_i),
+        }
 
     @classmethod
     def from_spin_system(
@@ -81,6 +102,8 @@ class Spectrometer:
 
     def __init__(self, engine: ISLiouvillianEngine) -> None:
         self._engine = engine
+        self._native_kernel_descriptor: dict[str, object] | None = None
+        self._native_workspace_template: Spectrometer | None = None
         self._pulse_kernel = PulseKernel(engine)
         self._pulse_library = PulseLibrary(self._pulse_kernel)
         self.analysis = SpectrometerAnalysis(self._engine)

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -628,6 +628,7 @@ class ActiveParameterization:
     source_revision: int
     _roles: tuple[tuple[str, ParameterRole], ...]
     identity: str = field(init=False)
+    evaluator_identity: str = field(init=False)
     _role_index: Mapping[str, ParameterRole] = field(
         init=False,
         repr=False,
@@ -651,6 +652,21 @@ class ActiveParameterization:
                     self.program.fingerprint,
                     self.occurrence_identity,
                     self.source_revision,
+                    tuple((param_id, role.value) for param_id, role in roles),
+                ),
+            ),
+        )
+        # The occurrence and source revision protect the lifecycle boundary.
+        # Evaluation is deliberately downstream of that check: two valid
+        # occurrences with the same compiled scientific program must have the
+        # same evaluator-facing identity.
+        object.__setattr__(
+            self,
+            "evaluator_identity",
+            _fingerprint(
+                "evaluator-parameterization",
+                (
+                    self.program.fingerprint,
                     tuple((param_id, role.value) for param_id, role in roles),
                 ),
             ),

--- a/tests/test_native_evaluation.py
+++ b/tests/test_native_evaluation.py
@@ -1,0 +1,612 @@
+"""Qualification tests for the #585 native evaluation boundary.
+
+The public seam is an immutable evaluation plan bound to an isolated evaluator.
+Legacy Profile residuals remain the independent scientific oracle at this
+checkpoint.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+from threading import Thread
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from chemex.configuration.methods import Method, Selection
+from chemex.configuration.parameters import read_defaults
+from chemex.containers.experiments import Experiments
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationPlan,
+    EvaluationResult,
+)
+from chemex.experiments.builder import build_experiments
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+from chemex.typing import Array
+
+ROOT = Path(__file__).parent.parent
+EXPERIMENT = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Experiments/3hz.toml"
+PARAMETERS = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Parameters/parameters.toml"
+
+
+def _shipped_dcest(*names: str) -> tuple[AnalysisSession, Experiments]:
+    session = AnalysisSession.create()
+    session.set_model("2st_hd")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(
+            include=[SpinSystem.from_name(name) for name in (names or ("1N",))],
+            exclude=None,
+        ),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    return session, experiments
+
+
+def _evaluation_frame(
+    session: AnalysisSession, parameterization: object
+) -> EvaluationFrame:
+    return EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+    )
+
+
+def test_shipped_two_profile_dcest_plan_matches_legacy_completely() -> None:
+    native_session, native_experiments = _shipped_dcest("1N", "2N")
+    legacy_session, legacy_experiments = _shipped_dcest("1N", "2N")
+    parameterization = native_session.compile_parameterization(
+        Method(), native_experiments.param_ids
+    )
+    native = EvaluationEngine.from_experiments(native_experiments, parameterization)
+    evaluator = native.new_evaluator()
+    outcome = evaluator.evaluate(_evaluation_frame(native_session, parameterization))
+    assert isinstance(outcome, EvaluationResult)
+    legacy_parameters = legacy_session.parameters.build_lmfit_params(
+        legacy_experiments.param_ids
+    )
+    legacy_residuals = legacy_experiments.residuals(legacy_parameters)
+    legacy_profiles = next(iter(legacy_experiments)).profiles
+    assert [item.profile_ordinal for item in native.plan.profiles] == [0, 1]
+    assert outcome.resolved_values == pytest.approx(legacy_parameters.valuesdict())
+    np.testing.assert_array_equal(
+        outcome.unscaled_calculations,
+        np.concatenate([profile.data.calc_unscaled for profile in legacy_profiles]),
+    )
+    np.testing.assert_array_equal(
+        outcome.normalized_calculations,
+        np.concatenate([profile.data.calc for profile in legacy_profiles]),
+    )
+    np.testing.assert_array_equal(outcome.residuals, legacy_residuals)
+    assert [item.normalization_factor for item in outcome.profiles] == [
+        profile.data.scale for profile in legacy_profiles
+    ]
+    assert [item.retained_observation_indices for item in outcome.profiles] == [
+        tuple(np.flatnonzero(profile.data.mask)) for profile in legacy_profiles
+    ]
+    repeated = evaluator.evaluate(_evaluation_frame(native_session, parameterization))
+    assert isinstance(repeated, EvaluationResult)
+    np.testing.assert_array_equal(repeated.residuals, outcome.residuals)
+    assert evaluator.cache_statistics.hits == 2
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (
+        ("kernel_identity", "other:kernel:v2"),
+        ("kernel_configuration", "{}"),
+        ("spectrometer_configuration", "{}"),
+        ("local_inputs", (("wrong", "__wrong"),)),
+        ("observation_metadata", "[]"),
+        ("output_shape", (999,)),
+        ("observation_offset", 1),
+        ("experiment_ordinal", 1),
+        ("profile_ordinal", 1),
+        ("identity", "foreign-profile-identity"),
+    ),
+)
+def test_trusted_rebinding_rejects_each_mutated_kernel_descriptor(
+    field: str, value: object
+) -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    payload = json.loads(json.dumps(engine.plan.to_record()))
+    serialized_value = (
+        [list(item) for item in value]
+        if field == "local_inputs"
+        else list(value)
+        if field == "output_shape"
+        else value
+    )
+    payload["profiles"][0][field] = serialized_value
+    descriptor = dataclasses.replace(engine.plan.profiles[0], **{field: value})
+    signed_plan = EvaluationPlan(
+        engine.plan.parameterization_identity,
+        engine.plan.constraint_program_identity,
+        (descriptor,),
+    )
+    payload["identity"] = signed_plan.identity
+    plan = EvaluationPlan.from_record(payload)
+    with pytest.raises(ValueError, match="Trusted"):
+        EvaluationEngine.bind(plan, parameterization, experiments)
+
+
+def test_trusted_rebinding_rejects_nested_serialized_basis_descriptor_mutation() -> (
+    None
+):
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    payload = json.loads(json.dumps(engine.plan.to_record()))
+    spectrometer = json.loads(payload["profiles"][0]["spectrometer_configuration"])
+    spectrometer["basis_type"] = "other-basis"
+    configuration = json.dumps(spectrometer, separators=(",", ":"), sort_keys=True)
+    payload["profiles"][0]["spectrometer_configuration"] = configuration
+    descriptor = dataclasses.replace(
+        engine.plan.profiles[0], spectrometer_configuration=configuration
+    )
+    payload["identity"] = EvaluationPlan(
+        engine.plan.parameterization_identity,
+        engine.plan.constraint_program_identity,
+        (descriptor,),
+    ).identity
+    plan = EvaluationPlan.from_record(payload)
+    with pytest.raises(ValueError, match="Trusted"):
+        EvaluationEngine.bind(plan, parameterization, experiments)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("normalization_version", "other-normalization"),
+        ("residual_version", "other-residual"),
+    ),
+)
+def test_serialized_plan_execution_semantics_must_match_local_contract(
+    field: str, value: str
+) -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    payload = json.loads(json.dumps(engine.plan.to_record()))
+    payload[field] = value
+    signed_plan = dataclasses.replace(engine.plan, **{field: value})
+    payload["identity"] = signed_plan.identity
+    plan = EvaluationPlan.from_record(payload)
+    with pytest.raises(ValueError, match="execution semantics"):
+        EvaluationEngine.bind(plan, parameterization, experiments)
+
+
+def test_spectrometer_native_kernel_descriptor_is_immutable_by_value() -> None:
+    _session, experiments = _shipped_dcest()
+    descriptor = (
+        next(iter(experiments)).profiles[0].spectrometer.native_kernel_descriptor()
+    )
+    with pytest.raises(TypeError):
+        descriptor["basis_type"] = "other-basis"
+    with pytest.raises(TypeError):
+        descriptor["jeff_i"]["dephasing"] = True
+
+
+def test_lifecycle_frames_reject_stale_and_foreign_snapshots_before_projection() -> (
+    None
+):
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    snapshot = session.analysis_values.snapshot()
+    with pytest.raises(ValueError):
+        parameterization.frame_from_snapshot(dataclasses.replace(snapshot, revision=1))
+    foreign, _ = _shipped_dcest()
+    with pytest.raises(ValueError):
+        parameterization.frame_from_snapshot(foreign.analysis_values.snapshot())
+
+
+def test_evaluation_frame_validates_canonical_binary64_input_and_projection_order() -> (
+    None
+):
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    lifecycle = parameterization.frame_from_snapshot(session.analysis_values.snapshot())
+
+    with pytest.raises(ValueError, match="unique"):
+        EvaluationFrame(parameterization.identity, (("a", 1.0), ("a", 2.0)))
+    with pytest.raises(TypeError, match="real binary64"):
+        EvaluationFrame(parameterization.identity, (("a", True),))
+    with pytest.raises(ValueError, match="finite"):
+        EvaluationFrame(parameterization.identity, (("a", np.inf),))
+    with pytest.raises(ValueError, match="finite"):
+        EvaluationFrame(parameterization.identity, (("a", 10**10_000),))
+    with pytest.raises(ValueError, match="canonical independent ID order"):
+        EvaluationFrame.from_lifecycle_frame(
+            parameterization,
+            dataclasses.replace(lifecycle, _items=tuple(reversed(lifecycle._items))),
+        )
+    with pytest.raises(ValueError, match="incompatible"):
+        EvaluationFrame.from_lifecycle_frame(
+            parameterization,
+            dataclasses.replace(lifecycle, program_fingerprint="foreign"),
+        )
+
+    frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
+    assert tuple(field.name for field in dataclasses.fields(frame)) == (
+        "parameterization_identity",
+        "_items",
+    )
+
+
+def test_later_profile_invalid_trial_is_atomic_resets_workspace_and_isolates_legacy() -> (
+    None
+):
+    session, experiments = _shipped_dcest("1N", "2N")
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    evaluator = engine.new_evaluator()
+    frame = _evaluation_frame(session, parameterization)
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    original = pulse_type.calculate
+    calls: list[object] = []
+
+    def fail_second(self: object, spectrometer: object, data: object) -> Array:
+        calls.append(self)
+        if len(calls) == 2:
+            return np.full_like(data.metadata, np.nan)
+        return original(self, spectrometer, data)
+
+    with patch.object(pulse_type, "calculate", fail_second):
+        failed = evaluator.evaluate(frame)
+    assert isinstance(failed, EvaluationFailure)
+    assert failed.validity == "INVALID_TRIAL"
+    assert len(calls) == 2
+    assert evaluator.cache_statistics.entries == 0
+    recovered = evaluator.evaluate(frame)
+    fresh = engine.new_evaluator().evaluate(frame)
+    assert isinstance(recovered, EvaluationResult)
+    assert isinstance(fresh, EvaluationResult)
+    np.testing.assert_array_equal(recovered.residuals, fresh.residuals)
+    legacy = experiments.residuals(
+        session.parameters.build_lmfit_params(experiments.param_ids)
+    )
+    np.testing.assert_array_equal(legacy, recovered.residuals)
+
+
+def test_later_profile_implementation_failure_poisoning_requires_fresh_evaluator() -> (
+    None
+):
+    session, experiments = _shipped_dcest("1N", "2N")
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    frame = _evaluation_frame(session, parameterization)
+    evaluator = engine.new_evaluator()
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    original = pulse_type.calculate
+    calls: list[object] = []
+
+    def fail_second(self: object, spectrometer: object, data: object) -> Array:
+        calls.append(self)
+        if len(calls) == 2:
+            return np.array([0.0])
+        return original(self, spectrometer, data)
+
+    with patch.object(pulse_type, "calculate", fail_second):
+        failed = evaluator.evaluate(frame)
+    assert isinstance(failed, EvaluationFailure)
+    assert failed.validity == "IMPLEMENTATION_FAILURE"
+    assert failed.category == "unexpected_shape"
+    assert len(calls) == 2
+    assert evaluator.cache_statistics.entries == 0
+    poisoned = evaluator.evaluate(frame)
+    assert isinstance(poisoned, EvaluationFailure)
+    assert poisoned.category == "workspace_poisoned"
+    recovered = engine.new_evaluator().evaluate(frame)
+    assert isinstance(recovered, EvaluationResult)
+    reference = engine.new_evaluator().evaluate(frame)
+    assert isinstance(reference, EvaluationResult)
+    assert recovered.identity == reference.identity
+
+
+def test_one_evaluation_frame_has_identical_complete_results_across_evaluators() -> (
+    None
+):
+    session, experiments = _shipped_dcest("1N", "2N")
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    frame = _evaluation_frame(session, parameterization)
+    first_engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    second_engine = EvaluationEngine.bind(
+        EvaluationPlan.from_record(first_engine.plan.to_record()),
+        parameterization,
+        experiments,
+    )
+    first = first_engine.new_evaluator().evaluate(frame)
+    second = second_engine.new_evaluator().evaluate(frame)
+    assert isinstance(first, EvaluationResult)
+    assert isinstance(second, EvaluationResult)
+    assert first.identity == second.identity
+    assert first.resolved_values == second.resolved_values
+    assert first.profiles == second.profiles
+    np.testing.assert_array_equal(
+        first.unscaled_calculations, second.unscaled_calculations
+    )
+    np.testing.assert_array_equal(
+        first.normalized_calculations, second.normalized_calculations
+    )
+    np.testing.assert_array_equal(first.residuals, second.residuals)
+
+
+def test_native_plan_matches_legacy_complete_profile_evaluation() -> None:
+    native_session, native_experiments = _shipped_dcest()
+    legacy_session, legacy_experiments = _shipped_dcest()
+    parameterization = native_session.compile_parameterization(
+        Method(), native_experiments.param_ids
+    )
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(native_session.analysis_values.snapshot()),
+    )
+    engine = EvaluationEngine.from_experiments(native_experiments, parameterization)
+
+    assert not hasattr(frame, "occurrence_identity")
+    assert not hasattr(frame, "revision")
+
+    outcome = engine.new_evaluator().evaluate(frame)
+    assert isinstance(outcome, EvaluationResult)
+
+    legacy_parameters = legacy_session.parameters.build_lmfit_params(
+        legacy_experiments.param_ids
+    )
+    legacy_residuals = legacy_experiments.residuals(legacy_parameters)
+    legacy_profile = next(iter(legacy_experiments)).profiles[0]
+
+    assert outcome.plan_identity == engine.plan.identity
+    assert outcome.resolved_values == pytest.approx(legacy_parameters.valuesdict())
+    np.testing.assert_allclose(
+        outcome.unscaled_calculations,
+        legacy_profile.data.calc_unscaled,
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_array_equal(
+        outcome.normalized_calculations, legacy_profile.data.calc
+    )
+    np.testing.assert_array_equal(outcome.residuals, legacy_residuals)
+    assert outcome.profiles[0].normalization_factor == legacy_profile.data.scale
+    assert outcome.profiles[0].retained_observation_indices == tuple(
+        np.flatnonzero(legacy_profile.data.mask)
+    )
+
+
+def test_plan_identity_is_deterministic_and_rebinds_after_serialization() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+
+    record = engine.plan.to_record()
+    restored = EvaluationPlan.from_record(record)
+    rebound = EvaluationEngine.bind(restored, parameterization, experiments)
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+    )
+
+    assert restored.identity == engine.plan.identity
+    assert restored.profiles == engine.plan.profiles
+    original = engine.new_evaluator().evaluate(frame)
+    rebound_result = rebound.new_evaluator().evaluate(frame)
+    assert isinstance(original, EvaluationResult)
+    assert isinstance(rebound_result, EvaluationResult)
+    np.testing.assert_array_equal(
+        original.unscaled_calculations, rebound_result.unscaled_calculations
+    )
+    np.testing.assert_array_equal(
+        original.normalized_calculations, rebound_result.normalized_calculations
+    )
+    np.testing.assert_array_equal(original.residuals, rebound_result.residuals)
+    restored_result = EvaluationResult.from_record(
+        json.loads(json.dumps(original.to_record())), restored
+    )
+    np.testing.assert_array_equal(
+        original.unscaled_calculations, restored_result.unscaled_calculations
+    )
+    np.testing.assert_array_equal(
+        original.normalized_calculations, restored_result.normalized_calculations
+    )
+    np.testing.assert_array_equal(original.residuals, restored_result.residuals)
+
+
+def test_workspace_reuse_cache_and_fresh_workspace_are_scientifically_identical() -> (
+    None
+):
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    reused = engine.new_evaluator()
+
+    first = reused.evaluate(frame)
+    second = reused.evaluate(frame)
+    fresh = engine.new_evaluator().evaluate(frame)
+    changed_id = parameterization.independent_ids[0]
+    changed_frame = EvaluationFrame(
+        frame.parameterization_identity,
+        tuple(
+            (
+                param_id,
+                session.analysis_values.snapshot()[param_id] * 1.000001
+                if param_id == changed_id
+                else value,
+            )
+            for param_id, value in frame._items
+        ),
+    )
+    changed = reused.evaluate(changed_frame)
+
+    assert isinstance(first, EvaluationResult)
+    assert isinstance(second, EvaluationResult)
+    assert isinstance(fresh, EvaluationResult)
+    assert isinstance(changed, EvaluationResult)
+    assert reused.cache_statistics.hits == 1
+    assert reused.cache_statistics.misses == 2
+    np.testing.assert_array_equal(
+        first.unscaled_calculations, second.unscaled_calculations
+    )
+    np.testing.assert_array_equal(
+        first.normalized_calculations, second.normalized_calculations
+    )
+    np.testing.assert_array_equal(first.residuals, fresh.residuals)
+    assert not first.unscaled_calculations.flags.writeable
+    assert not first.normalized_calculations.flags.writeable
+    assert not first.residuals.flags.writeable
+    with pytest.raises(ValueError):
+        first.residuals[0] = 0.0
+
+
+def test_native_normalization_uses_the_no_epsilon_572_formula() -> None:
+    session, experiments = _shipped_dcest()
+    profile = next(iter(experiments)).profiles[0]
+    profile.data.err = np.linspace(1.0e-18, 2.0e-15, profile.data.exp.size)
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    evaluator = EvaluationEngine.from_experiments(
+        experiments, parameterization
+    ).new_evaluator()
+    outcome = evaluator.evaluate(_evaluation_frame(session, parameterization))
+    assert isinstance(outcome, EvaluationResult)
+
+    unscaled = outcome.unscaled_calculations
+    expected = float(
+        np.dot(profile.data.exp / profile.data.err, unscaled / profile.data.err)
+        / np.dot(unscaled / profile.data.err, unscaled / profile.data.err)
+    )
+    assert outcome.profiles[0].normalization_factor == expected
+    profile.calculate(session.parameters.build_lmfit_params(experiments.param_ids))
+    assert profile.data.scale != expected
+
+
+def test_distinct_evaluators_are_reentrant_while_workspace_owner_is_enforced() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    first = engine.new_evaluator()
+    thread_outcomes: list[EvaluationResult | EvaluationFailure] = []
+
+    def evaluate_second() -> None:
+        thread_outcomes.append(engine.new_evaluator().evaluate(frame))
+
+    worker = Thread(target=evaluate_second)
+    worker.start()
+    worker.join()
+    owner_violation: list[EvaluationResult | EvaluationFailure] = []
+
+    def misuse_first() -> None:
+        owner_violation.append(first.evaluate(frame))
+
+    misuse = Thread(target=misuse_first)
+    misuse.start()
+    misuse.join()
+
+    assert isinstance(thread_outcomes[0], EvaluationResult)
+    assert isinstance(owner_violation[0], EvaluationFailure)
+    assert owner_violation[0].validity == "INVALID_REQUEST"
+
+
+@pytest.mark.parametrize(
+    ("values", "category", "validity"),
+    (
+        (np.array([np.nan]), "unexpected_shape", "IMPLEMENTATION_FAILURE"),
+        (np.array([]), "invalid_normalization", "INVALID_TRIAL"),
+    ),
+)
+def test_native_kernel_and_normalization_failures_are_atomic(
+    values: Array,
+    category: str,
+    validity: str,
+) -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+    )
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    if not values.size:
+        values = np.zeros_like(next(iter(experiments)).profiles[0].data.exp)
+
+    def calculate(_self: object, _spectrometer: object, _data: object) -> Array:
+        return values
+
+    with patch.object(pulse_type, "calculate", calculate):
+        outcome = (
+            EvaluationEngine.from_experiments(experiments, parameterization)
+            .new_evaluator()
+            .evaluate(frame)
+        )
+
+    assert isinstance(outcome, EvaluationFailure)
+    assert outcome.category == category
+    assert outcome.validity == validity
+    assert not hasattr(outcome, "residuals")
+
+
+def test_non_finite_kernel_output_is_an_invalid_trial_without_partial_result() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+    )
+    profile = next(iter(experiments)).profiles[0]
+    pulse_type = type(profile.pulse_sequence)
+
+    def calculate(_self: object, _spectrometer: object, _data: object) -> Array:
+        return np.full_like(profile.data.exp, np.nan)
+
+    with patch.object(pulse_type, "calculate", calculate):
+        outcome = (
+            EvaluationEngine.from_experiments(experiments, parameterization)
+            .new_evaluator()
+            .evaluate(frame)
+        )
+
+    assert isinstance(outcome, EvaluationFailure)
+    assert outcome.category == "non_finite_calculation"
+    assert outcome.validity == "INVALID_TRIAL"
+    restored_plan = EvaluationPlan.from_record(
+        EvaluationEngine.from_experiments(
+            experiments, parameterization
+        ).plan.to_record()
+    )
+    assert EvaluationFailure.from_record(outcome.to_record(), restored_plan) == outcome
+
+
+def test_native_failure_is_qualification_only_and_cannot_veto_legacy() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    with (
+        patch(
+            "chemex.evaluation.native.EvaluationEngine.from_experiments",
+            side_effect=ValueError("native qualification failure"),
+        ),
+        pytest.raises(ValueError, match="native qualification failure"),
+    ):
+        EvaluationEngine.from_experiments(experiments, parameterization)
+    legacy = experiments.residuals(
+        session.parameters.build_lmfit_params(experiments.param_ids)
+    )
+    assert legacy.size and np.all(np.isfinite(legacy))

--- a/tests/test_native_evaluation.py
+++ b/tests/test_native_evaluation.py
@@ -25,8 +25,24 @@ from chemex.evaluation.native import (
     EvaluationFrame,
     EvaluationPlan,
     EvaluationResult,
+    _identity,
+    _parameterization_failure_validity,
 )
 from chemex.experiments.builder import build_experiments
+from chemex.parameters.parameterization import (
+    AmbiguousParameterReferenceError,
+    ConstraintCycleError,
+    ConstraintDomainError,
+    ConstraintEvaluationError,
+    ConstraintProgramMismatchError,
+    ConstraintSelfReferenceError,
+    IncompatibleParameterizationInputError,
+    IncompleteParameterDependenciesError,
+    ModelDerivationOverrideError,
+    NonFiniteParameterValueError,
+    NoParameterMatchError,
+    UnsupportedConstraintExpressionError,
+)
 from chemex.parameters.spin_system import SpinSystem
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
@@ -84,14 +100,20 @@ def test_shipped_two_profile_dcest_plan_matches_legacy_completely() -> None:
         outcome.unscaled_calculations,
         np.concatenate([profile.data.calc_unscaled for profile in legacy_profiles]),
     )
-    np.testing.assert_array_equal(
+    # #572 deliberately replaces legacy BLAS dot accumulation with the frozen
+    # ordered binary64 reduction.  The DCEST difference is confined to scale.
+    np.testing.assert_allclose(
         outcome.normalized_calculations,
         np.concatenate([profile.data.calc for profile in legacy_profiles]),
+        rtol=6.0e-16,
+        atol=1.2e-8,
     )
-    np.testing.assert_array_equal(outcome.residuals, legacy_residuals)
-    assert [item.normalization_factor for item in outcome.profiles] == [
-        profile.data.scale for profile in legacy_profiles
-    ]
+    np.testing.assert_allclose(outcome.residuals, legacy_residuals, rtol=6.0e-13)
+    np.testing.assert_allclose(
+        [item.normalization_factor for item in outcome.profiles],
+        [profile.data.scale for profile in legacy_profiles],
+        rtol=6.0e-16,
+    )
     assert [item.retained_observation_indices for item in outcome.profiles] == [
         tuple(np.flatnonzero(profile.data.mask)) for profile in legacy_profiles
     ]
@@ -136,11 +158,22 @@ def test_trusted_rebinding_rejects_each_mutated_kernel_descriptor(
         engine.plan.parameterization_identity,
         engine.plan.constraint_program_identity,
         (descriptor,),
+        resolved_ids=engine.plan.resolved_ids,
     )
     payload["identity"] = signed_plan.identity
-    plan = EvaluationPlan.from_record(payload)
-    with pytest.raises(ValueError, match="Trusted"):
-        EvaluationEngine.bind(plan, parameterization, experiments)
+    if field in {
+        "output_shape",
+        "observation_offset",
+        "experiment_ordinal",
+        "profile_ordinal",
+        "identity",
+    }:
+        with pytest.raises(ValueError):
+            EvaluationPlan.from_record(payload)
+    else:
+        plan = EvaluationPlan.from_record(payload)
+        with pytest.raises(ValueError, match="Trusted"):
+            EvaluationEngine.bind(plan, parameterization, experiments)
 
 
 def test_trusted_rebinding_rejects_nested_serialized_basis_descriptor_mutation() -> (
@@ -161,6 +194,7 @@ def test_trusted_rebinding_rejects_nested_serialized_basis_descriptor_mutation()
         engine.plan.parameterization_identity,
         engine.plan.constraint_program_identity,
         (descriptor,),
+        resolved_ids=engine.plan.resolved_ids,
     ).identity
     plan = EvaluationPlan.from_record(payload)
     with pytest.raises(ValueError, match="Trusted"):
@@ -226,7 +260,7 @@ def test_evaluation_frame_validates_canonical_binary64_input_and_projection_orde
         EvaluationFrame(parameterization.identity, (("a", True),))
     with pytest.raises(ValueError, match="finite"):
         EvaluationFrame(parameterization.identity, (("a", np.inf),))
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(TypeError, match="real binary64"):
         EvaluationFrame(parameterization.identity, (("a", 10**10_000),))
     with pytest.raises(ValueError, match="canonical independent ID order"):
         EvaluationFrame.from_lifecycle_frame(
@@ -278,7 +312,7 @@ def test_later_profile_invalid_trial_is_atomic_resets_workspace_and_isolates_leg
     legacy = experiments.residuals(
         session.parameters.build_lmfit_params(experiments.param_ids)
     )
-    np.testing.assert_array_equal(legacy, recovered.residuals)
+    np.testing.assert_allclose(legacy, recovered.residuals, rtol=6.0e-13)
 
 
 def test_later_profile_implementation_failure_poisoning_requires_fresh_evaluator() -> (
@@ -490,7 +524,7 @@ def test_native_normalization_uses_the_no_epsilon_572_formula() -> None:
         np.dot(profile.data.exp / profile.data.err, unscaled / profile.data.err)
         / np.dot(unscaled / profile.data.err, unscaled / profile.data.err)
     )
-    assert outcome.profiles[0].normalization_factor == expected
+    assert outcome.profiles[0].normalization_factor == pytest.approx(expected)
     profile.calculate(session.parameters.build_lmfit_params(experiments.param_ids))
     assert profile.data.scale != expected
 
@@ -610,3 +644,470 @@ def test_native_failure_is_qualification_only_and_cannot_veto_legacy() -> None:
         session.parameters.build_lmfit_params(experiments.param_ids)
     )
     assert legacy.size and np.all(np.isfinite(legacy))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("experimental_values", 1.0),
+        ("uncertainties", 1.0),
+        ("mask", False),
+        ("is_scaled", False),
+        ("source_identity", "foreign-source"),
+    ),
+)
+def test_trusted_rebinding_rejects_complete_profile_population_tampering(
+    field: str, value: object
+) -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    descriptor = engine.plan.profiles[0]
+    if field in {"experimental_values", "uncertainties", "mask"}:
+        changed = list(getattr(descriptor, field))
+        changed[0] = not changed[0] if field == "mask" else value
+        value = tuple(changed)
+    tampered = dataclasses.replace(descriptor, **{field: value})
+    # A hostile serializer can recompute every fingerprint; trusted rebinding
+    # must still compare the complete local scientific descriptor.
+    if field in {"source_identity"}:
+        tampered = dataclasses.replace(
+            tampered,
+            identity=_identity(
+                "profile-plan",
+                (
+                    tampered.source_identity,
+                    tampered.experiment_ordinal,
+                    tampered.profile_ordinal,
+                    tampered.observation_offset,
+                ),
+            ),
+        )
+    plan = EvaluationPlan.from_record(
+        json.loads(
+            json.dumps(
+                dataclasses.replace(engine.plan, profiles=(tampered,)).to_record()
+            )
+        )
+    )
+    with pytest.raises(ValueError):
+        EvaluationEngine.bind(plan, parameterization, experiments)
+
+
+def test_frame_result_and_failure_records_fail_closed_after_tampering() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    frame = _evaluation_frame(session, parameterization)
+    result = engine.new_evaluator().evaluate(frame)
+    assert isinstance(result, EvaluationResult)
+    for mutate in (
+        lambda record: record["items"].__setitem__(0, ["bad", "0x1.0000000000000p+0"]),
+        lambda record: record.__setitem__("identity", "bad"),
+    ):
+        record = json.loads(json.dumps(frame.to_record()))
+        mutate(record)
+        with pytest.raises((TypeError, ValueError)):
+            EvaluationFrame.from_record(record)
+    for mutate in (
+        lambda record: record["profiles"][0].__setitem__("observation_offset", 999),
+        lambda record: record["profiles"][0].__setitem__(
+            "normalization_factor", "0x1.0000000000000p+0"
+        ),
+        lambda record: record["residuals"].__setitem__(0, "0x1.0000000000000p+0"),
+        lambda record: record.__setitem__("parameterization_identity", "foreign"),
+    ):
+        record = json.loads(json.dumps(result.to_record()))
+        mutate(record)
+        with pytest.raises((TypeError, ValueError)):
+            EvaluationResult.from_record(record, engine.plan)
+    failure = EvaluationFailure(
+        engine.plan.identity,
+        engine.plan.parameterization_identity,
+        "kernel",
+        "non_finite_calculation",
+        "INVALID_TRIAL",
+        engine.plan.profiles[0].identity,
+    )
+    record = failure.to_record()
+    record["identity"] = "foreign"
+    with pytest.raises(ValueError):
+        EvaluationFailure.from_record(record, engine.plan)
+
+
+def test_result_buffers_are_owned_immutable_bytes() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    result = (
+        EvaluationEngine.from_experiments(experiments, parameterization)
+        .new_evaluator()
+        .evaluate(_evaluation_frame(session, parameterization))
+    )
+    assert isinstance(result, EvaluationResult)
+    for values in (
+        result.unscaled_calculations,
+        result.normalized_calculations,
+        result.residuals,
+    ):
+        before = values.copy()
+        with pytest.raises(ValueError):
+            values[0] = 0.0
+        with pytest.raises(ValueError):
+            values.flags.writeable = True
+        assert isinstance(values.base, bytes)
+        np.testing.assert_array_equal(values, before)
+
+
+def test_native_evaluation_is_stable_under_hostile_numpy_error_state() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    previous = np.seterr(all="raise")
+    try:
+        outcome = (
+            EvaluationEngine.from_experiments(experiments, parameterization)
+            .new_evaluator()
+            .evaluate(_evaluation_frame(session, parameterization))
+        )
+    finally:
+        np.seterr(**previous)
+    assert isinstance(outcome, EvaluationResult)
+
+
+def test_semantic_parameterization_identity_excludes_lifecycle_identity() -> None:
+    first_session, first_experiments = _shipped_dcest()
+    second_session, second_experiments = _shipped_dcest()
+    first = first_session.compile_parameterization(
+        Method(), first_experiments.param_ids
+    )
+    second = second_session.compile_parameterization(
+        Method(), second_experiments.param_ids
+    )
+    assert first.identity != second.identity
+    assert first.evaluator_identity == second.evaluator_identity
+    assert (
+        EvaluationEngine.from_experiments(
+            first_experiments, first
+        ).plan.parameterization_identity
+        == EvaluationEngine.from_experiments(
+            second_experiments, second
+        ).plan.parameterization_identity
+    )
+
+
+def test_masked_and_empty_unscaled_profiles_preserve_complete_calculations() -> None:
+    session, experiments = _shipped_dcest()
+    profile = next(iter(experiments)).profiles[0]
+    profile.data.mask[0] = False
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    masked_engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    restored_plan = EvaluationPlan.from_record(
+        json.loads(json.dumps(masked_engine.plan.to_record()))
+    )
+    masked = (
+        EvaluationEngine.bind(restored_plan, parameterization, experiments)
+        .new_evaluator()
+        .evaluate(_evaluation_frame(session, parameterization))
+    )
+    assert isinstance(masked, EvaluationResult)
+    assert masked.unscaled_calculations.size == profile.data.exp.size
+    assert masked.normalized_calculations.size == profile.data.exp.size
+    assert masked.residuals.size == profile.data.exp.size - 1
+    assert masked.profiles[0].retained_observation_indices == tuple(
+        np.flatnonzero(profile.data.mask)
+    )
+    assert masked.profiles[0].observation_offset == 0
+    assert masked.profiles[0].residual_offset == 0
+    assert masked.profiles[0].residual_count == profile.data.exp.size - 1
+    retained = profile.data.mask
+    unscaled = masked.unscaled_calculations
+    numerator = 0.0
+    denominator = 0.0
+    for exp, calc, err in zip(
+        profile.data.exp[retained],
+        unscaled[retained],
+        profile.data.err[retained],
+        strict=True,
+    ):
+        numerator += (calc / err) * (exp / err)
+        denominator += (calc / err) * (calc / err)
+    assert masked.profiles[0].normalization_factor == numerator / denominator
+    profile.is_scaled = False
+    profile.data.mask[:] = False
+    empty = (
+        EvaluationEngine.from_experiments(experiments, parameterization)
+        .new_evaluator()
+        .evaluate(_evaluation_frame(session, parameterization))
+    )
+    assert isinstance(empty, EvaluationResult)
+    assert empty.profiles[0].normalization_factor == 1.0
+    assert empty.residuals.size == 0
+    assert empty.unscaled_calculations.size == profile.data.exp.size
+
+
+@pytest.mark.parametrize("sign", (0.0, -1.0))
+def test_finite_zero_and_negative_normalization_are_valid(sign: float) -> None:
+    session, experiments = _shipped_dcest()
+    profile = next(iter(experiments)).profiles[0]
+    profile.data.exp = sign * np.abs(profile.data.exp)
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    result = (
+        EvaluationEngine.from_experiments(experiments, parameterization)
+        .new_evaluator()
+        .evaluate(_evaluation_frame(session, parameterization))
+    )
+    assert isinstance(result, EvaluationResult)
+    factor = result.profiles[0].normalization_factor
+    assert factor == 0.0 if sign == 0.0 else factor < 0.0
+
+
+def test_descriptor_is_history_independent_and_evaluator_rejects_reentry_and_pid() -> (
+    None
+):
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    first = EvaluationEngine.from_experiments(experiments, parameterization).plan
+    profile = next(iter(experiments)).profiles[0]
+    profile.calculate(session.parameters.build_lmfit_params(experiments.param_ids))
+    second = EvaluationEngine.from_experiments(experiments, parameterization).plan
+    assert first.identity == second.identity
+    evaluator = EvaluationEngine.from_experiments(
+        experiments, parameterization
+    ).new_evaluator()
+    frame = _evaluation_frame(session, parameterization)
+    pulse_type = type(profile.pulse_sequence)
+    original = pulse_type.calculate
+    nested: list[EvaluationFailure] = []
+
+    def calculate(self: object, spectrometer: object, data: object) -> Array:
+        nested_result = evaluator.evaluate(frame)
+        assert isinstance(nested_result, EvaluationFailure)
+        nested.append(nested_result)
+        return original(self, spectrometer, data)
+
+    with patch.object(pulse_type, "calculate", calculate):
+        assert isinstance(evaluator.evaluate(frame), EvaluationResult)
+    assert nested[0].category == "workspace_reentrant"
+    evaluator._owner_pid = -1
+    failed = evaluator.evaluate(frame)
+    assert isinstance(failed, EvaluationFailure)
+    assert failed.category == "workspace_process_violation"
+
+
+def test_dcest_construction_descriptor_precedes_and_survives_pulse_history() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    profile = next(iter(experiments)).profiles[0]
+    initial = dict(profile.spectrometer.native_kernel_descriptor())
+    profile.calculate(session.parameters.build_lmfit_params(experiments.param_ids))
+    after_legacy = dict(profile.spectrometer.native_kernel_descriptor())
+    before_plan = EvaluationEngine.from_experiments(experiments, parameterization).plan
+    profile.calculate(session.parameters.build_lmfit_params(experiments.param_ids))
+    after_plan = EvaluationEngine.from_experiments(experiments, parameterization).plan
+    assert initial == after_legacy
+    assert before_plan.identity == after_plan.identity
+
+
+def test_construction_setting_changes_native_descriptor_and_plan_identity() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    original = EvaluationEngine.from_experiments(experiments, parameterization).plan
+    changed = next(iter(experiments)).profiles[0].spectrometer
+    changed._native_kernel_descriptor = None
+    changed._native_workspace_template = None
+    changed.detection = "[iz_b]"
+    changed.finalize_native_construction()
+    changed_plan = EvaluationEngine.from_experiments(experiments, parameterization).plan
+    assert changed.native_kernel_descriptor()["detection"] == "[iz_b]"
+    assert original.identity != changed_plan.identity
+
+
+def test_native_workspace_cannot_mutate_authoritative_profile_or_metadata() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    profile = next(iter(experiments)).profiles[0]
+    metadata = profile.data.metadata.copy()
+    profile.data.mask[0] = False
+    legacy_params = session.parameters.build_lmfit_params(experiments.param_ids)
+    profile.calculate(legacy_params)
+    legacy_unscaled = profile.data.calc_unscaled.copy()
+    offset = profile.spectrometer.offset_i
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    baseline = engine.new_evaluator().evaluate(
+        _evaluation_frame(session, parameterization)
+    )
+    assert isinstance(baseline, EvaluationResult)
+    observed_parameter_ids: list[set[str]] = []
+    observed_data: list[tuple[Array, Array, Array]] = []
+    pulse_type = type(profile.pulse_sequence)
+    original = pulse_type.calculate
+    spectrometer_type = type(profile.spectrometer)
+    original_update = spectrometer_type.update
+
+    def update(self: object, values: dict[str, float]) -> None:
+        observed_parameter_ids.append(set(values))
+        original_update(self, values)
+
+    def mutate(self: object, spectrometer: object, data: object) -> Array:
+        observed_data.append((data.exp.copy(), data.err.copy(), data.mask.copy()))
+        data.metadata[:] = 999.0
+        spectrometer.offset_i = 999.0
+        return original(self, spectrometer, data)
+
+    with (
+        patch.object(pulse_type, "calculate", mutate),
+        patch.object(spectrometer_type, "update", update),
+    ):
+        result = engine.new_evaluator().evaluate(
+            _evaluation_frame(session, parameterization)
+        )
+    assert isinstance(result, EvaluationResult)
+    np.testing.assert_array_equal(profile.data.metadata, metadata)
+    assert profile.spectrometer.offset_i == offset
+    assert observed_parameter_ids
+    assert observed_parameter_ids[0] == set(profile.name_map)
+    assert all(
+        np.array_equal(exp, np.zeros_like(exp)) for exp, _err, _mask in observed_data
+    )
+    assert all(
+        np.array_equal(err, np.ones_like(err)) for _exp, err, _mask in observed_data
+    )
+    assert all(np.all(mask) for _exp, _err, mask in observed_data)
+    repeated = engine.new_evaluator().evaluate(
+        _evaluation_frame(session, parameterization)
+    )
+    assert isinstance(repeated, EvaluationResult)
+    np.testing.assert_array_equal(
+        baseline.unscaled_calculations, repeated.unscaled_calculations
+    )
+    profile.calculate(legacy_params)
+    np.testing.assert_array_equal(profile.data.calc_unscaled, legacy_unscaled)
+
+
+def test_normalization_overflow_is_typed_under_hostile_numpy_settings() -> None:
+    session, experiments = _shipped_dcest()
+    profile = next(iter(experiments)).profiles[0]
+    profile.data.err[:] = np.finfo(np.float64).tiny
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    frame = _evaluation_frame(session, parameterization)
+    default = (
+        EvaluationEngine.from_experiments(experiments, parameterization)
+        .new_evaluator()
+        .evaluate(frame)
+    )
+    previous = np.seterr(all="raise")
+    try:
+        outcome = (
+            EvaluationEngine.from_experiments(experiments, parameterization)
+            .new_evaluator()
+            .evaluate(frame)
+        )
+        assert np.geterr() == {
+            "divide": "raise",
+            "over": "raise",
+            "under": "raise",
+            "invalid": "raise",
+        }
+    finally:
+        np.seterr(**previous)
+    assert isinstance(default, EvaluationFailure)
+    assert (default.stage, default.category, default.validity) == (
+        outcome.stage,
+        outcome.category,
+        outcome.validity,
+    )
+    assert isinstance(outcome, EvaluationFailure)
+    assert (outcome.stage, outcome.category, outcome.validity) == (
+        "normalization",
+        "invalid_normalization",
+        "INVALID_TRIAL",
+    )
+
+
+def test_normalization_is_independent_of_blas_thread_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    frame = _evaluation_frame(session, parameterization)
+    outcomes: list[EvaluationResult] = []
+    for threads in ("1", "4"):
+        monkeypatch.setenv("OPENBLAS_NUM_THREADS", threads)
+        outcome = (
+            EvaluationEngine.from_experiments(experiments, parameterization)
+            .new_evaluator()
+            .evaluate(frame)
+        )
+        assert isinstance(outcome, EvaluationResult)
+        outcomes.append(outcome)
+    np.testing.assert_array_equal(
+        outcomes[0].normalized_calculations, outcomes[1].normalized_calculations
+    )
+    assert [item.normalization_factor for item in outcomes[0].profiles] == [
+        item.normalization_factor for item in outcomes[1].profiles
+    ]
+
+
+@pytest.mark.parametrize(
+    ("error_type", "expected"),
+    (
+        (NoParameterMatchError, "INVALID_PLAN_OR_BINDING"),
+        (AmbiguousParameterReferenceError, "INVALID_PLAN_OR_BINDING"),
+        (ConstraintSelfReferenceError, "INVALID_PLAN_OR_BINDING"),
+        (ConstraintCycleError, "INVALID_PLAN_OR_BINDING"),
+        (ConstraintDomainError, "INVALID_TRIAL"),
+        (ConstraintEvaluationError, "INVALID_TRIAL"),
+        (NonFiniteParameterValueError, "INVALID_TRIAL"),
+        (IncompleteParameterDependenciesError, "INVALID_PLAN_OR_BINDING"),
+        (IncompatibleParameterizationInputError, "INVALID_PLAN_OR_BINDING"),
+        (ConstraintProgramMismatchError, "INVALID_PLAN_OR_BINDING"),
+        (UnsupportedConstraintExpressionError, "INVALID_PLAN_OR_BINDING"),
+        (ModelDerivationOverrideError, "INVALID_PLAN_OR_BINDING"),
+    ),
+)
+def test_parameterization_failure_taxonomy_is_closed(
+    error_type: type[Exception], expected: str
+) -> None:
+    error = error_type("qualification")
+    assert _parameterization_failure_validity(error) == expected
+
+
+@pytest.mark.parametrize(
+    ("error_type", "expected"),
+    (
+        (ConstraintDomainError, "INVALID_TRIAL"),
+        (NonFiniteParameterValueError, "INVALID_TRIAL"),
+        (ConstraintProgramMismatchError, "INVALID_PLAN_OR_BINDING"),
+    ),
+)
+def test_evaluator_maps_declared_parameterization_failures(
+    error_type: type[Exception], expected: str
+) -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    evaluator = EvaluationEngine.from_experiments(
+        experiments, parameterization
+    ).new_evaluator()
+    with patch.object(
+        type(parameterization), "resolve", side_effect=error_type("test")
+    ):
+        outcome = evaluator.evaluate(_evaluation_frame(session, parameterization))
+    assert isinstance(outcome, EvaluationFailure)
+    assert outcome.validity == expected
+
+
+def test_projection_and_result_assembly_failures_are_typed() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    profile = next(iter(experiments)).profiles[0]
+    profile.name_map["missing"] = "__missing"
+    try:
+        with pytest.raises(ValueError, match="outside its closure"):
+            EvaluationEngine.from_experiments(experiments, parameterization)
+    finally:
+        del profile.name_map["missing"]
+    evaluator = engine.new_evaluator()
+    with patch("chemex.evaluation.native.EvaluationResult", side_effect=RuntimeError):
+        outcome = evaluator.evaluate(_evaluation_frame(session, parameterization))
+    assert isinstance(outcome, EvaluationFailure)
+    assert (outcome.stage, outcome.validity) == ("result", "IMPLEMENTATION_FAILURE")

--- a/tests/test_native_evaluation.py
+++ b/tests/test_native_evaluation.py
@@ -240,6 +240,48 @@ def test_spectrometer_native_kernel_descriptor_is_immutable_by_value() -> None:
         descriptor["jeff_i"]["dephasing"] = True
 
 
+def test_native_snapshot_failure_does_not_disable_legacy_dcest() -> None:
+    normal_session, normal_experiments = _shipped_dcest()
+    normal_parameters = normal_session.parameters.build_lmfit_params(
+        normal_experiments.param_ids
+    )
+    normal_residuals = normal_experiments.residuals(normal_parameters)
+    normal_profile = next(iter(normal_experiments)).profiles[0]
+    normal_calculation = normal_profile.data.calc.copy()
+
+    with patch(
+        "chemex.nmr.spectrometer.deepcopy",
+        side_effect=RuntimeError("native snapshot failed"),
+    ):
+        failed_session, failed_experiments = _shipped_dcest()
+    failed_profile = next(iter(failed_experiments)).profiles[0]
+    failed_spectrometer = failed_profile.spectrometer
+    assert failed_spectrometer.native_construction_diagnostic == (
+        "RuntimeError: native snapshot failed"
+    )
+    with pytest.raises(ValueError, match="Native construction is unavailable"):
+        failed_spectrometer.native_kernel_descriptor()
+    with pytest.raises(ValueError, match="Native construction is unavailable"):
+        failed_spectrometer.new_native_workspace()
+
+    failed_parameters = failed_session.parameters.build_lmfit_params(
+        failed_experiments.param_ids
+    )
+    failed_residuals = failed_experiments.residuals(failed_parameters)
+    np.testing.assert_array_equal(failed_profile.data.calc, normal_calculation)
+    np.testing.assert_array_equal(failed_residuals, normal_residuals)
+    parameterization = failed_session.compile_parameterization(
+        Method(), failed_experiments.param_ids
+    )
+    with pytest.raises(ValueError, match="Native construction is unavailable"):
+        EvaluationEngine.from_experiments(failed_experiments, parameterization)
+
+    failed_profile.calculate(failed_parameters)
+    assert not failed_spectrometer.try_finalize_native_construction()
+    with pytest.raises(ValueError, match="native snapshot failed"):
+        failed_spectrometer.native_kernel_descriptor()
+
+
 def test_lifecycle_frames_reject_stale_and_foreign_snapshots_before_projection() -> (
     None
 ):
@@ -1011,6 +1053,8 @@ def test_construction_setting_changes_native_descriptor_and_plan_identity() -> N
     changed = next(iter(experiments)).profiles[0].spectrometer
     changed._native_kernel_descriptor = None
     changed._native_workspace_template = None
+    changed._native_construction_attempted = False
+    changed._native_construction_diagnostic = None
     changed.detection = "[iz_b]"
     changed.finalize_native_construction()
     changed_plan = EvaluationEngine.from_experiments(experiments, parameterization).plan

--- a/tests/test_native_evaluation.py
+++ b/tests/test_native_evaluation.py
@@ -96,9 +96,15 @@ def test_shipped_two_profile_dcest_plan_matches_legacy_completely() -> None:
     legacy_profiles = next(iter(legacy_experiments)).profiles
     assert [item.profile_ordinal for item in native.plan.profiles] == [0, 1]
     assert outcome.resolved_values == pytest.approx(legacy_parameters.valuesdict())
-    np.testing.assert_array_equal(
+    # The isolated native workspace has bitwise-identical pulse-entry inputs,
+    # but the SciPy/BLAS propagator path is allowed a few binary64 ulps across
+    # independent workspace executions on Linux.  Keep this separate from the
+    # deliberate ordered-normalization tolerance below.
+    np.testing.assert_allclose(
         outcome.unscaled_calculations,
         np.concatenate([profile.data.calc_unscaled for profile in legacy_profiles]),
+        rtol=6.0e-16,
+        atol=0.0,
     )
     # #572 deliberately replaces legacy BLAS dot accumulation with the frozen
     # ordered binary64 reduction.  The DCEST difference is confined to scale.
@@ -404,20 +410,111 @@ def test_native_plan_matches_legacy_complete_profile_evaluation() -> None:
 
     assert outcome.plan_identity == engine.plan.identity
     assert outcome.resolved_values == pytest.approx(legacy_parameters.valuesdict())
+    # Native and legacy calculate through separate isolated Spectrometers.
+    # Their pulse-entry scalar values, matrices, weights, and detection vector
+    # are bitwise-identical; Linux SciPy/BLAS propagator reductions may differ
+    # by a few ulps between those independent executions.
     np.testing.assert_allclose(
         outcome.unscaled_calculations,
         legacy_profile.data.calc_unscaled,
-        rtol=0.0,
+        rtol=6.0e-16,
         atol=0.0,
     )
-    np.testing.assert_array_equal(
-        outcome.normalized_calculations, legacy_profile.data.calc
+    np.testing.assert_allclose(
+        outcome.normalized_calculations,
+        legacy_profile.data.calc,
+        rtol=6.0e-16,
+        atol=1.2e-8,
     )
-    np.testing.assert_array_equal(outcome.residuals, legacy_residuals)
-    assert outcome.profiles[0].normalization_factor == legacy_profile.data.scale
+    np.testing.assert_allclose(outcome.residuals, legacy_residuals, rtol=6.0e-13)
+    assert outcome.profiles[0].normalization_factor == pytest.approx(
+        legacy_profile.data.scale, rel=6.0e-16
+    )
     assert outcome.profiles[0].retained_observation_indices == tuple(
         np.flatnonzero(legacy_profile.data.mask)
     )
+
+
+def test_native_private_workspace_has_bitwise_identical_dcest_pulse_inputs() -> None:
+    native_session, native_experiments = _shipped_dcest()
+    legacy_session, legacy_experiments = _shipped_dcest()
+    parameterization = native_session.compile_parameterization(
+        Method(), native_experiments.param_ids
+    )
+    frame = _evaluation_frame(native_session, parameterization)
+    captured: list[dict[str, object]] = []
+    pulse_type = type(next(iter(native_experiments)).profiles[0].pulse_sequence)
+    original = pulse_type.calculate
+
+    def capture(self: object, spectrometer: object, data: object) -> Array:
+        engine = spectrometer._engine
+        captured.append(
+            {
+                "settings": self.settings.model_dump(),
+                "metadata_dtype": data.metadata.dtype,
+                "metadata": data.metadata.copy(),
+                "scalars": {
+                    name: getattr(spectrometer, name)
+                    for name in (
+                        "ppm_i",
+                        "ppm_s",
+                        "carrier_i",
+                        "carrier_s",
+                        "offset_i",
+                        "offset_s",
+                        "b1_i",
+                        "b1_s",
+                        "detection",
+                    )
+                }
+                | {"h_larmor_frq": engine.h_frq},
+                "b1_i_values": spectrometer.b1_i_distribution.values.copy(),
+                "b1_i_weights": spectrometer.b1_i_distribution.weights.copy(),
+                "jeff_i_values": spectrometer.jeff_i.values.copy(),
+                "jeff_i_weights": spectrometer.jeff_i.weights.copy(),
+                "parameter_values": dict(engine.par_values),
+                "matrix_keys": frozenset(engine._matrices),
+                "matrices": {
+                    name: matrix.copy() for name, matrix in engine._matrices.items()
+                },
+                "l_free": engine.l_free.copy(),
+                "weights": engine.weights.copy(),
+                "detection_vector": engine._readout._detect_vector.copy(),
+            }
+        )
+        return original(self, spectrometer, data)
+
+    with patch.object(pulse_type, "calculate", capture):
+        outcome = (
+            EvaluationEngine.from_experiments(native_experiments, parameterization)
+            .new_evaluator()
+            .evaluate(frame)
+        )
+        legacy_experiments.residuals(
+            legacy_session.parameters.build_lmfit_params(legacy_experiments.param_ids)
+        )
+    assert isinstance(outcome, EvaluationResult)
+    native, legacy = captured
+    assert native["settings"] == legacy["settings"]
+    assert native["metadata_dtype"] == legacy["metadata_dtype"]
+    assert native["scalars"] == legacy["scalars"]
+    assert native["parameter_values"] == legacy["parameter_values"]
+    assert native["matrix_keys"] == legacy["matrix_keys"]
+    for name in (
+        "metadata",
+        "b1_i_values",
+        "b1_i_weights",
+        "jeff_i_values",
+        "jeff_i_weights",
+        "l_free",
+        "weights",
+        "detection_vector",
+    ):
+        np.testing.assert_array_equal(native[name], legacy[name])
+    for matrix_name in native["matrix_keys"]:
+        np.testing.assert_array_equal(
+            native["matrices"][matrix_name], legacy["matrices"][matrix_name]
+        )
 
 
 def test_plan_identity_is_deterministic_and_rebinds_after_serialization() -> None:


### PR DESCRIPTION
Closes #585.

## Summary

Introduces the native qualification-only evaluation boundary defined by #572 while keeping the legacy runner as the sole product authority.

The checkpoint adds:

* immutable, deterministic, serializable evaluation plans;
* a narrow evaluator-facing independent-value frame projected from the #584 lifecycle-safe parameterization;
* exactly-once constraint resolution per evaluation;
* isolated single-owner evaluator workspaces;
* evaluator-private spectrometer execution from frozen construction semantics;
* trusted kernel rebinding from fully by-value scientific descriptors;
* bounded per-profile calculation caching with explicit accounting;
* centralized deterministic profile normalization and residual construction;
* immutable complete evaluation results and deterministic identities;
* atomic typed failures with explicit reset/poison semantics;
* realistic native/legacy qualification using shipped multi-profile DCEST data.

## Evaluation boundary

The public native evaluation input contains only:

* evaluator-semantic active-parameterization identity;
* canonical ordered independent parameter IDs and finite binary64 values.

Analysis occurrence identity and Analysis Values revision remain upstream in the #583/#584 lifecycle boundary and are not exposed through the evaluator-facing frame or native result identity.

A lifecycle frame is projected into the narrower evaluation frame only after occurrence, revision, parameterization, program, and ordering compatibility have been validated.

## Evaluation semantics

For each evaluation:

1. validate the canonical independent-value frame;
2. resolve the #584 constraint program exactly once;
3. project each profile's required local parameter values;
4. evaluate profiles in frozen canonical order using evaluator-private workspaces;
5. apply per-profile analytic normalization centrally;
6. construct retained weighted residuals centrally;
7. return one complete immutable result or one atomic typed failure.

Residual semantics remain:

`(calculated - experimental) / uncertainty`

For scaled profiles, normalization uses the #572 zero-intercept weighted fit over retained observations only. The authoritative reduction uses an explicit fixed-order binary64 accumulation rather than `np.dot`/BLAS reduction, with no epsilon, clipping, regularization, or previous-scale reuse.

Finite zero and negative normalization factors remain valid. Invalid or non-finite normalization produces a typed invalid-trial failure.

## Plan, serialization, and semantic identity

Serialized evaluation plans contain the value-affecting scientific semantics by value, including:

* evaluator-semantic parameterization and constraint-program identities;
* kernel semantic identity/version;
* immutable kernel/settings configuration;
* frozen spectrometer, basis, model, and state descriptors;
* canonical local-input ordering and stable parameter projections;
* experimental values, uncertainties, masks, and scaling policy;
* observation metadata, ordinals, offsets, and retained mappings;
* declared output shape;
* scalar canonicalization, normalization/reduction, masking/order, residual, and failure-semantics versions.

Plans, frames, results, and failures have explicit serialization integrity checks and deterministic identities.

Serialized records contain no bound callables, closures, mutable runtime objects, private engine state, analysis occurrence/revision authority, process-local object identities, or source-path identity.

Trusted rebinding validates the complete serialized scientific population against the local trusted source before execution.

## Kernel and workspace ownership

Each `BoundEvaluator` owns exactly one private mutable workspace and is single-process, single-thread, and non-reentrant.

Native pulse execution uses:

* frozen scientific construction semantics;
* profile-local resolved parameters only;
* copied calculation metadata;
* evaluator-private mutable spectrometer/pulse state.

The native kernel boundary does not expose experimental values, uncertainties, masks, normalization state, complete resolved parameter state, committed Analysis Values, workflow state, or the authoritative legacy Profile/Spectrometer.

Successful result buffers are immutable and do not alias mutable workspace storage.

## Cache and failure semantics

Per-profile calculation caches are private to one evaluator, bounded, deterministically keyed, and never bypass constraint resolution.

The evaluation boundary has four declared validity classes:

* `INVALID_REQUEST`;
* `INVALID_TRIAL`;
* `INVALID_PLAN_OR_BINDING`;
* `IMPLEMENTATION_FAILURE`.

A call returns exactly one complete result or one typed failure.

Invalid trials reset the reusable workspace completely. Invalid binding/plan state and implementation failures poison the evaluator. Later-profile failures never publish partial results.

## Qualification parity

Qualification uses shipped:

* `DCEST_15N_HD_EXCH/Experiments/3hz.toml`;
* model `2st_hd`;
* profiles `1N`, then `2N`.

Native and separate legacy-authoritative occurrences preserve the same scientific behavior for:

* complete unscaled calculations;
* complete normalized calculations;
* per-profile normalization factors;
* masks and retained-observation mappings;
* complete relevant resolved parameter values;
* concatenated uncertainty-weighted residuals and residual sign.

Native-native repeat, fresh-evaluator, and serialized-rebind evaluations remain exactly deterministic.

Cross-workspace native/legacy numerical qualification uses narrow, explicitly justified tolerances where independent numerical linear-algebra execution is not bitwise reproducible:

* unscaled DCEST calculations: `rtol=6e-16`, `atol=0`;
* normalization-derived quantities use separately qualified tolerances reflecting the deliberate fixed-order binary64 normalization policy.

The underlying pulse-entry scientific inputs are checked independently; tolerances are not used to conceal configuration or state differences.

Masked-profile qualification also verifies that:

* full calculation buffers retain masked observations;
* normalization uses retained observations only;
* residuals omit masked observations;
* serialized plans preserve observation offsets and retained mappings.

## Legacy authority and failure isolation

This checkpoint remains qualification-only.

The legacy runner remains the sole product authority.

Native snapshot construction is best-effort during ordinary legacy experiment construction. Failure to create native frozen construction state:

* does not prevent legacy Profile/Experiment construction;
* does not alter legacy calculation or residual output;
* marks native qualification explicitly unavailable for that occurrence;
* cannot lazily recapture state after pulse execution.

Native plan construction, evaluation, cache, serialization, rebinding, or workspace failures cannot veto, replace, or alter an otherwise valid legacy-authoritative occurrence.

No native optimizer, fit acceptance, commit orchestration, GRID, DE, uncertainty, resampling, MCMC, grouped fitting, baseline release, or product-output migration is introduced.

## Validation

Final validation on the accepted PR head:

* Python 3.13: 529 passed;
* Python 3.14: 529 passed;
* focused native evaluation suite: 65 passed;
* `uv run ty check --python-version 3.13`;
* `uv run ty check --python-version 3.14`;
* `uv run ruff check .`;
* `uv run ruff format --check .`;
* `git diff --check`;
* `uv build`;
* required graph update completed.

Both full suites retain the existing emcee autocorrelation warning.

Repository Standards review: clean.

#566/#569/#570/#572/#579/#584/#585 specification review: clean.

Independent merge-readiness review verified all original blocking and important findings as resolved, rechecked the #579 legacy-isolation repair, and concluded:

`MERGE`
