### PR TITLE
Add native GRID to TRF qualification path

### DIFF
--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -15,9 +15,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from numbers import Real
-from threading import Event
-from typing import cast
+from threading import Event, RLock
+from typing import SupportsIndex, cast
 from uuid import uuid4
+from weakref import WeakKeyDictionary
 
 import numpy as np
 from scipy.optimize import least_squares
@@ -292,6 +293,66 @@ class ComponentProblemDerivation:
 
 
 @dataclass(frozen=True, slots=True)
+class GridSeedProblemDerivation:
+    """Exact lineage for one full-coordinate GRID seed child problem."""
+
+    root_problem_identity: str
+    seed_identity: str
+    seed_ordinal: int
+    axis_items: tuple[tuple[str, float], ...]
+    controlled_ids: tuple[str, ...]
+    start: tuple[float, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.seed_ordinal, bool) or self.seed_ordinal < 0:
+            raise DirectTrfConstructionError(
+                "GRID seed ordinal must be a non-negative integer"
+            )
+        axis_items = tuple(
+            (param_id, _finite_binary64(value, name=f"GRID axis {param_id!r}"))
+            for param_id, value in self.axis_items
+        )
+        axis_ids = tuple(param_id for param_id, _value in axis_items)
+        if (
+            not axis_items
+            or len(set(axis_ids)) != len(axis_ids)
+            or axis_ids
+            != tuple(sorted(axis_ids, key=lambda item: item.encode("utf-8")))
+            or not set(axis_ids).issubset(self.controlled_ids)
+        ):
+            raise DirectTrfConstructionError(
+                "GRID seed axes must be unique canonical controlled IDs"
+            )
+        start = tuple(
+            _finite_binary64(value, name=f"GRID start[{index}]")
+            for index, value in enumerate(self.start)
+        )
+        if len(start) != len(self.controlled_ids):
+            raise DirectTrfConstructionError("GRID seed start has the wrong dimension")
+        object.__setattr__(self, "axis_items", axis_items)
+        object.__setattr__(self, "start", start)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-seed-problem-derivation",
+                (
+                    self.root_problem_identity,
+                    self.seed_identity,
+                    self.seed_ordinal,
+                    tuple(
+                        (param_id, _float_token(value))
+                        for param_id, value in axis_items
+                    ),
+                    self.controlled_ids,
+                    _vector_tokens(start),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class OptimizationProblem:
     """One immutable canonical external-coordinate fit and commit context."""
 
@@ -308,7 +369,7 @@ class OptimizationProblem:
     lower_bounds: tuple[float, ...]
     upper_bounds: tuple[float, ...]
     commit_scope: tuple[str, ...]
-    derivation: ComponentProblemDerivation | None = None
+    derivation: ComponentProblemDerivation | GridSeedProblemDerivation | None = None
     scalarization_version: str = _SCALARIZATION_VERSION
     identity: str = field(init=False)
 
@@ -325,22 +386,31 @@ class OptimizationProblem:
             self.lower_bounds,
             self.upper_bounds,
         )
-        if self.derivation is not None and (
-            self.derivation.projected_plan_identity != self.evaluation_plan_identity
-            or self.derivation.controlled_ids != self.controlled_ids
-            or self.derivation.root_start_bindings != self.held_items
+        if isinstance(self.derivation, ComponentProblemDerivation):
+            if (
+                self.derivation.projected_plan_identity != self.evaluation_plan_identity
+                or self.derivation.controlled_ids != self.controlled_ids
+                or self.derivation.root_start_bindings != self.held_items
+            ):
+                raise DirectTrfConstructionError(
+                    "Component problem differs from its derivation record"
+                )
+        elif isinstance(self.derivation, GridSeedProblemDerivation) and (
+            self.derivation.controlled_ids != self.controlled_ids
+            or self.derivation.start != normalized_start
         ):
             raise DirectTrfConstructionError(
-                "Component problem differs from its derivation record"
+                "GRID seed problem differs from its derivation record"
             )
         object.__setattr__(self, "start", normalized_start)
         object.__setattr__(self, "lower_bounds", lower)
         object.__setattr__(self, "upper_bounds", upper)
-        derivation_record = (
-            ()
-            if self.derivation is None
-            else (("derived-fit-component", self.derivation.identity),)
-        )
+        if self.derivation is None:
+            derivation_record: tuple[tuple[str, str], ...] = ()
+        elif isinstance(self.derivation, ComponentProblemDerivation):
+            derivation_record = (("derived-fit-component", self.derivation.identity),)
+        else:
+            derivation_record = (("derived-grid-seed", self.derivation.identity),)
         object.__setattr__(
             self,
             "identity",
@@ -793,8 +863,73 @@ class CandidateMaterialization:
 
 
 @dataclass(frozen=True, slots=True)
+class GridSelectionProvenance:
+    """Exact GRID workflow selection that authorizes one root materialization."""
+
+    workflow_invocation_identity: str
+    root_problem_identity: str
+    selection_identity: str
+    selected_seed_identity: str
+    selected_seed_ordinal: int
+    grid_candidate_identity: str
+    materialized_candidate_identity: str
+    candidate_problem_identity: str
+    candidate_invocation_identity: str
+    candidate_execution_identity: str
+    candidate_materialization_identity: str
+    accepted_materialization_identity: str
+    accepted_evaluation_identity: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.selected_seed_ordinal, bool)
+            or self.selected_seed_ordinal < 0
+        ):
+            raise ValueError("Selected GRID seed ordinal must be non-negative")
+        identities = (
+            self.workflow_invocation_identity,
+            self.root_problem_identity,
+            self.selection_identity,
+            self.selected_seed_identity,
+            self.grid_candidate_identity,
+            self.materialized_candidate_identity,
+            self.candidate_problem_identity,
+            self.candidate_invocation_identity,
+            self.candidate_execution_identity,
+            self.candidate_materialization_identity,
+            self.accepted_materialization_identity,
+            self.accepted_evaluation_identity,
+        )
+        if any(not identity for identity in identities):
+            raise ValueError("GRID selection provenance identities cannot be empty")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-selection-provenance",
+                (
+                    self.workflow_invocation_identity,
+                    self.root_problem_identity,
+                    self.selection_identity,
+                    self.selected_seed_identity,
+                    self.selected_seed_ordinal,
+                    self.grid_candidate_identity,
+                    self.materialized_candidate_identity,
+                    self.candidate_problem_identity,
+                    self.candidate_invocation_identity,
+                    self.candidate_execution_identity,
+                    self.candidate_materialization_identity,
+                    self.accepted_materialization_identity,
+                    self.accepted_evaluation_identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class AcceptedFitResult:
-    """Fresh-materialized immutable fit result eligible for one atomic commit."""
+    """Fresh-materialized immutable evidence with no live commit authority."""
 
     occurrence_identity: str = field(compare=False)
     problem_identity: str
@@ -811,11 +946,14 @@ class AcceptedFitResult:
     evaluation_result: EvaluationResult = field(repr=False, compare=False)
     commit_scope: tuple[str, ...]
     commit_items: tuple[tuple[str, float], ...]
+    origin_context_identity: str
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         if self.evaluation_result.residuals.size < 1:
             raise ValueError("Accepted result cannot have an empty residual objective")
+        if not self.origin_context_identity:
+            raise ValueError("Accepted result requires an origin context identity")
         object.__setattr__(
             self,
             "identity",
@@ -839,9 +977,54 @@ class AcceptedFitResult:
                         (param_id, _float_token(value))
                         for param_id, value in self.commit_items
                     ),
+                    self.origin_context_identity,
                 ),
             ),
         )
+
+
+class LiveFitCommitAuthority:
+    """Opaque process-local token whose authority lives only in Direct TRF."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls) -> LiveFitCommitAuthority:
+        raise TypeError(
+            "Live fit commit authority is minted only by Direct TRF acceptance"
+        )
+
+    def __copy__(self) -> LiveFitCommitAuthority:
+        raise TypeError("Live fit commit authority cannot be copied")
+
+    def __deepcopy__(self, _memo: object) -> LiveFitCommitAuthority:
+        raise TypeError("Live fit commit authority cannot be copied")
+
+    def __reduce__(self) -> tuple[object, ...]:
+        raise TypeError("Live fit commit authority cannot be serialized")
+
+    def __reduce_ex__(self, _protocol: SupportsIndex, /) -> tuple[object, ...]:
+        raise TypeError("Live fit commit authority cannot be serialized")
+
+
+@dataclass(frozen=True, slots=True)
+class _CommitAuthorityBinding:
+    """Private immutable binding for one exact accepted evidence object."""
+
+    accepted_result: AcceptedFitResult = field(repr=False, compare=False)
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
+    problem_identity: str
+    snapshot_context_identity: str
+    source_occurrence_identity: str
+    source_revision: int
+    origin_context_identity: str
+
+
+_LIVE_FIT_COMMIT_AUTHORITIES: WeakKeyDictionary[
+    LiveFitCommitAuthority,
+    _CommitAuthorityBinding,
+] = WeakKeyDictionary()
+_LIVE_FIT_COMMIT_AUTHORITIES_LOCK = RLock()
 
 
 class DirectTrfOutcomeTerminal(StrEnum):
@@ -861,11 +1044,24 @@ class DirectTrfOutcome:
     execution: DirectTrfExecution
     materialization: CandidateMaterialization | None = None
     accepted_result: AcceptedFitResult | None = None
+    commit_authority: LiveFitCommitAuthority | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
 
     def __post_init__(self) -> None:
         accepted = self.terminal is DirectTrfOutcomeTerminal.ACCEPTED
-        if accepted != (self.accepted_result is not None):
-            raise ValueError("Only ACCEPTED may expose an Accepted Fit Result")
+        if accepted != (
+            self.accepted_result is not None and self.commit_authority is not None
+        ):
+            raise ValueError(
+                "Only ACCEPTED may expose fit evidence and live commit authority"
+            )
+        if not accepted and (
+            self.accepted_result is not None or self.commit_authority is not None
+        ):
+            raise ValueError("Unaccepted outcome cannot expose fit authority")
         if accepted and (
             self.materialization is None
             or self.materialization.terminal is not MaterializationTerminal.SUCCESS
@@ -1737,7 +1933,7 @@ def _materialize_candidate(
     )
 
 
-def accept_materialized_fit(
+def _accepted_fit_evidence(
     *,
     problem: OptimizationProblem,
     invocation_identity: str,
@@ -1746,8 +1942,9 @@ def accept_materialized_fit(
     vector: tuple[float, ...],
     chi_square: float,
     evaluation_result: EvaluationResult,
+    origin_context_identity: str,
 ) -> AcceptedFitResult:
-    """Grant fit authority only to one fresh complete root materialization."""
+    """Construct evidence only from one fresh complete root materialization."""
     if not problem.acceptance_authority:
         raise DirectTrfConstructionError(
             "A derived component problem has no acceptance authority"
@@ -1787,7 +1984,137 @@ def accept_materialized_fit(
         evaluation_result,
         problem.commit_scope,
         commit_items,
+        origin_context_identity,
     )
+
+
+def _snapshot_commit_context_identity(snapshot: AnalysisValuesSnapshot) -> str:
+    return _identity(
+        "native-analysis-values-commit-context",
+        (
+            snapshot.occurrence_identity,
+            snapshot.model_identity,
+            snapshot.definitions_identity,
+            snapshot.configuration_identity,
+            snapshot.revision,
+            tuple(
+                (param_id, _float_token(value)) for param_id, value in snapshot.items()
+            ),
+        ),
+    )
+
+
+def _mint_fit_commit_authority(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+) -> LiveFitCommitAuthority:
+    if (
+        accepted.problem_identity != problem.identity
+        or accepted.source_occurrence_identity
+        != problem.source_snapshot.occurrence_identity
+        or accepted.source_revision != problem.source_snapshot.revision
+        or not accepted.origin_context_identity
+    ):
+        raise DirectTrfConstructionError(
+            "Fit commit authority evidence differs from its root context"
+        )
+    authority = object.__new__(LiveFitCommitAuthority)
+    binding = _CommitAuthorityBinding(
+        accepted,
+        accepted.identity,
+        accepted.occurrence_identity,
+        problem.identity,
+        _snapshot_commit_context_identity(problem.source_snapshot),
+        problem.source_snapshot.occurrence_identity,
+        problem.source_snapshot.revision,
+        accepted.origin_context_identity,
+    )
+    with _LIVE_FIT_COMMIT_AUTHORITIES_LOCK:
+        _LIVE_FIT_COMMIT_AUTHORITIES[authority] = binding
+    return authority
+
+
+def _direct_fit_commit_origin(
+    problem: OptimizationProblem,
+    invocation_identity: str,
+    execution_identity: str,
+    materialization: CandidateMaterialization,
+    evaluation_result: EvaluationResult,
+) -> str:
+    return _identity(
+        "native-direct-trf-fit-commit-origin",
+        (
+            problem.identity,
+            invocation_identity,
+            execution_identity,
+            materialization.identity,
+            evaluation_result.identity,
+        ),
+    )
+
+
+def accept_materialized_fit(
+    *,
+    problem: OptimizationProblem,
+    invocation_identity: str,
+    execution_identity: str,
+    materialization: CandidateMaterialization,
+    vector: tuple[float, ...],
+    chi_square: float,
+    evaluation_result: EvaluationResult,
+) -> tuple[AcceptedFitResult, LiveFitCommitAuthority]:
+    """Accept a fresh Direct TRF fit and mint its process-owned capability."""
+    origin_context_identity = _direct_fit_commit_origin(
+        problem,
+        invocation_identity,
+        execution_identity,
+        materialization,
+        evaluation_result,
+    )
+    accepted = _accepted_fit_evidence(
+        problem=problem,
+        invocation_identity=invocation_identity,
+        execution_identity=execution_identity,
+        materialization=materialization,
+        vector=vector,
+        chi_square=chi_square,
+        evaluation_result=evaluation_result,
+        origin_context_identity=origin_context_identity,
+    )
+    authority = _mint_fit_commit_authority(accepted, problem)
+    return accepted, authority
+
+
+def _accept_materialized_fit_for_derived_workflow(
+    *,
+    problem: OptimizationProblem,
+    invocation_identity: str,
+    execution_identity: str,
+    materialization: CandidateMaterialization,
+    vector: tuple[float, ...],
+    chi_square: float,
+    evaluation_result: EvaluationResult,
+    authority_context_identity: str,
+) -> AcceptedFitResult:
+    """Construct derived evidence after workflow validation, before authority."""
+    return _accepted_fit_evidence(
+        problem=problem,
+        invocation_identity=invocation_identity,
+        execution_identity=execution_identity,
+        materialization=materialization,
+        vector=vector,
+        chi_square=chi_square,
+        evaluation_result=evaluation_result,
+        origin_context_identity=authority_context_identity,
+    )
+
+
+def _grant_derived_fit_commit_authority(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+) -> LiveFitCommitAuthority:
+    """Mint authority for one exact, already validated derived evidence object."""
+    return _mint_fit_commit_authority(accepted, problem)
 
 
 def _accepted_outcome(
@@ -1796,7 +2123,7 @@ def _accepted_outcome(
     problem: OptimizationProblem,
     invocation: DirectTrfInvocation,
 ) -> DirectTrfOutcome:
-    accepted = accept_materialized_fit(
+    accepted, authority = accept_materialized_fit(
         problem=problem,
         invocation_identity=invocation.identity,
         execution_identity=execution.identity,
@@ -1810,6 +2137,7 @@ def _accepted_outcome(
         execution,
         candidate.materialization,
         accepted,
+        authority,
     )
 
 
@@ -2009,14 +2337,162 @@ def execute_direct_trf_candidate(
     )
 
 
+def _materialize_direct_trf_candidate_for_root(
+    problem: OptimizationProblem,
+    candidate_problem: OptimizationProblem,
+    invocation: DirectTrfInvocation,
+    outcome: DirectTrfCandidateOutcome,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> MaterializedDirectTrfCandidate | DirectTrfOutcome:
+    """Freshly materialize one derived full-coordinate candidate at its root."""
+    derivation = candidate_problem.derivation
+    if (
+        not problem.acceptance_authority
+        or candidate_problem.acceptance_authority
+        or not isinstance(derivation, GridSeedProblemDerivation)
+        or derivation.root_problem_identity != problem.identity
+    ):
+        raise DirectTrfConstructionError(
+            "Selected candidate is not derived from this GRID root problem"
+        )
+    _validate_execution_context(
+        candidate_problem,
+        invocation,
+        parameterization,
+        engine,
+    )
+    candidate = outcome.candidate
+    materialization = outcome.materialization
+    if (
+        outcome.terminal is not DirectTrfCandidateTerminal.SUCCESS
+        or outcome.execution.terminal is not DirectTrfTerminal.CONVERGED
+        or candidate is None
+        or materialization is None
+        or materialization.terminal is not MaterializationTerminal.SUCCESS
+    ):
+        raise DirectTrfConstructionError(
+            "Only a successful converged GRID candidate may be selected"
+        )
+    unchanged_root_semantics = (
+        candidate_problem.evaluation_plan_identity == problem.evaluation_plan_identity
+        and candidate_problem.parameterization_identity
+        == problem.parameterization_identity
+        and candidate_problem.evaluator_parameterization_identity
+        == problem.evaluator_parameterization_identity
+        and candidate_problem.constraint_program_identity
+        == problem.constraint_program_identity
+        and candidate_problem.configuration_identity == problem.configuration_identity
+        and candidate_problem.source_snapshot == problem.source_snapshot
+        and candidate_problem.independent_items == problem.independent_items
+        and candidate_problem.controlled_ids == problem.controlled_ids
+        and candidate_problem.held_items == problem.held_items
+        and candidate_problem.lower_bounds == problem.lower_bounds
+        and candidate_problem.upper_bounds == problem.upper_bounds
+        and candidate_problem.commit_scope == problem.commit_scope
+        and candidate_problem.scalarization_version == problem.scalarization_version
+    )
+    evaluation = candidate.evaluation_result
+    try:
+        candidate_chi_square = canonical_chi_square(evaluation.residuals)
+    except (TypeError, ValueError, ObjectiveScalarizationError) as error:
+        raise DirectTrfConstructionError(
+            "Selected GRID candidate has invalid objective evidence"
+        ) from error
+    if (
+        not unchanged_root_semantics
+        or outcome.execution.problem_identity != candidate_problem.identity
+        or outcome.execution.invocation_identity != invocation.identity
+        or candidate.problem_identity != candidate_problem.identity
+        or candidate.invocation_identity != invocation.identity
+        or candidate.execution_identity != outcome.execution.identity
+        or candidate.materialization is not materialization
+        or materialization.problem_identity != candidate_problem.identity
+        or materialization.invocation_identity != invocation.identity
+        or materialization.execution_identity != outcome.execution.identity
+        or materialization.candidate.vector != candidate.vector
+        or materialization.candidate.chi_square != candidate.chi_square
+        or materialization.evaluation_identity != evaluation.identity
+        or evaluation.plan_identity != problem.evaluation_plan_identity
+        or evaluation.parameterization_identity
+        != problem.evaluator_parameterization_identity
+        or evaluation.evaluator_compatibility_identity != engine.compatibility_identity
+        or tuple(evaluation.resolved_values) != problem.commit_scope
+        or candidate.vector
+        != tuple(
+            evaluation.resolved_values[param_id] for param_id in problem.controlled_ids
+        )
+        or candidate.chi_square != candidate_chi_square
+    ):
+        raise DirectTrfConstructionError(
+            "Selected GRID candidate provenance is incompatible with its root"
+        )
+    token = CancellationToken() if cancellation is None else cancellation
+    if token.is_cancelled:
+        return DirectTrfOutcome(
+            DirectTrfOutcomeTerminal.CANCELLED,
+            outcome.execution,
+        )
+    request = _CompletedRequest(
+        materialization.candidate,
+        tuple(float(value) for value in evaluation.residuals),
+        evaluation.identity,
+    )
+    fresh = _materialize_candidate(
+        outcome.execution,
+        problem,
+        invocation,
+        parameterization,
+        engine,
+        request,
+        token,
+    )
+    if isinstance(fresh, DirectTrfOutcome):
+        return fresh
+    return fresh
+
+
+def _consume_fit_commit_authority(
+    accepted: AcceptedFitResult,
+    authority: LiveFitCommitAuthority,
+    problem: OptimizationProblem,
+) -> None:
+    if not isinstance(authority, LiveFitCommitAuthority):
+        raise DirectTrfConstructionError(
+            "Accepted result lacks its exact live Direct TRF commit authority"
+        )
+    with _LIVE_FIT_COMMIT_AUTHORITIES_LOCK:
+        binding = _LIVE_FIT_COMMIT_AUTHORITIES.get(authority)
+        if (
+            binding is None
+            or binding.accepted_result is not accepted
+            or binding.accepted_result_identity != accepted.identity
+            or binding.accepted_occurrence_identity != accepted.occurrence_identity
+            or binding.problem_identity != problem.identity
+            or binding.snapshot_context_identity
+            != _snapshot_commit_context_identity(problem.source_snapshot)
+            or binding.source_occurrence_identity
+            != problem.source_snapshot.occurrence_identity
+            or binding.source_revision != problem.source_snapshot.revision
+            or binding.origin_context_identity != accepted.origin_context_identity
+        ):
+            raise DirectTrfConstructionError(
+                "Accepted result lacks its exact live Direct TRF commit authority"
+            )
+        del _LIVE_FIT_COMMIT_AUTHORITIES[authority]
+
+
 def commit_accepted_fit(
     accepted: AcceptedFitResult,
+    authority: LiveFitCommitAuthority,
     *,
     problem: OptimizationProblem,
     parameterization: ActiveParameterization,
     analysis_values: AnalysisValues,
 ) -> CommitReceipt:
-    """Commit exactly one validated accepted result at its captured revision."""
+    """Commit evidence once through its exact process-owned live capability."""
     if not problem.acceptance_authority:
         raise DirectTrfConstructionError(
             "A derived component problem has no commit authority"
@@ -2043,6 +2519,7 @@ def commit_accepted_fit(
         raise DirectTrfConstructionError(
             "Accepted result commit snapshot is not its materialized aggregate"
         )
+    _consume_fit_commit_authority(accepted, authority, problem)
     committed = analysis_values.commit(
         dict(accepted.commit_items),
         expected=problem.source_snapshot,

--- a/src/chemex/optimize/grid_direct_trf.py
+++ b/src/chemex/optimize/grid_direct_trf.py
@@ -1,0 +1,1498 @@
+"""Single-component Cartesian GRID to native Direct TRF qualification (#595).
+
+This module is intentionally not wired into production dispatch.  It plans
+physical-coordinate Cartesian seeds rooted in one immutable native problem;
+execution and selection are added at the same public qualification seam.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from itertools import product
+from numbers import Real
+from typing import cast
+
+from chemex.evaluation.native import EvaluationEngine
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    CancellationToken,
+    CandidateMaterialization,
+    CommitReceipt,
+    DirectTrfCandidateOutcome,
+    DirectTrfCandidateTerminal,
+    DirectTrfConstructionError,
+    DirectTrfInterrupted,
+    DirectTrfInvocation,
+    DirectTrfOutcomeTerminal,
+    DirectTrfTerminal,
+    GridSeedProblemDerivation,
+    GridSelectionProvenance,
+    LiveFitCommitAuthority,
+    MaterializationTerminal,
+    MaterializedDirectTrfCandidate,
+    OptimizationProblem,
+    TerminalFailure,
+    _accept_materialized_fit_for_derived_workflow,
+    _grant_derived_fit_commit_authority,
+    _materialize_direct_trf_candidate_for_root,
+    commit_accepted_fit,
+    execute_direct_trf_candidate,
+)
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.values import AnalysisValues
+
+_SCHEMA_VERSION = 1
+_GRID_WORKFLOW_VERSION = "native-cartesian-grid-direct-trf-v1"
+_GRID_CANDIDATE_ORDER_VERSION = "chi-square-vector-seed-ordinal-v1"
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "record": record, "schema_version": _SCHEMA_VERSION},
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _float_token(value: float) -> str:
+    return float(value).hex()
+
+
+@dataclass(frozen=True, slots=True)
+class UnusableGridValue:
+    """Deterministic evidence for one seed-local unusable axis value."""
+
+    category: str
+    type_identity: str
+    value_token: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-unusable-value",
+                (self.category, self.type_identity, self.value_token),
+            ),
+        )
+
+
+type GridCoordinate = float | UnusableGridValue
+
+
+def _grid_coordinate(value: object) -> GridCoordinate:
+    if isinstance(value, UnusableGridValue):
+        return value
+    type_identity = f"{type(value).__module__}.{type(value).__qualname__}"
+    if not isinstance(value, bool) and isinstance(value, Real):
+        try:
+            result = float(value)
+        except (OverflowError, TypeError, ValueError):
+            return UnusableGridValue("non_real", type_identity, type_identity)
+        if math.isfinite(result):
+            return 0.0 if result == 0.0 else result
+        category = (
+            "nan"
+            if math.isnan(result)
+            else "positive_infinity"
+            if result > 0.0
+            else "negative_infinity"
+        )
+        return UnusableGridValue(category, type_identity, result.hex())
+    if isinstance(value, str):
+        canonical_value = value
+    elif isinstance(value, complex):
+        canonical_value = f"{float(value.real).hex()}:{float(value.imag).hex()}"
+    elif value is None:
+        canonical_value = "<none>"
+    else:
+        try:
+            canonical_value = json.dumps(
+                value,
+                allow_nan=False,
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        except (TypeError, ValueError):
+            canonical_value = type_identity
+    return UnusableGridValue("non_real", type_identity, canonical_value)
+
+
+def _coordinate_token(value: GridCoordinate) -> tuple[str, str]:
+    if isinstance(value, UnusableGridValue):
+        return "unusable", value.identity
+    return "finite", _float_token(value)
+
+
+@dataclass(frozen=True, slots=True)
+class GridAxis:
+    """One declared physical-coordinate axis with canonical binary64 values."""
+
+    param_id: str
+    values: tuple[GridCoordinate, ...]
+    declaration_ordinal: int
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.param_id:
+            raise DirectTrfConstructionError("GRID axis parameter ID cannot be empty")
+        if isinstance(self.declaration_ordinal, bool) or self.declaration_ordinal < 0:
+            raise DirectTrfConstructionError(
+                "GRID declaration ordinal must be a non-negative integer"
+            )
+        values = tuple(_grid_coordinate(value) for value in self.values)
+        if not values:
+            raise DirectTrfConstructionError("GRID axes cannot be empty")
+        object.__setattr__(self, "values", values)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-axis",
+                (
+                    self.param_id,
+                    tuple(_coordinate_token(value) for value in values),
+                    self.declaration_ordinal,
+                ),
+            ),
+        )
+
+
+def _seed_identity(
+    root_problem_identity: str,
+    ordinal: int,
+    axis_items: tuple[tuple[str, GridCoordinate], ...],
+    start: tuple[GridCoordinate, ...],
+) -> str:
+    return _identity(
+        "native-grid-seed",
+        (
+            root_problem_identity,
+            ordinal,
+            tuple(
+                (param_id, _coordinate_token(value)) for param_id, value in axis_items
+            ),
+            tuple(_coordinate_token(value) for value in start),
+        ),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class GridSeed:
+    """One canonical seed, including typed rejection before local TRF."""
+
+    root_problem_identity: str
+    ordinal: int
+    axis_items: tuple[tuple[str, GridCoordinate], ...]
+    start: tuple[GridCoordinate, ...]
+    problem: OptimizationProblem | None = field(repr=False, compare=False)
+    invocation: DirectTrfInvocation | None = field(repr=False, compare=False)
+    rejection: TerminalFailure | None = None
+    coordinate_identity: str = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        planned = self.problem is not None and self.invocation is not None
+        if planned == (self.rejection is not None):
+            raise ValueError(
+                "A GRID seed must have either one local attempt or one rejection"
+            )
+        coordinate_identity = _seed_identity(
+            self.root_problem_identity,
+            self.ordinal,
+            self.axis_items,
+            self.start,
+        )
+        if planned:
+            problem = self.problem
+            invocation = self.invocation
+            derivation = problem.derivation
+            if (
+                not isinstance(derivation, GridSeedProblemDerivation)
+                or derivation.root_problem_identity != self.root_problem_identity
+                or derivation.seed_identity != coordinate_identity
+                or derivation.seed_ordinal != self.ordinal
+                or derivation.axis_items != self.axis_items
+                or derivation.start != self.start
+                or invocation.problem_identity != problem.identity
+            ):
+                raise DirectTrfConstructionError(
+                    "GRID seed child problem or invocation differs from its seed"
+                )
+        object.__setattr__(self, "coordinate_identity", coordinate_identity)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-seed-plan",
+                (
+                    coordinate_identity,
+                    None if self.problem is None else self.problem.identity,
+                    None if self.invocation is None else self.invocation.identity,
+                    None if self.rejection is None else self.rejection.identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GridDirectTrfInvocation:
+    """Immutable Cartesian seed plan and uniform local Direct TRF policy."""
+
+    root_problem_identity: str
+    axes: tuple[GridAxis, ...]
+    seeds: tuple[GridSeed, ...]
+    objective_request_budget: int
+    x_scale: tuple[float, ...]
+    ftol: float | None
+    xtol: float | None
+    gtol: float | None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.axes or not self.seeds:
+            raise DirectTrfConstructionError("GRID requires at least one seed")
+        if any(
+            seed.root_problem_identity != self.root_problem_identity
+            for seed in self.seeds
+        ):
+            raise DirectTrfConstructionError(
+                "GRID seeds belong to another root problem"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-direct-trf-invocation",
+                (
+                    _GRID_WORKFLOW_VERSION,
+                    self.root_problem_identity,
+                    tuple(axis.identity for axis in self.axes),
+                    tuple(seed.identity for seed in self.seeds),
+                    self.objective_request_budget,
+                    tuple(_float_token(value) for value in self.x_scale),
+                    tuple(
+                        None if value is None else _float_token(value)
+                        for value in (self.ftol, self.xtol, self.gtol)
+                    ),
+                ),
+            ),
+        )
+
+    @classmethod
+    def for_problem(
+        cls,
+        problem: OptimizationProblem,
+        *,
+        axes: Sequence[tuple[str, Sequence[object]]],
+        objective_request_budget: int,
+        x_scale: float | Sequence[float] | None = None,
+        ftol: float | None = 1.0e-8,
+        xtol: float | None = 1.0e-8,
+        gtol: float | None = 1.0e-8,
+    ) -> GridDirectTrfInvocation:
+        """Plan stable-ID axes and lexicographic seeds in physical coordinates."""
+        if not problem.acceptance_authority:
+            raise DirectTrfConstructionError("GRID requires a complete root problem")
+        declared = tuple(
+            GridAxis(
+                param_id,
+                tuple(_grid_coordinate(value) for value in values),
+                ordinal,
+            )
+            for ordinal, (param_id, values) in enumerate(axes)
+        )
+        if not declared:
+            raise DirectTrfConstructionError("GRID requires at least one axis")
+        axis_ids = tuple(axis.param_id for axis in declared)
+        if len(set(axis_ids)) != len(axis_ids):
+            raise DirectTrfConstructionError("Duplicate GRID axis parameter ID")
+        unknown = set(axis_ids) - set(problem.controlled_ids)
+        if unknown:
+            raise DirectTrfConstructionError(
+                "GRID axes must target controlled external coordinates: "
+                + ", ".join(sorted(unknown))
+            )
+        canonical_axes = tuple(
+            sorted(declared, key=lambda axis: axis.param_id.encode("utf-8"))
+        )
+        template = DirectTrfInvocation.for_problem(
+            problem,
+            objective_request_budget=objective_request_budget,
+            x_scale=x_scale,
+            ftol=ftol,
+            xtol=xtol,
+            gtol=gtol,
+        )
+        coordinate_indices = {
+            param_id: index for index, param_id in enumerate(problem.controlled_ids)
+        }
+        seeds: list[GridSeed] = []
+        for ordinal, values in enumerate(
+            product(*(axis.values for axis in canonical_axes))
+        ):
+            axis_items = tuple(
+                (axis.param_id, value)
+                for axis, value in zip(canonical_axes, values, strict=True)
+            )
+            start_list: list[GridCoordinate] = [float(value) for value in problem.start]
+            for param_id, value in axis_items:
+                start_list[coordinate_indices[param_id]] = value
+            start = tuple(start_list)
+            seed_identity = _seed_identity(
+                problem.identity,
+                ordinal,
+                axis_items,
+                start,
+            )
+            unusable = tuple(
+                param_id
+                for param_id, value in axis_items
+                if isinstance(value, UnusableGridValue)
+            )
+            if unusable:
+                seeds.append(
+                    GridSeed(
+                        problem.identity,
+                        ordinal,
+                        axis_items,
+                        start,
+                        None,
+                        None,
+                        TerminalFailure(
+                            "grid_seed_unusable_value",
+                            "GRID seed has an unusable physical coordinate: "
+                            + ", ".join(unusable),
+                        ),
+                    )
+                )
+                continue
+            finite_axis_items = cast(
+                "tuple[tuple[str, float], ...]",
+                axis_items,
+            )
+            finite_start = cast("tuple[float, ...]", start)
+            outside = tuple(
+                param_id
+                for param_id, value in finite_axis_items
+                if not (
+                    problem.lower_bounds[coordinate_indices[param_id]]
+                    <= value
+                    <= problem.upper_bounds[coordinate_indices[param_id]]
+                )
+            )
+            if outside:
+                seeds.append(
+                    GridSeed(
+                        problem.identity,
+                        ordinal,
+                        axis_items,
+                        start,
+                        None,
+                        None,
+                        TerminalFailure(
+                            "grid_seed_out_of_bounds",
+                            "GRID seed is outside physical bounds: "
+                            + ", ".join(outside),
+                        ),
+                    )
+                )
+                continue
+            derivation = GridSeedProblemDerivation(
+                problem.identity,
+                seed_identity,
+                ordinal,
+                finite_axis_items,
+                problem.controlled_ids,
+                finite_start,
+            )
+            child = OptimizationProblem(
+                problem.evaluation_plan_identity,
+                problem.parameterization_identity,
+                problem.evaluator_parameterization_identity,
+                problem.constraint_program_identity,
+                problem.configuration_identity,
+                problem.source_snapshot,
+                problem.independent_items,
+                problem.controlled_ids,
+                problem.held_items,
+                finite_start,
+                problem.lower_bounds,
+                problem.upper_bounds,
+                problem.commit_scope,
+                derivation,
+                problem.scalarization_version,
+            )
+            child_invocation = DirectTrfInvocation.for_problem(
+                child,
+                objective_request_budget=template.objective_request_budget,
+                x_scale=template.x_scale,
+                ftol=template.ftol,
+                xtol=template.xtol,
+                gtol=template.gtol,
+            )
+            seeds.append(
+                GridSeed(
+                    problem.identity,
+                    ordinal,
+                    axis_items,
+                    start,
+                    child,
+                    child_invocation,
+                )
+            )
+        return cls(
+            problem.identity,
+            canonical_axes,
+            tuple(seeds),
+            template.objective_request_budget,
+            template.x_scale,
+            template.ftol,
+            template.xtol,
+            template.gtol,
+        )
+
+
+class GridSeedDisposition(StrEnum):
+    """Closed disposition for every canonical seed occurrence."""
+
+    ELIGIBLE = "eligible"
+    UNUSABLE_VALUE = "unusable_value"
+    OUT_OF_BOUNDS = "out_of_bounds"
+    PREFLIGHT_INVALID = "preflight_invalid"
+    INVALID_TRIAL = "invalid_trial"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    NON_CONVERGED = "non_converged"
+    BACKEND_FAILURE = "backend_failure"
+    IMPLEMENTATION_FAILURE = "implementation_failure"
+    MATERIALIZATION_FAILURE = "materialization_failure"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+    NOT_STARTED = "not_started"
+
+
+@dataclass(frozen=True, slots=True)
+class GridCandidate:
+    """One workflow-local eligible candidate under the canonical total order."""
+
+    seed_identity: str
+    seed_ordinal: int
+    candidate: MaterializedDirectTrfCandidate = field(repr=False, compare=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-candidate",
+                (
+                    _GRID_CANDIDATE_ORDER_VERSION,
+                    self.seed_identity,
+                    self.seed_ordinal,
+                    self.candidate.identity,
+                ),
+            ),
+        )
+
+    @property
+    def vector(self) -> tuple[float, ...]:
+        return self.candidate.vector
+
+    @property
+    def objective(self) -> float:
+        return self.candidate.chi_square
+
+    def ordering_key(self) -> tuple[float, tuple[float, ...], int]:
+        """Return χ², final external vector, then seed ordinal."""
+        return self.objective, self.vector, self.seed_ordinal
+
+
+@dataclass(frozen=True, slots=True)
+class GridSeedOutcome:
+    """Compact exact table/provenance row for one canonical seed."""
+
+    seed_identity: str
+    seed_ordinal: int
+    axis_items: tuple[tuple[str, GridCoordinate], ...]
+    start: tuple[GridCoordinate, ...]
+    disposition: GridSeedDisposition
+    execution_identity: str | None = None
+    objective: float | None = None
+    candidate: GridCandidate | None = field(default=None, repr=False, compare=False)
+    direct_outcome: DirectTrfCandidateOutcome | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    failure: TerminalFailure | None = None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        eligible = self.disposition is GridSeedDisposition.ELIGIBLE
+        candidate = self.candidate
+        if eligible != (self.candidate is not None and self.objective is not None):
+            raise ValueError("Only an eligible GRID seed may expose a candidate")
+        if candidate is not None and (
+            candidate.seed_identity != self.seed_identity
+            or candidate.seed_ordinal != self.seed_ordinal
+            or candidate.objective != self.objective
+        ):
+            raise ValueError("GRID seed candidate provenance is inconsistent")
+        if eligible and (
+            candidate is None
+            or self.direct_outcome is None
+            or self.direct_outcome.terminal is not DirectTrfCandidateTerminal.SUCCESS
+            or self.direct_outcome.candidate is not candidate.candidate
+            or self.execution_identity != self.direct_outcome.execution.identity
+        ):
+            raise ValueError(
+                "Eligible GRID seed lacks its exact Direct TRF candidate result"
+            )
+        if self.disposition is GridSeedDisposition.NOT_STARTED and (
+            self.execution_identity is not None or self.direct_outcome is not None
+        ):
+            raise ValueError("An unstarted GRID seed cannot expose attempt evidence")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-seed-outcome",
+                (
+                    self.seed_identity,
+                    self.seed_ordinal,
+                    tuple(
+                        (param_id, _coordinate_token(value))
+                        for param_id, value in self.axis_items
+                    ),
+                    tuple(_coordinate_token(value) for value in self.start),
+                    self.disposition.value,
+                    self.execution_identity,
+                    None if self.objective is None else _float_token(self.objective),
+                    None if self.candidate is None else self.candidate.identity,
+                    None if self.failure is None else self.failure.identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GridSelection:
+    """Deterministic winner and complete eligible-order provenance."""
+
+    selected_seed_identity: str
+    selected_seed_ordinal: int
+    selected_candidate_identity: str
+    eligible_candidate_identities: tuple[str, ...]
+    candidate_records: tuple[GridSeedOutcome, ...] = field(
+        repr=False,
+        compare=False,
+    )
+    ordering_policy: str = _GRID_CANDIDATE_ORDER_VERSION
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        records = self.candidate_records
+        record_candidate_identities = tuple(
+            record.candidate.identity
+            for record in records
+            if record.candidate is not None
+        )
+        selected_records = tuple(
+            record
+            for record in records
+            if record.seed_identity == self.selected_seed_identity
+            and record.seed_ordinal == self.selected_seed_ordinal
+            and record.candidate is not None
+            and record.candidate.identity == self.selected_candidate_identity
+        )
+        if (
+            not self.eligible_candidate_identities
+            or self.eligible_candidate_identities[0] != self.selected_candidate_identity
+            or not records
+            or any(
+                record.disposition is not GridSeedDisposition.ELIGIBLE
+                or record.candidate is None
+                for record in records
+            )
+            or record_candidate_identities != self.eligible_candidate_identities
+            or len(selected_records) != 1
+            or selected_records[0].identity != records[0].identity
+        ):
+            raise ValueError(
+                "GRID selection must lead with one exact canonical candidate record"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grid-selection",
+                (
+                    self.ordering_policy,
+                    self.selected_seed_identity,
+                    self.selected_seed_ordinal,
+                    self.selected_candidate_identity,
+                    self.eligible_candidate_identities,
+                ),
+            ),
+        )
+
+    @classmethod
+    def from_candidate_records(
+        cls,
+        *,
+        selected_seed_identity: str,
+        selected_seed_ordinal: int,
+        selected_candidate_identity: str,
+        candidate_records: Sequence[GridSeedOutcome],
+    ) -> GridSelection:
+        """Validate the requested winner against canonical eligible records."""
+        records = tuple(candidate_records)
+        if not records or any(
+            record.disposition is not GridSeedDisposition.ELIGIBLE
+            or record.candidate is None
+            for record in records
+        ):
+            raise ValueError(
+                "GRID selection requires exact canonical candidate records"
+            )
+        ordered = tuple(
+            sorted(
+                records,
+                key=lambda record: cast(
+                    "GridCandidate", record.candidate
+                ).ordering_key(),
+            )
+        )
+        return cls(
+            selected_seed_identity,
+            selected_seed_ordinal,
+            selected_candidate_identity,
+            tuple(
+                cast("GridCandidate", record.candidate).identity for record in ordered
+            ),
+            ordered,
+        )
+
+    @property
+    def selected_record(self) -> GridSeedOutcome:
+        """Return the one exact candidate record that won selection."""
+        return self.candidate_records[0]
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedGridDirectTrfResult(AcceptedFitResult):
+    """Convenient immutable evidence for one accepted GRID selection."""
+
+    grid_selection_provenance: GridSelectionProvenance
+    workflow_invocation: GridDirectTrfInvocation = field(repr=False, compare=False)
+    selection: GridSelection = field(repr=False, compare=False)
+    selected_seed: GridSeed = field(repr=False, compare=False)
+    selected_outcome: GridSeedOutcome = field(repr=False, compare=False)
+    fresh_candidate: MaterializedDirectTrfCandidate = field(
+        repr=False,
+        compare=False,
+    )
+
+    @classmethod
+    def from_accepted(
+        cls,
+        accepted: AcceptedFitResult,
+        provenance: GridSelectionProvenance,
+        workflow_invocation: GridDirectTrfInvocation,
+        selection: GridSelection,
+        selected_seed: GridSeed,
+        selected_outcome: GridSeedOutcome,
+        fresh_candidate: MaterializedDirectTrfCandidate,
+    ) -> AcceptedGridDirectTrfResult:
+        """Attach GRID provenance to already accepted root evidence."""
+        return cls(
+            accepted.occurrence_identity,
+            accepted.problem_identity,
+            accepted.invocation_identity,
+            accepted.execution_identity,
+            accepted.materialization_identity,
+            accepted.parameterization_identity,
+            accepted.evaluator_parameterization_identity,
+            accepted.source_occurrence_identity,
+            accepted.source_revision,
+            accepted.controlled_ids,
+            accepted.vector,
+            accepted.chi_square,
+            accepted.evaluation_result,
+            accepted.commit_scope,
+            accepted.commit_items,
+            accepted.origin_context_identity,
+            provenance,
+            workflow_invocation,
+            selection,
+            selected_seed,
+            selected_outcome,
+            fresh_candidate,
+        )
+
+
+def validate_grid_acceptance_lineage(
+    provenance: GridSelectionProvenance,
+    invocation: GridDirectTrfInvocation,
+    selection: GridSelection,
+    selected_seed: GridSeed,
+    selected_outcome: GridSeedOutcome,
+    fresh_candidate: MaterializedDirectTrfCandidate,
+    problem: OptimizationProblem,
+) -> None:
+    """Validate complete GRID lineage before Direct TRF grants live authority."""
+    fresh_materialization = fresh_candidate.materialization
+    candidate = selected_outcome.candidate
+    direct_outcome = selected_outcome.direct_outcome
+    try:
+        canonical_seed = invocation.seeds[provenance.selected_seed_ordinal]
+    except (AttributeError, IndexError, TypeError):
+        canonical_seed = None
+    child_problem = None if canonical_seed is None else canonical_seed.problem
+    child_invocation = None if canonical_seed is None else canonical_seed.invocation
+    materialized_candidate = None if candidate is None else candidate.candidate
+    candidate_materialization = (
+        None
+        if materialized_candidate is None
+        else materialized_candidate.materialization
+    )
+    candidate_evaluation = (
+        None
+        if materialized_candidate is None
+        else materialized_candidate.evaluation_result
+    )
+    derivation = None if child_problem is None else child_problem.derivation
+    if (
+        not isinstance(provenance, GridSelectionProvenance)
+        or invocation.root_problem_identity != problem.identity
+        or provenance.root_problem_identity != problem.identity
+        or provenance.workflow_invocation_identity != invocation.identity
+        or provenance.selection_identity != selection.identity
+        or canonical_seed is None
+        or canonical_seed.identity != selected_seed.identity
+        or canonical_seed.ordinal != provenance.selected_seed_ordinal
+        or provenance.selected_seed_identity != selected_seed.identity
+        or selection.selected_seed_identity != selected_seed.identity
+        or selection.selected_seed_ordinal != selected_seed.ordinal
+        or selection.selected_record.identity != selected_outcome.identity
+        or selected_outcome.seed_identity != selected_seed.identity
+        or selected_outcome.seed_ordinal != selected_seed.ordinal
+        or candidate is None
+        or materialized_candidate is None
+        or selection.selected_candidate_identity != candidate.identity
+        or provenance.grid_candidate_identity != candidate.identity
+        or direct_outcome is None
+        or direct_outcome.candidate is not materialized_candidate
+        or child_problem is None
+        or child_invocation is None
+        or not isinstance(derivation, GridSeedProblemDerivation)
+        or derivation.root_problem_identity != problem.identity
+        or derivation.seed_identity != selected_seed.coordinate_identity
+        or derivation.seed_ordinal != selected_seed.ordinal
+        or child_problem.source_snapshot != problem.source_snapshot
+        or provenance.materialized_candidate_identity != materialized_candidate.identity
+        or provenance.candidate_problem_identity != child_problem.identity
+        or provenance.candidate_invocation_identity != child_invocation.identity
+        or provenance.candidate_execution_identity != direct_outcome.execution.identity
+        or candidate_materialization is None
+        or provenance.candidate_materialization_identity
+        != candidate_materialization.identity
+        or candidate_evaluation is None
+        or candidate_materialization.evaluation_identity
+        != candidate_evaluation.identity
+        or candidate_materialization.problem_identity != child_problem.identity
+        or candidate_materialization.invocation_identity != child_invocation.identity
+        or candidate_materialization.execution_identity
+        != direct_outcome.execution.identity
+        or candidate_evaluation.plan_identity != problem.evaluation_plan_identity
+        or candidate_evaluation.parameterization_identity
+        != problem.evaluator_parameterization_identity
+        or tuple(candidate_evaluation.resolved_values) != problem.commit_scope
+        or provenance.accepted_materialization_identity
+        != fresh_materialization.identity
+        or fresh_candidate.problem_identity != problem.identity
+        or fresh_candidate.invocation_identity != child_invocation.identity
+        or fresh_candidate.execution_identity != direct_outcome.execution.identity
+        or fresh_materialization.problem_identity != problem.identity
+        or fresh_materialization.invocation_identity != child_invocation.identity
+        or fresh_materialization.execution_identity != direct_outcome.execution.identity
+        or fresh_materialization.terminal is not MaterializationTerminal.SUCCESS
+        or fresh_materialization.candidate.vector != fresh_candidate.vector
+        or fresh_materialization.candidate.chi_square != fresh_candidate.chi_square
+        or fresh_materialization.evaluation_identity
+        != fresh_candidate.evaluation_result.identity
+        or fresh_materialization.evaluator_compatibility_identity
+        != fresh_candidate.evaluation_result.evaluator_compatibility_identity
+        or provenance.accepted_evaluation_identity
+        != fresh_candidate.evaluation_result.identity
+        or fresh_candidate.evaluation_result.plan_identity
+        != problem.evaluation_plan_identity
+        or fresh_candidate.evaluation_result.parameterization_identity
+        != problem.evaluator_parameterization_identity
+        or tuple(fresh_candidate.evaluation_result.resolved_values)
+        != problem.commit_scope
+    ):
+        raise DirectTrfConstructionError(
+            "Accepted GRID result lacks its canonical selection authority"
+        )
+
+
+def validate_grid_commit_lineage(
+    accepted: AcceptedGridDirectTrfResult,
+    problem: OptimizationProblem,
+) -> None:
+    """Revalidate GRID evidence independently of generic commit authority."""
+    validate_grid_acceptance_lineage(
+        accepted.grid_selection_provenance,
+        accepted.workflow_invocation,
+        accepted.selection,
+        accepted.selected_seed,
+        accepted.selected_outcome,
+        accepted.fresh_candidate,
+        problem,
+    )
+    fresh = accepted.fresh_candidate
+    if (
+        accepted.problem_identity != problem.identity
+        or accepted.invocation_identity != fresh.invocation_identity
+        or accepted.execution_identity != fresh.execution_identity
+        or accepted.materialization_identity != fresh.materialization.identity
+        or accepted.vector != fresh.vector
+        or accepted.chi_square != fresh.chi_square
+        or accepted.evaluation_result.identity != fresh.evaluation_result.identity
+        or accepted.origin_context_identity
+        != accepted.grid_selection_provenance.identity
+    ):
+        raise DirectTrfConstructionError(
+            "Accepted GRID result lacks its canonical selection authority"
+        )
+
+
+def commit_grid_accepted_fit(
+    accepted: AcceptedGridDirectTrfResult,
+    authority: LiveFitCommitAuthority,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    analysis_values: AnalysisValues,
+) -> CommitReceipt:
+    """Validate GRID evidence, then cross the generic Direct TRF commit seam."""
+    validate_grid_commit_lineage(accepted, problem)
+    return commit_accepted_fit(
+        accepted,
+        authority,
+        problem=problem,
+        parameterization=parameterization,
+        analysis_values=analysis_values,
+    )
+
+
+class GridDirectTrfTerminal(StrEnum):
+    """Closed outcomes of one GRID to Direct TRF workflow occurrence."""
+
+    ACCEPTED = "accepted"
+    NO_ELIGIBLE_CANDIDATE = "no_eligible_candidate"
+    MATERIALIZATION_FAILURE = "materialization_failure"
+    EXECUTION_FAILURE = "execution_failure"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+
+
+@dataclass(frozen=True, slots=True)
+class GridTableRow:
+    """Exact per-seed evidence retained for a future GRID table renderer."""
+
+    seed_identity: str
+    seed_ordinal: int
+    axis_items: tuple[tuple[str, GridCoordinate], ...]
+    start: tuple[GridCoordinate, ...]
+    objective: float | None
+    disposition: GridSeedDisposition
+    candidate_identity: str | None
+    selected: bool
+    selection_identity: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class GridDiagnosticPoint:
+    """One exact seed projection for supported one- or two-axis diagnostics."""
+
+    seed_identity: str
+    seed_ordinal: int
+    coordinates: tuple[tuple[str, GridCoordinate], ...]
+    objective: float | None
+    disposition: GridSeedDisposition
+    candidate_identity: str | None
+    selected: bool
+    selection_identity: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class GridDirectTrfOutcome:
+    """Complete GRID occurrence; only ACCEPTED carries root fit authority."""
+
+    terminal: GridDirectTrfTerminal
+    attempts: tuple[GridSeedOutcome, ...]
+    selection: GridSelection | None = None
+    materialization: CandidateMaterialization | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    accepted_result: AcceptedGridDirectTrfResult | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    commit_authority: LiveFitCommitAuthority | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    failure: TerminalFailure | None = None
+
+    def __post_init__(self) -> None:
+        accepted = self.terminal is GridDirectTrfTerminal.ACCEPTED
+        if accepted != (
+            self.accepted_result is not None and self.commit_authority is not None
+        ):
+            raise ValueError(
+                "Only accepted GRID execution has evidence and live authority"
+            )
+        if not accepted and (
+            self.accepted_result is not None or self.commit_authority is not None
+        ):
+            raise ValueError("Unaccepted GRID execution cannot expose fit authority")
+        if (
+            self.terminal
+            in {
+                GridDirectTrfTerminal.ACCEPTED,
+                GridDirectTrfTerminal.MATERIALIZATION_FAILURE,
+            }
+            and self.selection is None
+        ):
+            raise ValueError("Completed GRID acceptance requires a selection")
+        if self.selection is not None:
+            canonical_candidates = tuple(
+                sorted(
+                    (
+                        attempt
+                        for attempt in self.attempts
+                        if attempt.disposition is GridSeedDisposition.ELIGIBLE
+                        and attempt.candidate is not None
+                    ),
+                    key=lambda attempt: cast(
+                        "GridCandidate", attempt.candidate
+                    ).ordering_key(),
+                )
+            )
+            if tuple(
+                record.identity for record in self.selection.candidate_records
+            ) != tuple(record.identity for record in canonical_candidates):
+                raise ValueError("GRID selection provenance is inconsistent")
+
+    @property
+    def table_rows(self) -> tuple[GridTableRow, ...]:
+        """Return canonical rows without re-evaluation or objective reduction."""
+        selected_record_identity = (
+            None if self.selection is None else self.selection.selected_record.identity
+        )
+        selection_identity = None if self.selection is None else self.selection.identity
+        return tuple(
+            GridTableRow(
+                attempt.seed_identity,
+                attempt.seed_ordinal,
+                attempt.axis_items,
+                attempt.start,
+                attempt.objective,
+                attempt.disposition,
+                None if attempt.candidate is None else attempt.candidate.identity,
+                attempt.identity == selected_record_identity,
+                selection_identity,
+            )
+            for attempt in self.attempts
+        )
+
+    def diagnostic_points(
+        self,
+        axis_ids: Sequence[str],
+    ) -> tuple[GridDiagnosticPoint, ...]:
+        """Project retained rows onto one or two explicitly ordered GRID axes."""
+        requested = tuple(axis_ids)
+        available = {
+            param_id
+            for attempt in self.attempts
+            for param_id, _value in attempt.axis_items
+        }
+        if (
+            len(requested) not in {1, 2}
+            or len(set(requested)) != len(requested)
+            or not set(requested).issubset(available)
+        ):
+            raise DirectTrfConstructionError(
+                "GRID diagnostics require one or two unique planned axis IDs"
+            )
+        return tuple(
+            GridDiagnosticPoint(
+                row.seed_identity,
+                row.seed_ordinal,
+                tuple(
+                    (param_id, dict(row.axis_items)[param_id]) for param_id in requested
+                ),
+                row.objective,
+                row.disposition,
+                row.candidate_identity,
+                row.selected,
+                row.selection_identity,
+            )
+            for row in self.table_rows
+        )
+
+
+class GridDirectTrfInterrupted(KeyboardInterrupt):
+    """Propagated interruption carrying the frozen GRID workflow outcome."""
+
+    def __init__(self, outcome: GridDirectTrfOutcome) -> None:
+        self.outcome = outcome
+        super().__init__("Native GRID to Direct TRF was interrupted")
+
+
+def _validate_grid_context(
+    problem: OptimizationProblem,
+    invocation: GridDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+) -> None:
+    problem.validate_parameterization(parameterization)
+    declared_axes = tuple(
+        (axis.param_id, axis.values)
+        for axis in sorted(invocation.axes, key=lambda axis: axis.declaration_ordinal)
+    )
+    expected = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=declared_axes,
+        objective_request_budget=invocation.objective_request_budget,
+        x_scale=invocation.x_scale,
+        ftol=invocation.ftol,
+        xtol=invocation.xtol,
+        gtol=invocation.gtol,
+    )
+    if (
+        invocation.root_problem_identity != problem.identity
+        or invocation.identity != expected.identity
+        or engine.plan.identity != problem.evaluation_plan_identity
+    ):
+        raise DirectTrfConstructionError(
+            "GRID invocation and evaluator must share one root problem"
+        )
+
+
+def _not_started(seed: GridSeed) -> GridSeedOutcome:
+    return GridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        GridSeedDisposition.NOT_STARTED,
+    )
+
+
+def _attempt_failure(
+    seed: GridSeed,
+    disposition: GridSeedDisposition,
+    outcome: DirectTrfCandidateOutcome,
+) -> GridSeedOutcome:
+    materialization_failure = (
+        outcome.materialization.failure if outcome.materialization is not None else None
+    )
+    return GridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        disposition,
+        outcome.execution.identity,
+        direct_outcome=outcome,
+        failure=materialization_failure or outcome.execution.failure,
+    )
+
+
+def _interrupted_attempt(
+    seed: GridSeed,
+    interrupted: DirectTrfInterrupted,
+) -> GridSeedOutcome:
+    return GridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        GridSeedDisposition.INTERRUPTED,
+        interrupted.execution.identity,
+        failure=(
+            interrupted.materialization.failure
+            if interrupted.materialization is not None
+            else interrupted.execution.failure
+        ),
+    )
+
+
+def _interrupted_outcome(
+    attempts: Sequence[GridSeedOutcome],
+    remaining: Sequence[GridSeed],
+    selection: GridSelection | None = None,
+    materialization: CandidateMaterialization | None = None,
+) -> GridDirectTrfOutcome:
+    return GridDirectTrfOutcome(
+        GridDirectTrfTerminal.INTERRUPTED,
+        (*attempts, *(_not_started(seed) for seed in remaining)),
+        selection,
+        materialization,
+    )
+
+
+def _disposition_for_unsuccessful(
+    outcome: DirectTrfCandidateOutcome,
+) -> GridSeedDisposition:
+    if outcome.terminal is DirectTrfCandidateTerminal.MATERIALIZATION_FAILURE:
+        return GridSeedDisposition.MATERIALIZATION_FAILURE
+    return {
+        DirectTrfTerminal.PREFLIGHT_INVALID: GridSeedDisposition.PREFLIGHT_INVALID,
+        DirectTrfTerminal.INVALID_TRIAL: GridSeedDisposition.INVALID_TRIAL,
+        DirectTrfTerminal.BUDGET_EXHAUSTED: GridSeedDisposition.BUDGET_EXHAUSTED,
+        DirectTrfTerminal.NON_CONVERGED: GridSeedDisposition.NON_CONVERGED,
+        DirectTrfTerminal.BACKEND_FAILURE: GridSeedDisposition.BACKEND_FAILURE,
+        DirectTrfTerminal.IMPLEMENTATION_FAILURE: (
+            GridSeedDisposition.IMPLEMENTATION_FAILURE
+        ),
+    }.get(
+        outcome.execution.terminal,
+        GridSeedDisposition.IMPLEMENTATION_FAILURE,
+    )
+
+
+def _selection(
+    attempts: Sequence[GridSeedOutcome],
+) -> tuple[GridSelection, GridSeedOutcome]:
+    eligible = sorted(
+        (
+            attempt
+            for attempt in attempts
+            if attempt.disposition is GridSeedDisposition.ELIGIBLE
+            and attempt.candidate is not None
+        ),
+        key=lambda attempt: cast("GridCandidate", attempt.candidate).ordering_key(),
+    )
+    selected = eligible[0]
+    candidate = cast("GridCandidate", selected.candidate)
+    selection = GridSelection.from_candidate_records(
+        selected_seed_identity=selected.seed_identity,
+        selected_seed_ordinal=selected.seed_ordinal,
+        selected_candidate_identity=candidate.identity,
+        candidate_records=eligible,
+    )
+    return selection, selected
+
+
+class _GridSeedInterrupted(KeyboardInterrupt):
+    def __init__(self, outcome: GridSeedOutcome) -> None:
+        self.outcome = outcome
+        super().__init__("Native GRID seed was interrupted")
+
+
+def _seed_execution_exception(seed: GridSeed, error: Exception) -> GridSeedOutcome:
+    failure = TerminalFailure(
+        "grid_seed_execution_exception",
+        f"{type(error).__name__}: {error}",
+    )
+    return GridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        GridSeedDisposition.IMPLEMENTATION_FAILURE,
+        failure=failure,
+    )
+
+
+def _execute_grid_seed(
+    seed: GridSeed,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    token: CancellationToken,
+) -> GridSeedOutcome:
+    if seed.rejection is not None:
+        disposition = (
+            GridSeedDisposition.UNUSABLE_VALUE
+            if seed.rejection.category == "grid_seed_unusable_value"
+            else GridSeedDisposition.OUT_OF_BOUNDS
+        )
+        return GridSeedOutcome(
+            seed.identity,
+            seed.ordinal,
+            seed.axis_items,
+            seed.start,
+            disposition,
+            failure=seed.rejection,
+        )
+    if seed.problem is None or seed.invocation is None:
+        return _seed_execution_exception(
+            seed,
+            RuntimeError("A feasible GRID seed lacks its Direct TRF child"),
+        )
+    try:
+        direct = execute_direct_trf_candidate(
+            seed.problem,
+            seed.invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+    except DirectTrfInterrupted as interrupted:
+        raise _GridSeedInterrupted(
+            _interrupted_attempt(seed, interrupted)
+        ) from interrupted
+    except KeyboardInterrupt as error:
+        raise _GridSeedInterrupted(
+            GridSeedOutcome(
+                seed.identity,
+                seed.ordinal,
+                seed.axis_items,
+                seed.start,
+                GridSeedDisposition.INTERRUPTED,
+                failure=TerminalFailure("interrupted", "KeyboardInterrupt"),
+            )
+        ) from error
+    except Exception as error:  # noqa: BLE001 - orchestration fails closed
+        return _seed_execution_exception(seed, error)
+    if direct.terminal is DirectTrfCandidateTerminal.SUCCESS:
+        if direct.candidate is None:
+            return _seed_execution_exception(
+                seed,
+                RuntimeError("Successful Direct TRF seed lacks its candidate"),
+            )
+        candidate = GridCandidate(seed.identity, seed.ordinal, direct.candidate)
+        return GridSeedOutcome(
+            seed.identity,
+            seed.ordinal,
+            seed.axis_items,
+            seed.start,
+            GridSeedDisposition.ELIGIBLE,
+            direct.execution.identity,
+            candidate.objective,
+            candidate,
+            direct,
+        )
+    if direct.terminal is DirectTrfCandidateTerminal.CANCELLED:
+        return _attempt_failure(seed, GridSeedDisposition.CANCELLED, direct)
+    return _attempt_failure(seed, _disposition_for_unsuccessful(direct), direct)
+
+
+def _execute_grid_seeds(
+    invocation: GridDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    token: CancellationToken,
+) -> tuple[GridSeedOutcome, ...] | GridDirectTrfOutcome:
+    attempts: list[GridSeedOutcome] = []
+    for index, seed in enumerate(invocation.seeds):
+        remaining = invocation.seeds[index + 1 :]
+        if token.is_cancelled:
+            return GridDirectTrfOutcome(
+                GridDirectTrfTerminal.CANCELLED,
+                (*attempts, *(_not_started(item) for item in invocation.seeds[index:])),
+            )
+        try:
+            seed_outcome = _execute_grid_seed(
+                seed,
+                parameterization,
+                engine,
+                token,
+            )
+        except _GridSeedInterrupted as interrupted:
+            attempts.append(interrupted.outcome)
+            raise GridDirectTrfInterrupted(
+                _interrupted_outcome(attempts, remaining)
+            ) from interrupted
+        attempts.append(seed_outcome)
+        if seed_outcome.disposition is GridSeedDisposition.CANCELLED:
+            return GridDirectTrfOutcome(
+                GridDirectTrfTerminal.CANCELLED,
+                (*attempts, *(_not_started(item) for item in remaining)),
+            )
+        if seed_outcome.disposition in {
+            GridSeedDisposition.BACKEND_FAILURE,
+            GridSeedDisposition.IMPLEMENTATION_FAILURE,
+        }:
+            return GridDirectTrfOutcome(
+                GridDirectTrfTerminal.EXECUTION_FAILURE,
+                (*attempts, *(_not_started(item) for item in remaining)),
+                failure=seed_outcome.failure,
+            )
+    return tuple(attempts)
+
+
+def execute_grid_direct_trf(
+    problem: OptimizationProblem,
+    invocation: GridDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> GridDirectTrfOutcome:
+    """Run every expected seed failure safely, then accept only the winner."""
+    _validate_grid_context(problem, invocation, parameterization, engine)
+    token = CancellationToken() if cancellation is None else cancellation
+    seed_execution = _execute_grid_seeds(
+        invocation,
+        parameterization,
+        engine,
+        token,
+    )
+    if isinstance(seed_execution, GridDirectTrfOutcome):
+        return seed_execution
+    attempts = seed_execution
+    if not any(
+        attempt.disposition is GridSeedDisposition.ELIGIBLE for attempt in attempts
+    ):
+        return GridDirectTrfOutcome(
+            GridDirectTrfTerminal.NO_ELIGIBLE_CANDIDATE,
+            tuple(attempts),
+        )
+    selection, selected = _selection(attempts)
+    selected_seed = invocation.seeds[selected.seed_ordinal]
+    if (
+        selected.direct_outcome is None
+        or selected_seed.problem is None
+        or selected_seed.invocation is None
+    ):
+        failure = TerminalFailure(
+            "grid_selection_failure",
+            "Selected GRID candidate lacks its exact attempt provenance",
+        )
+        return GridDirectTrfOutcome(
+            GridDirectTrfTerminal.EXECUTION_FAILURE,
+            tuple(attempts),
+            selection,
+            failure=failure,
+        )
+    selected_candidate = cast("GridCandidate", selected.candidate)
+    try:
+        promoted = _materialize_direct_trf_candidate_for_root(
+            problem,
+            selected_seed.problem,
+            selected_seed.invocation,
+            selected.direct_outcome,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+        if isinstance(promoted, MaterializedDirectTrfCandidate):
+            grid_selection_provenance = GridSelectionProvenance(
+                invocation.identity,
+                problem.identity,
+                selection.identity,
+                selected.seed_identity,
+                selected.seed_ordinal,
+                selected_candidate.identity,
+                selected_candidate.candidate.identity,
+                selected_seed.problem.identity,
+                selected_seed.invocation.identity,
+                selected.direct_outcome.execution.identity,
+                selected_candidate.candidate.materialization.identity,
+                promoted.materialization.identity,
+                promoted.evaluation_result.identity,
+            )
+            validate_grid_acceptance_lineage(
+                grid_selection_provenance,
+                invocation,
+                selection,
+                selected_seed,
+                selected,
+                promoted,
+                problem,
+            )
+            root_accepted = _accept_materialized_fit_for_derived_workflow(
+                problem=problem,
+                invocation_identity=selected_seed.invocation.identity,
+                execution_identity=selected.direct_outcome.execution.identity,
+                materialization=promoted.materialization,
+                vector=promoted.vector,
+                chi_square=promoted.chi_square,
+                evaluation_result=promoted.evaluation_result,
+                authority_context_identity=grid_selection_provenance.identity,
+            )
+            grid_accepted = AcceptedGridDirectTrfResult.from_accepted(
+                root_accepted,
+                grid_selection_provenance,
+                invocation,
+                selection,
+                selected_seed,
+                selected,
+                promoted,
+            )
+            validate_grid_commit_lineage(grid_accepted, problem)
+            authority = _grant_derived_fit_commit_authority(
+                grid_accepted,
+                problem,
+            )
+            return GridDirectTrfOutcome(
+                GridDirectTrfTerminal.ACCEPTED,
+                tuple(attempts),
+                selection,
+                promoted.materialization,
+                grid_accepted,
+                authority,
+            )
+    except DirectTrfInterrupted as interrupted:
+        raise GridDirectTrfInterrupted(
+            _interrupted_outcome(
+                attempts,
+                (),
+                selection,
+                interrupted.materialization,
+            )
+        ) from interrupted
+    except KeyboardInterrupt as error:
+        raise GridDirectTrfInterrupted(
+            _interrupted_outcome(attempts, (), selection)
+        ) from error
+    except Exception as error:  # noqa: BLE001 - selection promotion fails closed
+        failure = TerminalFailure(
+            "grid_selection_materialization_exception",
+            f"{type(error).__name__}: {error}",
+        )
+        return GridDirectTrfOutcome(
+            GridDirectTrfTerminal.EXECUTION_FAILURE,
+            tuple(attempts),
+            selection,
+            failure=failure,
+        )
+    if promoted.terminal is DirectTrfOutcomeTerminal.CANCELLED:
+        return GridDirectTrfOutcome(
+            GridDirectTrfTerminal.CANCELLED,
+            tuple(attempts),
+            selection,
+            promoted.materialization,
+        )
+    return GridDirectTrfOutcome(
+        GridDirectTrfTerminal.MATERIALIZATION_FAILURE,
+        tuple(attempts),
+        selection,
+        promoted.materialization,
+        failure=(
+            promoted.materialization.failure
+            if promoted.materialization is not None
+            else promoted.execution.failure
+        ),
+    )

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -33,6 +33,7 @@ from chemex.optimize.direct_trf import (
     DirectTrfInterrupted,
     DirectTrfInvocation,
     DirectTrfTerminal,
+    LiveFitCommitAuthority,
     MaterializationTerminal,
     MaterializedDirectTrfCandidate,
     ObjectiveScalarizationError,
@@ -692,13 +693,22 @@ class GroupedDirectTrfOutcome:
         repr=False,
         compare=False,
     )
+    commit_authority: LiveFitCommitAuthority | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     failure: TerminalFailure | None = None
 
     def __post_init__(self) -> None:
         if (self.terminal is GroupedDirectTrfTerminal.ACCEPTED) != (
-            self.accepted_result is not None
+            self.accepted_result is not None and self.commit_authority is not None
         ):
             raise ValueError("Only accepted grouped execution has root fit authority")
+        if self.terminal is not GroupedDirectTrfTerminal.ACCEPTED and (
+            self.accepted_result is not None or self.commit_authority is not None
+        ):
+            raise ValueError("Unaccepted grouped execution cannot expose fit authority")
 
 
 def _validate_grouped_context(
@@ -1298,7 +1308,7 @@ def _accept_grouped_aggregate_unchecked(
     )
     if token.is_cancelled:
         return GroupedDirectTrfOutcome(GroupedDirectTrfTerminal.CANCELLED, outcomes)
-    accepted = accept_materialized_fit(
+    accepted, authority = accept_materialized_fit(
         problem=problem,
         invocation_identity=invocation.identity,
         execution_identity=execution_identity,
@@ -1311,6 +1321,7 @@ def _accept_grouped_aggregate_unchecked(
         GroupedDirectTrfTerminal.ACCEPTED,
         outcomes,
         accepted,
+        authority,
     )
 
 

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -7,9 +7,13 @@ The production lmfit runner remains outside this qualification harness.
 
 from __future__ import annotations
 
+import copy
 import dataclasses
+import pickle
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import patch
@@ -30,6 +34,7 @@ from chemex.optimize.direct_trf import (
     DirectTrfInvocation,
     DirectTrfOutcomeTerminal,
     DirectTrfTerminal,
+    LiveFitCommitAuthority,
     MaterializationTerminal,
     ObjectiveScalarizationError,
     OptimizationProblem,
@@ -152,7 +157,7 @@ def _one_request_converged_backend(
 def test_representative_single_component_fit_materializes_and_commits_atomically() -> (
     None
 ):
-    session, _experiments, parameterization, engine, problem, invocation = (
+    session, experiments, parameterization, engine, problem, invocation = (
         _qualification_fit()
     )
     before = session.analysis_values.snapshot()
@@ -168,6 +173,7 @@ def test_representative_single_component_fit_materializes_and_commits_atomically
     assert first.terminal is DirectTrfOutcomeTerminal.ACCEPTED
     assert first.execution.terminal is DirectTrfTerminal.CONVERGED
     assert first.accepted_result is not None
+    assert first.commit_authority is not None
     assert first.materialization is not None
     assert first.materialization.terminal is MaterializationTerminal.SUCCESS
     assert first.materialization.evaluation_count == 1
@@ -191,6 +197,7 @@ def test_representative_single_component_fit_materializes_and_commits_atomically
     assert first.execution.identity == second.execution.identity
     assert second.materialization is not None
     assert second.accepted_result is not None
+    assert second.commit_authority is not None
     assert first.materialization.identity == second.materialization.identity
     assert first.accepted_result.identity == second.accepted_result.identity
     assert session.analysis_values.snapshot() == before
@@ -198,6 +205,7 @@ def test_representative_single_component_fit_materializes_and_commits_atomically
 
     receipt = commit_accepted_fit(
         first.accepted_result,
+        first.commit_authority,
         problem=problem,
         parameterization=parameterization,
         analysis_values=session.analysis_values,
@@ -213,6 +221,183 @@ def test_representative_single_component_fit_materializes_and_commits_atomically
         rel=2.0e-8,
         abs=1.0e-10,
     )
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_accepted_fit(
+            first.accepted_result,
+            first.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+    assert session.analysis_values.snapshot() == committed
+
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    revision_one_parameterization = session.compile_parameterization(
+        read_methods([METHOD])["DEFAULT"],
+        experiments.param_ids,
+    )
+    revision_one_engine = EvaluationEngine.from_experiments(
+        experiments,
+        revision_one_parameterization,
+    )
+    revision_one_problem = OptimizationProblem.from_native(
+        revision_one_engine.plan,
+        revision_one_parameterization,
+        configuration,
+        committed,
+    )
+    revision_one_invocation = DirectTrfInvocation.for_problem(
+        revision_one_problem,
+        objective_request_budget=invocation.objective_request_budget,
+        x_scale=invocation.x_scale,
+        ftol=invocation.ftol,
+        xtol=invocation.xtol,
+        gtol=invocation.gtol,
+    )
+    revision_one = execute_direct_trf(
+        revision_one_problem,
+        revision_one_invocation,
+        revision_one_parameterization,
+        revision_one_engine,
+    )
+    assert revision_one.accepted_result is not None
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_accepted_fit(
+            revision_one.accepted_result,
+            first.commit_authority,
+            problem=revision_one_problem,
+            parameterization=revision_one_parameterization,
+            analysis_values=session.analysis_values,
+        )
+    assert session.analysis_values.snapshot() == committed
+    assert _legacy_values(session, problem.commit_scope) == legacy_before
+
+
+def test_live_commit_authority_is_atomic_under_concurrent_use() -> None:
+    session, _experiments, parameterization, engine, problem, invocation = (
+        _qualification_fit()
+    )
+    outcome = execute_direct_trf(problem, invocation, parameterization, engine)
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    before = session.analysis_values.snapshot()
+    legacy_before = _legacy_values(session, problem.commit_scope)
+    barrier = Barrier(2)
+
+    def commit_once() -> object:
+        barrier.wait()
+        try:
+            return commit_accepted_fit(
+                outcome.accepted_result,
+                outcome.commit_authority,
+                problem=problem,
+                parameterization=parameterization,
+                analysis_values=session.analysis_values,
+            )
+        except DirectTrfConstructionError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = tuple(executor.map(lambda _index: commit_once(), range(2)))
+
+    errors = tuple(
+        result for result in results if isinstance(result, DirectTrfConstructionError)
+    )
+    receipts = tuple(result for result in results if result not in errors)
+    assert len(errors) == len(receipts) == 1
+    assert "exact live Direct TRF commit authority" in str(errors[0])
+    assert session.analysis_values.snapshot().revision == before.revision + 1
+    assert _legacy_values(session, problem.commit_scope) == legacy_before
+
+
+def test_commit_rejects_absent_foreign_or_wrongly_bound_live_authority() -> None:
+    session, _experiments, parameterization, engine, problem, invocation = (
+        _qualification_fit()
+    )
+    first = execute_direct_trf(problem, invocation, parameterization, engine)
+    second = execute_direct_trf(problem, invocation, parameterization, engine)
+    assert first.accepted_result is not None
+    assert first.commit_authority is not None
+    assert second.accepted_result is not None
+    assert second.commit_authority is not None
+    before = session.analysis_values.snapshot()
+    legacy_before = _legacy_values(session, problem.commit_scope)
+
+    with pytest.raises(TypeError, match="minted only"):
+        LiveFitCommitAuthority()
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.copy(first.commit_authority)
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.deepcopy(first.commit_authority)
+    with pytest.raises(TypeError, match="cannot be serialized"):
+        pickle.dumps(first.commit_authority)
+    with pytest.raises(AttributeError):
+        first.commit_authority.origin_context_identity = "foreign-origin"  # type: ignore[attr-defined]
+    with pytest.raises(AttributeError):
+        first.commit_authority._problem_identity = "foreign-problem"  # type: ignore[attr-defined]
+    equivalent_evidence = dataclasses.replace(first.accepted_result)
+    assert equivalent_evidence is not first.accepted_result
+    assert equivalent_evidence.identity == first.accepted_result.identity
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_accepted_fit(
+            equivalent_evidence,
+            first.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_accepted_fit(
+            first.accepted_result,
+            second.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_accepted_fit(
+            first.accepted_result,
+            None,  # type: ignore[arg-type] - adversarial runtime absence
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+
+    wrong_snapshot = dataclasses.replace(
+        problem.source_snapshot,
+        occurrence_identity="foreign-analysis-values",
+        revision=problem.source_snapshot.revision + 1,
+    )
+    wrong_problem = dataclasses.replace(problem, source_snapshot=wrong_snapshot)
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="commit context",
+    ):
+        commit_accepted_fit(
+            first.accepted_result,
+            first.commit_authority,
+            problem=wrong_problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+
+    assert session.analysis_values.snapshot() == before
     assert _legacy_values(session, problem.commit_scope) == legacy_before
 
 
@@ -773,6 +958,7 @@ def test_stale_commit_rejects_the_complete_accepted_scope_atomically() -> None:
     )
     outcome = execute_direct_trf(problem, invocation, parameterization, engine)
     assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
     start = session.analysis_values.snapshot()
     session.analysis_values.commit({"__PB": 0.01}, expected=start, scope=("__PB",))
     advanced = session.analysis_values.snapshot()
@@ -780,6 +966,18 @@ def test_stale_commit_rejects_the_complete_accepted_scope_atomically() -> None:
     with pytest.raises(StaleAnalysisValuesError):
         commit_accepted_fit(
             outcome.accepted_result,
+            outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_accepted_fit(
+            outcome.accepted_result,
+            outcome.commit_authority,
             problem=problem,
             parameterization=parameterization,
             analysis_values=session.analysis_values,

--- a/tests/test_native_grid_direct_trf.py
+++ b/tests/test_native_grid_direct_trf.py
@@ -1,0 +1,978 @@
+"""Behavioral qualification for single-component native GRID -> TRF (#595).
+
+The public seams are the immutable Cartesian workflow invocation, typed seed
+outcomes and selection provenance, and the existing revision-checked Direct TRF
+commit boundary.  Legacy GRID execution remains outside this qualification.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.parameters import read_defaults
+from chemex.containers.experiments import Experiments
+from chemex.evaluation.native import EvaluationEngine
+from chemex.experiments.builder import build_experiments
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    CancellationToken,
+    DirectTrfConstructionError,
+    DirectTrfInvocation,
+    OptimizationProblem,
+    commit_accepted_fit,
+    execute_direct_trf,
+)
+from chemex.optimize.grid_direct_trf import (
+    GridDirectTrfInterrupted,
+    GridDirectTrfInvocation,
+    GridDirectTrfTerminal,
+    GridSeedDisposition,
+    GridSelection,
+    commit_grid_accepted_fit,
+    execute_grid_direct_trf,
+)
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+from chemex.typing import Array
+
+ROOT = Path(__file__).parent.parent
+EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
+METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+def _qualification_problem(
+    method: Method,
+) -> tuple[
+    AnalysisSession,
+    Experiments,
+    ActiveParameterization,
+    EvaluationEngine,
+    OptimizationProblem,
+]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    return session, experiments, parameterization, engine, problem
+
+
+def test_cartesian_seed_plan_is_canonical_physical_and_rooted_once() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        Method(fit=["PB"], fix=["KEX_AB"]),
+    )
+    pb_id, r1_id = problem.controlled_ids
+    pb_lower, r1_lower = problem.lower_bounds
+    pb_upper, _r1_upper = problem.upper_bounds
+
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=(
+            (r1_id, (r1_lower, r1_lower)),
+            (pb_id, (pb_lower, pb_upper)),
+        ),
+        objective_request_budget=5,
+    )
+
+    assert tuple(axis.param_id for axis in invocation.axes) == (pb_id, r1_id)
+    assert tuple(axis.declaration_ordinal for axis in invocation.axes) == (1, 0)
+    assert tuple(seed.ordinal for seed in invocation.seeds) == (0, 1, 2, 3)
+    assert tuple(seed.axis_items for seed in invocation.seeds) == (
+        ((pb_id, pb_lower), (r1_id, r1_lower)),
+        ((pb_id, pb_lower), (r1_id, r1_lower)),
+        ((pb_id, pb_upper), (r1_id, r1_lower)),
+        ((pb_id, pb_upper), (r1_id, r1_lower)),
+    )
+    assert tuple(seed.start for seed in invocation.seeds) == (
+        (pb_lower, r1_lower),
+        (pb_lower, r1_lower),
+        (pb_upper, r1_lower),
+        (pb_upper, r1_lower),
+    )
+    assert len({seed.identity for seed in invocation.seeds}) == 4
+    assert all(seed.problem is not None for seed in invocation.seeds)
+    assert all(seed.invocation is not None for seed in invocation.seeds)
+    assert all(
+        seed.problem is not None
+        and seed.problem.source_snapshot is problem.source_snapshot
+        and seed.problem.controlled_ids == problem.controlled_ids
+        and seed.problem.held_items == problem.held_items
+        and seed.problem.lower_bounds == problem.lower_bounds
+        and seed.problem.upper_bounds == problem.upper_bounds
+        and seed.problem.commit_scope == problem.commit_scope
+        and not seed.problem.acceptance_authority
+        for seed in invocation.seeds
+    )
+    assert (
+        invocation.identity
+        == GridDirectTrfInvocation.for_problem(
+            problem,
+            axes=(
+                (r1_id, (r1_lower, r1_lower)),
+                (pb_id, (pb_lower, pb_upper)),
+            ),
+            objective_request_budget=5,
+        ).identity
+    )
+    first_seed = invocation.seeds[0]
+    replacement_seed = invocation.seeds[2]
+    assert first_seed.problem is not None
+    assert first_seed.invocation is not None
+    with pytest.raises(DirectTrfConstructionError, match="no acceptance authority"):
+        execute_direct_trf(
+            first_seed.problem,
+            first_seed.invocation,
+            parameterization,
+            engine,
+        )
+    with pytest.raises(DirectTrfConstructionError, match="differs from its seed"):
+        dataclasses.replace(
+            first_seed,
+            problem=replacement_seed.problem,
+            invocation=replacement_seed.invocation,
+        )
+
+
+def test_duplicate_axis_declarations_are_rejected_after_canonical_resolution() -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(
+            Method(fit=["PB"], fix=["KEX_AB"]),
+        )
+    )
+    param_id = problem.controlled_ids[0]
+
+    with pytest.raises(ValueError, match="Duplicate GRID axis"):
+        GridDirectTrfInvocation.for_problem(
+            problem,
+            axes=((param_id, (0.1,)), (param_id, (0.2,))),
+            objective_request_budget=5,
+        )
+
+
+@pytest.mark.parametrize(
+    "unusable",
+    (np.nan, np.inf, -np.inf, "not-a-real-coordinate"),
+    ids=("nan", "positive-infinity", "negative-infinity", "non-real"),
+)
+def test_unusable_axis_value_is_seed_local_and_later_seeds_run(
+    unusable: object,
+) -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    start = problem.start[0]
+    axes = ((param_id, (start, unusable, start * 1.1)),)
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=axes,
+        objective_request_budget=5,
+    )
+    backend_calls = 0
+
+    def finite_only_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        nonlocal backend_calls
+        backend_calls += 1
+        assert np.isfinite(x0).all()
+        candidate = np.asarray(problem.start, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate), status=1, success=True)
+
+    with patch("chemex.optimize.direct_trf.least_squares", finite_only_backend):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert backend_calls == 2
+    assert tuple(attempt.seed_ordinal for attempt in outcome.attempts) == (0, 1, 2)
+    assert tuple(attempt.disposition for attempt in outcome.attempts) == (
+        GridSeedDisposition.ELIGIBLE,
+        GridSeedDisposition.UNUSABLE_VALUE,
+        GridSeedDisposition.ELIGIBLE,
+    )
+    assert outcome.attempts[1].failure is not None
+    assert outcome.attempts[1].failure.category == "grid_seed_unusable_value"
+    assert outcome.attempts[2].execution_identity is not None
+    assert tuple(row.seed_ordinal for row in outcome.table_rows) == (0, 1, 2)
+    assert (
+        invocation.identity
+        == GridDirectTrfInvocation.for_problem(
+            problem,
+            axes=axes,
+            objective_request_budget=5,
+        ).identity
+    )
+
+
+def _backend_result(
+    candidate: Array,
+    residuals: Array,
+    *,
+    status: int,
+    success: bool,
+) -> object:
+    return SimpleNamespace(
+        x=candidate,
+        fun=residuals,
+        status=status,
+        success=success,
+        message="qualified backend result",
+        nfev=1,
+        njev=0,
+        cost=0.5 * float(np.dot(residuals, residuals)),
+        optimality=0.0 if success else 1.0,
+        active_mask=np.zeros_like(candidate, dtype=np.int64),
+    )
+
+
+def _legacy_values(
+    session: AnalysisSession, scope: tuple[str, ...]
+) -> dict[str, float]:
+    return {
+        param_id: parameter.value
+        for param_id, parameter in session.parameters.build_lmfit_params(
+            set(scope)
+        ).items()
+    }
+
+
+def test_failed_seed_continues_and_canonical_tie_commits_only_selected_once() -> None:
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    (lower,) = problem.lower_bounds
+    start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (lower - 1.0, start * 1.1, start, start)),),
+        objective_request_budget=5,
+    )
+    before = session.analysis_values.snapshot()
+    backend_calls = 0
+
+    def mixed_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        nonlocal backend_calls
+        backend_calls += 1
+        if backend_calls == 1:
+            candidate = np.asarray(x0, dtype=np.float64)
+            return _backend_result(
+                candidate,
+                fun(candidate),
+                status=0,
+                success=False,
+            )
+        candidate = np.asarray(problem.start, dtype=np.float64) * 0.9
+        return _backend_result(
+            candidate,
+            fun(candidate),
+            status=1,
+            success=True,
+        )
+
+    with patch("chemex.optimize.direct_trf.least_squares", mixed_backend):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert backend_calls == 3
+    assert outcome.terminal is GridDirectTrfTerminal.ACCEPTED
+    assert tuple(attempt.disposition for attempt in outcome.attempts) == (
+        GridSeedDisposition.OUT_OF_BOUNDS,
+        GridSeedDisposition.NON_CONVERGED,
+        GridSeedDisposition.ELIGIBLE,
+        GridSeedDisposition.ELIGIBLE,
+    )
+    assert outcome.selection is not None
+    assert outcome.selection.selected_seed_ordinal == 2
+    assert outcome.selection.ordering_policy == "chi-square-vector-seed-ordinal-v1"
+    assert len(outcome.selection.eligible_candidate_identities) == 2
+    assert outcome.attempts[2].objective == outcome.attempts[3].objective
+    assert outcome.attempts[2].candidate is not None
+    assert outcome.attempts[3].candidate is not None
+    assert (
+        outcome.attempts[2].candidate.identity != outcome.attempts[3].candidate.identity
+    )
+    assert all(not hasattr(attempt, "accepted_result") for attempt in outcome.attempts)
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    assert outcome.accepted_result.problem_identity == problem.identity
+    grid_selection = outcome.accepted_result.grid_selection_provenance
+    assert grid_selection is not None
+    assert grid_selection.workflow_invocation_identity == invocation.identity
+    assert grid_selection.selection_identity == outcome.selection.identity
+    assert outcome.accepted_result.origin_context_identity == grid_selection.identity
+    assert grid_selection.selected_seed_identity == outcome.attempts[2].seed_identity
+    assert grid_selection.selected_seed_ordinal == 2
+    assert session.analysis_values.snapshot() == before
+    legacy_before = _legacy_values(session, problem.commit_scope)
+
+    replaced_provenance = (
+        dataclasses.replace(
+            grid_selection,
+            workflow_invocation_identity="foreign-grid-workflow",
+        ),
+        dataclasses.replace(
+            grid_selection,
+            selection_identity="foreign-grid-selection",
+        ),
+        dataclasses.replace(
+            grid_selection,
+            selected_seed_identity="foreign-grid-seed",
+        ),
+        dataclasses.replace(
+            grid_selection,
+            selected_seed_ordinal=grid_selection.selected_seed_ordinal + 1,
+        ),
+        dataclasses.replace(
+            grid_selection,
+            grid_candidate_identity="foreign-grid-candidate",
+        ),
+        dataclasses.replace(
+            grid_selection,
+            candidate_execution_identity="foreign-execution",
+        ),
+        None,
+    )
+    for invalid_provenance in replaced_provenance:
+        invalid_accepted = dataclasses.replace(
+            outcome.accepted_result,
+            grid_selection_provenance=invalid_provenance,
+        )
+        with pytest.raises(
+            DirectTrfConstructionError,
+            match="canonical selection authority",
+        ):
+            commit_grid_accepted_fit(
+                invalid_accepted,
+                outcome.commit_authority,
+                problem=problem,
+                parameterization=parameterization,
+                analysis_values=session.analysis_values,
+            )
+        assert session.analysis_values.snapshot() == before
+        assert _legacy_values(session, problem.commit_scope) == legacy_before
+
+    invalid_origin = dataclasses.replace(
+        outcome.accepted_result,
+        origin_context_identity="foreign-origin-context",
+    )
+    assert invalid_origin.identity != outcome.accepted_result.identity
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="canonical selection authority",
+    ):
+        commit_grid_accepted_fit(
+            invalid_origin,
+            outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+    assert session.analysis_values.snapshot() == before
+    assert _legacy_values(session, problem.commit_scope) == legacy_before
+
+    receipt = commit_grid_accepted_fit(
+        outcome.accepted_result,
+        outcome.commit_authority,
+        problem=problem,
+        parameterization=parameterization,
+        analysis_values=session.analysis_values,
+    )
+
+    assert receipt.old_revision == before.revision
+    assert receipt.new_revision == before.revision + 1
+    committed = session.analysis_values.snapshot()
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_grid_accepted_fit(
+            outcome.accepted_result,
+            outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+    assert session.analysis_values.snapshot() == committed
+
+
+def test_plain_base_evidence_cannot_recreate_grid_commit_authority() -> None:
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (start,)),),
+        objective_request_budget=5,
+    )
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(problem.start, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate), status=1, success=True)
+
+    with patch("chemex.optimize.direct_trf.least_squares", successful_backend):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    accepted = outcome.accepted_result
+    plain_evidence = AcceptedFitResult(
+        accepted.occurrence_identity,
+        accepted.problem_identity,
+        accepted.invocation_identity,
+        accepted.execution_identity,
+        accepted.materialization_identity,
+        accepted.parameterization_identity,
+        accepted.evaluator_parameterization_identity,
+        accepted.source_occurrence_identity,
+        accepted.source_revision,
+        accepted.controlled_ids,
+        accepted.vector,
+        accepted.chi_square,
+        accepted.evaluation_result,
+        accepted.commit_scope,
+        accepted.commit_items,
+        accepted.origin_context_identity,
+    )
+    assert plain_evidence.identity == accepted.identity
+    replaced_evidence = dataclasses.replace(accepted)
+    assert replaced_evidence is not accepted
+    assert replaced_evidence.identity == accepted.identity
+    before = session.analysis_values.snapshot()
+    legacy_before = _legacy_values(session, problem.commit_scope)
+
+    for reconstructed in (plain_evidence, replaced_evidence):
+        with pytest.raises(
+            DirectTrfConstructionError,
+            match="exact live Direct TRF commit authority",
+        ):
+            commit_accepted_fit(
+                reconstructed,
+                outcome.commit_authority,
+                problem=problem,
+                parameterization=parameterization,
+                analysis_values=session.analysis_values,
+            )
+    with pytest.raises(TypeError, match="authority"):
+        commit_accepted_fit(
+            plain_evidence,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+
+    assert (
+        plain_evidence.identity
+        == AcceptedFitResult(
+            plain_evidence.occurrence_identity,
+            plain_evidence.problem_identity,
+            plain_evidence.invocation_identity,
+            plain_evidence.execution_identity,
+            plain_evidence.materialization_identity,
+            plain_evidence.parameterization_identity,
+            plain_evidence.evaluator_parameterization_identity,
+            plain_evidence.source_occurrence_identity,
+            plain_evidence.source_revision,
+            plain_evidence.controlled_ids,
+            plain_evidence.vector,
+            plain_evidence.chi_square,
+            plain_evidence.evaluation_result,
+            plain_evidence.commit_scope,
+            plain_evidence.commit_items,
+            plain_evidence.origin_context_identity,
+        ).identity
+    )
+    assert session.analysis_values.snapshot() == before
+    assert _legacy_values(session, problem.commit_scope) == legacy_before
+
+
+def test_grid_commit_rejects_foreign_direct_origin_authority_atomically() -> None:
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    grid_invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (problem.start[0],)),),
+        objective_request_budget=5,
+    )
+    direct_invocation = DirectTrfInvocation.for_problem(
+        problem,
+        objective_request_budget=5,
+    )
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(problem.start, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate), status=1, success=True)
+
+    with patch("chemex.optimize.direct_trf.least_squares", successful_backend):
+        grid_outcome = execute_grid_direct_trf(
+            problem,
+            grid_invocation,
+            parameterization,
+            engine,
+        )
+        direct_outcome = execute_direct_trf(
+            problem,
+            direct_invocation,
+            parameterization,
+            engine,
+        )
+
+    assert grid_outcome.accepted_result is not None
+    assert grid_outcome.commit_authority is not None
+    assert direct_outcome.commit_authority is not None
+    before = session.analysis_values.snapshot()
+    legacy_before = _legacy_values(session, problem.commit_scope)
+
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_grid_accepted_fit(
+            grid_outcome.accepted_result,
+            direct_outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+
+    assert session.analysis_values.snapshot() == before
+    assert _legacy_values(session, problem.commit_scope) == legacy_before
+
+
+def test_selection_requires_one_exact_canonical_seed_candidate_record() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (start, start * 1.1)),),
+        objective_request_budget=5,
+    )
+
+    def tied_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(problem.start, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate), status=1, success=True)
+
+    with patch("chemex.optimize.direct_trf.least_squares", tied_backend):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.selection is not None
+    eligible = tuple(
+        attempt
+        for attempt in outcome.attempts
+        if attempt.disposition is GridSeedDisposition.ELIGIBLE
+    )
+    winner, other = eligible
+    assert winner.candidate is not None
+
+    mismatches = (
+        (other.seed_identity, other.seed_ordinal, winner.candidate.identity),
+        (winner.seed_identity, other.seed_ordinal, winner.candidate.identity),
+        (other.seed_identity, winner.seed_ordinal, winner.candidate.identity),
+    )
+    for seed_identity, seed_ordinal, candidate_identity in mismatches:
+        with pytest.raises(ValueError, match="exact canonical candidate record"):
+            GridSelection.from_candidate_records(
+                selected_seed_identity=seed_identity,
+                selected_seed_ordinal=seed_ordinal,
+                selected_candidate_identity=candidate_identity,
+                candidate_records=eligible,
+            )
+
+    selection = GridSelection.from_candidate_records(
+        selected_seed_identity=winner.seed_identity,
+        selected_seed_ordinal=winner.seed_ordinal,
+        selected_candidate_identity=winner.candidate.identity,
+        candidate_records=eligible,
+    )
+    rendered = dataclasses.replace(outcome, selection=selection)
+    selected_rows = tuple(row for row in rendered.table_rows if row.selected)
+    selected_points = tuple(
+        point for point in rendered.diagnostic_points((param_id,)) if point.selected
+    )
+    assert len(selected_rows) == len(selected_points) == 1
+    assert selected_rows[0].seed_identity == winner.seed_identity
+    assert selected_rows[0].candidate_identity == winner.candidate.identity
+    assert selected_points[0].seed_identity == winner.seed_identity
+    assert selected_points[0].candidate_identity == winner.candidate.identity
+
+
+def test_invalid_trial_continues_to_later_seed() -> None:
+    session, experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (start, start * 1.1)),),
+        objective_request_budget=5,
+    )
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    original = pulse_type.calculate
+    reject_trial = False
+    backend_calls = 0
+
+    def controlled_calculate(*args: object, **kwargs: object) -> Array:
+        calculated = original(*args, **kwargs)
+        if reject_trial:
+            return np.full_like(calculated, np.nan)
+        return calculated
+
+    def invalid_then_converged(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        nonlocal backend_calls, reject_trial
+        backend_calls += 1
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        if backend_calls == 1:
+            reject_trial = True
+            try:
+                fun(candidate)
+            finally:
+                reject_trial = False
+            raise AssertionError("invalid trial must stop the first backend")
+        return _backend_result(candidate, fun(candidate), status=1, success=True)
+
+    with (
+        patch.object(pulse_type, "calculate", controlled_calculate),
+        patch("chemex.optimize.direct_trf.least_squares", invalid_then_converged),
+    ):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert backend_calls == 2
+    assert outcome.terminal is GridDirectTrfTerminal.ACCEPTED
+    assert tuple(attempt.disposition for attempt in outcome.attempts) == (
+        GridSeedDisposition.INVALID_TRIAL,
+        GridSeedDisposition.ELIGIBLE,
+    )
+    assert outcome.attempts[0].candidate is None
+    assert outcome.selection is not None
+    assert outcome.selection.selected_seed_ordinal == 1
+    assert session.analysis_values.snapshot().revision == 0
+
+
+def test_cancellation_and_interruption_stop_later_seeds() -> None:
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (start, start, start)),),
+        objective_request_budget=5,
+    )
+    token = CancellationToken()
+    cancellation_backend_calls = 0
+
+    def cancel_after_trial(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        nonlocal cancellation_backend_calls
+        cancellation_backend_calls += 1
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        residuals = fun(candidate)
+        if cancellation_backend_calls == 2:
+            token.cancel()
+        return _backend_result(candidate, residuals, status=1, success=True)
+
+    with patch("chemex.optimize.direct_trf.least_squares", cancel_after_trial):
+        cancelled = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+
+    assert cancelled.terminal is GridDirectTrfTerminal.CANCELLED
+    assert tuple(attempt.disposition for attempt in cancelled.attempts) == (
+        GridSeedDisposition.ELIGIBLE,
+        GridSeedDisposition.CANCELLED,
+        GridSeedDisposition.NOT_STARTED,
+    )
+    assert cancelled.selection is None
+    assert cancelled.accepted_result is None
+
+    interruption_backend_calls = 0
+
+    def interrupt_after_trial(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        nonlocal interruption_backend_calls
+        interruption_backend_calls += 1
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        residuals = fun(candidate)
+        if interruption_backend_calls == 2:
+            raise KeyboardInterrupt
+        return _backend_result(candidate, residuals, status=1, success=True)
+
+    with (
+        patch("chemex.optimize.direct_trf.least_squares", interrupt_after_trial),
+        pytest.raises(GridDirectTrfInterrupted) as interrupted,
+    ):
+        execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert interrupted.value.outcome.terminal is GridDirectTrfTerminal.INTERRUPTED
+    assert tuple(
+        attempt.disposition for attempt in interrupted.value.outcome.attempts
+    ) == (
+        GridSeedDisposition.ELIGIBLE,
+        GridSeedDisposition.INTERRUPTED,
+        GridSeedDisposition.NOT_STARTED,
+    )
+    assert interrupted.value.outcome.selection is None
+    assert interrupted.value.outcome.accepted_result is None
+    assert session.analysis_values.snapshot().revision == 0
+
+
+def test_table_and_two_dimensional_diagnostics_retain_exact_seed_provenance() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        Method(fit=["PB"], fix=["KEX_AB"]),
+    )
+    pb_id, r1_id = problem.controlled_ids
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((r1_id, (problem.start[1],)), (pb_id, (problem.start[0],))),
+        objective_request_budget=5,
+    )
+
+    def converge(fun: Callable[[Array], Array], x0: Array, **_kwargs: object) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate), status=1, success=True)
+
+    with patch("chemex.optimize.direct_trf.least_squares", converge):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is GridDirectTrfTerminal.ACCEPTED
+    (row,) = outcome.table_rows
+    assert row.seed_identity == invocation.seeds[0].identity
+    assert row.seed_ordinal == 0
+    assert row.axis_items == (
+        (pb_id, problem.start[0]),
+        (r1_id, problem.start[1]),
+    )
+    assert row.objective == outcome.attempts[0].objective
+    assert row.disposition is GridSeedDisposition.ELIGIBLE
+    assert row.selected
+    (point_1d,) = outcome.diagnostic_points((pb_id,))
+    (point_2d,) = outcome.diagnostic_points((r1_id, pb_id))
+    assert point_1d.coordinates == ((pb_id, problem.start[0]),)
+    assert point_2d.coordinates == (
+        (r1_id, problem.start[1]),
+        (pb_id, problem.start[0]),
+    )
+    assert point_1d.objective == point_2d.objective == row.objective
+    assert point_1d.seed_identity == point_2d.seed_identity == row.seed_identity
+
+
+def test_no_converged_candidate_has_no_selection_or_commit_authority() -> None:
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (start, start * 1.1)),),
+        objective_request_budget=5,
+    )
+
+    def never_converge(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate), status=0, success=False)
+
+    with patch("chemex.optimize.direct_trf.least_squares", never_converge):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is GridDirectTrfTerminal.NO_ELIGIBLE_CANDIDATE
+    assert all(
+        attempt.disposition is GridSeedDisposition.NON_CONVERGED
+        and attempt.candidate is None
+        and attempt.objective is None
+        for attempt in outcome.attempts
+    )
+    assert outcome.selection is None
+    assert outcome.materialization is None
+    assert outcome.accepted_result is None
+    assert session.analysis_values.snapshot().revision == 0
+
+
+def test_seed_local_materialization_failure_continues_to_later_seed() -> None:
+    session, experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (start, start)),),
+        objective_request_budget=5,
+    )
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    original = pulse_type.calculate
+    kernel_calls = 0
+
+    def fail_first_local_materialization(*args: object, **kwargs: object) -> Array:
+        nonlocal kernel_calls
+        kernel_calls += 1
+        if kernel_calls == 3:
+            raise RuntimeError("qualified seed-local materialization failure")
+        return original(*args, **kwargs)
+
+    def converge(fun: Callable[[Array], Array], x0: Array, **_kwargs: object) -> object:
+        candidate = np.asarray(problem.start, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate), status=1, success=True)
+
+    with (
+        patch.object(pulse_type, "calculate", fail_first_local_materialization),
+        patch("chemex.optimize.direct_trf.least_squares", converge),
+    ):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert kernel_calls == 7
+    assert outcome.terminal is GridDirectTrfTerminal.ACCEPTED
+    assert tuple(attempt.disposition for attempt in outcome.attempts) == (
+        GridSeedDisposition.MATERIALIZATION_FAILURE,
+        GridSeedDisposition.ELIGIBLE,
+    )
+    assert outcome.selection is not None
+    assert outcome.selection.selected_seed_ordinal == 1
+    assert outcome.accepted_result is not None
+    assert session.analysis_values.snapshot().revision == 0
+
+
+def test_selected_root_materialization_failure_never_falls_back() -> None:
+    session, experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((param_id, (start, start)),),
+        objective_request_budget=5,
+    )
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    original = pulse_type.calculate
+    kernel_calls = 0
+
+    def fail_seventh_evaluation(*args: object, **kwargs: object) -> Array:
+        nonlocal kernel_calls
+        kernel_calls += 1
+        if kernel_calls == 7:
+            raise RuntimeError("qualified final materialization failure")
+        return original(*args, **kwargs)
+
+    def converge(fun: Callable[[Array], Array], x0: Array, **_kwargs: object) -> object:
+        candidate = np.asarray(problem.start, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate), status=1, success=True)
+
+    with (
+        patch.object(pulse_type, "calculate", fail_seventh_evaluation),
+        patch("chemex.optimize.direct_trf.least_squares", converge),
+    ):
+        outcome = execute_grid_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert kernel_calls == 7
+    assert outcome.terminal is GridDirectTrfTerminal.MATERIALIZATION_FAILURE
+    assert outcome.selection is not None
+    assert outcome.selection.selected_seed_ordinal == 0
+    assert outcome.materialization is not None
+    assert outcome.accepted_result is None
+    assert all(
+        attempt.disposition is GridSeedDisposition.ELIGIBLE
+        for attempt in outcome.attempts
+    )
+    assert session.analysis_values.snapshot().revision == 0

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -433,12 +433,23 @@ def test_component_vector_cannot_be_retargeted_to_transposed_controlled_ids() ->
         objective_request_budgets=(80,),
     )
     before = session.analysis_values.snapshot()
-    components = execute_direct_trf_components(
-        decomposition,
-        invocation,
-        parameterization,
-        engine,
-    )
+
+    def successful_backend(
+        fun: Callable[[Array], Array],
+        x0: Array,
+        **_settings: object,
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64)
+        assert np.isfinite(candidate).all()
+        return _backend_result(candidate, fun(candidate), success=True)
+
+    with patch("chemex.optimize.direct_trf.least_squares", successful_backend):
+        components = execute_direct_trf_components(
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
     assert len(components) == 1
     component = components[0]
     assert component.candidate is not None

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -36,7 +36,6 @@ from chemex.optimize.grouped_direct_trf import (
     materialize_grouped_direct_trf,
 )
 from chemex.parameters.parameterization import ActiveParameterization
-from chemex.parameters.values import StaleAnalysisValuesError
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
 
@@ -251,6 +250,7 @@ def test_successful_components_compose_one_fresh_root_accepted_result_and_commit
         not hasattr(component, "accepted_result") for component in outcome.components
     )
     assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
     accepted = outcome.accepted_result
     selected = {
         param_id: component.candidate.vector[index]
@@ -268,6 +268,7 @@ def test_successful_components_compose_one_fresh_root_accepted_result_and_commit
 
     receipt = commit_accepted_fit(
         accepted,
+        outcome.commit_authority,
         problem=problem,
         parameterization=parameterization,
         analysis_values=session.analysis_values,
@@ -275,9 +276,13 @@ def test_successful_components_compose_one_fresh_root_accepted_result_and_commit
     assert receipt.old_revision == before.revision
     assert receipt.new_revision == before.revision + 1
     committed = session.analysis_values.snapshot()
-    with pytest.raises(StaleAnalysisValuesError):
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
         commit_accepted_fit(
             accepted,
+            outcome.commit_authority,
             problem=problem,
             parameterization=parameterization,
             analysis_values=session.analysis_values,


### PR DESCRIPTION
Closes #595.

## Summary

Adds the isolated native single-component GRID → TRF qualification path.

Canonical physical-coordinate Cartesian seeds now drive independent native
Direct TRF attempts, with deterministic candidate disposition and winner
selection. Only the selected winner can undergo fresh root validation and
receive single-use commit authority.

Production legacy GRID execution, CLI, TOML, and output behavior remain unchanged.

## Behavior

- Deterministic canonical GRID-axis and Cartesian seed ordering.
- Final axis varies fastest.
- Duplicate physical seeds remain distinct attempts with distinct provenance.
- Boundary seeds are valid.
- Invalid, non-finite, malformed, and finite out-of-bounds individual seeds receive
  typed dispositions without preventing later valid seeds from running.
- Seed-local invalid trials, non-convergence, and materialization failures continue
  to later seeds.
- Cancellation, interruption, backend failure, and implementation failure stop
  scheduling safely.
- Candidate attempts have no acceptance or commit authority.
- Winner ordering is canonical and deterministic using χ², final vector, and seed ordinal.
- GRID selection proves exact seed/candidate/selection lineage.
- The winner is freshly validated against the root problem before acceptance.
- GRID-derived accepted evidence commits to its complete origin context.

## Commit authority

Accepted fit evidence alone is not commit authority.

`commit_accepted_fit()` now requires a Direct-TRF-owned `LiveFitCommitAuthority`:

- opaque and process-local;
- non-constructible, non-copyable, non-serializable, and non-retargetable;
- bound in a private immutable registry to the exact accepted evidence object,
  occurrence, root problem, snapshot context, revision, and origin context;
- single-use and consumed before the authoritative state transition.

Equivalent, copied, reconstructed, subtype-erased, stale, foreign, or replayed
evidence cannot reuse the capability.

The dependency direction remains:

`grid_direct_trf.py → direct_trf.py`

The generic Direct TRF commit boundary contains no GRID imports or policy.

## Qualification

Adversarial coverage includes:

- seed/vector ownership and ordering;
- duplicate and boundary seeds;
- invalid/non-finite seed continuation;
- failed/non-converged candidate continuation;
- deterministic ties;
- selection retargeting;
- foreign candidate/materialization provenance;
- fresh-root rejection;
- GRID evidence stripping;
- equivalent accepted-result substitution;
- capability mutation, copying, serialization, replay, and retargeting;
- stale commit;
- concurrent capability use.

## Scope

This PR intentionally does not implement:

- grouped GRID (#596);
- differential evolution (#597);
- uncertainty;
- resampling;
- MCMC;
- output migration;
- production native dispatch.

## Validation

- Focused Direct/Grouped/GRID tests: 59 passed
- Full suite: 623 passed
- `uv run ty check`: passed
- Ruff lint: passed
- Ruff format check: passed
- `git diff --check`: passed
- Graphify refreshed

One existing emcee autocorrelation warning remains.

## Review

The implementation underwent independent adversarial review.

Final review: **MERGE**, with no material Standards or Spec findings.