### PR TITLE
Add decomposed GRID to TRF qualification

### DIFF
--- a/src/chemex/optimize/grid_direct_trf.py
+++ b/src/chemex/optimize/grid_direct_trf.py
@@ -15,20 +15,25 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from itertools import product
 from numbers import Real
-from typing import cast
+from typing import Protocol, cast
+from uuid import uuid4
 
-from chemex.evaluation.native import EvaluationEngine
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+)
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     CancellationToken,
     CandidateMaterialization,
+    CandidateSummary,
     CommitReceipt,
     DirectTrfCandidateOutcome,
     DirectTrfCandidateTerminal,
     DirectTrfConstructionError,
     DirectTrfInterrupted,
     DirectTrfInvocation,
-    DirectTrfOutcomeTerminal,
     DirectTrfTerminal,
     GridSeedProblemDerivation,
     GridSelectionProvenance,
@@ -39,7 +44,7 @@ from chemex.optimize.direct_trf import (
     TerminalFailure,
     _accept_materialized_fit_for_derived_workflow,
     _grant_derived_fit_commit_authority,
-    _materialize_direct_trf_candidate_for_root,
+    canonical_chi_square,
     commit_accepted_fit,
     execute_direct_trf_candidate,
 )
@@ -518,6 +523,49 @@ class GridCandidate:
         return self.objective, self.vector, self.seed_ordinal
 
 
+class GridCandidateRecord(Protocol):
+    """Narrow evidence contract consumed by canonical GRID finalization."""
+
+    @property
+    def seed_identity(self) -> str: ...
+
+    @property
+    def seed_ordinal(self) -> int: ...
+
+    @property
+    def axis_items(self) -> tuple[tuple[str, GridCoordinate], ...]: ...
+
+    @property
+    def start(self) -> tuple[GridCoordinate, ...]: ...
+
+    @property
+    def disposition(self) -> GridSeedDisposition: ...
+
+    @property
+    def execution_identity(self) -> str | None: ...
+
+    @property
+    def objective(self) -> float | None: ...
+
+    @property
+    def candidate(self) -> GridCandidate | None: ...
+
+    @property
+    def failure(self) -> TerminalFailure | None: ...
+
+    @property
+    def identity(self) -> str: ...
+
+    def validate_for_grid_selection(
+        self,
+        problem: OptimizationProblem,
+        invocation: GridDirectTrfInvocation,
+        seed: GridSeed,
+    ) -> None:
+        """Raise when this candidate is not exact evidence for ``seed``."""
+        ...
+
+
 @dataclass(frozen=True, slots=True)
 class GridSeedOutcome:
     """Compact exact table/provenance row for one canonical seed."""
@@ -585,6 +633,122 @@ class GridSeedOutcome:
             ),
         )
 
+    def validate_for_grid_selection(
+        self,
+        problem: OptimizationProblem,
+        invocation: GridDirectTrfInvocation,
+        seed: GridSeed,
+    ) -> None:
+        """Prove exact single-component seed lineage before selection."""
+        _validate_direct_grid_record(self, problem, invocation, seed)
+
+
+def _validate_direct_grid_record(
+    record: GridSeedOutcome,
+    problem: OptimizationProblem,
+    invocation: GridDirectTrfInvocation,
+    seed: GridSeed,
+) -> None:
+    """Validate #595 child/candidate evidence at GRID's ownership boundary."""
+    candidate = record.candidate
+    direct = record.direct_outcome
+    child_problem = seed.problem
+    child_invocation = seed.invocation
+    materialized = None if candidate is None else candidate.candidate
+    materialization = None if materialized is None else materialized.materialization
+    derivation = None if child_problem is None else child_problem.derivation
+    unchanged_root_semantics = (
+        child_problem is not None
+        and child_problem.evaluation_plan_identity == problem.evaluation_plan_identity
+        and child_problem.parameterization_identity == problem.parameterization_identity
+        and child_problem.evaluator_parameterization_identity
+        == problem.evaluator_parameterization_identity
+        and child_problem.constraint_program_identity
+        == problem.constraint_program_identity
+        and child_problem.configuration_identity == problem.configuration_identity
+        and child_problem.source_snapshot == problem.source_snapshot
+        and child_problem.independent_items == problem.independent_items
+        and child_problem.controlled_ids == problem.controlled_ids
+        and child_problem.held_items == problem.held_items
+        and child_problem.lower_bounds == problem.lower_bounds
+        and child_problem.upper_bounds == problem.upper_bounds
+        and child_problem.commit_scope == problem.commit_scope
+        and child_problem.scalarization_version == problem.scalarization_version
+    )
+    if (
+        invocation.root_problem_identity != problem.identity
+        or seed.root_problem_identity != problem.identity
+        or seed.identity != record.seed_identity
+        or seed.ordinal != record.seed_ordinal
+        or record.disposition is not GridSeedDisposition.ELIGIBLE
+        or candidate is None
+        or candidate.seed_identity != seed.identity
+        or candidate.seed_ordinal != seed.ordinal
+        or direct is None
+        or materialized is None
+        or direct.terminal is not DirectTrfCandidateTerminal.SUCCESS
+        or direct.execution.terminal is not DirectTrfTerminal.CONVERGED
+        or direct.candidate is not materialized
+        or direct.materialization is not materialization
+        or record.execution_identity != direct.execution.identity
+        or child_problem is None
+        or child_invocation is None
+        or not isinstance(derivation, GridSeedProblemDerivation)
+        or derivation.root_problem_identity != problem.identity
+        or derivation.seed_identity != seed.coordinate_identity
+        or derivation.seed_ordinal != seed.ordinal
+        or not unchanged_root_semantics
+        or direct.execution.problem_identity != child_problem.identity
+        or direct.execution.invocation_identity != child_invocation.identity
+        or not _materialized_grid_candidate_matches(
+            materialized,
+            child_problem,
+            child_invocation.identity,
+            direct.execution.identity,
+        )
+    ):
+        raise DirectTrfConstructionError(
+            "GRID candidate lacks exact canonical seed lineage"
+        )
+
+
+def _materialized_grid_candidate_matches(
+    candidate: MaterializedDirectTrfCandidate,
+    problem: OptimizationProblem,
+    invocation_identity: str,
+    execution_identity: str,
+) -> bool:
+    """Check self-consistent materialized evidence for a known GRID problem."""
+    evaluation = candidate.evaluation_result
+    materialization = candidate.materialization
+    try:
+        objective = canonical_chi_square(evaluation.residuals)
+        vector = tuple(
+            evaluation.resolved_values[param_id] for param_id in problem.controlled_ids
+        )
+    except Exception:  # noqa: BLE001 - malformed evidence fails closed
+        return False
+    return (
+        candidate.problem_identity == problem.identity
+        and candidate.invocation_identity == invocation_identity
+        and candidate.execution_identity == execution_identity
+        and candidate.vector == vector
+        and candidate.chi_square == objective
+        and materialization.problem_identity == problem.identity
+        and materialization.invocation_identity == invocation_identity
+        and materialization.execution_identity == execution_identity
+        and materialization.terminal is MaterializationTerminal.SUCCESS
+        and materialization.candidate.vector == candidate.vector
+        and materialization.candidate.chi_square == candidate.chi_square
+        and materialization.evaluation_identity == evaluation.identity
+        and materialization.evaluator_compatibility_identity
+        == evaluation.evaluator_compatibility_identity
+        and evaluation.plan_identity == problem.evaluation_plan_identity
+        and evaluation.parameterization_identity
+        == problem.evaluator_parameterization_identity
+        and tuple(evaluation.resolved_values) == problem.commit_scope
+    )
+
 
 @dataclass(frozen=True, slots=True)
 class GridSelection:
@@ -594,7 +758,7 @@ class GridSelection:
     selected_seed_ordinal: int
     selected_candidate_identity: str
     eligible_candidate_identities: tuple[str, ...]
-    candidate_records: tuple[GridSeedOutcome, ...] = field(
+    candidate_records: tuple[GridCandidateRecord, ...] = field(
         repr=False,
         compare=False,
     )
@@ -654,7 +818,7 @@ class GridSelection:
         selected_seed_identity: str,
         selected_seed_ordinal: int,
         selected_candidate_identity: str,
-        candidate_records: Sequence[GridSeedOutcome],
+        candidate_records: Sequence[GridCandidateRecord],
     ) -> GridSelection:
         """Validate the requested winner against canonical eligible records."""
         records = tuple(candidate_records)
@@ -685,7 +849,7 @@ class GridSelection:
         )
 
     @property
-    def selected_record(self) -> GridSeedOutcome:
+    def selected_record(self) -> GridCandidateRecord:
         """Return the one exact candidate record that won selection."""
         return self.candidate_records[0]
 
@@ -698,7 +862,7 @@ class AcceptedGridDirectTrfResult(AcceptedFitResult):
     workflow_invocation: GridDirectTrfInvocation = field(repr=False, compare=False)
     selection: GridSelection = field(repr=False, compare=False)
     selected_seed: GridSeed = field(repr=False, compare=False)
-    selected_outcome: GridSeedOutcome = field(repr=False, compare=False)
+    selected_outcome: GridCandidateRecord = field(repr=False, compare=False)
     fresh_candidate: MaterializedDirectTrfCandidate = field(
         repr=False,
         compare=False,
@@ -712,7 +876,7 @@ class AcceptedGridDirectTrfResult(AcceptedFitResult):
         workflow_invocation: GridDirectTrfInvocation,
         selection: GridSelection,
         selected_seed: GridSeed,
-        selected_outcome: GridSeedOutcome,
+        selected_outcome: GridCandidateRecord,
         fresh_candidate: MaterializedDirectTrfCandidate,
     ) -> AcceptedGridDirectTrfResult:
         """Attach GRID provenance to already accepted root evidence."""
@@ -747,32 +911,34 @@ def validate_grid_acceptance_lineage(
     invocation: GridDirectTrfInvocation,
     selection: GridSelection,
     selected_seed: GridSeed,
-    selected_outcome: GridSeedOutcome,
+    selected_outcome: GridCandidateRecord,
     fresh_candidate: MaterializedDirectTrfCandidate,
     problem: OptimizationProblem,
 ) -> None:
-    """Validate complete GRID lineage before Direct TRF grants live authority."""
-    fresh_materialization = fresh_candidate.materialization
+    """Validate canonical selection and fresh root promotion for any GRID record."""
     candidate = selected_outcome.candidate
-    direct_outcome = selected_outcome.direct_outcome
     try:
         canonical_seed = invocation.seeds[provenance.selected_seed_ordinal]
     except (AttributeError, IndexError, TypeError):
         canonical_seed = None
-    child_problem = None if canonical_seed is None else canonical_seed.problem
-    child_invocation = None if canonical_seed is None else canonical_seed.invocation
     materialized_candidate = None if candidate is None else candidate.candidate
     candidate_materialization = (
         None
         if materialized_candidate is None
         else materialized_candidate.materialization
     )
-    candidate_evaluation = (
-        None
-        if materialized_candidate is None
-        else materialized_candidate.evaluation_result
-    )
-    derivation = None if child_problem is None else child_problem.derivation
+    fresh_materialization = fresh_candidate.materialization
+    try:
+        if canonical_seed is not None:
+            selected_outcome.validate_for_grid_selection(
+                problem,
+                invocation,
+                canonical_seed,
+            )
+    except Exception as error:
+        raise DirectTrfConstructionError(
+            "Accepted GRID result lacks its canonical selection authority"
+        ) from error
     if (
         not isinstance(provenance, GridSelectionProvenance)
         or invocation.root_problem_identity != problem.identity
@@ -792,41 +958,36 @@ def validate_grid_acceptance_lineage(
         or materialized_candidate is None
         or selection.selected_candidate_identity != candidate.identity
         or provenance.grid_candidate_identity != candidate.identity
-        or direct_outcome is None
-        or direct_outcome.candidate is not materialized_candidate
-        or child_problem is None
-        or child_invocation is None
-        or not isinstance(derivation, GridSeedProblemDerivation)
-        or derivation.root_problem_identity != problem.identity
-        or derivation.seed_identity != selected_seed.coordinate_identity
-        or derivation.seed_ordinal != selected_seed.ordinal
-        or child_problem.source_snapshot != problem.source_snapshot
         or provenance.materialized_candidate_identity != materialized_candidate.identity
-        or provenance.candidate_problem_identity != child_problem.identity
-        or provenance.candidate_invocation_identity != child_invocation.identity
-        or provenance.candidate_execution_identity != direct_outcome.execution.identity
+        or provenance.candidate_problem_identity
+        != materialized_candidate.problem_identity
+        or provenance.candidate_invocation_identity
+        != materialized_candidate.invocation_identity
+        or provenance.candidate_execution_identity
+        != materialized_candidate.execution_identity
         or candidate_materialization is None
         or provenance.candidate_materialization_identity
         != candidate_materialization.identity
-        or candidate_evaluation is None
-        or candidate_materialization.evaluation_identity
-        != candidate_evaluation.identity
-        or candidate_materialization.problem_identity != child_problem.identity
-        or candidate_materialization.invocation_identity != child_invocation.identity
+        or candidate_materialization.problem_identity
+        != materialized_candidate.problem_identity
+        or candidate_materialization.invocation_identity
+        != materialized_candidate.invocation_identity
         or candidate_materialization.execution_identity
-        != direct_outcome.execution.identity
-        or candidate_evaluation.plan_identity != problem.evaluation_plan_identity
-        or candidate_evaluation.parameterization_identity
-        != problem.evaluator_parameterization_identity
-        or tuple(candidate_evaluation.resolved_values) != problem.commit_scope
+        != materialized_candidate.execution_identity
+        or candidate_materialization.evaluation_identity
+        != materialized_candidate.evaluation_result.identity
         or provenance.accepted_materialization_identity
         != fresh_materialization.identity
         or fresh_candidate.problem_identity != problem.identity
-        or fresh_candidate.invocation_identity != child_invocation.identity
-        or fresh_candidate.execution_identity != direct_outcome.execution.identity
+        or fresh_candidate.invocation_identity
+        != materialized_candidate.invocation_identity
+        or fresh_candidate.execution_identity
+        != materialized_candidate.execution_identity
         or fresh_materialization.problem_identity != problem.identity
-        or fresh_materialization.invocation_identity != child_invocation.identity
-        or fresh_materialization.execution_identity != direct_outcome.execution.identity
+        or fresh_materialization.invocation_identity
+        != materialized_candidate.invocation_identity
+        or fresh_materialization.execution_identity
+        != materialized_candidate.execution_identity
         or fresh_materialization.terminal is not MaterializationTerminal.SUCCESS
         or fresh_materialization.candidate.vector != fresh_candidate.vector
         or fresh_materialization.candidate.chi_square != fresh_candidate.chi_square
@@ -842,6 +1003,8 @@ def validate_grid_acceptance_lineage(
         != problem.evaluator_parameterization_identity
         or tuple(fresh_candidate.evaluation_result.resolved_values)
         != problem.commit_scope
+        or fresh_candidate.vector != candidate.vector
+        or fresh_candidate.chi_square != candidate.objective
     ):
         raise DirectTrfConstructionError(
             "Accepted GRID result lacks its canonical selection authority"
@@ -943,7 +1106,7 @@ class GridDirectTrfOutcome:
     """Complete GRID occurrence; only ACCEPTED carries root fit authority."""
 
     terminal: GridDirectTrfTerminal
-    attempts: tuple[GridSeedOutcome, ...]
+    attempts: tuple[GridCandidateRecord, ...]
     selection: GridSelection | None = None
     materialization: CandidateMaterialization | None = field(
         default=None,
@@ -1182,8 +1345,8 @@ def _disposition_for_unsuccessful(
 
 
 def _selection(
-    attempts: Sequence[GridSeedOutcome],
-) -> tuple[GridSelection, GridSeedOutcome]:
+    attempts: Sequence[GridCandidateRecord],
+) -> tuple[GridSelection, GridCandidateRecord]:
     eligible = sorted(
         (
             attempt
@@ -1202,6 +1365,286 @@ def _selection(
         candidate_records=eligible,
     )
     return selection, selected
+
+
+def _grid_finalization_gate(
+    cancellation: CancellationToken,
+) -> GridDirectTrfTerminal | None:
+    """Gate canonical selection against late cancellation or interruption."""
+    try:
+        return GridDirectTrfTerminal.CANCELLED if cancellation.is_cancelled else None
+    except KeyboardInterrupt:
+        return GridDirectTrfTerminal.INTERRUPTED
+
+
+def _failed_root_materialization(
+    problem: OptimizationProblem,
+    candidate: MaterializedDirectTrfCandidate,
+    evaluator_compatibility_identity: str,
+    evaluation_count: int,
+    cache_hits: int,
+    cache_misses: int,
+    failure: TerminalFailure,
+    *,
+    terminal: MaterializationTerminal = MaterializationTerminal.FAILURE,
+) -> CandidateMaterialization:
+    return CandidateMaterialization(
+        uuid4().hex,
+        problem.identity,
+        candidate.invocation_identity,
+        candidate.execution_identity,
+        CandidateSummary(candidate.vector, candidate.chi_square, 0),
+        terminal,
+        evaluation_count,
+        evaluator_compatibility_identity,
+        None,
+        cache_hits,
+        cache_misses,
+        failure,
+    )
+
+
+def _materialize_grid_candidate_for_root(
+    problem: OptimizationProblem,
+    candidate: MaterializedDirectTrfCandidate,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    cancellation: CancellationToken,
+) -> MaterializedDirectTrfCandidate | CandidateMaterialization:
+    """Freshly evaluate one selected GRID vector against the complete root."""
+    try:
+        evaluator = engine.new_evaluator()
+    except Exception as error:  # noqa: BLE001 - binding failure is typed evidence
+        return _failed_root_materialization(
+            problem,
+            candidate,
+            engine.compatibility_identity,
+            0,
+            0,
+            0,
+            TerminalFailure(
+                "grid_selection_materialization_binding_failure",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    if cancellation.is_cancelled:
+        return _failed_root_materialization(
+            problem,
+            candidate,
+            evaluator.compatibility_identity,
+            0,
+            0,
+            0,
+            TerminalFailure("cancelled", "Cancellation before GRID promotion"),
+            terminal=MaterializationTerminal.CANCELLED,
+        )
+    try:
+        lifecycle = problem.lifecycle_frame(candidate.vector, parameterization)
+        frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
+        evaluated = evaluator.evaluate(frame)
+    except KeyboardInterrupt:
+        statistics = evaluator.cache_statistics
+        return _failed_root_materialization(
+            problem,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure("interrupted", "KeyboardInterrupt during GRID promotion"),
+            terminal=MaterializationTerminal.INTERRUPTED,
+        )
+    except Exception as error:  # noqa: BLE001 - root evaluation fails closed
+        statistics = evaluator.cache_statistics
+        return _failed_root_materialization(
+            problem,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(
+                "grid_selection_materialization_exception",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    statistics = evaluator.cache_statistics
+    if cancellation.is_cancelled:
+        return _failed_root_materialization(
+            problem,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure("cancelled", "Cancellation after GRID promotion"),
+            terminal=MaterializationTerminal.CANCELLED,
+        )
+    if isinstance(evaluated, EvaluationFailure):
+        return _failed_root_materialization(
+            problem,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(evaluated.category, evaluated.message, evaluated),
+        )
+    chi_square = canonical_chi_square(evaluated.residuals)
+    if chi_square != candidate.chi_square:
+        return _failed_root_materialization(
+            problem,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(
+                "grid_selection_objective_mismatch",
+                "Fresh root objective differs from the selected aggregate candidate",
+            ),
+        )
+    materialization = CandidateMaterialization(
+        uuid4().hex,
+        problem.identity,
+        candidate.invocation_identity,
+        candidate.execution_identity,
+        CandidateSummary(candidate.vector, chi_square, 0),
+        MaterializationTerminal.SUCCESS,
+        1,
+        evaluator.compatibility_identity,
+        evaluated.identity,
+        statistics.hits,
+        statistics.misses,
+    )
+    return MaterializedDirectTrfCandidate(
+        problem.identity,
+        candidate.invocation_identity,
+        candidate.execution_identity,
+        materialization,
+        candidate.vector,
+        chi_square,
+        evaluated,
+    )
+
+
+def _finalize_grid_candidates(
+    problem: OptimizationProblem,
+    invocation: GridDirectTrfInvocation,
+    attempts: Sequence[GridCandidateRecord],
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    cancellation: CancellationToken,
+) -> GridDirectTrfOutcome:
+    """Own canonical validation, selection, promotion, acceptance, and authority."""
+    records = tuple(attempts)
+    gate = _grid_finalization_gate(cancellation)
+    if gate is not None:
+        return GridDirectTrfOutcome(gate, records)
+    eligible = tuple(
+        record
+        for record in records
+        if record.disposition is GridSeedDisposition.ELIGIBLE
+    )
+    if not eligible:
+        return GridDirectTrfOutcome(
+            GridDirectTrfTerminal.NO_ELIGIBLE_CANDIDATE,
+            records,
+        )
+    try:
+        for record in eligible:
+            seed = invocation.seeds[record.seed_ordinal]
+            record.validate_for_grid_selection(problem, invocation, seed)
+    except Exception as error:  # noqa: BLE001 - foreign evidence fails closed
+        return GridDirectTrfOutcome(
+            GridDirectTrfTerminal.EXECUTION_FAILURE,
+            records,
+            failure=TerminalFailure(
+                "grid_candidate_lineage_failure",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    gate = _grid_finalization_gate(cancellation)
+    if gate is not None:
+        return GridDirectTrfOutcome(gate, records)
+    selection, selected = _selection(eligible)
+    selected_seed = invocation.seeds[selected.seed_ordinal]
+    selected_candidate = cast("GridCandidate", selected.candidate)
+    promoted = _materialize_grid_candidate_for_root(
+        problem,
+        selected_candidate.candidate,
+        parameterization,
+        engine,
+        cancellation,
+    )
+    if isinstance(promoted, CandidateMaterialization):
+        terminal = {
+            MaterializationTerminal.CANCELLED: GridDirectTrfTerminal.CANCELLED,
+            MaterializationTerminal.INTERRUPTED: GridDirectTrfTerminal.INTERRUPTED,
+        }.get(
+            promoted.terminal,
+            GridDirectTrfTerminal.MATERIALIZATION_FAILURE,
+        )
+        return GridDirectTrfOutcome(
+            terminal,
+            records,
+            selection,
+            promoted,
+            failure=promoted.failure,
+        )
+    provenance = GridSelectionProvenance(
+        invocation.identity,
+        problem.identity,
+        selection.identity,
+        selected.seed_identity,
+        selected.seed_ordinal,
+        selected_candidate.identity,
+        selected_candidate.candidate.identity,
+        selected_candidate.candidate.problem_identity,
+        selected_candidate.candidate.invocation_identity,
+        selected_candidate.candidate.execution_identity,
+        selected_candidate.candidate.materialization.identity,
+        promoted.materialization.identity,
+        promoted.evaluation_result.identity,
+    )
+    validate_grid_acceptance_lineage(
+        provenance,
+        invocation,
+        selection,
+        selected_seed,
+        selected,
+        promoted,
+        problem,
+    )
+    root_accepted = _accept_materialized_fit_for_derived_workflow(
+        problem=problem,
+        invocation_identity=promoted.invocation_identity,
+        execution_identity=promoted.execution_identity,
+        materialization=promoted.materialization,
+        vector=promoted.vector,
+        chi_square=promoted.chi_square,
+        evaluation_result=promoted.evaluation_result,
+        authority_context_identity=provenance.identity,
+    )
+    accepted = AcceptedGridDirectTrfResult.from_accepted(
+        root_accepted,
+        provenance,
+        invocation,
+        selection,
+        selected_seed,
+        selected,
+        promoted,
+    )
+    validate_grid_commit_lineage(accepted, problem)
+    authority = _grant_derived_fit_commit_authority(accepted, problem)
+    return GridDirectTrfOutcome(
+        GridDirectTrfTerminal.ACCEPTED,
+        records,
+        selection,
+        promoted.materialization,
+        accepted,
+        authority,
+    )
 
 
 class _GridSeedInterrupted(KeyboardInterrupt):
@@ -1361,138 +1804,11 @@ def execute_grid_direct_trf(
     )
     if isinstance(seed_execution, GridDirectTrfOutcome):
         return seed_execution
-    attempts = seed_execution
-    if not any(
-        attempt.disposition is GridSeedDisposition.ELIGIBLE for attempt in attempts
-    ):
-        return GridDirectTrfOutcome(
-            GridDirectTrfTerminal.NO_ELIGIBLE_CANDIDATE,
-            tuple(attempts),
-        )
-    selection, selected = _selection(attempts)
-    selected_seed = invocation.seeds[selected.seed_ordinal]
-    if (
-        selected.direct_outcome is None
-        or selected_seed.problem is None
-        or selected_seed.invocation is None
-    ):
-        failure = TerminalFailure(
-            "grid_selection_failure",
-            "Selected GRID candidate lacks its exact attempt provenance",
-        )
-        return GridDirectTrfOutcome(
-            GridDirectTrfTerminal.EXECUTION_FAILURE,
-            tuple(attempts),
-            selection,
-            failure=failure,
-        )
-    selected_candidate = cast("GridCandidate", selected.candidate)
-    try:
-        promoted = _materialize_direct_trf_candidate_for_root(
-            problem,
-            selected_seed.problem,
-            selected_seed.invocation,
-            selected.direct_outcome,
-            parameterization,
-            engine,
-            cancellation=token,
-        )
-        if isinstance(promoted, MaterializedDirectTrfCandidate):
-            grid_selection_provenance = GridSelectionProvenance(
-                invocation.identity,
-                problem.identity,
-                selection.identity,
-                selected.seed_identity,
-                selected.seed_ordinal,
-                selected_candidate.identity,
-                selected_candidate.candidate.identity,
-                selected_seed.problem.identity,
-                selected_seed.invocation.identity,
-                selected.direct_outcome.execution.identity,
-                selected_candidate.candidate.materialization.identity,
-                promoted.materialization.identity,
-                promoted.evaluation_result.identity,
-            )
-            validate_grid_acceptance_lineage(
-                grid_selection_provenance,
-                invocation,
-                selection,
-                selected_seed,
-                selected,
-                promoted,
-                problem,
-            )
-            root_accepted = _accept_materialized_fit_for_derived_workflow(
-                problem=problem,
-                invocation_identity=selected_seed.invocation.identity,
-                execution_identity=selected.direct_outcome.execution.identity,
-                materialization=promoted.materialization,
-                vector=promoted.vector,
-                chi_square=promoted.chi_square,
-                evaluation_result=promoted.evaluation_result,
-                authority_context_identity=grid_selection_provenance.identity,
-            )
-            grid_accepted = AcceptedGridDirectTrfResult.from_accepted(
-                root_accepted,
-                grid_selection_provenance,
-                invocation,
-                selection,
-                selected_seed,
-                selected,
-                promoted,
-            )
-            validate_grid_commit_lineage(grid_accepted, problem)
-            authority = _grant_derived_fit_commit_authority(
-                grid_accepted,
-                problem,
-            )
-            return GridDirectTrfOutcome(
-                GridDirectTrfTerminal.ACCEPTED,
-                tuple(attempts),
-                selection,
-                promoted.materialization,
-                grid_accepted,
-                authority,
-            )
-    except DirectTrfInterrupted as interrupted:
-        raise GridDirectTrfInterrupted(
-            _interrupted_outcome(
-                attempts,
-                (),
-                selection,
-                interrupted.materialization,
-            )
-        ) from interrupted
-    except KeyboardInterrupt as error:
-        raise GridDirectTrfInterrupted(
-            _interrupted_outcome(attempts, (), selection)
-        ) from error
-    except Exception as error:  # noqa: BLE001 - selection promotion fails closed
-        failure = TerminalFailure(
-            "grid_selection_materialization_exception",
-            f"{type(error).__name__}: {error}",
-        )
-        return GridDirectTrfOutcome(
-            GridDirectTrfTerminal.EXECUTION_FAILURE,
-            tuple(attempts),
-            selection,
-            failure=failure,
-        )
-    if promoted.terminal is DirectTrfOutcomeTerminal.CANCELLED:
-        return GridDirectTrfOutcome(
-            GridDirectTrfTerminal.CANCELLED,
-            tuple(attempts),
-            selection,
-            promoted.materialization,
-        )
-    return GridDirectTrfOutcome(
-        GridDirectTrfTerminal.MATERIALIZATION_FAILURE,
-        tuple(attempts),
-        selection,
-        promoted.materialization,
-        failure=(
-            promoted.materialization.failure
-            if promoted.materialization is not None
-            else promoted.execution.failure
-        ),
+    return _finalize_grid_candidates(
+        problem,
+        invocation,
+        seed_execution,
+        parameterization,
+        engine,
+        token,
     )

--- a/src/chemex/optimize/grouped_grid_direct_trf.py
+++ b/src/chemex/optimize/grouped_grid_direct_trf.py
@@ -1,0 +1,1166 @@
+"""Exact fit-component GRID to native Direct TRF qualification (#596).
+
+This isolated qualification path composes the grouped Direct TRF contract with
+the Cartesian GRID contract.  It is intentionally not wired into production
+dispatch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import cast
+from uuid import uuid4
+
+from chemex.evaluation.native import (
+    BoundEvaluator,
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationResult,
+)
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    CancellationToken,
+    CandidateMaterialization,
+    CandidateSummary,
+    CommitReceipt,
+    DirectTrfConstructionError,
+    DirectTrfInvocation,
+    GridSeedProblemDerivation,
+    LiveFitCommitAuthority,
+    MaterializationTerminal,
+    MaterializedDirectTrfCandidate,
+    OptimizationProblem,
+    TerminalFailure,
+    _accept_materialized_fit_for_derived_workflow,
+    _grant_derived_fit_commit_authority,
+    canonical_chi_square,
+    commit_accepted_fit,
+)
+from chemex.optimize.grid_direct_trf import (
+    GridCandidate,
+    GridCoordinate,
+    GridDirectTrfInvocation,
+    GridSeed,
+    GridSeedDisposition,
+    _validate_grid_context,
+)
+from chemex.optimize.grouped_direct_trf import (
+    ComponentDisposition,
+    FitComponentOutcome,
+    FitDecomposition,
+    GroupedDirectTrfInvocation,
+    GroupedDirectTrfOutcome,
+    GroupedDirectTrfTerminal,
+    _reconstruct_fresh_aggregate,
+    _root_projection_matches,
+    _validate_component_projections,
+    execute_direct_trf_components,
+)
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.values import AnalysisValues
+
+_SCHEMA_VERSION = 1
+_WORKFLOW_VERSION = "native-grouped-cartesian-grid-direct-trf-v1"
+_AGGREGATE_ORDER_VERSION = "aggregate-chi-square-vector-seed-ordinal-v1"
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "record": record, "schema_version": _SCHEMA_VERSION},
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedGridSeedOutcome:
+    """One seed's component evidence and fresh non-authoritative aggregate."""
+
+    seed_identity: str
+    seed_ordinal: int
+    axis_items: tuple[tuple[str, GridCoordinate], ...]
+    start: tuple[GridCoordinate, ...]
+    disposition: GridSeedDisposition
+    components: tuple[FitComponentOutcome, ...]
+    seed_decomposition: FitDecomposition | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        kw_only=True,
+    )
+    component_invocation: GroupedDirectTrfInvocation | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    execution_identity: str | None = None
+    objective: float | None = None
+    candidate: GridCandidate | None = field(default=None, repr=False, compare=False)
+    failure: TerminalFailure | None = None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        eligible = self.disposition is GridSeedDisposition.ELIGIBLE
+        if eligible != (self.candidate is not None and self.objective is not None):
+            raise ValueError("Only an eligible grouped GRID seed has an aggregate")
+        if eligible and (
+            self.seed_decomposition is None
+            or self.component_invocation is None
+            or self.execution_identity is None
+            or self.candidate is None
+            or self.candidate.seed_identity != self.seed_identity
+            or self.candidate.seed_ordinal != self.seed_ordinal
+            or self.candidate.objective != self.objective
+            or self.candidate.candidate.execution_identity != self.execution_identity
+            or any(
+                component.disposition is not ComponentDisposition.SUCCEEDED
+                for component in self.components
+            )
+        ):
+            raise ValueError(
+                "Eligible grouped GRID seed lacks its exact aggregate evidence"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grouped-grid-seed-outcome",
+                (
+                    self.seed_identity,
+                    self.seed_ordinal,
+                    self.disposition.value,
+                    tuple(component.identity for component in self.components),
+                    None
+                    if self.seed_decomposition is None
+                    else self.seed_decomposition.identity,
+                    None
+                    if self.component_invocation is None
+                    else self.component_invocation.identity,
+                    self.execution_identity,
+                    None if self.candidate is None else self.candidate.identity,
+                    None if self.failure is None else self.failure.identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedGridSelection:
+    """Canonical ordering over fresh whole-problem aggregate candidates."""
+
+    selected_seed_identity: str
+    selected_seed_ordinal: int
+    selected_candidate_identity: str
+    eligible_candidate_identities: tuple[str, ...]
+    candidate_records: tuple[GroupedGridSeedOutcome, ...] = field(
+        repr=False,
+        compare=False,
+    )
+    ordering_policy: str = _AGGREGATE_ORDER_VERSION
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        selected = tuple(
+            record
+            for record in self.candidate_records
+            if record.seed_identity == self.selected_seed_identity
+            and record.seed_ordinal == self.selected_seed_ordinal
+            and record.candidate is not None
+            and record.candidate.identity == self.selected_candidate_identity
+        )
+        candidate_identities = tuple(
+            cast("GridCandidate", record.candidate).identity
+            for record in self.candidate_records
+        )
+        if (
+            self.ordering_policy != _AGGREGATE_ORDER_VERSION
+            or not self.candidate_records
+            or any(
+                record.disposition is not GridSeedDisposition.ELIGIBLE
+                or record.candidate is None
+                for record in self.candidate_records
+            )
+            or candidate_identities != self.eligible_candidate_identities
+            or self.eligible_candidate_identities[0] != self.selected_candidate_identity
+            or len(selected) != 1
+            or selected[0].identity != self.candidate_records[0].identity
+        ):
+            raise ValueError(
+                "Grouped GRID selection requires one canonical aggregate winner"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grouped-grid-selection",
+                (
+                    self.ordering_policy,
+                    self.selected_seed_identity,
+                    self.selected_seed_ordinal,
+                    self.selected_candidate_identity,
+                    self.eligible_candidate_identities,
+                ),
+            ),
+        )
+
+    @classmethod
+    def from_candidate_records(
+        cls,
+        records: Sequence[GroupedGridSeedOutcome],
+    ) -> GroupedGridSelection:
+        ordered = tuple(
+            sorted(
+                records,
+                key=lambda record: cast(
+                    "GridCandidate", record.candidate
+                ).ordering_key(),
+            )
+        )
+        if not ordered or any(record.candidate is None for record in ordered):
+            raise ValueError("Grouped GRID selection requires aggregate candidates")
+        selected = ordered[0]
+        candidate = cast("GridCandidate", selected.candidate)
+        return cls(
+            selected.seed_identity,
+            selected.seed_ordinal,
+            candidate.identity,
+            tuple(
+                cast("GridCandidate", record.candidate).identity for record in ordered
+            ),
+            ordered,
+        )
+
+    @property
+    def selected_record(self) -> GroupedGridSeedOutcome:
+        return self.candidate_records[0]
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedGridSelectionProvenance:
+    """Complete authority lineage from one aggregate GRID winner."""
+
+    workflow_invocation_identity: str
+    root_problem_identity: str
+    decomposition_identity: str
+    selection_identity: str
+    selected_seed_identity: str
+    selected_seed_ordinal: int
+    selected_outcome_identity: str
+    aggregate_candidate_identity: str
+    aggregate_materialization_identity: str
+    accepted_materialization_identity: str
+    accepted_evaluation_identity: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-grouped-grid-selection-provenance",
+                (
+                    _WORKFLOW_VERSION,
+                    self.workflow_invocation_identity,
+                    self.root_problem_identity,
+                    self.decomposition_identity,
+                    self.selection_identity,
+                    self.selected_seed_identity,
+                    self.selected_seed_ordinal,
+                    self.selected_outcome_identity,
+                    self.aggregate_candidate_identity,
+                    self.aggregate_materialization_identity,
+                    self.accepted_materialization_identity,
+                    self.accepted_evaluation_identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedGroupedGridDirectTrfResult(AcceptedFitResult):
+    """Accepted root evidence carrying exact grouped-GRID selection lineage."""
+
+    grouped_grid_provenance: GroupedGridSelectionProvenance
+    workflow_invocation: GridDirectTrfInvocation = field(repr=False, compare=False)
+    decomposition: FitDecomposition = field(repr=False, compare=False)
+    selection: GroupedGridSelection = field(repr=False, compare=False)
+    selected_seed: GridSeed = field(repr=False, compare=False)
+    selected_outcome: GroupedGridSeedOutcome = field(repr=False, compare=False)
+    fresh_candidate: MaterializedDirectTrfCandidate = field(
+        repr=False,
+        compare=False,
+    )
+
+    @classmethod
+    def from_accepted(
+        cls,
+        accepted: AcceptedFitResult,
+        provenance: GroupedGridSelectionProvenance,
+        workflow_invocation: GridDirectTrfInvocation,
+        decomposition: FitDecomposition,
+        selection: GroupedGridSelection,
+        selected_seed: GridSeed,
+        selected_outcome: GroupedGridSeedOutcome,
+        fresh_candidate: MaterializedDirectTrfCandidate,
+    ) -> AcceptedGroupedGridDirectTrfResult:
+        return cls(
+            accepted.occurrence_identity,
+            accepted.problem_identity,
+            accepted.invocation_identity,
+            accepted.execution_identity,
+            accepted.materialization_identity,
+            accepted.parameterization_identity,
+            accepted.evaluator_parameterization_identity,
+            accepted.source_occurrence_identity,
+            accepted.source_revision,
+            accepted.controlled_ids,
+            accepted.vector,
+            accepted.chi_square,
+            accepted.evaluation_result,
+            accepted.commit_scope,
+            accepted.commit_items,
+            accepted.origin_context_identity,
+            provenance,
+            workflow_invocation,
+            decomposition,
+            selection,
+            selected_seed,
+            selected_outcome,
+            fresh_candidate,
+        )
+
+
+class GroupedGridDirectTrfTerminal(StrEnum):
+    """Closed outcomes of one grouped GRID to Direct TRF occurrence."""
+
+    ACCEPTED = "accepted"
+    NO_ELIGIBLE_CANDIDATE = "no_eligible_candidate"
+    EXECUTION_FAILURE = "execution_failure"
+    MATERIALIZATION_FAILURE = "materialization_failure"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedGridDirectTrfOutcome:
+    """Complete occurrence; only the selected root aggregate has authority."""
+
+    terminal: GroupedGridDirectTrfTerminal
+    attempts: tuple[GroupedGridSeedOutcome, ...]
+    selection: GroupedGridSelection | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    accepted_result: AcceptedGroupedGridDirectTrfResult | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    commit_authority: LiveFitCommitAuthority | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    failure: TerminalFailure | None = None
+
+    def __post_init__(self) -> None:
+        accepted = self.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
+        if accepted != (
+            self.accepted_result is not None and self.commit_authority is not None
+        ):
+            raise ValueError("Only accepted grouped GRID execution has authority")
+        if not accepted and (
+            self.accepted_result is not None or self.commit_authority is not None
+        ):
+            raise ValueError("Unaccepted grouped GRID execution cannot have authority")
+        if accepted and self.selection is None:
+            raise ValueError("Accepted grouped GRID execution requires a selection")
+
+
+def _validate_context(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    invocation: GridDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+) -> None:
+    _validate_grid_context(problem, invocation, parameterization, engine)
+    expected = FitDecomposition.from_root(problem, parameterization, engine)
+    if (
+        not problem.acceptance_authority
+        or decomposition.root_problem_identity != problem.identity
+        or decomposition.identity != expected.identity
+        or invocation.root_problem_identity != problem.identity
+    ):
+        raise DirectTrfConstructionError(
+            "Grouped GRID context is not rooted in one complete problem"
+        )
+
+
+def _component_invocation(
+    root_problem: OptimizationProblem,
+    seed_decomposition: FitDecomposition,
+    invocation: GridDirectTrfInvocation,
+) -> GroupedDirectTrfInvocation:
+    root_scales = dict(
+        zip(root_problem.controlled_ids, invocation.x_scale, strict=True)
+    )
+    component_invocations = tuple(
+        DirectTrfInvocation.for_problem(
+            component.problem,
+            objective_request_budget=invocation.objective_request_budget,
+            x_scale=tuple(
+                root_scales[param_id] for param_id in component.controlled_ids
+            ),
+            ftol=invocation.ftol,
+            xtol=invocation.xtol,
+            gtol=invocation.gtol,
+        )
+        for component in seed_decomposition.components
+    )
+    return GroupedDirectTrfInvocation(
+        seed_decomposition.root_problem_identity,
+        seed_decomposition.identity,
+        component_invocations,
+    )
+
+
+def _fresh_root_candidate(
+    problem: OptimizationProblem,
+    invocation_identity: str,
+    execution_identity: str,
+    vector: tuple[float, ...],
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+) -> MaterializedDirectTrfCandidate:
+    lifecycle = problem.lifecycle_frame(vector, parameterization)
+    frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
+    evaluator = engine.new_evaluator()
+    evaluated = evaluator.evaluate(frame)
+    if isinstance(evaluated, EvaluationFailure):
+        raise DirectTrfConstructionError(
+            f"Grouped GRID root materialization failed: {evaluated.message}"
+        )
+    return _materialized_root_candidate(
+        problem,
+        invocation_identity,
+        execution_identity,
+        vector,
+        evaluator,
+        evaluated,
+    )
+
+
+def _materialized_root_candidate(
+    problem: OptimizationProblem,
+    invocation_identity: str,
+    execution_identity: str,
+    vector: tuple[float, ...],
+    evaluator: BoundEvaluator,
+    evaluated: EvaluationResult,
+) -> MaterializedDirectTrfCandidate:
+    """Record one already evaluated root vector as fresh candidate evidence."""
+    chi_square = canonical_chi_square(evaluated.residuals)
+    statistics = evaluator.cache_statistics
+    summary = CandidateSummary(vector, chi_square, 0)
+    materialization = CandidateMaterialization(
+        uuid4().hex,
+        problem.identity,
+        invocation_identity,
+        execution_identity,
+        summary,
+        MaterializationTerminal.SUCCESS,
+        1,
+        evaluator.compatibility_identity,
+        evaluated.identity,
+        statistics.hits,
+        statistics.misses,
+    )
+    return MaterializedDirectTrfCandidate(
+        problem.identity,
+        invocation_identity,
+        execution_identity,
+        materialization,
+        vector,
+        chi_square,
+        evaluated,
+    )
+
+
+def _failed_component_seed_outcome(
+    seed: GridSeed,
+    seed_decomposition: FitDecomposition,
+    components: tuple[FitComponentOutcome, ...],
+    component_invocation: GroupedDirectTrfInvocation,
+) -> GroupedGridSeedOutcome:
+    dispositions = tuple(component.disposition for component in components)
+    if ComponentDisposition.CANCELLED in dispositions:
+        disposition = GridSeedDisposition.CANCELLED
+    elif ComponentDisposition.INTERRUPTED in dispositions:
+        disposition = GridSeedDisposition.INTERRUPTED
+    elif ComponentDisposition.EXECUTION_FAILURE in dispositions:
+        disposition = GridSeedDisposition.IMPLEMENTATION_FAILURE
+    else:
+        disposition = GridSeedDisposition.NON_CONVERGED
+    failure = next(
+        (component.failure for component in components if component.failure),
+        TerminalFailure("component_failure", "A grouped GRID component failed"),
+    )
+    return GroupedGridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        disposition,
+        components,
+        component_invocation,
+        failure=failure,
+        seed_decomposition=seed_decomposition,
+    )
+
+
+def _failed_aggregate_seed_outcome(
+    seed: GridSeed,
+    seed_decomposition: FitDecomposition,
+    components: tuple[FitComponentOutcome, ...],
+    component_invocation: GroupedDirectTrfInvocation,
+    outcome: GroupedDirectTrfOutcome,
+) -> GroupedGridSeedOutcome:
+    disposition = {
+        GroupedDirectTrfTerminal.CANCELLED: GridSeedDisposition.CANCELLED,
+        GroupedDirectTrfTerminal.INTERRUPTED: GridSeedDisposition.INTERRUPTED,
+        GroupedDirectTrfTerminal.EXECUTION_FAILURE: (
+            GridSeedDisposition.IMPLEMENTATION_FAILURE
+        ),
+    }.get(outcome.terminal, GridSeedDisposition.MATERIALIZATION_FAILURE)
+    return GroupedGridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        disposition,
+        components,
+        component_invocation,
+        failure=outcome.failure,
+        seed_decomposition=seed_decomposition,
+    )
+
+
+def _execute_seed(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    invocation: GridDirectTrfInvocation,
+    seed: GridSeed,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    token: CancellationToken,
+) -> GroupedGridSeedOutcome:
+    if seed.rejection is not None:
+        disposition = (
+            GridSeedDisposition.UNUSABLE_VALUE
+            if seed.rejection.category == "grid_seed_unusable_value"
+            else GridSeedDisposition.OUT_OF_BOUNDS
+        )
+        return GroupedGridSeedOutcome(
+            seed.identity,
+            seed.ordinal,
+            seed.axis_items,
+            seed.start,
+            disposition,
+            (),
+            failure=seed.rejection,
+        )
+    if seed.problem is None:
+        raise DirectTrfConstructionError("Feasible grouped GRID seed lacks a problem")
+    seed_decomposition = FitDecomposition.from_root(
+        seed.problem,
+        parameterization,
+        engine,
+        cancellation=token,
+    )
+    if (
+        seed_decomposition.identity != decomposition.identity
+        or tuple(component.identity for component in seed_decomposition.components)
+        != tuple(component.identity for component in decomposition.components)
+        or seed.problem.source_snapshot is not problem.source_snapshot
+    ):
+        raise DirectTrfConstructionError(
+            "Grouped GRID seed differs from the exact root decomposition"
+        )
+    component_invocation = _component_invocation(
+        problem,
+        seed_decomposition,
+        invocation,
+    )
+    components = execute_direct_trf_components(
+        seed_decomposition,
+        component_invocation,
+        parameterization,
+        engine,
+        cancellation=token,
+    )
+    if any(
+        component.disposition is not ComponentDisposition.SUCCEEDED
+        for component in components
+    ):
+        return _failed_component_seed_outcome(
+            seed,
+            seed_decomposition,
+            components,
+            component_invocation,
+        )
+    projections = _validate_component_projections(
+        seed_decomposition,
+        component_invocation,
+        engine,
+        components,
+        token,
+    )
+    if isinstance(projections, GroupedDirectTrfOutcome):
+        return _failed_aggregate_seed_outcome(
+            seed,
+            seed_decomposition,
+            components,
+            component_invocation,
+            projections,
+        )
+    fresh = _reconstruct_fresh_aggregate(
+        problem,
+        seed_decomposition,
+        parameterization,
+        engine,
+        components,
+        token,
+    )
+    if isinstance(fresh, GroupedDirectTrfOutcome):
+        return _failed_aggregate_seed_outcome(
+            seed,
+            seed_decomposition,
+            components,
+            component_invocation,
+            fresh,
+        )
+    vector, evaluator, aggregate = fresh
+    if any(
+        not _root_projection_matches(aggregate, engine, component, projection)
+        for component, projection in zip(
+            seed_decomposition.components,
+            projections,
+            strict=True,
+        )
+    ):
+        return GroupedGridSeedOutcome(
+            seed.identity,
+            seed.ordinal,
+            seed.axis_items,
+            seed.start,
+            GridSeedDisposition.MATERIALIZATION_FAILURE,
+            components,
+            component_invocation,
+            failure=TerminalFailure(
+                "decomposition_projection_mismatch",
+                "Fresh grouped GRID aggregate differs from component evidence",
+            ),
+            seed_decomposition=seed_decomposition,
+        )
+    execution_identity = _identity(
+        "native-grouped-grid-seed-execution",
+        (
+            invocation.identity,
+            seed.identity,
+            component_invocation.identity,
+            tuple(component.identity for component in components),
+            aggregate.identity,
+        ),
+    )
+    materialized = _materialized_root_candidate(
+        problem,
+        invocation.identity,
+        execution_identity,
+        vector,
+        evaluator,
+        aggregate,
+    )
+    candidate = GridCandidate(seed.identity, seed.ordinal, materialized)
+    return GroupedGridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        GridSeedDisposition.ELIGIBLE,
+        components,
+        component_invocation,
+        execution_identity,
+        candidate.objective,
+        candidate,
+        seed_decomposition=seed_decomposition,
+    )
+
+
+def _not_started_seed(
+    seed: GridSeed,
+    decomposition: FitDecomposition,
+) -> GroupedGridSeedOutcome:
+    components = tuple(
+        FitComponentOutcome(
+            component.identity,
+            component.controlled_ids,
+            ComponentDisposition.NOT_STARTED,
+        )
+        for component in decomposition.components
+    )
+    return GroupedGridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        GridSeedDisposition.NOT_STARTED,
+        components,
+    )
+
+
+def _seed_exception(
+    seed: GridSeed,
+    decomposition: FitDecomposition,
+    error: BaseException,
+    *,
+    interrupted: bool = False,
+) -> GroupedGridSeedOutcome:
+    components = tuple(
+        FitComponentOutcome(
+            component.identity,
+            component.controlled_ids,
+            ComponentDisposition.NOT_STARTED,
+        )
+        for component in decomposition.components
+    )
+    return GroupedGridSeedOutcome(
+        seed.identity,
+        seed.ordinal,
+        seed.axis_items,
+        seed.start,
+        (
+            GridSeedDisposition.INTERRUPTED
+            if interrupted
+            else GridSeedDisposition.IMPLEMENTATION_FAILURE
+        ),
+        components,
+        failure=TerminalFailure(
+            "interrupted" if interrupted else "grouped_grid_seed_exception",
+            f"{type(error).__name__}: {error}",
+        ),
+    )
+
+
+def _select(
+    attempts: Sequence[GroupedGridSeedOutcome],
+) -> tuple[GroupedGridSelection, GroupedGridSeedOutcome]:
+    eligible = tuple(
+        attempt
+        for attempt in attempts
+        if attempt.disposition is GridSeedDisposition.ELIGIBLE
+        and attempt.candidate is not None
+    )
+    selection = GroupedGridSelection.from_candidate_records(eligible)
+    return selection, selection.selected_record
+
+
+def _component_lineage_matches(
+    accepted: AcceptedGroupedGridDirectTrfResult,
+    selected: GroupedGridSeedOutcome,
+    seed: GridSeed,
+    problem: OptimizationProblem,
+) -> bool:
+    seed_problem = seed.problem
+    seed_decomposition = selected.seed_decomposition
+    component_invocation = selected.component_invocation
+    if (
+        seed_problem is None
+        or seed_problem.source_snapshot != problem.source_snapshot
+        or not isinstance(seed_problem.derivation, GridSeedProblemDerivation)
+        or seed_problem.derivation.root_problem_identity != problem.identity
+        or seed_problem.derivation.seed_identity != seed.coordinate_identity
+        or seed_problem.derivation.seed_ordinal != seed.ordinal
+        or seed_decomposition is None
+        or seed_decomposition.root_problem_identity != seed_problem.identity
+        or seed_decomposition.identity != accepted.decomposition.identity
+        or component_invocation is None
+        or component_invocation.root_problem_identity != seed_problem.identity
+        or component_invocation.decomposition_identity
+        != accepted.decomposition.identity
+    ):
+        return False
+    root_components = accepted.decomposition.components
+    seed_components = seed_decomposition.components
+    direct_invocations = component_invocation.component_invocations
+    if not (
+        len(root_components)
+        == len(seed_components)
+        == len(selected.components)
+        == len(direct_invocations)
+    ):
+        return False
+    root_scales = dict(
+        zip(
+            problem.controlled_ids,
+            accepted.workflow_invocation.x_scale,
+            strict=True,
+        )
+    )
+    for root_component, seed_component, outcome, direct in zip(
+        root_components,
+        seed_components,
+        selected.components,
+        direct_invocations,
+        strict=True,
+    ):
+        component_candidate = outcome.candidate
+        if component_candidate is None:
+            return False
+        materialization = component_candidate.materialization
+        if (
+            seed_component.identity != root_component.identity
+            or seed_component.controlled_ids != root_component.controlled_ids
+            or outcome.component_identity != root_component.identity
+            or outcome.controlled_ids != root_component.controlled_ids
+            or outcome.disposition is not ComponentDisposition.SUCCEEDED
+            or outcome.execution_identity != component_candidate.execution_identity
+            or direct.problem_identity != seed_component.problem.identity
+            or component_candidate.problem_identity != direct.problem_identity
+            or component_candidate.invocation_identity != direct.identity
+            or direct.objective_request_budget
+            != accepted.workflow_invocation.objective_request_budget
+            or direct.x_scale
+            != tuple(
+                root_scales[param_id] for param_id in root_component.controlled_ids
+            )
+            or direct.ftol != accepted.workflow_invocation.ftol
+            or direct.xtol != accepted.workflow_invocation.xtol
+            or direct.gtol != accepted.workflow_invocation.gtol
+            or materialization.problem_identity != component_candidate.problem_identity
+            or materialization.invocation_identity
+            != component_candidate.invocation_identity
+            or materialization.execution_identity
+            != component_candidate.execution_identity
+            or materialization.evaluation_identity
+            != component_candidate.evaluation_result.identity
+            or component_candidate.evaluation_result.plan_identity
+            != seed_component.problem.evaluation_plan_identity
+        ):
+            return False
+    return True
+
+
+def _root_candidate_matches(
+    candidate: MaterializedDirectTrfCandidate,
+    problem: OptimizationProblem,
+    invocation_identity: str,
+) -> bool:
+    materialization = candidate.materialization
+    return (
+        candidate.problem_identity == problem.identity
+        and candidate.invocation_identity == invocation_identity
+        and materialization.problem_identity == problem.identity
+        and materialization.invocation_identity == invocation_identity
+        and materialization.execution_identity == candidate.execution_identity
+        and materialization.evaluation_identity == candidate.evaluation_result.identity
+        and candidate.evaluation_result.plan_identity
+        == problem.evaluation_plan_identity
+        and candidate.evaluation_result.parameterization_identity
+        == problem.evaluator_parameterization_identity
+        and tuple(candidate.evaluation_result.resolved_values) == problem.commit_scope
+    )
+
+
+def _aggregate_lineage_matches(
+    accepted: AcceptedGroupedGridDirectTrfResult,
+    selected: GroupedGridSeedOutcome,
+    candidate: GridCandidate,
+    fresh: MaterializedDirectTrfCandidate,
+    problem: OptimizationProblem,
+) -> bool:
+    aggregate = candidate.candidate
+    invocation_identity = accepted.workflow_invocation.identity
+    return (
+        candidate.seed_identity == selected.seed_identity
+        and candidate.seed_ordinal == selected.seed_ordinal
+        and selected.execution_identity == aggregate.execution_identity
+        and _root_candidate_matches(aggregate, problem, invocation_identity)
+        and _root_candidate_matches(fresh, problem, invocation_identity)
+        and fresh.vector == candidate.vector
+        and fresh.chi_square == candidate.objective
+    )
+
+
+def _validate_acceptance_lineage(
+    accepted: AcceptedGroupedGridDirectTrfResult,
+    problem: OptimizationProblem,
+) -> None:
+    provenance = accepted.grouped_grid_provenance
+    selected = accepted.selected_outcome
+    candidate = selected.candidate
+    fresh = accepted.fresh_candidate
+    try:
+        seed = accepted.workflow_invocation.seeds[provenance.selected_seed_ordinal]
+    except (AttributeError, IndexError, TypeError):
+        seed = None
+    if (
+        accepted.workflow_invocation.root_problem_identity != problem.identity
+        or len(accepted.workflow_invocation.x_scale) != len(problem.controlled_ids)
+        or accepted.decomposition.root_problem_identity != problem.identity
+        or accepted.decomposition.identity != provenance.decomposition_identity
+        or provenance.root_problem_identity != problem.identity
+        or provenance.workflow_invocation_identity
+        != accepted.workflow_invocation.identity
+        or provenance.selection_identity != accepted.selection.identity
+        or seed is None
+        or seed.identity != accepted.selected_seed.identity
+        or provenance.selected_seed_identity != seed.identity
+        or provenance.selected_seed_ordinal != seed.ordinal
+        or selected.seed_identity != seed.identity
+        or selected.seed_ordinal != seed.ordinal
+        or accepted.selection.selected_seed_identity != seed.identity
+        or accepted.selection.selected_seed_ordinal != seed.ordinal
+        or not _component_lineage_matches(accepted, selected, seed, problem)
+        or selected.identity != provenance.selected_outcome_identity
+        or accepted.selection.selected_record.identity != selected.identity
+        or candidate is None
+        or candidate.identity != provenance.aggregate_candidate_identity
+        or candidate.candidate.materialization.identity
+        != provenance.aggregate_materialization_identity
+        or not _aggregate_lineage_matches(
+            accepted,
+            selected,
+            candidate,
+            fresh,
+            problem,
+        )
+        or fresh.materialization.identity
+        != provenance.accepted_materialization_identity
+        or fresh.evaluation_result.identity != provenance.accepted_evaluation_identity
+        or accepted.problem_identity != problem.identity
+        or accepted.vector != fresh.vector
+        or accepted.chi_square != fresh.chi_square
+        or accepted.materialization_identity != fresh.materialization.identity
+        or accepted.evaluation_result.identity != fresh.evaluation_result.identity
+        or accepted.origin_context_identity != provenance.identity
+    ):
+        raise DirectTrfConstructionError(
+            "Accepted grouped GRID result lacks canonical aggregate authority"
+        )
+
+
+def _execute_all_seeds(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    invocation: GridDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    token: CancellationToken,
+) -> tuple[GroupedGridSeedOutcome, ...] | GroupedGridDirectTrfOutcome:
+    attempted: list[GroupedGridSeedOutcome] = []
+    for index, seed in enumerate(invocation.seeds):
+        if token.is_cancelled:
+            attempted.extend(
+                _not_started_seed(item, decomposition)
+                for item in invocation.seeds[index:]
+            )
+            return GroupedGridDirectTrfOutcome(
+                GroupedGridDirectTrfTerminal.CANCELLED,
+                tuple(attempted),
+            )
+        try:
+            attempt = _execute_seed(
+                problem,
+                decomposition,
+                invocation,
+                seed,
+                parameterization,
+                engine,
+                token,
+            )
+        except KeyboardInterrupt as error:
+            attempt = _seed_exception(
+                seed,
+                decomposition,
+                error,
+                interrupted=True,
+            )
+        except Exception as error:  # noqa: BLE001 - orchestration fails closed
+            attempt = _seed_exception(seed, decomposition, error)
+        attempted.append(attempt)
+        if attempt.disposition in {
+            GridSeedDisposition.CANCELLED,
+            GridSeedDisposition.INTERRUPTED,
+            GridSeedDisposition.IMPLEMENTATION_FAILURE,
+            GridSeedDisposition.BACKEND_FAILURE,
+        }:
+            attempted.extend(
+                _not_started_seed(item, decomposition)
+                for item in invocation.seeds[index + 1 :]
+            )
+            terminal = (
+                GroupedGridDirectTrfTerminal.CANCELLED
+                if attempt.disposition is GridSeedDisposition.CANCELLED
+                else GroupedGridDirectTrfTerminal.INTERRUPTED
+                if attempt.disposition is GridSeedDisposition.INTERRUPTED
+                else GroupedGridDirectTrfTerminal.EXECUTION_FAILURE
+            )
+            return GroupedGridDirectTrfOutcome(
+                terminal,
+                tuple(attempted),
+                failure=attempt.failure,
+            )
+    return tuple(attempted)
+
+
+def commit_grouped_grid_accepted_fit(
+    accepted: AcceptedGroupedGridDirectTrfResult,
+    authority: LiveFitCommitAuthority,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    analysis_values: AnalysisValues,
+) -> CommitReceipt:
+    """Validate grouped-GRID lineage, then use the generic commit seam."""
+    _validate_acceptance_lineage(accepted, problem)
+    return commit_accepted_fit(
+        accepted,
+        authority,
+        problem=problem,
+        parameterization=parameterization,
+        analysis_values=analysis_values,
+    )
+
+
+def execute_grouped_grid_direct_trf(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    invocation: GridDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> GroupedGridDirectTrfOutcome:
+    """Run exact components per seed and accept only the best root aggregate."""
+    _validate_context(problem, decomposition, invocation, parameterization, engine)
+    token = CancellationToken() if cancellation is None else cancellation
+    seed_execution = _execute_all_seeds(
+        problem,
+        decomposition,
+        invocation,
+        parameterization,
+        engine,
+        token,
+    )
+    if isinstance(seed_execution, GroupedGridDirectTrfOutcome):
+        return seed_execution
+    attempts = seed_execution
+    if not any(
+        attempt.disposition is GridSeedDisposition.ELIGIBLE for attempt in attempts
+    ):
+        return GroupedGridDirectTrfOutcome(
+            GroupedGridDirectTrfTerminal.NO_ELIGIBLE_CANDIDATE,
+            attempts,
+        )
+    selection, selected = _select(attempts)
+    aggregate_candidate = cast("GridCandidate", selected.candidate)
+    execution_identity = _identity(
+        "native-grouped-grid-selection-execution",
+        (
+            invocation.identity,
+            decomposition.identity,
+            selection.identity,
+            selected.identity,
+            aggregate_candidate.identity,
+        ),
+    )
+    if token.is_cancelled:
+        return GroupedGridDirectTrfOutcome(
+            GroupedGridDirectTrfTerminal.CANCELLED,
+            attempts,
+            selection,
+        )
+    try:
+        fresh = _fresh_root_candidate(
+            problem,
+            invocation.identity,
+            execution_identity,
+            aggregate_candidate.vector,
+            parameterization,
+            engine,
+        )
+    except KeyboardInterrupt:
+        return GroupedGridDirectTrfOutcome(
+            GroupedGridDirectTrfTerminal.INTERRUPTED,
+            attempts,
+            selection,
+        )
+    except Exception as error:  # noqa: BLE001 - root promotion fails closed
+        return GroupedGridDirectTrfOutcome(
+            GroupedGridDirectTrfTerminal.MATERIALIZATION_FAILURE,
+            attempts,
+            selection,
+            failure=TerminalFailure(
+                "grouped_grid_selection_materialization_exception",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    if token.is_cancelled:
+        return GroupedGridDirectTrfOutcome(
+            GroupedGridDirectTrfTerminal.CANCELLED,
+            attempts,
+            selection,
+        )
+    provenance = GroupedGridSelectionProvenance(
+        invocation.identity,
+        problem.identity,
+        decomposition.identity,
+        selection.identity,
+        selected.seed_identity,
+        selected.seed_ordinal,
+        selected.identity,
+        aggregate_candidate.identity,
+        aggregate_candidate.candidate.materialization.identity,
+        fresh.materialization.identity,
+        fresh.evaluation_result.identity,
+    )
+    base_accepted = _accept_materialized_fit_for_derived_workflow(
+        problem=problem,
+        invocation_identity=invocation.identity,
+        execution_identity=execution_identity,
+        materialization=fresh.materialization,
+        vector=fresh.vector,
+        chi_square=fresh.chi_square,
+        evaluation_result=fresh.evaluation_result,
+        authority_context_identity=provenance.identity,
+    )
+    selected_seed = invocation.seeds[selected.seed_ordinal]
+    accepted = AcceptedGroupedGridDirectTrfResult.from_accepted(
+        base_accepted,
+        provenance,
+        invocation,
+        decomposition,
+        selection,
+        selected_seed,
+        selected,
+        fresh,
+    )
+    _validate_acceptance_lineage(accepted, problem)
+    authority = _grant_derived_fit_commit_authority(accepted, problem)
+    return GroupedGridDirectTrfOutcome(
+        GroupedGridDirectTrfTerminal.ACCEPTED,
+        attempts,
+        selection,
+        accepted,
+        authority,
+    )

--- a/src/chemex/optimize/grouped_grid_direct_trf.py
+++ b/src/chemex/optimize/grouped_grid_direct_trf.py
@@ -9,25 +9,20 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Sequence
 from dataclasses import dataclass, field
-from enum import StrEnum
-from typing import cast
 from uuid import uuid4
 
 from chemex.evaluation.native import (
     BoundEvaluator,
     EvaluationEngine,
-    EvaluationFailure,
-    EvaluationFrame,
     EvaluationResult,
 )
 from chemex.optimize.direct_trf import (
-    AcceptedFitResult,
     CancellationToken,
     CandidateMaterialization,
     CandidateSummary,
     CommitReceipt,
+    ComponentProblemDerivation,
     DirectTrfConstructionError,
     DirectTrfInvocation,
     GridSeedProblemDerivation,
@@ -36,18 +31,22 @@ from chemex.optimize.direct_trf import (
     MaterializedDirectTrfCandidate,
     OptimizationProblem,
     TerminalFailure,
-    _accept_materialized_fit_for_derived_workflow,
-    _grant_derived_fit_commit_authority,
     canonical_chi_square,
-    commit_accepted_fit,
 )
 from chemex.optimize.grid_direct_trf import (
+    AcceptedGridDirectTrfResult,
     GridCandidate,
     GridCoordinate,
     GridDirectTrfInvocation,
+    GridDirectTrfOutcome,
+    GridDirectTrfTerminal,
     GridSeed,
     GridSeedDisposition,
+    GridSelection,
+    _finalize_grid_candidates,
+    _materialized_grid_candidate_matches,
     _validate_grid_context,
+    commit_grid_accepted_fit,
 )
 from chemex.optimize.grouped_direct_trf import (
     ComponentDisposition,
@@ -65,8 +64,6 @@ from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.values import AnalysisValues
 
 _SCHEMA_VERSION = 1
-_WORKFLOW_VERSION = "native-grouped-cartesian-grid-direct-trf-v1"
-_AGGREGATE_ORDER_VERSION = "aggregate-chi-square-vector-seed-ordinal-v1"
 
 
 def _identity(kind: str, record: object) -> str:
@@ -90,6 +87,7 @@ class GroupedGridSeedOutcome:
     start: tuple[GridCoordinate, ...]
     disposition: GridSeedDisposition
     components: tuple[FitComponentOutcome, ...]
+    root_decomposition_identity: str = field(kw_only=True)
     seed_decomposition: FitDecomposition | None = field(
         default=None,
         repr=False,
@@ -112,7 +110,8 @@ class GroupedGridSeedOutcome:
         if eligible != (self.candidate is not None and self.objective is not None):
             raise ValueError("Only an eligible grouped GRID seed has an aggregate")
         if eligible and (
-            self.seed_decomposition is None
+            not self.root_decomposition_identity
+            or self.seed_decomposition is None
             or self.component_invocation is None
             or self.execution_identity is None
             or self.candidate is None
@@ -138,6 +137,7 @@ class GroupedGridSeedOutcome:
                     self.seed_ordinal,
                     self.disposition.value,
                     tuple(component.identity for component in self.components),
+                    self.root_decomposition_identity,
                     None
                     if self.seed_decomposition is None
                     else self.seed_decomposition.identity,
@@ -151,239 +151,51 @@ class GroupedGridSeedOutcome:
             ),
         )
 
-
-@dataclass(frozen=True, slots=True)
-class GroupedGridSelection:
-    """Canonical ordering over fresh whole-problem aggregate candidates."""
-
-    selected_seed_identity: str
-    selected_seed_ordinal: int
-    selected_candidate_identity: str
-    eligible_candidate_identities: tuple[str, ...]
-    candidate_records: tuple[GroupedGridSeedOutcome, ...] = field(
-        repr=False,
-        compare=False,
-    )
-    ordering_policy: str = _AGGREGATE_ORDER_VERSION
-    identity: str = field(init=False)
-
-    def __post_init__(self) -> None:
-        selected = tuple(
-            record
-            for record in self.candidate_records
-            if record.seed_identity == self.selected_seed_identity
-            and record.seed_ordinal == self.selected_seed_ordinal
-            and record.candidate is not None
-            and record.candidate.identity == self.selected_candidate_identity
-        )
-        candidate_identities = tuple(
-            cast("GridCandidate", record.candidate).identity
-            for record in self.candidate_records
-        )
-        if (
-            self.ordering_policy != _AGGREGATE_ORDER_VERSION
-            or not self.candidate_records
-            or any(
-                record.disposition is not GridSeedDisposition.ELIGIBLE
-                or record.candidate is None
-                for record in self.candidate_records
-            )
-            or candidate_identities != self.eligible_candidate_identities
-            or self.eligible_candidate_identities[0] != self.selected_candidate_identity
-            or len(selected) != 1
-            or selected[0].identity != self.candidate_records[0].identity
-        ):
-            raise ValueError(
-                "Grouped GRID selection requires one canonical aggregate winner"
-            )
-        object.__setattr__(
-            self,
-            "identity",
-            _identity(
-                "native-grouped-grid-selection",
-                (
-                    self.ordering_policy,
-                    self.selected_seed_identity,
-                    self.selected_seed_ordinal,
-                    self.selected_candidate_identity,
-                    self.eligible_candidate_identities,
-                ),
-            ),
-        )
-
-    @classmethod
-    def from_candidate_records(
-        cls,
-        records: Sequence[GroupedGridSeedOutcome],
-    ) -> GroupedGridSelection:
-        ordered = tuple(
-            sorted(
-                records,
-                key=lambda record: cast(
-                    "GridCandidate", record.candidate
-                ).ordering_key(),
-            )
-        )
-        if not ordered or any(record.candidate is None for record in ordered):
-            raise ValueError("Grouped GRID selection requires aggregate candidates")
-        selected = ordered[0]
-        candidate = cast("GridCandidate", selected.candidate)
-        return cls(
-            selected.seed_identity,
-            selected.seed_ordinal,
-            candidate.identity,
-            tuple(
-                cast("GridCandidate", record.candidate).identity for record in ordered
-            ),
-            ordered,
-        )
-
-    @property
-    def selected_record(self) -> GroupedGridSeedOutcome:
-        return self.candidate_records[0]
-
-
-@dataclass(frozen=True, slots=True)
-class GroupedGridSelectionProvenance:
-    """Complete authority lineage from one aggregate GRID winner."""
-
-    workflow_invocation_identity: str
-    root_problem_identity: str
-    decomposition_identity: str
-    selection_identity: str
-    selected_seed_identity: str
-    selected_seed_ordinal: int
-    selected_outcome_identity: str
-    aggregate_candidate_identity: str
-    aggregate_materialization_identity: str
-    accepted_materialization_identity: str
-    accepted_evaluation_identity: str
-    identity: str = field(init=False)
-
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "identity",
-            _identity(
-                "native-grouped-grid-selection-provenance",
-                (
-                    _WORKFLOW_VERSION,
-                    self.workflow_invocation_identity,
-                    self.root_problem_identity,
-                    self.decomposition_identity,
-                    self.selection_identity,
-                    self.selected_seed_identity,
-                    self.selected_seed_ordinal,
-                    self.selected_outcome_identity,
-                    self.aggregate_candidate_identity,
-                    self.aggregate_materialization_identity,
-                    self.accepted_materialization_identity,
-                    self.accepted_evaluation_identity,
-                ),
-            ),
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class AcceptedGroupedGridDirectTrfResult(AcceptedFitResult):
-    """Accepted root evidence carrying exact grouped-GRID selection lineage."""
-
-    grouped_grid_provenance: GroupedGridSelectionProvenance
-    workflow_invocation: GridDirectTrfInvocation = field(repr=False, compare=False)
-    decomposition: FitDecomposition = field(repr=False, compare=False)
-    selection: GroupedGridSelection = field(repr=False, compare=False)
-    selected_seed: GridSeed = field(repr=False, compare=False)
-    selected_outcome: GroupedGridSeedOutcome = field(repr=False, compare=False)
-    fresh_candidate: MaterializedDirectTrfCandidate = field(
-        repr=False,
-        compare=False,
-    )
-
-    @classmethod
-    def from_accepted(
-        cls,
-        accepted: AcceptedFitResult,
-        provenance: GroupedGridSelectionProvenance,
-        workflow_invocation: GridDirectTrfInvocation,
-        decomposition: FitDecomposition,
-        selection: GroupedGridSelection,
-        selected_seed: GridSeed,
-        selected_outcome: GroupedGridSeedOutcome,
-        fresh_candidate: MaterializedDirectTrfCandidate,
-    ) -> AcceptedGroupedGridDirectTrfResult:
-        return cls(
-            accepted.occurrence_identity,
-            accepted.problem_identity,
-            accepted.invocation_identity,
-            accepted.execution_identity,
-            accepted.materialization_identity,
-            accepted.parameterization_identity,
-            accepted.evaluator_parameterization_identity,
-            accepted.source_occurrence_identity,
-            accepted.source_revision,
-            accepted.controlled_ids,
-            accepted.vector,
-            accepted.chi_square,
-            accepted.evaluation_result,
-            accepted.commit_scope,
-            accepted.commit_items,
-            accepted.origin_context_identity,
-            provenance,
-            workflow_invocation,
-            decomposition,
-            selection,
-            selected_seed,
-            selected_outcome,
-            fresh_candidate,
-        )
-
-
-class GroupedGridDirectTrfTerminal(StrEnum):
-    """Closed outcomes of one grouped GRID to Direct TRF occurrence."""
-
-    ACCEPTED = "accepted"
-    NO_ELIGIBLE_CANDIDATE = "no_eligible_candidate"
-    EXECUTION_FAILURE = "execution_failure"
-    MATERIALIZATION_FAILURE = "materialization_failure"
-    CANCELLED = "cancelled"
-    INTERRUPTED = "interrupted"
+    def validate_for_grid_selection(
+        self,
+        problem: OptimizationProblem,
+        invocation: GridDirectTrfInvocation,
+        seed: GridSeed,
+    ) -> None:
+        """Prove exact grouped component ownership before GRID selection."""
+        _validate_grouped_grid_seed(self, problem, invocation, seed)
 
 
 @dataclass(frozen=True, slots=True)
 class GroupedGridDirectTrfOutcome:
-    """Complete occurrence; only the selected root aggregate has authority."""
+    """Thin grouped-evidence view over canonical #595 GRID lifecycle state."""
 
-    terminal: GroupedGridDirectTrfTerminal
     attempts: tuple[GroupedGridSeedOutcome, ...]
-    selection: GroupedGridSelection | None = field(
-        default=None,
-        repr=False,
-        compare=False,
-    )
-    accepted_result: AcceptedGroupedGridDirectTrfResult | None = field(
-        default=None,
-        repr=False,
-        compare=False,
-    )
-    commit_authority: LiveFitCommitAuthority | None = field(
-        default=None,
-        repr=False,
-        compare=False,
-    )
-    failure: TerminalFailure | None = None
+    grid_outcome: GridDirectTrfOutcome = field(repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        accepted = self.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
-        if accepted != (
-            self.accepted_result is not None and self.commit_authority is not None
+        if tuple(record.identity for record in self.grid_outcome.attempts) != tuple(
+            record.identity for record in self.attempts
         ):
-            raise ValueError("Only accepted grouped GRID execution has authority")
-        if not accepted and (
-            self.accepted_result is not None or self.commit_authority is not None
-        ):
-            raise ValueError("Unaccepted grouped GRID execution cannot have authority")
-        if accepted and self.selection is None:
-            raise ValueError("Accepted grouped GRID execution requires a selection")
+            raise ValueError("Grouped evidence differs from canonical GRID outcome")
+
+    @property
+    def terminal(self) -> GridDirectTrfTerminal:
+        return self.grid_outcome.terminal
+
+    @property
+    def selection(self) -> GridSelection | None:
+        return self.grid_outcome.selection
+
+    @property
+    def accepted_result(self) -> AcceptedGridDirectTrfResult | None:
+        return self.grid_outcome.accepted_result
+
+    @property
+    def commit_authority(self) -> LiveFitCommitAuthority | None:
+        return self.grid_outcome.commit_authority
+
+    @property
+    def failure(self) -> TerminalFailure | None:
+        return self.grid_outcome.failure
+
+
+GroupedGridDirectTrfTerminal = GridDirectTrfTerminal
 
 
 def _validate_context(
@@ -434,32 +246,6 @@ def _component_invocation(
     )
 
 
-def _fresh_root_candidate(
-    problem: OptimizationProblem,
-    invocation_identity: str,
-    execution_identity: str,
-    vector: tuple[float, ...],
-    parameterization: ActiveParameterization,
-    engine: EvaluationEngine,
-) -> MaterializedDirectTrfCandidate:
-    lifecycle = problem.lifecycle_frame(vector, parameterization)
-    frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
-    evaluator = engine.new_evaluator()
-    evaluated = evaluator.evaluate(frame)
-    if isinstance(evaluated, EvaluationFailure):
-        raise DirectTrfConstructionError(
-            f"Grouped GRID root materialization failed: {evaluated.message}"
-        )
-    return _materialized_root_candidate(
-        problem,
-        invocation_identity,
-        execution_identity,
-        vector,
-        evaluator,
-        evaluated,
-    )
-
-
 def _materialized_root_candidate(
     problem: OptimizationProblem,
     invocation_identity: str,
@@ -498,6 +284,7 @@ def _materialized_root_candidate(
 
 def _failed_component_seed_outcome(
     seed: GridSeed,
+    root_decomposition_identity: str,
     seed_decomposition: FitDecomposition,
     components: tuple[FitComponentOutcome, ...],
     component_invocation: GroupedDirectTrfInvocation,
@@ -524,12 +311,14 @@ def _failed_component_seed_outcome(
         components,
         component_invocation,
         failure=failure,
+        root_decomposition_identity=root_decomposition_identity,
         seed_decomposition=seed_decomposition,
     )
 
 
 def _failed_aggregate_seed_outcome(
     seed: GridSeed,
+    root_decomposition_identity: str,
     seed_decomposition: FitDecomposition,
     components: tuple[FitComponentOutcome, ...],
     component_invocation: GroupedDirectTrfInvocation,
@@ -551,6 +340,7 @@ def _failed_aggregate_seed_outcome(
         components,
         component_invocation,
         failure=outcome.failure,
+        root_decomposition_identity=root_decomposition_identity,
         seed_decomposition=seed_decomposition,
     )
 
@@ -578,6 +368,7 @@ def _execute_seed(
             disposition,
             (),
             failure=seed.rejection,
+            root_decomposition_identity=decomposition.identity,
         )
     if seed.problem is None:
         raise DirectTrfConstructionError("Feasible grouped GRID seed lacks a problem")
@@ -614,6 +405,7 @@ def _execute_seed(
     ):
         return _failed_component_seed_outcome(
             seed,
+            decomposition.identity,
             seed_decomposition,
             components,
             component_invocation,
@@ -628,6 +420,7 @@ def _execute_seed(
     if isinstance(projections, GroupedDirectTrfOutcome):
         return _failed_aggregate_seed_outcome(
             seed,
+            decomposition.identity,
             seed_decomposition,
             components,
             component_invocation,
@@ -644,6 +437,7 @@ def _execute_seed(
     if isinstance(fresh, GroupedDirectTrfOutcome):
         return _failed_aggregate_seed_outcome(
             seed,
+            decomposition.identity,
             seed_decomposition,
             components,
             component_invocation,
@@ -670,6 +464,7 @@ def _execute_seed(
                 "decomposition_projection_mismatch",
                 "Fresh grouped GRID aggregate differs from component evidence",
             ),
+            root_decomposition_identity=decomposition.identity,
             seed_decomposition=seed_decomposition,
         )
     execution_identity = _identity(
@@ -691,7 +486,7 @@ def _execute_seed(
         aggregate,
     )
     candidate = GridCandidate(seed.identity, seed.ordinal, materialized)
-    return GroupedGridSeedOutcome(
+    record = GroupedGridSeedOutcome(
         seed.identity,
         seed.ordinal,
         seed.axis_items,
@@ -702,8 +497,11 @@ def _execute_seed(
         execution_identity,
         candidate.objective,
         candidate,
+        root_decomposition_identity=decomposition.identity,
         seed_decomposition=seed_decomposition,
     )
+    record.validate_for_grid_selection(problem, invocation, seed)
+    return record
 
 
 def _not_started_seed(
@@ -725,6 +523,7 @@ def _not_started_seed(
         seed.start,
         GridSeedDisposition.NOT_STARTED,
         components,
+        root_decomposition_identity=decomposition.identity,
     )
 
 
@@ -758,205 +557,223 @@ def _seed_exception(
             "interrupted" if interrupted else "grouped_grid_seed_exception",
             f"{type(error).__name__}: {error}",
         ),
+        root_decomposition_identity=decomposition.identity,
     )
 
 
-def _select(
-    attempts: Sequence[GroupedGridSeedOutcome],
-) -> tuple[GroupedGridSelection, GroupedGridSeedOutcome]:
-    eligible = tuple(
-        attempt
-        for attempt in attempts
-        if attempt.disposition is GridSeedDisposition.ELIGIBLE
-        and attempt.candidate is not None
-    )
-    selection = GroupedGridSelection.from_candidate_records(eligible)
-    return selection, selection.selected_record
-
-
-def _component_lineage_matches(
-    accepted: AcceptedGroupedGridDirectTrfResult,
+def _validate_grouped_grid_seed(
     selected: GroupedGridSeedOutcome,
-    seed: GridSeed,
     problem: OptimizationProblem,
-) -> bool:
+    invocation: GridDirectTrfInvocation,
+    seed: GridSeed,
+) -> None:
+    """Reject foreign or cross-seed component evidence before selection."""
     seed_problem = seed.problem
     seed_decomposition = selected.seed_decomposition
     component_invocation = selected.component_invocation
+    aggregate = selected.candidate
+    materialized_aggregate = None if aggregate is None else aggregate.candidate
+    aggregate_evaluation = (
+        None
+        if materialized_aggregate is None
+        else materialized_aggregate.evaluation_result
+    )
+    seed_derivation = None if seed_problem is None else seed_problem.derivation
     if (
-        seed_problem is None
-        or seed_problem.source_snapshot != problem.source_snapshot
-        or not isinstance(seed_problem.derivation, GridSeedProblemDerivation)
-        or seed_problem.derivation.root_problem_identity != problem.identity
-        or seed_problem.derivation.seed_identity != seed.coordinate_identity
-        or seed_problem.derivation.seed_ordinal != seed.ordinal
+        invocation.root_problem_identity != problem.identity
+        or selected.seed_identity != seed.identity
+        or selected.seed_ordinal != seed.ordinal
+        or selected.axis_items != seed.axis_items
+        or selected.start != seed.start
+        or selected.disposition is not GridSeedDisposition.ELIGIBLE
+        or seed_problem is None
+        or seed_problem.source_snapshot is not problem.source_snapshot
+        or not isinstance(seed_derivation, GridSeedProblemDerivation)
+        or seed_derivation.root_problem_identity != problem.identity
+        or seed_derivation.seed_identity != seed.coordinate_identity
+        or seed_derivation.seed_ordinal != seed.ordinal
+        or seed_derivation.axis_items != seed.axis_items
+        or seed_derivation.start != seed.start
+        or seed_problem.parameterization_identity != problem.parameterization_identity
+        or seed_problem.evaluator_parameterization_identity
+        != problem.evaluator_parameterization_identity
+        or seed_problem.constraint_program_identity
+        != problem.constraint_program_identity
+        or seed_problem.configuration_identity != problem.configuration_identity
+        or seed_problem.independent_items != problem.independent_items
+        or seed_problem.controlled_ids != problem.controlled_ids
+        or seed_problem.held_items != problem.held_items
+        or seed_problem.lower_bounds != problem.lower_bounds
+        or seed_problem.upper_bounds != problem.upper_bounds
+        or seed_problem.commit_scope != problem.commit_scope
+        or seed_problem.scalarization_version != problem.scalarization_version
         or seed_decomposition is None
         or seed_decomposition.root_problem_identity != seed_problem.identity
-        or seed_decomposition.identity != accepted.decomposition.identity
+        or seed_decomposition.root_plan_identity
+        != seed_problem.evaluation_plan_identity
+        or seed_decomposition.identity != selected.root_decomposition_identity
         or component_invocation is None
         or component_invocation.root_problem_identity != seed_problem.identity
-        or component_invocation.decomposition_identity
-        != accepted.decomposition.identity
+        or component_invocation.decomposition_identity != seed_decomposition.identity
+        or aggregate is None
+        or materialized_aggregate is None
+        or aggregate.seed_identity != seed.identity
+        or aggregate.seed_ordinal != seed.ordinal
+        or selected.execution_identity != materialized_aggregate.execution_identity
+        or selected.objective != aggregate.objective
+        or aggregate_evaluation is None
+        or not _materialized_grid_candidate_matches(
+            materialized_aggregate,
+            problem,
+            invocation.identity,
+            materialized_aggregate.execution_identity,
+        )
     ):
-        return False
-    root_components = accepted.decomposition.components
+        raise DirectTrfConstructionError(
+            "Grouped GRID seed lacks exact component ownership"
+        )
     seed_components = seed_decomposition.components
     direct_invocations = component_invocation.component_invocations
     if not (
-        len(root_components)
-        == len(seed_components)
-        == len(selected.components)
-        == len(direct_invocations)
+        len(seed_components) == len(selected.components) == len(direct_invocations)
+        and seed_components
     ):
-        return False
+        raise DirectTrfConstructionError(
+            "Grouped GRID seed lacks exact component ownership"
+        )
     root_scales = dict(
         zip(
             problem.controlled_ids,
-            accepted.workflow_invocation.x_scale,
+            invocation.x_scale,
             strict=True,
         )
     )
-    for root_component, seed_component, outcome, direct in zip(
-        root_components,
+    expected_execution_identity = _identity(
+        "native-grouped-grid-seed-execution",
+        (
+            invocation.identity,
+            seed.identity,
+            component_invocation.identity,
+            tuple(component.identity for component in selected.components),
+            aggregate_evaluation.identity,
+        ),
+    )
+    if selected.execution_identity != expected_execution_identity:
+        raise DirectTrfConstructionError(
+            "Grouped GRID seed lacks exact component ownership"
+        )
+    component_assignments: dict[str, float] = {}
+    for seed_component, outcome, direct in zip(
         seed_components,
         selected.components,
         direct_invocations,
         strict=True,
     ):
         component_candidate = outcome.candidate
-        if component_candidate is None:
-            return False
-        materialization = component_candidate.materialization
+        component_problem = seed_component.problem
+        component_derivation = component_problem.derivation
+        expected_held = tuple(
+            item
+            for item in seed_problem.independent_items
+            if item[0] not in set(seed_component.controlled_ids)
+        )
+        seed_coordinates = dict(
+            zip(seed_problem.controlled_ids, seed_problem.start, strict=True)
+        )
+        seed_lower = dict(
+            zip(seed_problem.controlled_ids, seed_problem.lower_bounds, strict=True)
+        )
+        seed_upper = dict(
+            zip(seed_problem.controlled_ids, seed_problem.upper_bounds, strict=True)
+        )
         if (
-            seed_component.identity != root_component.identity
-            or seed_component.controlled_ids != root_component.controlled_ids
-            or outcome.component_identity != root_component.identity
-            or outcome.controlled_ids != root_component.controlled_ids
+            component_candidate is None
+            or outcome.component_identity != seed_component.identity
+            or outcome.controlled_ids != seed_component.controlled_ids
             or outcome.disposition is not ComponentDisposition.SUCCEEDED
             or outcome.execution_identity != component_candidate.execution_identity
-            or direct.problem_identity != seed_component.problem.identity
+            or component_problem.source_snapshot is not problem.source_snapshot
+            or not isinstance(component_derivation, ComponentProblemDerivation)
+            or component_derivation.root_problem_identity != seed_problem.identity
+            or component_derivation.component_identity != seed_component.identity
+            or component_derivation.controlled_ids != seed_component.controlled_ids
+            or component_problem.parameterization_identity
+            != seed_problem.parameterization_identity
+            or component_problem.evaluator_parameterization_identity
+            != seed_problem.evaluator_parameterization_identity
+            or component_problem.constraint_program_identity
+            != seed_problem.constraint_program_identity
+            or component_problem.configuration_identity
+            != seed_problem.configuration_identity
+            or component_problem.independent_items != seed_problem.independent_items
+            or component_problem.held_items != expected_held
+            or component_problem.start
+            != tuple(
+                seed_coordinates[param_id] for param_id in seed_component.controlled_ids
+            )
+            or component_problem.lower_bounds
+            != tuple(seed_lower[param_id] for param_id in seed_component.controlled_ids)
+            or component_problem.upper_bounds
+            != tuple(seed_upper[param_id] for param_id in seed_component.controlled_ids)
+            or component_problem.commit_scope != seed_problem.commit_scope
+            or component_problem.scalarization_version
+            != seed_problem.scalarization_version
+            or direct.problem_identity != component_problem.identity
             or component_candidate.problem_identity != direct.problem_identity
             or component_candidate.invocation_identity != direct.identity
-            or direct.objective_request_budget
-            != accepted.workflow_invocation.objective_request_budget
+            or direct.objective_request_budget != invocation.objective_request_budget
             or direct.x_scale
             != tuple(
-                root_scales[param_id] for param_id in root_component.controlled_ids
+                root_scales[param_id] for param_id in seed_component.controlled_ids
             )
-            or direct.ftol != accepted.workflow_invocation.ftol
-            or direct.xtol != accepted.workflow_invocation.xtol
-            or direct.gtol != accepted.workflow_invocation.gtol
-            or materialization.problem_identity != component_candidate.problem_identity
-            or materialization.invocation_identity
-            != component_candidate.invocation_identity
-            or materialization.execution_identity
-            != component_candidate.execution_identity
-            or materialization.evaluation_identity
-            != component_candidate.evaluation_result.identity
-            or component_candidate.evaluation_result.plan_identity
-            != seed_component.problem.evaluation_plan_identity
+            or direct.ftol != invocation.ftol
+            or direct.xtol != invocation.xtol
+            or direct.gtol != invocation.gtol
+            or not _materialized_grid_candidate_matches(
+                component_candidate,
+                component_problem,
+                direct.identity,
+                component_candidate.execution_identity,
+            )
         ):
-            return False
-    return True
-
-
-def _root_candidate_matches(
-    candidate: MaterializedDirectTrfCandidate,
-    problem: OptimizationProblem,
-    invocation_identity: str,
-) -> bool:
-    materialization = candidate.materialization
-    return (
-        candidate.problem_identity == problem.identity
-        and candidate.invocation_identity == invocation_identity
-        and materialization.problem_identity == problem.identity
-        and materialization.invocation_identity == invocation_identity
-        and materialization.execution_identity == candidate.execution_identity
-        and materialization.evaluation_identity == candidate.evaluation_result.identity
-        and candidate.evaluation_result.plan_identity
-        == problem.evaluation_plan_identity
-        and candidate.evaluation_result.parameterization_identity
-        == problem.evaluator_parameterization_identity
-        and tuple(candidate.evaluation_result.resolved_values) == problem.commit_scope
-    )
-
-
-def _aggregate_lineage_matches(
-    accepted: AcceptedGroupedGridDirectTrfResult,
-    selected: GroupedGridSeedOutcome,
-    candidate: GridCandidate,
-    fresh: MaterializedDirectTrfCandidate,
-    problem: OptimizationProblem,
-) -> bool:
-    aggregate = candidate.candidate
-    invocation_identity = accepted.workflow_invocation.identity
-    return (
-        candidate.seed_identity == selected.seed_identity
-        and candidate.seed_ordinal == selected.seed_ordinal
-        and selected.execution_identity == aggregate.execution_identity
-        and _root_candidate_matches(aggregate, problem, invocation_identity)
-        and _root_candidate_matches(fresh, problem, invocation_identity)
-        and fresh.vector == candidate.vector
-        and fresh.chi_square == candidate.objective
-    )
-
-
-def _validate_acceptance_lineage(
-    accepted: AcceptedGroupedGridDirectTrfResult,
-    problem: OptimizationProblem,
-) -> None:
-    provenance = accepted.grouped_grid_provenance
-    selected = accepted.selected_outcome
-    candidate = selected.candidate
-    fresh = accepted.fresh_candidate
-    try:
-        seed = accepted.workflow_invocation.seeds[provenance.selected_seed_ordinal]
-    except (AttributeError, IndexError, TypeError):
-        seed = None
-    if (
-        accepted.workflow_invocation.root_problem_identity != problem.identity
-        or len(accepted.workflow_invocation.x_scale) != len(problem.controlled_ids)
-        or accepted.decomposition.root_problem_identity != problem.identity
-        or accepted.decomposition.identity != provenance.decomposition_identity
-        or provenance.root_problem_identity != problem.identity
-        or provenance.workflow_invocation_identity
-        != accepted.workflow_invocation.identity
-        or provenance.selection_identity != accepted.selection.identity
-        or seed is None
-        or seed.identity != accepted.selected_seed.identity
-        or provenance.selected_seed_identity != seed.identity
-        or provenance.selected_seed_ordinal != seed.ordinal
-        or selected.seed_identity != seed.identity
-        or selected.seed_ordinal != seed.ordinal
-        or accepted.selection.selected_seed_identity != seed.identity
-        or accepted.selection.selected_seed_ordinal != seed.ordinal
-        or not _component_lineage_matches(accepted, selected, seed, problem)
-        or selected.identity != provenance.selected_outcome_identity
-        or accepted.selection.selected_record.identity != selected.identity
-        or candidate is None
-        or candidate.identity != provenance.aggregate_candidate_identity
-        or candidate.candidate.materialization.identity
-        != provenance.aggregate_materialization_identity
-        or not _aggregate_lineage_matches(
-            accepted,
-            selected,
-            candidate,
-            fresh,
-            problem,
+            raise DirectTrfConstructionError(
+                "Grouped GRID seed lacks exact component ownership"
+            )
+        component_assignments.update(
+            zip(
+                seed_component.controlled_ids,
+                component_candidate.vector,
+                strict=True,
+            )
         )
-        or fresh.materialization.identity
-        != provenance.accepted_materialization_identity
-        or fresh.evaluation_result.identity != provenance.accepted_evaluation_identity
-        or accepted.problem_identity != problem.identity
-        or accepted.vector != fresh.vector
-        or accepted.chi_square != fresh.chi_square
-        or accepted.materialization_identity != fresh.materialization.identity
-        or accepted.evaluation_result.identity != fresh.evaluation_result.identity
-        or accepted.origin_context_identity != provenance.identity
+    if materialized_aggregate.vector != tuple(
+        component_assignments[param_id] for param_id in problem.controlled_ids
     ):
         raise DirectTrfConstructionError(
-            "Accepted grouped GRID result lacks canonical aggregate authority"
+            "Grouped GRID seed lacks exact component ownership"
         )
+
+
+def _lineage_failure(
+    record: GroupedGridSeedOutcome,
+    error: BaseException,
+) -> GroupedGridSeedOutcome:
+    """Strip aggregate eligibility from one invalid grouped seed record."""
+    return GroupedGridSeedOutcome(
+        record.seed_identity,
+        record.seed_ordinal,
+        record.axis_items,
+        record.start,
+        GridSeedDisposition.IMPLEMENTATION_FAILURE,
+        record.components,
+        record.component_invocation,
+        failure=TerminalFailure(
+            "grouped_grid_seed_lineage_failure",
+            f"{type(error).__name__}: {error}",
+        ),
+        root_decomposition_identity=record.root_decomposition_identity,
+        seed_decomposition=record.seed_decomposition,
+    )
 
 
 def _execute_all_seeds(
@@ -969,14 +786,33 @@ def _execute_all_seeds(
 ) -> tuple[GroupedGridSeedOutcome, ...] | GroupedGridDirectTrfOutcome:
     attempted: list[GroupedGridSeedOutcome] = []
     for index, seed in enumerate(invocation.seeds):
-        if token.is_cancelled:
+        try:
+            cancelled = token.is_cancelled
+        except KeyboardInterrupt:
             attempted.extend(
                 _not_started_seed(item, decomposition)
                 for item in invocation.seeds[index:]
             )
+            records = tuple(attempted)
             return GroupedGridDirectTrfOutcome(
-                GroupedGridDirectTrfTerminal.CANCELLED,
-                tuple(attempted),
+                records,
+                GridDirectTrfOutcome(
+                    GridDirectTrfTerminal.INTERRUPTED,
+                    records,
+                ),
+            )
+        if cancelled:
+            attempted.extend(
+                _not_started_seed(item, decomposition)
+                for item in invocation.seeds[index:]
+            )
+            records = tuple(attempted)
+            return GroupedGridDirectTrfOutcome(
+                records,
+                GridDirectTrfOutcome(
+                    GridDirectTrfTerminal.CANCELLED,
+                    records,
+                ),
             )
         try:
             attempt = _execute_seed(
@@ -1009,22 +845,79 @@ def _execute_all_seeds(
                 for item in invocation.seeds[index + 1 :]
             )
             terminal = (
-                GroupedGridDirectTrfTerminal.CANCELLED
+                GridDirectTrfTerminal.CANCELLED
                 if attempt.disposition is GridSeedDisposition.CANCELLED
-                else GroupedGridDirectTrfTerminal.INTERRUPTED
+                else GridDirectTrfTerminal.INTERRUPTED
                 if attempt.disposition is GridSeedDisposition.INTERRUPTED
-                else GroupedGridDirectTrfTerminal.EXECUTION_FAILURE
+                else GridDirectTrfTerminal.EXECUTION_FAILURE
             )
+            records = tuple(attempted)
             return GroupedGridDirectTrfOutcome(
-                terminal,
-                tuple(attempted),
-                failure=attempt.failure,
+                records,
+                GridDirectTrfOutcome(
+                    terminal,
+                    records,
+                    failure=attempt.failure,
+                ),
             )
     return tuple(attempted)
 
 
+def _validate_grouped_attempts(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    invocation: GridDirectTrfInvocation,
+    attempts: tuple[GroupedGridSeedOutcome, ...],
+) -> GroupedGridDirectTrfOutcome | None:
+    """Fail closed before canonical GRID sees malformed grouped evidence."""
+    records = list(attempts)
+    failure: BaseException | None = None
+    failed_index: int | None = None
+    if len(records) != len(invocation.seeds):
+        failure = DirectTrfConstructionError(
+            "Grouped GRID occurrence lacks its complete canonical seed table"
+        )
+    else:
+        for index, (record, seed) in enumerate(
+            zip(records, invocation.seeds, strict=True)
+        ):
+            if (
+                record.seed_identity != seed.identity
+                or record.seed_ordinal != seed.ordinal
+                or record.root_decomposition_identity != decomposition.identity
+            ):
+                failure = DirectTrfConstructionError(
+                    "Grouped GRID occurrence contains foreign seed evidence"
+                )
+                failed_index = index
+                break
+            if record.disposition is GridSeedDisposition.ELIGIBLE:
+                try:
+                    record.validate_for_grid_selection(problem, invocation, seed)
+                except Exception as error:  # noqa: BLE001 - evidence fails closed
+                    failure = error
+                    failed_index = index
+                    break
+    if failure is None:
+        return None
+    if failed_index is not None:
+        records[failed_index] = _lineage_failure(records[failed_index], failure)
+    frozen = tuple(records)
+    return GroupedGridDirectTrfOutcome(
+        frozen,
+        GridDirectTrfOutcome(
+            GridDirectTrfTerminal.EXECUTION_FAILURE,
+            frozen,
+            failure=TerminalFailure(
+                "grouped_grid_occurrence_lineage_failure",
+                f"{type(failure).__name__}: {failure}",
+            ),
+        ),
+    )
+
+
 def commit_grouped_grid_accepted_fit(
-    accepted: AcceptedGroupedGridDirectTrfResult,
+    accepted: AcceptedGridDirectTrfResult,
     authority: LiveFitCommitAuthority,
     *,
     problem: OptimizationProblem,
@@ -1032,8 +925,17 @@ def commit_grouped_grid_accepted_fit(
     analysis_values: AnalysisValues,
 ) -> CommitReceipt:
     """Validate grouped-GRID lineage, then use the generic commit seam."""
-    _validate_acceptance_lineage(accepted, problem)
-    return commit_accepted_fit(
+    selected = accepted.selected_outcome
+    if not isinstance(selected, GroupedGridSeedOutcome):
+        raise DirectTrfConstructionError(
+            "Accepted grouped GRID result lacks grouped seed evidence"
+        )
+    selected.validate_for_grid_selection(
+        problem,
+        accepted.workflow_invocation,
+        accepted.selected_seed,
+    )
+    return commit_grid_accepted_fit(
         accepted,
         authority,
         problem=problem,
@@ -1065,102 +967,20 @@ def execute_grouped_grid_direct_trf(
     if isinstance(seed_execution, GroupedGridDirectTrfOutcome):
         return seed_execution
     attempts = seed_execution
-    if not any(
-        attempt.disposition is GridSeedDisposition.ELIGIBLE for attempt in attempts
-    ):
-        return GroupedGridDirectTrfOutcome(
-            GroupedGridDirectTrfTerminal.NO_ELIGIBLE_CANDIDATE,
-            attempts,
-        )
-    selection, selected = _select(attempts)
-    aggregate_candidate = cast("GridCandidate", selected.candidate)
-    execution_identity = _identity(
-        "native-grouped-grid-selection-execution",
-        (
-            invocation.identity,
-            decomposition.identity,
-            selection.identity,
-            selected.identity,
-            aggregate_candidate.identity,
-        ),
-    )
-    if token.is_cancelled:
-        return GroupedGridDirectTrfOutcome(
-            GroupedGridDirectTrfTerminal.CANCELLED,
-            attempts,
-            selection,
-        )
-    try:
-        fresh = _fresh_root_candidate(
-            problem,
-            invocation.identity,
-            execution_identity,
-            aggregate_candidate.vector,
-            parameterization,
-            engine,
-        )
-    except KeyboardInterrupt:
-        return GroupedGridDirectTrfOutcome(
-            GroupedGridDirectTrfTerminal.INTERRUPTED,
-            attempts,
-            selection,
-        )
-    except Exception as error:  # noqa: BLE001 - root promotion fails closed
-        return GroupedGridDirectTrfOutcome(
-            GroupedGridDirectTrfTerminal.MATERIALIZATION_FAILURE,
-            attempts,
-            selection,
-            failure=TerminalFailure(
-                "grouped_grid_selection_materialization_exception",
-                f"{type(error).__name__}: {error}",
-            ),
-        )
-    if token.is_cancelled:
-        return GroupedGridDirectTrfOutcome(
-            GroupedGridDirectTrfTerminal.CANCELLED,
-            attempts,
-            selection,
-        )
-    provenance = GroupedGridSelectionProvenance(
-        invocation.identity,
-        problem.identity,
-        decomposition.identity,
-        selection.identity,
-        selected.seed_identity,
-        selected.seed_ordinal,
-        selected.identity,
-        aggregate_candidate.identity,
-        aggregate_candidate.candidate.materialization.identity,
-        fresh.materialization.identity,
-        fresh.evaluation_result.identity,
-    )
-    base_accepted = _accept_materialized_fit_for_derived_workflow(
-        problem=problem,
-        invocation_identity=invocation.identity,
-        execution_identity=execution_identity,
-        materialization=fresh.materialization,
-        vector=fresh.vector,
-        chi_square=fresh.chi_square,
-        evaluation_result=fresh.evaluation_result,
-        authority_context_identity=provenance.identity,
-    )
-    selected_seed = invocation.seeds[selected.seed_ordinal]
-    accepted = AcceptedGroupedGridDirectTrfResult.from_accepted(
-        base_accepted,
-        provenance,
-        invocation,
+    invalid = _validate_grouped_attempts(
+        problem,
         decomposition,
-        selection,
-        selected_seed,
-        selected,
-        fresh,
-    )
-    _validate_acceptance_lineage(accepted, problem)
-    authority = _grant_derived_fit_commit_authority(accepted, problem)
-    return GroupedGridDirectTrfOutcome(
-        GroupedGridDirectTrfTerminal.ACCEPTED,
+        invocation,
         attempts,
-        selection,
-        accepted,
-        authority,
     )
+    if invalid is not None:
+        return invalid
+    grid_outcome = _finalize_grid_candidates(
+        problem,
+        invocation,
+        attempts,
+        parameterization,
+        engine,
+        token,
+    )
+    return GroupedGridDirectTrfOutcome(attempts, grid_outcome)

--- a/tests/test_native_grouped_grid_direct_trf.py
+++ b/tests/test_native_grouped_grid_direct_trf.py
@@ -1,0 +1,509 @@
+"""Behavioral qualification for exact grouped native GRID -> TRF (#596)."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from chemex.configuration.methods import Selection, read_methods
+from chemex.configuration.parameters import read_defaults
+from chemex.containers.experiments import Experiments
+from chemex.evaluation.native import EvaluationEngine
+from chemex.experiments.builder import build_experiments
+from chemex.optimize.direct_trf import (
+    CancellationToken,
+    DirectTrfConstructionError,
+    OptimizationProblem,
+)
+from chemex.optimize.grid_direct_trf import (
+    GridDirectTrfInvocation,
+    GridSeedDisposition,
+)
+from chemex.optimize.grouped_direct_trf import ComponentDisposition, FitDecomposition
+from chemex.optimize.grouped_grid_direct_trf import (
+    GroupedGridDirectTrfTerminal,
+    GroupedGridSeedOutcome,
+    commit_grouped_grid_accepted_fit,
+    execute_grouped_grid_direct_trf,
+)
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.runtime import AnalysisSession
+from chemex.typing import Array
+
+ROOT = Path(__file__).parent.parent
+EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
+METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+def _grouped_grid_problem() -> tuple[
+    AnalysisSession,
+    Experiments,
+    ActiveParameterization,
+    EvaluationEngine,
+    OptimizationProblem,
+]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=None, exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    parameterization = session.compile_parameterization(
+        read_methods([METHOD])["DEFAULT"],
+        experiments.param_ids,
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    return session, experiments, parameterization, engine, problem
+
+
+def _backend_result(
+    candidate: Array,
+    residuals: Array,
+    *,
+    status: int = 1,
+    success: bool = True,
+) -> object:
+    return SimpleNamespace(
+        x=candidate,
+        fun=residuals,
+        status=status,
+        success=success,
+        message="qualified grouped GRID backend result",
+        nfev=1,
+        njev=0,
+        cost=0.5 * float(np.dot(residuals, residuals)),
+        optimality=0.0,
+        active_mask=np.zeros_like(candidate, dtype=np.int64),
+    )
+
+
+def _component_objective(
+    attempt: GroupedGridSeedOutcome,
+    component_ordinal: int,
+) -> float:
+    candidate = attempt.components[component_ordinal].candidate
+    assert candidate is not None
+    return candidate.chi_square
+
+
+def test_each_seed_uses_exact_components_and_only_selected_aggregate_commits() -> None:
+    session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    axis_start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (axis_start, axis_start * 1.1)),),
+        objective_request_budget=10,
+    )
+    before = session.analysis_values.snapshot()
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate))
+
+    with patch("chemex.optimize.direct_trf.least_squares", successful_backend):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
+    assert tuple(attempt.disposition for attempt in outcome.attempts) == (
+        GridSeedDisposition.ELIGIBLE,
+        GridSeedDisposition.ELIGIBLE,
+    )
+    assert outcome.selection is not None
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    assert session.analysis_values.snapshot() == before
+
+    for seed, attempt in zip(invocation.seeds, outcome.attempts, strict=True):
+        assert seed.problem is not None
+        assert seed.problem.source_snapshot is problem.source_snapshot
+        seed_decomposition = FitDecomposition.from_root(
+            seed.problem,
+            parameterization,
+            engine,
+        )
+        assert attempt.seed_decomposition is not None
+        assert attempt.seed_decomposition.root_problem_identity == seed.problem.identity
+        assert attempt.seed_decomposition.identity == seed_decomposition.identity
+        assert seed_decomposition.identity == decomposition.identity
+        assert tuple(item.component_identity for item in attempt.components) == tuple(
+            component.identity for component in decomposition.components
+        )
+        assert tuple(
+            item.candidate.problem_identity
+            for item in attempt.components
+            if item.candidate is not None
+        ) == tuple(
+            component.problem.identity for component in seed_decomposition.components
+        )
+        assert all(not hasattr(item, "accepted_result") for item in attempt.components)
+        assert not hasattr(attempt, "accepted_result")
+        assert attempt.candidate is not None
+        assert attempt.candidate.candidate.problem_identity == problem.identity
+
+    selected = outcome.selection.selected_record
+    assert selected.candidate is not None
+    assert outcome.accepted_result.vector == selected.candidate.vector
+    assert outcome.accepted_result.chi_square == selected.candidate.objective
+    assert outcome.accepted_result.problem_identity == problem.identity
+
+    receipt = commit_grouped_grid_accepted_fit(
+        outcome.accepted_result,
+        outcome.commit_authority,
+        problem=problem,
+        parameterization=parameterization,
+        analysis_values=session.analysis_values,
+    )
+
+    assert receipt.old_revision == before.revision
+    assert receipt.new_revision == before.revision + 1
+
+
+def test_selection_orders_whole_aggregates_and_never_combines_marginal_minima() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    component_count = len(decomposition.components)
+    (axis_id,) = problem.controlled_ids[:1]
+    axis_start = problem.start[0]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (axis_start, axis_start * 1.1)),),
+        objective_request_budget=10,
+    )
+    backend_calls = 0
+
+    def crossed_component_backend(
+        fun: Callable[[Array], Array],
+        x0: Array,
+        **kwargs: object,
+    ) -> object:
+        nonlocal backend_calls
+        call_ordinal = backend_calls
+        backend_calls += 1
+        seed_ordinal, component_ordinal = divmod(call_ordinal, component_count)
+        lower, upper = kwargs["bounds"]
+        lower_array = np.asarray(lower, dtype=np.float64)
+        upper_array = np.asarray(upper, dtype=np.float64)
+        start = np.asarray(x0, dtype=np.float64)
+        low = np.minimum(np.maximum(start * 0.8, lower_array), upper_array)
+        high = np.minimum(np.maximum(start * 1.2, lower_array), upper_array)
+        low_residuals = fun(low)
+        high_residuals = fun(high)
+        low_objective = float(np.dot(low_residuals, low_residuals))
+        high_objective = float(np.dot(high_residuals, high_residuals))
+        better, worse = (low, high) if low_objective < high_objective else (high, low)
+        if component_ordinal == 0:
+            candidate = better if seed_ordinal == 0 else worse
+        elif component_ordinal == 1:
+            candidate = worse if seed_ordinal == 0 else better
+        else:
+            candidate = better
+        residuals = fun(candidate)
+        return _backend_result(candidate, residuals)
+
+    with patch("chemex.optimize.direct_trf.least_squares", crossed_component_backend):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
+    assert outcome.selection is not None
+    assert outcome.selection.ordering_policy == (
+        "aggregate-chi-square-vector-seed-ordinal-v1"
+    )
+    assert all(attempt.candidate is not None for attempt in outcome.attempts)
+
+    aggregate_vectors: list[tuple[float, ...]] = []
+    for attempt in outcome.attempts:
+        assignments = {
+            param_id: value
+            for component in attempt.components
+            if component.candidate is not None
+            for param_id, value in zip(
+                component.controlled_ids,
+                component.candidate.vector,
+                strict=True,
+            )
+        }
+        expected = tuple(assignments[param_id] for param_id in problem.controlled_ids)
+        assert attempt.candidate is not None
+        assert attempt.candidate.vector == expected
+        aggregate_vectors.append(expected)
+
+    marginal_sources: list[int] = []
+    marginal_assignments: dict[str, float] = {}
+    for component_ordinal, component in enumerate(decomposition.components):
+        source_ordinal, source = min(
+            enumerate(outcome.attempts),
+            key=lambda item: _component_objective(item[1], component_ordinal),
+        )
+        marginal_sources.append(source_ordinal)
+        source_candidate = source.components[component_ordinal].candidate
+        assert source_candidate is not None
+        marginal_assignments.update(
+            zip(component.controlled_ids, source_candidate.vector, strict=True)
+        )
+    marginal_vector = tuple(
+        marginal_assignments[param_id] for param_id in problem.controlled_ids
+    )
+
+    assert set(marginal_sources[:2]) == {0, 1}
+    assert marginal_vector not in aggregate_vectors
+    selected = outcome.selection.selected_record
+    assert selected.candidate is not None
+    assert selected.candidate.vector in aggregate_vectors
+    assert selected.candidate.objective == min(
+        attempt.candidate.objective
+        for attempt in outcome.attempts
+        if attempt.candidate is not None
+    )
+
+
+def test_commit_rejects_tampered_component_lineage_before_generic_authority() -> None:
+    session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0],)),),
+        objective_request_budget=10,
+    )
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate))
+
+    with patch("chemex.optimize.direct_trf.least_squares", successful_backend):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.selection is not None
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    selected = outcome.selection.selected_record
+    first_component = selected.components[0]
+    assert first_component.candidate is not None
+    foreign_candidate = dataclasses.replace(
+        first_component.candidate,
+        problem_identity="foreign-component-problem",
+    )
+    foreign_component = dataclasses.replace(
+        first_component,
+        candidate=foreign_candidate,
+    )
+    foreign_selected = dataclasses.replace(
+        selected,
+        components=(foreign_component, *selected.components[1:]),
+    )
+    selection_type = type(outcome.selection)
+    foreign_selection = selection_type.from_candidate_records((foreign_selected,))
+    foreign_provenance = dataclasses.replace(
+        outcome.accepted_result.grouped_grid_provenance,
+        selection_identity=foreign_selection.identity,
+        selected_outcome_identity=foreign_selected.identity,
+    )
+    foreign_accepted = dataclasses.replace(
+        outcome.accepted_result,
+        grouped_grid_provenance=foreign_provenance,
+        selection=foreign_selection,
+        selected_outcome=foreign_selected,
+        origin_context_identity=foreign_provenance.identity,
+    )
+    before = session.analysis_values.snapshot()
+
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="canonical aggregate authority",
+    ):
+        commit_grouped_grid_accepted_fit(
+            foreign_accepted,
+            outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+
+    assert session.analysis_values.snapshot() == before
+
+
+def test_cancellation_stops_later_seeds_without_aggregate_authority() -> None:
+    session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0], problem.start[0] * 1.1)),),
+        objective_request_budget=10,
+    )
+    token = CancellationToken()
+    backend_calls = 0
+
+    def cancelling_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        nonlocal backend_calls
+        backend_calls += 1
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        residuals = fun(candidate)
+        token.cancel()
+        return _backend_result(candidate, residuals)
+
+    before = session.analysis_values.snapshot()
+    with patch("chemex.optimize.direct_trf.least_squares", cancelling_backend):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+
+    assert backend_calls == 1
+    assert outcome.terminal is GroupedGridDirectTrfTerminal.CANCELLED
+    assert tuple(attempt.disposition for attempt in outcome.attempts) == (
+        GridSeedDisposition.CANCELLED,
+        GridSeedDisposition.NOT_STARTED,
+    )
+    assert outcome.selection is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    assert session.analysis_values.snapshot() == before
+
+
+def test_failed_seed_keeps_component_evidence_and_later_seed_can_win() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0], problem.start[0] * 1.1)),),
+        objective_request_budget=10,
+    )
+    backend_calls = 0
+
+    def first_component_does_not_converge(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        nonlocal backend_calls
+        backend_calls += 1
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        residuals = fun(candidate)
+        if backend_calls == 1:
+            return _backend_result(
+                candidate,
+                residuals,
+                status=0,
+                success=False,
+            )
+        return _backend_result(candidate, residuals)
+
+    with patch(
+        "chemex.optimize.direct_trf.least_squares",
+        first_component_does_not_converge,
+    ):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert backend_calls == 2 * len(decomposition.components)
+    assert outcome.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
+    assert tuple(attempt.disposition for attempt in outcome.attempts) == (
+        GridSeedDisposition.NON_CONVERGED,
+        GridSeedDisposition.ELIGIBLE,
+    )
+    assert outcome.attempts[0].candidate is None
+    assert outcome.attempts[0].components[0].disposition is (
+        ComponentDisposition.FAILED
+    )
+    assert outcome.selection is not None
+    assert outcome.selection.selected_seed_ordinal == 1
+
+
+def test_equal_aggregate_objective_and_vector_tie_selects_first_seed() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0], problem.start[0] * 1.1)),),
+        objective_request_budget=10,
+    )
+    starts = dict(zip(problem.controlled_ids, problem.start, strict=True))
+    backend_calls = 0
+
+    def tied_backend(
+        fun: Callable[[Array], Array], _x0: Array, **_kwargs: object
+    ) -> object:
+        nonlocal backend_calls
+        component = decomposition.components[
+            backend_calls % len(decomposition.components)
+        ]
+        backend_calls += 1
+        candidate = np.asarray(
+            tuple(starts[param_id] for param_id in component.controlled_ids),
+            dtype=np.float64,
+        )
+        return _backend_result(candidate, fun(candidate))
+
+    with patch("chemex.optimize.direct_trf.least_squares", tied_backend):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
+    assert outcome.selection is not None
+    first, second = outcome.attempts
+    assert first.candidate is not None
+    assert second.candidate is not None
+    assert first.candidate.objective == second.candidate.objective
+    assert first.candidate.vector == second.candidate.vector
+    assert outcome.selection.selected_seed_ordinal == 0

--- a/tests/test_native_grouped_grid_direct_trf.py
+++ b/tests/test_native_grouped_grid_direct_trf.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+import chemex.optimize.grouped_grid_direct_trf as grouped_grid
 from chemex.configuration.methods import Selection, read_methods
 from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
@@ -33,6 +34,7 @@ from chemex.optimize.grouped_grid_direct_trf import (
     execute_grouped_grid_direct_trf,
 )
 from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.values import StaleAnalysisValuesError
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
 
@@ -132,6 +134,13 @@ def test_each_seed_uses_exact_components_and_only_selected_aggregate_commits() -
             parameterization,
             engine,
         )
+        stale_outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
 
     assert outcome.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
     assert tuple(attempt.disposition for attempt in outcome.attempts) == (
@@ -141,6 +150,8 @@ def test_each_seed_uses_exact_components_and_only_selected_aggregate_commits() -
     assert outcome.selection is not None
     assert outcome.accepted_result is not None
     assert outcome.commit_authority is not None
+    assert stale_outcome.accepted_result is not None
+    assert stale_outcome.commit_authority is not None
     assert session.analysis_values.snapshot() == before
 
     for seed, attempt in zip(invocation.seeds, outcome.attempts, strict=True):
@@ -186,6 +197,27 @@ def test_each_seed_uses_exact_components_and_only_selected_aggregate_commits() -
 
     assert receipt.old_revision == before.revision
     assert receipt.new_revision == before.revision + 1
+    committed = session.analysis_values.snapshot()
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exact live Direct TRF commit authority",
+    ):
+        commit_grouped_grid_accepted_fit(
+            outcome.accepted_result,
+            outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+    with pytest.raises(StaleAnalysisValuesError, match="revision is stale"):
+        commit_grouped_grid_accepted_fit(
+            stale_outcome.accepted_result,
+            stale_outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+    assert session.analysis_values.snapshot() == committed
 
 
 def test_selection_orders_whole_aggregates_and_never_combines_marginal_minima() -> None:
@@ -241,9 +273,7 @@ def test_selection_orders_whole_aggregates_and_never_combines_marginal_minima() 
 
     assert outcome.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
     assert outcome.selection is not None
-    assert outcome.selection.ordering_policy == (
-        "aggregate-chi-square-vector-seed-ordinal-v1"
-    )
+    assert outcome.selection.ordering_policy == "chi-square-vector-seed-ordinal-v1"
     assert all(attempt.candidate is not None for attempt in outcome.attempts)
 
     aggregate_vectors: list[tuple[float, ...]] = []
@@ -335,25 +365,15 @@ def test_commit_rejects_tampered_component_lineage_before_generic_authority() ->
         selected,
         components=(foreign_component, *selected.components[1:]),
     )
-    selection_type = type(outcome.selection)
-    foreign_selection = selection_type.from_candidate_records((foreign_selected,))
-    foreign_provenance = dataclasses.replace(
-        outcome.accepted_result.grouped_grid_provenance,
-        selection_identity=foreign_selection.identity,
-        selected_outcome_identity=foreign_selected.identity,
-    )
     foreign_accepted = dataclasses.replace(
         outcome.accepted_result,
-        grouped_grid_provenance=foreign_provenance,
-        selection=foreign_selection,
         selected_outcome=foreign_selected,
-        origin_context_identity=foreign_provenance.identity,
     )
     before = session.analysis_values.snapshot()
 
     with pytest.raises(
         DirectTrfConstructionError,
-        match="canonical aggregate authority",
+        match="exact component ownership",
     ):
         commit_grouped_grid_accepted_fit(
             foreign_accepted,
@@ -507,3 +527,297 @@ def test_equal_aggregate_objective_and_vector_tie_selects_first_seed() -> None:
     assert first.candidate.objective == second.candidate.objective
     assert first.candidate.vector == second.candidate.vector
     assert outcome.selection.selected_seed_ordinal == 0
+
+
+def test_cross_seed_component_mix_is_rejected_before_grid_selection() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0], problem.start[0] * 1.1)),),
+        objective_request_budget=10,
+    )
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate))
+
+    with patch("chemex.optimize.direct_trf.least_squares", successful_backend):
+        clean = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    seed_0, seed_1 = clean.attempts
+    mixed_seed_0 = dataclasses.replace(
+        seed_0,
+        components=(seed_1.components[0], *seed_0.components[1:]),
+    )
+
+    with patch.object(
+        grouped_grid,
+        "_execute_all_seeds",
+        return_value=(mixed_seed_0, seed_1),
+    ):
+        attacked = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert attacked.terminal is GroupedGridDirectTrfTerminal.EXECUTION_FAILURE
+    assert attacked.attempts[0].disposition is (
+        GridSeedDisposition.IMPLEMENTATION_FAILURE
+    )
+    assert attacked.attempts[0].candidate is None
+    assert attacked.selection is None
+    assert attacked.accepted_result is None
+    assert attacked.commit_authority is None
+
+
+def test_foreign_grouped_seed_evidence_is_rejected_before_grid_selection() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0], problem.start[0] * 1.1)),),
+        objective_request_budget=10,
+    )
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate))
+
+    with patch("chemex.optimize.direct_trf.least_squares", successful_backend):
+        clean = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    seed_0, seed_1 = clean.attempts
+    first_outcome = seed_0.components[0]
+    assert first_outcome.candidate is not None
+    assert seed_0.seed_decomposition is not None
+    assert seed_1.seed_decomposition is not None
+    assert seed_0.component_invocation is not None
+    assert seed_1.component_invocation is not None
+    first_fit_component = seed_0.seed_decomposition.components[0]
+
+    wrong_controlled = dataclasses.replace(
+        first_outcome,
+        controlled_ids=("foreign-control",),
+    )
+    wrong_child_component = dataclasses.replace(
+        first_fit_component,
+        problem=seed_1.seed_decomposition.components[0].problem,
+    )
+    wrong_child_decomposition = dataclasses.replace(
+        seed_0.seed_decomposition,
+        components=(
+            wrong_child_component,
+            *seed_0.seed_decomposition.components[1:],
+        ),
+    )
+    wrong_direct_invocation = dataclasses.replace(
+        seed_0.component_invocation,
+        component_invocations=(
+            seed_1.component_invocation.component_invocations[0],
+            *seed_0.component_invocation.component_invocations[1:],
+        ),
+    )
+    foreign_candidate = dataclasses.replace(
+        first_outcome.candidate,
+        problem_identity="foreign-component-problem",
+    )
+    foreign_materialization = dataclasses.replace(
+        first_outcome.candidate.materialization,
+        problem_identity="foreign-materialization-problem",
+    )
+    candidate_with_foreign_materialization = dataclasses.replace(
+        first_outcome.candidate,
+        materialization=foreign_materialization,
+    )
+    duplicate_missing = (
+        first_outcome,
+        first_outcome,
+        *seed_0.components[2:],
+    )
+    attacks = {
+        "wrong decomposition": dataclasses.replace(
+            seed_0,
+            root_decomposition_identity="foreign-decomposition",
+        ),
+        "wrong controlled IDs": dataclasses.replace(
+            seed_0,
+            components=(wrong_controlled, *seed_0.components[1:]),
+        ),
+        "wrong child problem": dataclasses.replace(
+            seed_0,
+            seed_decomposition=wrong_child_decomposition,
+        ),
+        "wrong child invocation": dataclasses.replace(
+            seed_0,
+            component_invocation=wrong_direct_invocation,
+        ),
+        "duplicate and missing component": dataclasses.replace(
+            seed_0,
+            components=duplicate_missing,
+        ),
+        "foreign candidate": dataclasses.replace(
+            seed_0,
+            components=(
+                dataclasses.replace(first_outcome, candidate=foreign_candidate),
+                *seed_0.components[1:],
+            ),
+        ),
+        "foreign materialization": dataclasses.replace(
+            seed_0,
+            components=(
+                dataclasses.replace(
+                    first_outcome,
+                    candidate=candidate_with_foreign_materialization,
+                ),
+                *seed_0.components[1:],
+            ),
+        ),
+    }
+
+    for attack_name, attacked_seed in attacks.items():
+        with patch.object(
+            grouped_grid,
+            "_execute_all_seeds",
+            return_value=(attacked_seed, seed_1),
+        ):
+            attacked = execute_grouped_grid_direct_trf(
+                problem,
+                decomposition,
+                invocation,
+                parameterization,
+                engine,
+            )
+
+        assert attacked.terminal is GroupedGridDirectTrfTerminal.EXECUTION_FAILURE, (
+            attack_name
+        )
+        assert attacked.attempts[0].disposition is (
+            GridSeedDisposition.IMPLEMENTATION_FAILURE
+        ), attack_name
+        assert attacked.attempts[0].candidate is None, attack_name
+        assert attacked.selection is None, attack_name
+        assert attacked.accepted_result is None, attack_name
+        assert attacked.commit_authority is None, attack_name
+
+
+def test_cancellation_after_seed_execution_gates_selection() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0], problem.start[0] * 1.1)),),
+        objective_request_budget=10,
+    )
+    token = CancellationToken()
+    execute_all_seeds = grouped_grid._execute_all_seeds
+
+    def cancel_after_seed_execution(*args: object, **kwargs: object) -> object:
+        result = execute_all_seeds(*args, **kwargs)
+        token.cancel()
+        return result
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate))
+
+    with (
+        patch("chemex.optimize.direct_trf.least_squares", successful_backend),
+        patch.object(
+            grouped_grid,
+            "_execute_all_seeds",
+            side_effect=cancel_after_seed_execution,
+        ),
+    ):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+
+    assert outcome.terminal is GroupedGridDirectTrfTerminal.CANCELLED
+    assert outcome.selection is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+
+
+def test_interruption_after_seed_execution_gates_selection() -> None:
+    class InterruptAfterSeedExecution(CancellationToken):
+        armed = False
+
+        @property
+        def is_cancelled(self) -> bool:
+            if self.armed:
+                raise KeyboardInterrupt
+            return super().is_cancelled
+
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0], problem.start[0] * 1.1)),),
+        objective_request_budget=10,
+    )
+    token = InterruptAfterSeedExecution()
+    execute_all_seeds = grouped_grid._execute_all_seeds
+
+    def interrupt_after_seed_execution(*args: object, **kwargs: object) -> object:
+        result = execute_all_seeds(*args, **kwargs)
+        token.armed = True
+        return result
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate))
+
+    with (
+        patch("chemex.optimize.direct_trf.least_squares", successful_backend),
+        patch.object(
+            grouped_grid,
+            "_execute_all_seeds",
+            side_effect=interrupt_after_seed_execution,
+        ),
+    ):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+
+    assert outcome.terminal is GroupedGridDirectTrfTerminal.INTERRUPTED
+    assert outcome.selection is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None


### PR DESCRIPTION
Closes #596.

## Summary

Adds the isolated native decomposed GRID → TRF qualification path by composing
the merged #594 grouped-fit semantics with the #595 GRID lifecycle.

Each GRID seed is projected through its exact fit decomposition, its component
fits remain non-authoritative, and successful components are recomposed into one
fresh complete-problem aggregate candidate.

Canonical GRID selection then operates only on those aggregate candidates.
Independent component minima can never be mixed across seeds.

## Architecture

The implementation keeps lifecycle ownership in the existing layers:

- #594 owns exact fit decomposition and per-seed aggregate construction.
- #595 owns canonical GRID ordering, selection, promotion, cancellation gating,
  acceptance, and live commit authority.
- #596 specializes GRID seed execution through the exact decomposition and
  validates the additional grouped lineage.

The resulting flow is:

root GRID seed
→ exact decomposition
→ non-authoritative component fits
→ grouped-seed lineage validation
→ fresh complete-root aggregate candidate
→ canonical #595 GRID finalization
→ selected accepted result
→ existing Direct-TRF live commit authority

`grouped_grid_direct_trf.py` does not implement a parallel selection or authority
lifecycle.

## Safety and provenance

- Every seed derives from the same root problem and starting snapshot.
- Components must belong to the exact seed-specific decomposition.
- Cross-seed component mixing is rejected before eligibility.
- Missing, duplicate, retargeted, or foreign component evidence cannot become
  selectable.
- Candidate ordering uses only fresh complete-problem aggregate objectives.
- Deterministic GRID tie-breaking is inherited from #595.
- Cancellation or interruption before finalization exposes no selection,
  accepted result, or authority.
- Only the selected aggregate result receives live commit authority.
- Grouped commit validates grouped lineage and delegates to
  `commit_grid_accepted_fit`.
- Existing exact-object, single-use, replay-resistant, and stale-safe authority
  semantics are preserved.

## Qualification

Behavioral coverage includes:

- exact per-seed component projection;
- fresh aggregate candidates;
- deterministic aggregate ordering;
- prevention of cross-seed marginal mixing;
- malformed decomposition and controlled-ID ownership;
- foreign child problem/invocation;
- duplicate and missing components;
- foreign candidate/materialization/execution evidence;
- cancellation and interruption before selection;
- selected-result-only authority;
- replay and stale commit behavior.

## Scope

Qualification path only.

No changes to:

- production dispatch;
- legacy GRID behavior;
- CLI or TOML;
- output;
- documentation;
- examples;
- scientific/numerical algorithms.

## Validation

Implementation validation:

- Focused qualification suites: 69 passed
- Full suite: 633 passed
- `uv run ty check`: passed
- Ruff lint: passed
- Ruff format check: passed
- `git diff --check`: passed
- Graphify refreshed

One existing non-failing `emcee` autocorrelation warning remains.

Independent adversarial review: **MERGE**

- Standards: 0 Blocking/Important findings
- Spec: 0 Blocking/Important findings