### PR TITLE
Add selected-coordinate DE to TRF qualification

### DIFF
--- a/src/chemex/optimize/de_direct_trf.py
+++ b/src/chemex/optimize/de_direct_trf.py
@@ -22,7 +22,6 @@ import numpy as np
 from scipy.optimize import Bounds, differential_evolution
 
 from chemex.evaluation.native import (
-    BoundEvaluator,
     EvaluationEngine,
     EvaluationFailure,
     EvaluationFrame,
@@ -33,7 +32,6 @@ from chemex.optimize.direct_trf import (
     AttemptCounters,
     CancellationToken,
     CandidateMaterialization,
-    CandidateSummary,
     CommitReceipt,
     DePolishProblemDerivation,
     DeSearchProblemDerivation,
@@ -42,7 +40,6 @@ from chemex.optimize.direct_trf import (
     DirectTrfConstructionError,
     DirectTrfInterrupted,
     DirectTrfInvocation,
-    DirectTrfTerminal,
     LiveFitCommitAuthority,
     MaterializationTerminal,
     MaterializedDirectTrfCandidate,
@@ -51,6 +48,7 @@ from chemex.optimize.direct_trf import (
     TerminalFailure,
     _accept_materialized_fit_for_derived_workflow,
     _grant_derived_fit_commit_authority,
+    _materialize_derived_direct_trf_candidate_for_root,
     canonical_chi_square,
     commit_accepted_fit,
     execute_direct_trf_candidate,
@@ -214,7 +212,15 @@ class DePopulation:
 
     def __post_init__(self) -> None:
         if (
-            self.dimension < 1
+            isinstance(self.dimension, bool)
+            or not isinstance(self.dimension, int)
+            or isinstance(self.multiplier, bool)
+            or not isinstance(self.multiplier, int)
+            or isinstance(self.size, bool)
+            or not isinstance(self.size, int)
+            or isinstance(self.maximum_generations, bool)
+            or not isinstance(self.maximum_generations, int)
+            or self.dimension < 1
             or self.multiplier < 1
             or self.size != max(5, self.dimension * self.multiplier)
             or self.maximum_generations < 1
@@ -244,6 +250,63 @@ class DePopulation:
         )
 
 
+def _validate_invocation_search_contract(
+    root_problem_identity: str,
+    coordinates: tuple[DeSearchCoordinate, ...],
+    search_problem: OptimizationProblem,
+) -> None:
+    derivation = search_problem.derivation
+    if (
+        not root_problem_identity
+        or not isinstance(derivation, DeSearchProblemDerivation)
+        or derivation.root_problem_identity != root_problem_identity
+    ):
+        raise DirectTrfConstructionError(
+            "DE search problem must retain its exact root derivation"
+        )
+    if not isinstance(coordinates, tuple) or not coordinates:
+        raise DirectTrfConstructionError(
+            "DE requires immutable explicitly selected coordinates"
+        )
+    if any(not isinstance(item, DeSearchCoordinate) for item in coordinates):
+        raise DirectTrfConstructionError("DE search coordinates are malformed")
+    selected_ids = tuple(item.param_id for item in coordinates)
+    known_ids = {param_id for param_id, _value in search_problem.independent_items}
+    if (
+        selected_ids != search_problem.controlled_ids
+        or selected_ids
+        != tuple(sorted(selected_ids, key=lambda item: item.encode("utf-8")))
+        or len(set(selected_ids)) != len(selected_ids)
+        or set(selected_ids) - known_ids
+    ):
+        raise DirectTrfConstructionError(
+            "DE coordinates must exactly match canonical selected ownership"
+        )
+    if {item.declaration_ordinal for item in coordinates} != set(
+        range(len(coordinates))
+    ):
+        raise DirectTrfConstructionError(
+            "DE coordinate declaration ordinals must be unique and complete"
+        )
+    specification_identity = _identity(
+        "native-de-search-specification",
+        tuple(item.identity for item in coordinates),
+    )
+    if derivation.search_specification_identity != specification_identity:
+        raise DirectTrfConstructionError(
+            "DE coordinate transforms or bounds differ from their parameter IDs"
+        )
+    for index, coordinate in enumerate(coordinates):
+        if (
+            coordinate.physical_lower < search_problem.lower_bounds[index]
+            or coordinate.physical_upper > search_problem.upper_bounds[index]
+        ):
+            raise DirectTrfConstructionError(
+                f"DE search range for {coordinate.param_id!r} exceeds physical bounds"
+            )
+        coordinate.to_solver(search_problem.start[index])
+
+
 @dataclass(frozen=True, slots=True)
 class DeDirectTrfInvocation:
     """Immutable selected-coordinate DE search and one full TRF polish policy."""
@@ -266,12 +329,67 @@ class DeDirectTrfInvocation:
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        if self.search_problem.derivation is None:
-            raise DirectTrfConstructionError("DE search problem must be derived")
-        if self.de_objective_request_budget < self.population.size:
+        coordinates = self.search_coordinates
+        _validate_invocation_search_contract(
+            self.root_problem_identity,
+            coordinates,
+            self.search_problem,
+        )
+        if (
+            isinstance(self.root_seed, bool)
+            or not isinstance(self.root_seed, int)
+            or not 0 <= self.root_seed <= _UINT64_MAX
+        ):
+            raise DirectTrfConstructionError(
+                "DE requires an explicit unsigned 64-bit root seed"
+            )
+        if not isinstance(self.population, DePopulation) or (
+            self.population.dimension != len(coordinates)
+        ):
+            raise DirectTrfConstructionError(
+                "DE population topology does not match selected coordinates"
+            )
+        de_budget = _positive_integer_budget(
+            self.de_objective_request_budget,
+            name="DE objective-request budget",
+        )
+        polish_budget = _positive_integer_budget(
+            self.polish_objective_request_budget,
+            name="TRF polish objective-request budget",
+        )
+        if de_budget < self.population.size:
             raise DirectTrfConstructionError(
                 "DE objective-request budget must cover the initial population"
             )
+        mutation = _mutation(self.mutation)
+        recombination = _probability(
+            self.recombination,
+            name="DE recombination probability",
+        )
+        tol = _non_negative(self.tol, name="DE relative tolerance")
+        atol = _non_negative(self.atol, name="DE absolute tolerance")
+        polish = DirectTrfInvocation(
+            self.root_problem_identity,
+            polish_budget,
+            self.polish_x_scale,
+            self.polish_ftol,
+            self.polish_xtol,
+            self.polish_gtol,
+        )
+        if len(polish.x_scale) < len(coordinates):
+            raise DirectTrfConstructionError(
+                "TRF polish scale cannot omit selected coordinates"
+            )
+        object.__setattr__(self, "de_objective_request_budget", de_budget)
+        object.__setattr__(self, "polish_objective_request_budget", polish_budget)
+        object.__setattr__(self, "mutation", mutation)
+        object.__setattr__(self, "recombination", recombination)
+        object.__setattr__(self, "tol", tol)
+        object.__setattr__(self, "atol", atol)
+        object.__setattr__(self, "polish_x_scale", polish.x_scale)
+        object.__setattr__(self, "polish_ftol", polish.ftol)
+        object.__setattr__(self, "polish_xtol", polish.xtol)
+        object.__setattr__(self, "polish_gtol", polish.gtol)
         object.__setattr__(
             self,
             "identity",
@@ -285,23 +403,23 @@ class DeDirectTrfInvocation:
                     self.search_problem.identity,
                     self.root_seed,
                     self.population.identity,
-                    self.de_objective_request_budget,
-                    self.polish_objective_request_budget,
+                    de_budget,
+                    polish_budget,
                     (
-                        tuple(_float_token(value) for value in self.mutation)
-                        if isinstance(self.mutation, tuple)
-                        else _float_token(self.mutation)
+                        tuple(_float_token(value) for value in mutation)
+                        if isinstance(mutation, tuple)
+                        else _float_token(mutation)
                     ),
-                    _float_token(self.recombination),
-                    _float_token(self.tol),
-                    _float_token(self.atol),
-                    tuple(_float_token(value) for value in self.polish_x_scale),
+                    _float_token(recombination),
+                    _float_token(tol),
+                    _float_token(atol),
+                    tuple(_float_token(value) for value in polish.x_scale),
                     tuple(
                         None if value is None else _float_token(value)
                         for value in (
-                            self.polish_ftol,
-                            self.polish_xtol,
-                            self.polish_gtol,
+                            polish.ftol,
+                            polish.xtol,
+                            polish.gtol,
                         )
                     ),
                 ),
@@ -1331,6 +1449,60 @@ def _derive_polish_problem(
     return child, polish
 
 
+def _validate_de_transition_lineage(
+    problem: OptimizationProblem,
+    invocation: DeDirectTrfInvocation,
+    search: DeSearchExecution,
+) -> None:
+    """Validate DE-owned candidate lineage before any TRF transfer exists."""
+    candidate = search.best_candidate
+    if candidate is None:
+        raise DirectTrfConstructionError(
+            "Restart-eligible DE search lacks a transition candidate"
+        )
+    selected_ids = invocation.search_problem.controlled_ids
+    root_indices = {
+        param_id: index for index, param_id in enumerate(problem.controlled_ids)
+    }
+    expected_selected = tuple(
+        candidate.full_vector[root_indices[param_id]] for param_id in selected_ids
+    )
+    unselected_ids = tuple(
+        param_id
+        for param_id in problem.controlled_ids
+        if param_id not in set(selected_ids)
+    )
+    root_start = dict(zip(problem.controlled_ids, problem.start, strict=True))
+    expected_solver = tuple(
+        coordinate.to_solver(value)
+        for coordinate, value in zip(
+            invocation.search_coordinates,
+            candidate.selected_vector,
+            strict=True,
+        )
+    )
+    if (
+        search.problem_identity != invocation.search_problem.identity
+        or search.workflow_invocation_identity != invocation.identity
+        or search.population_identity != invocation.population.identity
+        or search.candidate_ordering_policy != _DE_CANDIDATE_ORDER_VERSION
+        or len(candidate.full_vector) != len(problem.controlled_ids)
+        or len(candidate.selected_vector) != len(selected_ids)
+        or candidate.selected_vector != expected_selected
+        or candidate.solver_vector != expected_solver
+        or any(
+            candidate.full_vector[root_indices[param_id]] != root_start[param_id]
+            for param_id in unselected_ids
+        )
+        or candidate.request_ordinal > search.counters.objective_requests_accepted
+        or search.valid_candidate_count
+        > search.counters.objective_evaluations_completed
+    ):
+        raise DirectTrfConstructionError(
+            "Eligible DE candidate lineage is incompatible with its root problem"
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class DeTrfTransitionAccounting:
     """Explicit non-fungible accounting owned by the DE→TRF transition."""
@@ -1558,246 +1730,6 @@ def _transition_accounting(
     )
 
 
-def _failed_root_materialization(
-    problem: OptimizationProblem,
-    polish_invocation: DirectTrfInvocation,
-    polish: DirectTrfCandidateOutcome,
-    candidate: MaterializedDirectTrfCandidate,
-    compatibility_identity: str,
-    evaluation_count: int,
-    cache_hits: int,
-    cache_misses: int,
-    failure: TerminalFailure,
-    *,
-    terminal: MaterializationTerminal = MaterializationTerminal.FAILURE,
-) -> CandidateMaterialization:
-    return CandidateMaterialization(
-        uuid4().hex,
-        problem.identity,
-        polish_invocation.identity,
-        polish.execution.identity,
-        CandidateSummary(candidate.vector, candidate.chi_square, 0),
-        terminal,
-        evaluation_count,
-        compatibility_identity,
-        None,
-        cache_hits,
-        cache_misses,
-        failure,
-    )
-
-
-def _bind_root_materialization_evaluator(
-    problem: OptimizationProblem,
-    polish_invocation: DirectTrfInvocation,
-    polish: DirectTrfCandidateOutcome,
-    candidate: MaterializedDirectTrfCandidate,
-    engine: EvaluationEngine,
-) -> BoundEvaluator | CandidateMaterialization:
-    try:
-        return engine.new_evaluator()
-    except KeyboardInterrupt:
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            engine.compatibility_identity,
-            0,
-            0,
-            0,
-            TerminalFailure(
-                "interrupted",
-                "KeyboardInterrupt while binding root materialization",
-            ),
-            terminal=MaterializationTerminal.INTERRUPTED,
-        )
-    except Exception as error:  # noqa: BLE001 - root binding fails closed
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            engine.compatibility_identity,
-            0,
-            0,
-            0,
-            TerminalFailure(
-                "de_polish_materialization_binding_failure",
-                f"{type(error).__name__}: {error}",
-            ),
-        )
-
-
-def _materialize_polished_candidate_for_root(
-    problem: OptimizationProblem,
-    polish_invocation: DirectTrfInvocation,
-    polish: DirectTrfCandidateOutcome,
-    parameterization: ActiveParameterization,
-    engine: EvaluationEngine,
-    cancellation: CancellationToken,
-) -> MaterializedDirectTrfCandidate | CandidateMaterialization:
-    candidate = polish.candidate
-    if (
-        polish.terminal is not DirectTrfCandidateTerminal.SUCCESS
-        or polish.execution.terminal is not DirectTrfTerminal.CONVERGED
-        or candidate is None
-    ):
-        raise DirectTrfConstructionError(
-            "Only a converged materialized TRF polish may reach root validation"
-        )
-    bound = _bind_root_materialization_evaluator(
-        problem,
-        polish_invocation,
-        polish,
-        candidate,
-        engine,
-    )
-    if isinstance(bound, CandidateMaterialization):
-        return bound
-    evaluator = bound
-    if cancellation.is_cancelled:
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            evaluator.compatibility_identity,
-            0,
-            0,
-            0,
-            TerminalFailure("cancelled", "Cancellation before root materialization"),
-            terminal=MaterializationTerminal.CANCELLED,
-        )
-    try:
-        lifecycle = problem.lifecycle_frame(candidate.vector, parameterization)
-        frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
-        evaluated = evaluator.evaluate(frame)
-    except KeyboardInterrupt:
-        statistics = evaluator.cache_statistics
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure("interrupted", "KeyboardInterrupt in root materialization"),
-            terminal=MaterializationTerminal.INTERRUPTED,
-        )
-    except Exception as error:  # noqa: BLE001 - root materialization fails closed
-        statistics = evaluator.cache_statistics
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure(
-                "de_polish_materialization_exception",
-                f"{type(error).__name__}: {error}",
-            ),
-        )
-    statistics = evaluator.cache_statistics
-    if cancellation.is_cancelled:
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure(
-                "cancelled",
-                "Cancellation after fresh root evaluation",
-            ),
-            terminal=MaterializationTerminal.CANCELLED,
-        )
-    if isinstance(evaluated, EvaluationFailure):
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure(evaluated.category, evaluated.message, evaluated),
-        )
-    try:
-        objective = canonical_chi_square(evaluated.residuals)
-        vector = tuple(
-            evaluated.resolved_values[param_id] for param_id in problem.controlled_ids
-        )
-    except Exception as error:  # noqa: BLE001 - malformed evidence fails closed
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure(
-                "de_polish_materialization_validation_failure",
-                f"{type(error).__name__}: {error}",
-            ),
-        )
-    if (
-        vector != candidate.vector
-        or objective != candidate.chi_square
-        or evaluated.plan_identity != problem.evaluation_plan_identity
-        or evaluated.parameterization_identity
-        != problem.evaluator_parameterization_identity
-        or tuple(evaluated.resolved_values) != problem.commit_scope
-    ):
-        return _failed_root_materialization(
-            problem,
-            polish_invocation,
-            polish,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure(
-                "de_polish_materialization_mismatch",
-                "Fresh root evidence differs from the polished candidate",
-            ),
-        )
-    materialization = CandidateMaterialization(
-        uuid4().hex,
-        problem.identity,
-        polish_invocation.identity,
-        polish.execution.identity,
-        CandidateSummary(candidate.vector, objective, 0),
-        MaterializationTerminal.SUCCESS,
-        1,
-        evaluator.compatibility_identity,
-        evaluated.identity,
-        statistics.hits,
-        statistics.misses,
-    )
-    return MaterializedDirectTrfCandidate(
-        problem.identity,
-        polish_invocation.identity,
-        polish.execution.identity,
-        materialization,
-        candidate.vector,
-        objective,
-        evaluated,
-    )
-
-
 def execute_de_direct_trf(
     problem: OptimizationProblem,
     invocation: DeDirectTrfInvocation,
@@ -1834,6 +1766,59 @@ def execute_de_direct_trf(
         if terminal is DeDirectTrfTerminal.INTERRUPTED:
             raise DeDirectTrfInterrupted(outcome)
         return outcome
+    try:
+        _validate_de_transition_lineage(problem, invocation, search)
+    except Exception as error:  # noqa: BLE001 - transition lineage fails closed
+        return DeDirectTrfOutcome(
+            DeDirectTrfTerminal.EXECUTION_FAILURE,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                None,
+                transferred=False,
+                materialized=False,
+            ),
+            failure=TerminalFailure(
+                "de_search_lineage_failure",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    try:
+        cancelled_before_polish = token.is_cancelled
+    except KeyboardInterrupt as error:
+        outcome = DeDirectTrfOutcome(
+            DeDirectTrfTerminal.INTERRUPTED,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                None,
+                transferred=False,
+                materialized=False,
+            ),
+            failure=TerminalFailure(
+                "interrupted",
+                "KeyboardInterrupt at DE to TRF transition gate",
+            ),
+        )
+        raise DeDirectTrfInterrupted(outcome) from error
+    if cancelled_before_polish:
+        return DeDirectTrfOutcome(
+            DeDirectTrfTerminal.CANCELLED,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                None,
+                transferred=False,
+                materialized=False,
+            ),
+            failure=TerminalFailure(
+                "cancelled",
+                "Cancellation observed before DE to TRF transfer",
+            ),
+        )
     polish_problem, polish_invocation = _derive_polish_problem(
         problem,
         invocation,
@@ -1892,19 +1877,20 @@ def execute_de_direct_trf(
             polish,
             failure=polish.execution.failure,
         )
-    fresh = _materialize_polished_candidate_for_root(
+    polished_candidate = cast("MaterializedDirectTrfCandidate", polish.candidate)
+    fresh = _materialize_derived_direct_trf_candidate_for_root(
         problem,
-        polish_invocation,
-        polish,
+        polished_candidate,
         parameterization,
         engine,
-        token,
+        cancellation=token,
     )
     if isinstance(fresh, CandidateMaterialization):
         terminal = {
             MaterializationTerminal.CANCELLED: DeDirectTrfTerminal.CANCELLED,
             MaterializationTerminal.INTERRUPTED: DeDirectTrfTerminal.INTERRUPTED,
         }.get(fresh.terminal, DeDirectTrfTerminal.MATERIALIZATION_FAILURE)
+        materialization = fresh
         outcome = DeDirectTrfOutcome(
             terminal,
             search,
@@ -1918,14 +1904,13 @@ def execute_de_direct_trf(
             polish_problem,
             polish_invocation,
             polish,
-            fresh,
-            failure=fresh.failure,
+            materialization,
+            failure=materialization.failure,
         )
         if terminal is DeDirectTrfTerminal.INTERRUPTED:
             raise DeDirectTrfInterrupted(outcome)
         return outcome
     search_candidate = cast("DeSearchCandidate", search.best_candidate)
-    polished_candidate = cast("MaterializedDirectTrfCandidate", polish.candidate)
     provenance = DePolishProvenance(
         invocation.identity,
         problem.identity,

--- a/src/chemex/optimize/de_direct_trf.py
+++ b/src/chemex/optimize/de_direct_trf.py
@@ -63,6 +63,15 @@ _DE_BACKEND_POLICY_VERSION = "scipy-de-best1bin-lhs-deferred-pcg64-v1"
 _UINT64_MAX = 2**64 - 1
 
 
+@dataclass(frozen=True, slots=True)
+class _ExpectedSearchProjection:
+    held_items: tuple[tuple[str, float], ...]
+    start: tuple[float, ...]
+    lower_bounds: tuple[float, ...]
+    upper_bounds: tuple[float, ...]
+    derivation: DeSearchProblemDerivation
+
+
 def _identity(kind: str, record: object) -> str:
     encoded = json.dumps(
         {"kind": kind, "record": record, "schema_version": _SCHEMA_VERSION},
@@ -252,12 +261,15 @@ class DePopulation:
 
 def _validate_invocation_search_contract(
     root_problem_identity: str,
+    root_problem: OptimizationProblem,
     coordinates: tuple[DeSearchCoordinate, ...],
     search_problem: OptimizationProblem,
 ) -> None:
     derivation = search_problem.derivation
     if (
         not root_problem_identity
+        or not root_problem.acceptance_authority
+        or root_problem.identity != root_problem_identity
         or not isinstance(derivation, DeSearchProblemDerivation)
         or derivation.root_problem_identity != root_problem_identity
     ):
@@ -296,6 +308,25 @@ def _validate_invocation_search_contract(
         raise DirectTrfConstructionError(
             "DE coordinate transforms or bounds differ from their parameter IDs"
         )
+    root_indices = {
+        param_id: index for index, param_id in enumerate(root_problem.controlled_ids)
+    }
+    if set(selected_ids) - set(root_indices):
+        raise DirectTrfConstructionError(
+            "DE search coordinates are not eligible root-controlled coordinates"
+        )
+    expected = _expected_search_projection(
+        root_problem,
+        selected_ids,
+        specification_identity,
+        root_indices,
+    )
+    _validate_exact_search_projection(
+        root_problem,
+        search_problem,
+        selected_ids,
+        expected,
+    )
     for index, coordinate in enumerate(coordinates):
         if (
             coordinate.physical_lower < search_problem.lower_bounds[index]
@@ -307,11 +338,77 @@ def _validate_invocation_search_contract(
         coordinate.to_solver(search_problem.start[index])
 
 
+def _expected_search_projection(
+    root_problem: OptimizationProblem,
+    selected_ids: tuple[str, ...],
+    specification_identity: str,
+    root_indices: dict[str, int],
+) -> _ExpectedSearchProjection:
+    selected = set(selected_ids)
+    held_items = tuple(
+        item for item in root_problem.independent_items if item[0] not in selected
+    )
+    root_starts = dict(root_problem.independent_items)
+    start = tuple(root_starts[param_id] for param_id in selected_ids)
+    return _ExpectedSearchProjection(
+        held_items,
+        start,
+        tuple(
+            root_problem.lower_bounds[root_indices[param_id]]
+            for param_id in selected_ids
+        ),
+        tuple(
+            root_problem.upper_bounds[root_indices[param_id]]
+            for param_id in selected_ids
+        ),
+        DeSearchProblemDerivation(
+            root_problem.identity,
+            specification_identity,
+            selected_ids,
+            held_items,
+            start,
+        ),
+    )
+
+
+def _validate_exact_search_projection(
+    root_problem: OptimizationProblem,
+    search_problem: OptimizationProblem,
+    selected_ids: tuple[str, ...],
+    expected: _ExpectedSearchProjection,
+) -> None:
+    derivation = search_problem.derivation
+    if (
+        search_problem.evaluation_plan_identity != root_problem.evaluation_plan_identity
+        or search_problem.parameterization_identity
+        != root_problem.parameterization_identity
+        or search_problem.evaluator_parameterization_identity
+        != root_problem.evaluator_parameterization_identity
+        or search_problem.constraint_program_identity
+        != root_problem.constraint_program_identity
+        or search_problem.configuration_identity != root_problem.configuration_identity
+        or search_problem.source_snapshot != root_problem.source_snapshot
+        or search_problem.independent_items != root_problem.independent_items
+        or search_problem.controlled_ids != selected_ids
+        or search_problem.held_items != expected.held_items
+        or search_problem.start != expected.start
+        or search_problem.lower_bounds != expected.lower_bounds
+        or search_problem.upper_bounds != expected.upper_bounds
+        or search_problem.commit_scope != root_problem.commit_scope
+        or search_problem.scalarization_version != root_problem.scalarization_version
+        or derivation != expected.derivation
+    ):
+        raise DirectTrfConstructionError(
+            "DE search problem is not the exact canonical root projection"
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class DeDirectTrfInvocation:
     """Immutable selected-coordinate DE search and one full TRF polish policy."""
 
     root_problem_identity: str
+    root_problem: OptimizationProblem = field(repr=False, compare=False)
     search_coordinates: tuple[DeSearchCoordinate, ...]
     search_problem: OptimizationProblem = field(repr=False, compare=False)
     root_seed: int
@@ -332,6 +429,7 @@ class DeDirectTrfInvocation:
         coordinates = self.search_coordinates
         _validate_invocation_search_contract(
             self.root_problem_identity,
+            self.root_problem,
             coordinates,
             self.search_problem,
         )
@@ -376,9 +474,9 @@ class DeDirectTrfInvocation:
             self.polish_xtol,
             self.polish_gtol,
         )
-        if len(polish.x_scale) < len(coordinates):
+        if len(polish.x_scale) != len(self.root_problem.controlled_ids):
             raise DirectTrfConstructionError(
-                "TRF polish scale cannot omit selected coordinates"
+                "TRF polish scale must match the complete root coordinate dimension"
             )
         object.__setattr__(self, "de_objective_request_budget", de_budget)
         object.__setattr__(self, "polish_objective_request_budget", polish_budget)
@@ -659,6 +757,7 @@ class DeDirectTrfInvocation:
         )
         return cls(
             problem.identity,
+            problem,
             coordinates,
             search_problem,
             cast("int", root_seed),
@@ -1503,6 +1602,77 @@ def _validate_de_transition_lineage(
         )
 
 
+def _validate_de_polish_transition_lineage(
+    problem: OptimizationProblem,
+    invocation: DeDirectTrfInvocation,
+    search: DeSearchExecution,
+    polish_problem: OptimizationProblem,
+    polish_invocation: DirectTrfInvocation,
+    polish: DirectTrfCandidateOutcome,
+) -> None:
+    """Bind successful Direct TRF evidence to this exact DE transition."""
+    search_candidate = search.best_candidate
+    polished_candidate = polish.candidate
+    materialization = polish.materialization
+    derivation = polish_problem.derivation
+    expected_derivation = None
+    if search_candidate is not None:
+        expected_derivation = DePolishProblemDerivation(
+            problem.identity,
+            invocation.identity,
+            invocation.search_problem.identity,
+            search.identity,
+            search_candidate.identity,
+            problem.controlled_ids,
+            search_candidate.full_vector,
+        )
+    if (
+        search_candidate is None
+        or polish.terminal is not DirectTrfCandidateTerminal.SUCCESS
+        or polished_candidate is None
+        or materialization is None
+        or not isinstance(derivation, DePolishProblemDerivation)
+        or derivation != expected_derivation
+        or polish_problem.evaluation_plan_identity != problem.evaluation_plan_identity
+        or polish_problem.parameterization_identity != problem.parameterization_identity
+        or polish_problem.evaluator_parameterization_identity
+        != problem.evaluator_parameterization_identity
+        or polish_problem.constraint_program_identity
+        != problem.constraint_program_identity
+        or polish_problem.configuration_identity != problem.configuration_identity
+        or polish_problem.source_snapshot != problem.source_snapshot
+        or polish_problem.independent_items != problem.independent_items
+        or polish_problem.controlled_ids != problem.controlled_ids
+        or polish_problem.held_items != problem.held_items
+        or polish_problem.start != search_candidate.full_vector
+        or polish_problem.lower_bounds != problem.lower_bounds
+        or polish_problem.upper_bounds != problem.upper_bounds
+        or polish_problem.commit_scope != problem.commit_scope
+        or polish_problem.scalarization_version != problem.scalarization_version
+        or polish_invocation.problem_identity != polish_problem.identity
+        or polish_invocation.objective_request_budget
+        != invocation.polish_objective_request_budget
+        or polish_invocation.x_scale != invocation.polish_x_scale
+        or polish_invocation.ftol != invocation.polish_ftol
+        or polish_invocation.xtol != invocation.polish_xtol
+        or polish_invocation.gtol != invocation.polish_gtol
+        or polish.execution.problem_identity != polish_problem.identity
+        or polish.execution.invocation_identity != polish_invocation.identity
+        or polished_candidate.problem_identity != polish_problem.identity
+        or polished_candidate.invocation_identity != polish_invocation.identity
+        or polished_candidate.execution_identity != polish.execution.identity
+        or polish.materialization is not polished_candidate.materialization
+        or materialization.problem_identity != polish_problem.identity
+        or materialization.invocation_identity != polish_invocation.identity
+        or materialization.execution_identity != polish.execution.identity
+        or materialization.evaluation_identity
+        != polished_candidate.evaluation_result.identity
+    ):
+        raise DirectTrfConstructionError(
+            "Successful TRF candidate lacks exact DE polish transition lineage"
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class DeTrfTransitionAccounting:
     """Explicit non-fungible accounting owned by the DE→TRF transition."""
@@ -1730,6 +1900,49 @@ def _transition_accounting(
     )
 
 
+def _gate_de_to_trf_transition(
+    invocation: DeDirectTrfInvocation,
+    search: DeSearchExecution,
+    token: CancellationToken,
+) -> DeDirectTrfOutcome | None:
+    try:
+        cancelled_before_polish = token.is_cancelled
+    except KeyboardInterrupt as error:
+        outcome = DeDirectTrfOutcome(
+            DeDirectTrfTerminal.INTERRUPTED,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                None,
+                transferred=False,
+                materialized=False,
+            ),
+            failure=TerminalFailure(
+                "interrupted",
+                "KeyboardInterrupt at DE to TRF transition gate",
+            ),
+        )
+        raise DeDirectTrfInterrupted(outcome) from error
+    if not cancelled_before_polish:
+        return None
+    return DeDirectTrfOutcome(
+        DeDirectTrfTerminal.CANCELLED,
+        search,
+        _transition_accounting(
+            invocation,
+            search,
+            None,
+            transferred=False,
+            materialized=False,
+        ),
+        failure=TerminalFailure(
+            "cancelled",
+            "Cancellation observed before DE to TRF transfer",
+        ),
+    )
+
+
 def execute_de_direct_trf(
     problem: OptimizationProblem,
     invocation: DeDirectTrfInvocation,
@@ -1784,41 +1997,9 @@ def execute_de_direct_trf(
                 f"{type(error).__name__}: {error}",
             ),
         )
-    try:
-        cancelled_before_polish = token.is_cancelled
-    except KeyboardInterrupt as error:
-        outcome = DeDirectTrfOutcome(
-            DeDirectTrfTerminal.INTERRUPTED,
-            search,
-            _transition_accounting(
-                invocation,
-                search,
-                None,
-                transferred=False,
-                materialized=False,
-            ),
-            failure=TerminalFailure(
-                "interrupted",
-                "KeyboardInterrupt at DE to TRF transition gate",
-            ),
-        )
-        raise DeDirectTrfInterrupted(outcome) from error
-    if cancelled_before_polish:
-        return DeDirectTrfOutcome(
-            DeDirectTrfTerminal.CANCELLED,
-            search,
-            _transition_accounting(
-                invocation,
-                search,
-                None,
-                transferred=False,
-                materialized=False,
-            ),
-            failure=TerminalFailure(
-                "cancelled",
-                "Cancellation observed before DE to TRF transfer",
-            ),
-        )
+    transition_failure = _gate_de_to_trf_transition(invocation, search, token)
+    if transition_failure is not None:
+        return transition_failure
     polish_problem, polish_invocation = _derive_polish_problem(
         problem,
         invocation,
@@ -1857,11 +2038,9 @@ def execute_de_direct_trf(
         )
         raise DeDirectTrfInterrupted(outcome) from error
     if polish.terminal is not DirectTrfCandidateTerminal.SUCCESS:
-        terminal = (
-            DeDirectTrfTerminal.CANCELLED
-            if polish.terminal is DirectTrfCandidateTerminal.CANCELLED
-            else DeDirectTrfTerminal.POLISH_UNSUCCESSFUL
-        )
+        terminal = {
+            DirectTrfCandidateTerminal.CANCELLED: DeDirectTrfTerminal.CANCELLED,
+        }.get(polish.terminal, DeDirectTrfTerminal.POLISH_UNSUCCESSFUL)
         return DeDirectTrfOutcome(
             terminal,
             search,
@@ -1876,6 +2055,34 @@ def execute_de_direct_trf(
             polish_invocation,
             polish,
             failure=polish.execution.failure,
+        )
+    try:
+        _validate_de_polish_transition_lineage(
+            problem,
+            invocation,
+            search,
+            polish_problem,
+            polish_invocation,
+            polish,
+        )
+    except Exception as error:  # noqa: BLE001 - polish lineage fails closed
+        return DeDirectTrfOutcome(
+            DeDirectTrfTerminal.EXECUTION_FAILURE,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                polish,
+                transferred=True,
+                materialized=False,
+            ),
+            polish_problem,
+            polish_invocation,
+            polish,
+            failure=TerminalFailure(
+                "de_polish_lineage_failure",
+                f"{type(error).__name__}: {error}",
+            ),
         )
     polished_candidate = cast("MaterializedDirectTrfCandidate", polish.candidate)
     fresh = _materialize_derived_direct_trf_candidate_for_root(

--- a/src/chemex/optimize/de_direct_trf.py
+++ b/src/chemex/optimize/de_direct_trf.py
@@ -1,0 +1,2049 @@
+"""Selected-coordinate differential evolution to native TRF qualification (#597).
+
+This isolated native seam is intentionally not wired into production dispatch.
+It owns an immutable selected-coordinate DE plan rooted in one complete native
+problem.  Execution and the authoritative TRF transition are added in vertical
+slices below the same seam.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from numbers import Real
+from typing import Protocol, cast
+from uuid import uuid4
+
+import numpy as np
+from scipy.optimize import Bounds, differential_evolution
+
+from chemex.evaluation.native import (
+    BoundEvaluator,
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationResult,
+)
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    AttemptCounters,
+    CancellationToken,
+    CandidateMaterialization,
+    CandidateSummary,
+    CommitReceipt,
+    DePolishProblemDerivation,
+    DeSearchProblemDerivation,
+    DirectTrfCandidateOutcome,
+    DirectTrfCandidateTerminal,
+    DirectTrfConstructionError,
+    DirectTrfInterrupted,
+    DirectTrfInvocation,
+    DirectTrfTerminal,
+    LiveFitCommitAuthority,
+    MaterializationTerminal,
+    MaterializedDirectTrfCandidate,
+    ObjectiveScalarizationError,
+    OptimizationProblem,
+    TerminalFailure,
+    _accept_materialized_fit_for_derived_workflow,
+    _grant_derived_fit_commit_authority,
+    canonical_chi_square,
+    commit_accepted_fit,
+    execute_direct_trf_candidate,
+)
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.values import AnalysisValues
+from chemex.typing import Array
+
+_SCHEMA_VERSION = 1
+_DE_WORKFLOW_VERSION = "native-selected-coordinate-de-direct-trf-v1"
+_DE_BACKEND_POLICY_VERSION = "scipy-de-best1bin-lhs-deferred-pcg64-v1"
+_UINT64_MAX = 2**64 - 1
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "record": record, "schema_version": _SCHEMA_VERSION},
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _finite_binary64(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise DirectTrfConstructionError(f"{name} must be a finite real number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise DirectTrfConstructionError(f"{name} must be finite")
+    return 0.0 if result == 0.0 else result
+
+
+def _float_token(value: float) -> str:
+    return float(value).hex()
+
+
+class DeCoordinateSemantics(StrEnum):
+    """Closed physical-to-search coordinate maps supported by DE v1."""
+
+    LINEAR = "linear"
+    LOG = "log"
+
+
+@dataclass(frozen=True, slots=True)
+class DeSearchCoordinate:
+    """One selected independent physical coordinate and finite search range."""
+
+    param_id: str
+    physical_lower: float
+    physical_upper: float
+    semantics: DeCoordinateSemantics | str
+    declaration_ordinal: int
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.param_id:
+            raise DirectTrfConstructionError("DE coordinate ID cannot be empty")
+        lower = _finite_binary64(self.physical_lower, name="DE search lower bound")
+        upper = _finite_binary64(self.physical_upper, name="DE search upper bound")
+        if lower >= upper:
+            raise DirectTrfConstructionError(
+                "DE search coordinates require strictly ordered finite bounds"
+            )
+        try:
+            semantics = DeCoordinateSemantics(self.semantics)
+        except ValueError as error:
+            raise DirectTrfConstructionError(
+                "DE coordinate semantics must be 'linear' or 'log'"
+            ) from error
+        if semantics is DeCoordinateSemantics.LOG and lower <= 0.0:
+            raise DirectTrfConstructionError(
+                "Logarithmic DE coordinates require positive physical bounds"
+            )
+        if (
+            isinstance(self.declaration_ordinal, bool)
+            or not isinstance(self.declaration_ordinal, int)
+            or self.declaration_ordinal < 0
+        ):
+            raise DirectTrfConstructionError(
+                "DE declaration ordinal must be a non-negative integer"
+            )
+        object.__setattr__(self, "physical_lower", lower)
+        object.__setattr__(self, "physical_upper", upper)
+        object.__setattr__(self, "semantics", semantics)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-search-coordinate",
+                (
+                    self.param_id,
+                    _float_token(lower),
+                    _float_token(upper),
+                    semantics.value,
+                    self.declaration_ordinal,
+                ),
+            ),
+        )
+
+    @property
+    def physical_bounds(self) -> tuple[float, float]:
+        return self.physical_lower, self.physical_upper
+
+    @property
+    def solver_bounds(self) -> tuple[float, float]:
+        if self.semantics is DeCoordinateSemantics.LOG:
+            return math.log(self.physical_lower), math.log(self.physical_upper)
+        return self.physical_bounds
+
+    def to_solver(self, physical_value: float) -> float:
+        value = _finite_binary64(physical_value, name=f"DE start {self.param_id!r}")
+        if not self.physical_lower <= value <= self.physical_upper:
+            raise DirectTrfConstructionError(
+                f"DE start for {self.param_id!r} is outside its search range"
+            )
+        if self.semantics is DeCoordinateSemantics.LOG:
+            if value <= 0.0:
+                raise DirectTrfConstructionError(
+                    f"Logarithmic DE start for {self.param_id!r} must be positive"
+                )
+            return math.log(value)
+        return value
+
+    def to_physical(self, solver_value: float) -> float:
+        """Map one finite solver coordinate to its canonical physical value."""
+        value = _finite_binary64(
+            solver_value,
+            name=f"DE solver coordinate {self.param_id!r}",
+        )
+        solver_lower, solver_upper = self.solver_bounds
+        if not solver_lower <= value <= solver_upper:
+            raise ValueError(
+                f"DE solver coordinate for {self.param_id!r} is out of bounds"
+            )
+        if self.semantics is DeCoordinateSemantics.LINEAR:
+            return value
+        if value == solver_lower:
+            return self.physical_lower
+        if value == solver_upper:
+            return self.physical_upper
+        physical = math.exp(value)
+        if not math.isfinite(physical):
+            raise ValueError(f"DE logarithmic map for {self.param_id!r} is non-finite")
+        return 0.0 if physical == 0.0 else physical
+
+
+@dataclass(frozen=True, slots=True)
+class DePopulation:
+    """Serializable fixed population topology for one DE search attempt."""
+
+    dimension: int
+    multiplier: int
+    size: int
+    maximum_generations: int
+    strategy: str = "best1bin"
+    initialization: str = "latinhypercube"
+    updating: str = "deferred"
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            self.dimension < 1
+            or self.multiplier < 1
+            or self.size != max(5, self.dimension * self.multiplier)
+            or self.maximum_generations < 1
+        ):
+            raise DirectTrfConstructionError("Invalid DE population topology")
+        if (
+            self.strategy != "best1bin"
+            or self.initialization != "latinhypercube"
+            or self.updating != "deferred"
+        ):
+            raise DirectTrfConstructionError("Unsupported DE backend topology")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-population",
+                (
+                    self.dimension,
+                    self.multiplier,
+                    self.size,
+                    self.maximum_generations,
+                    self.strategy,
+                    self.initialization,
+                    self.updating,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DeDirectTrfInvocation:
+    """Immutable selected-coordinate DE search and one full TRF polish policy."""
+
+    root_problem_identity: str
+    search_coordinates: tuple[DeSearchCoordinate, ...]
+    search_problem: OptimizationProblem = field(repr=False, compare=False)
+    root_seed: int
+    population: DePopulation
+    de_objective_request_budget: int
+    polish_objective_request_budget: int
+    mutation: float | tuple[float, float]
+    recombination: float
+    tol: float
+    atol: float
+    polish_x_scale: tuple[float, ...]
+    polish_ftol: float | None
+    polish_xtol: float | None
+    polish_gtol: float | None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.search_problem.derivation is None:
+            raise DirectTrfConstructionError("DE search problem must be derived")
+        if self.de_objective_request_budget < self.population.size:
+            raise DirectTrfConstructionError(
+                "DE objective-request budget must cover the initial population"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-direct-trf-invocation",
+                (
+                    _DE_WORKFLOW_VERSION,
+                    _DE_BACKEND_POLICY_VERSION,
+                    self.root_problem_identity,
+                    tuple(item.identity for item in self.search_coordinates),
+                    self.search_problem.identity,
+                    self.root_seed,
+                    self.population.identity,
+                    self.de_objective_request_budget,
+                    self.polish_objective_request_budget,
+                    (
+                        tuple(_float_token(value) for value in self.mutation)
+                        if isinstance(self.mutation, tuple)
+                        else _float_token(self.mutation)
+                    ),
+                    _float_token(self.recombination),
+                    _float_token(self.tol),
+                    _float_token(self.atol),
+                    tuple(_float_token(value) for value in self.polish_x_scale),
+                    tuple(
+                        None if value is None else _float_token(value)
+                        for value in (
+                            self.polish_ftol,
+                            self.polish_xtol,
+                            self.polish_gtol,
+                        )
+                    ),
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        """Return a JSON-safe declarative record with no live runtime state."""
+        mutation: float | list[float]
+        if isinstance(self.mutation, tuple):
+            mutation = list(self.mutation)
+        else:
+            mutation = self.mutation
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "workflow_version": _DE_WORKFLOW_VERSION,
+            "backend_policy_version": _DE_BACKEND_POLICY_VERSION,
+            "identity": self.identity,
+            "root_problem_identity": self.root_problem_identity,
+            "search_problem_identity": self.search_problem.identity,
+            "search_problem": {
+                "controlled_ids": list(self.search_problem.controlled_ids),
+                "captured_held_items": [
+                    [param_id, value]
+                    for param_id, value in self.search_problem.held_items
+                ],
+                "physical_start": list(self.search_problem.start),
+                "physical_lower_bound_tokens": [
+                    _float_token(value) for value in self.search_problem.lower_bounds
+                ],
+                "physical_upper_bound_tokens": [
+                    _float_token(value) for value in self.search_problem.upper_bounds
+                ],
+                "solver_x0": [
+                    coordinate.to_solver(value)
+                    for coordinate, value in zip(
+                        self.search_coordinates,
+                        self.search_problem.start,
+                        strict=True,
+                    )
+                ],
+            },
+            "search_coordinates": [
+                {
+                    "identity": item.identity,
+                    "param_id": item.param_id,
+                    "physical_lower": item.physical_lower,
+                    "physical_upper": item.physical_upper,
+                    "semantics": cast("DeCoordinateSemantics", item.semantics).value,
+                    "declaration_ordinal": item.declaration_ordinal,
+                }
+                for item in self.search_coordinates
+            ],
+            "root_seed": self.root_seed,
+            "population": {
+                "identity": self.population.identity,
+                "dimension": self.population.dimension,
+                "multiplier": self.population.multiplier,
+                "size": self.population.size,
+                "maximum_generations": self.population.maximum_generations,
+                "strategy": self.population.strategy,
+                "initialization": self.population.initialization,
+                "updating": self.population.updating,
+            },
+            "budgets": {
+                "de_objective_requests": self.de_objective_request_budget,
+                "polish_objective_requests": self.polish_objective_request_budget,
+            },
+            "candidate_ordering_policy": _DE_CANDIDATE_ORDER_VERSION,
+            "mutation": mutation,
+            "recombination": self.recombination,
+            "tol": self.tol,
+            "atol": self.atol,
+            "polish": {
+                "x_scale": list(self.polish_x_scale),
+                "ftol": self.polish_ftol,
+                "xtol": self.polish_xtol,
+                "gtol": self.polish_gtol,
+            },
+            "authority": {
+                "de_acceptance": False,
+                "de_commit": False,
+                "eligible_transition_count": 1,
+            },
+        }
+
+    @classmethod
+    def for_problem(
+        cls,
+        problem: OptimizationProblem,
+        *,
+        search_coordinates: Sequence[
+            tuple[str, float, float, DeCoordinateSemantics | str]
+        ],
+        root_seed: object,
+        de_objective_request_budget: int,
+        polish_objective_request_budget: int,
+        population_multiplier: int = 15,
+        mutation: float | tuple[float, float] = (0.5, 1.0),
+        recombination: float = 0.7,
+        tol: float = 0.01,
+        atol: float = 0.0,
+        maximum_generations: int = 1000,
+        polish_x_scale: float | Sequence[float] | None = None,
+        polish_ftol: float | None = 1.0e-8,
+        polish_xtol: float | None = 1.0e-8,
+        polish_gtol: float | None = 1.0e-8,
+    ) -> DeDirectTrfInvocation:
+        """Compile one canonical bounded selected-coordinate search plan."""
+        if not problem.acceptance_authority:
+            raise DirectTrfConstructionError("DE requires a complete root problem")
+        if (
+            isinstance(root_seed, bool)
+            or not isinstance(root_seed, int)
+            or not 0 <= root_seed <= _UINT64_MAX
+        ):
+            raise DirectTrfConstructionError(
+                "DE requires an explicit unsigned 64-bit root seed"
+            )
+        if (
+            isinstance(population_multiplier, bool)
+            or not isinstance(population_multiplier, int)
+            or population_multiplier < 1
+            or isinstance(maximum_generations, bool)
+            or not isinstance(maximum_generations, int)
+            or maximum_generations < 1
+        ):
+            raise DirectTrfConstructionError(
+                "DE population multiplier and generation limit must be positive integers"
+            )
+        declared = tuple(
+            DeSearchCoordinate(param_id, lower, upper, semantics, ordinal)
+            for ordinal, (param_id, lower, upper, semantics) in enumerate(
+                search_coordinates
+            )
+        )
+        if not declared:
+            raise DirectTrfConstructionError(
+                "DE requires at least one explicitly selected coordinate"
+            )
+        selected_ids = tuple(item.param_id for item in declared)
+        if len(set(selected_ids)) != len(selected_ids):
+            raise DirectTrfConstructionError("Duplicate DE search coordinate ID")
+        unknown = set(selected_ids) - set(problem.controlled_ids)
+        if unknown:
+            raise DirectTrfConstructionError(
+                "DE search coordinates must target controlled independent IDs: "
+                + ", ".join(sorted(unknown))
+            )
+        coordinates = tuple(
+            sorted(declared, key=lambda item: item.param_id.encode("utf-8"))
+        )
+        root_indices = {
+            param_id: index for index, param_id in enumerate(problem.controlled_ids)
+        }
+        root_starts = dict(zip(problem.controlled_ids, problem.start, strict=True))
+        for item in coordinates:
+            index = root_indices[item.param_id]
+            if (
+                item.physical_lower < problem.lower_bounds[index]
+                or item.physical_upper > problem.upper_bounds[index]
+            ):
+                raise DirectTrfConstructionError(
+                    f"DE search range for {item.param_id!r} exceeds physical bounds"
+                )
+            item.to_solver(root_starts[item.param_id])
+        canonical_selected_ids = tuple(item.param_id for item in coordinates)
+        selected = set(canonical_selected_ids)
+        held_items = tuple(
+            (param_id, value)
+            for param_id, value in problem.independent_items
+            if param_id not in selected
+        )
+        start = tuple(root_starts[param_id] for param_id in canonical_selected_ids)
+        search_specification_identity = _identity(
+            "native-de-search-specification",
+            tuple(item.identity for item in coordinates),
+        )
+        derivation = DeSearchProblemDerivation(
+            problem.identity,
+            search_specification_identity,
+            canonical_selected_ids,
+            held_items,
+            start,
+        )
+        search_problem = OptimizationProblem(
+            problem.evaluation_plan_identity,
+            problem.parameterization_identity,
+            problem.evaluator_parameterization_identity,
+            problem.constraint_program_identity,
+            problem.configuration_identity,
+            problem.source_snapshot,
+            problem.independent_items,
+            canonical_selected_ids,
+            held_items,
+            start,
+            tuple(
+                problem.lower_bounds[root_indices[item]]
+                for item in canonical_selected_ids
+            ),
+            tuple(
+                problem.upper_bounds[root_indices[item]]
+                for item in canonical_selected_ids
+            ),
+            problem.commit_scope,
+            derivation,
+            problem.scalarization_version,
+        )
+        population = DePopulation(
+            len(coordinates),
+            population_multiplier,
+            max(5, len(coordinates) * population_multiplier),
+            maximum_generations,
+        )
+        de_budget = _positive_integer_budget(
+            de_objective_request_budget,
+            name="DE objective-request budget",
+        )
+        polish_budget = _positive_integer_budget(
+            polish_objective_request_budget,
+            name="TRF polish objective-request budget",
+        )
+        normalized_mutation = _mutation(mutation)
+        normalized_recombination = _probability(
+            recombination,
+            name="DE recombination probability",
+        )
+        normalized_tol = _non_negative(tol, name="DE relative tolerance")
+        normalized_atol = _non_negative(atol, name="DE absolute tolerance")
+        polish_template = DirectTrfInvocation.for_problem(
+            problem,
+            objective_request_budget=polish_budget,
+            x_scale=polish_x_scale,
+            ftol=polish_ftol,
+            xtol=polish_xtol,
+            gtol=polish_gtol,
+        )
+        return cls(
+            problem.identity,
+            coordinates,
+            search_problem,
+            cast("int", root_seed),
+            population,
+            de_budget,
+            polish_budget,
+            normalized_mutation,
+            normalized_recombination,
+            normalized_tol,
+            normalized_atol,
+            polish_template.x_scale,
+            polish_template.ftol,
+            polish_template.xtol,
+            polish_template.gtol,
+        )
+
+
+def _positive_integer_budget(value: int, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise DirectTrfConstructionError(f"{name} must be a positive integer")
+    return value
+
+
+def _mutation(value: float | tuple[float, float]) -> float | tuple[float, float]:
+    if isinstance(value, tuple):
+        if len(value) != 2:
+            raise DirectTrfConstructionError(
+                "DE mutation dithering requires exactly two values"
+            )
+        lower = _finite_binary64(value[0], name="DE mutation lower")
+        upper = _finite_binary64(value[1], name="DE mutation upper")
+        if not 0.0 <= lower < upper < 2.0:
+            raise DirectTrfConstructionError(
+                "DE mutation dithering must satisfy 0 <= lower < upper < 2"
+            )
+        return lower, upper
+    scalar = _finite_binary64(value, name="DE mutation")
+    if not 0.0 <= scalar < 2.0:
+        raise DirectTrfConstructionError("DE mutation must satisfy 0 <= value < 2")
+    return scalar
+
+
+def _probability(value: float, *, name: str) -> float:
+    result = _finite_binary64(value, name=name)
+    if not 0.0 <= result <= 1.0:
+        raise DirectTrfConstructionError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _non_negative(value: float, *, name: str) -> float:
+    result = _finite_binary64(value, name=name)
+    if result < 0.0:
+        raise DirectTrfConstructionError(f"{name} must be non-negative")
+    return result
+
+
+_DE_RESTART_TERMINALS = frozenset(
+    {
+        "population_converged",
+        "generation_limit",
+        "budget_exhausted",
+    }
+)
+_DE_CANDIDATE_ORDER_VERSION = "chi-square-root-vector-request-ordinal-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class DeSearchCandidate:
+    """One valid DE evaluation under the root-coordinate total order."""
+
+    solver_vector: tuple[float, ...]
+    selected_vector: tuple[float, ...]
+    full_vector: tuple[float, ...]
+    chi_square: float
+    request_ordinal: int
+    evaluation_identity: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        solver = tuple(
+            _finite_binary64(value, name=f"DE solver vector[{index}]")
+            for index, value in enumerate(self.solver_vector)
+        )
+        selected = tuple(
+            _finite_binary64(value, name=f"DE selected vector[{index}]")
+            for index, value in enumerate(self.selected_vector)
+        )
+        full = tuple(
+            _finite_binary64(value, name=f"DE full vector[{index}]")
+            for index, value in enumerate(self.full_vector)
+        )
+        objective = _finite_binary64(self.chi_square, name="DE candidate chi-square")
+        if (
+            not solver
+            or len(solver) != len(selected)
+            or not full
+            or objective < 0.0
+            or isinstance(self.request_ordinal, bool)
+            or self.request_ordinal < 1
+            or not self.evaluation_identity
+        ):
+            raise ValueError("Invalid DE search candidate evidence")
+        object.__setattr__(self, "solver_vector", solver)
+        object.__setattr__(self, "selected_vector", selected)
+        object.__setattr__(self, "full_vector", full)
+        object.__setattr__(self, "chi_square", objective)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-search-candidate",
+                (
+                    _DE_CANDIDATE_ORDER_VERSION,
+                    tuple(_float_token(value) for value in solver),
+                    tuple(_float_token(value) for value in selected),
+                    tuple(_float_token(value) for value in full),
+                    _float_token(objective),
+                    self.request_ordinal,
+                    self.evaluation_identity,
+                ),
+            ),
+        )
+
+    def ordering_key(self) -> tuple[float, tuple[float, ...], int]:
+        return self.chi_square, self.full_vector, self.request_ordinal
+
+
+class DeSearchTerminal(StrEnum):
+    """Closed terminal outcomes for the selected-coordinate DE stage."""
+
+    POPULATION_CONVERGED = "population_converged"
+    GENERATION_LIMIT = "generation_limit"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    NO_VALID_CANDIDATE = "no_valid_candidate"
+    PREFLIGHT_INVALID = "preflight_invalid"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+    BACKEND_FAILURE = "backend_failure"
+    IMPLEMENTATION_FAILURE = "implementation_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class DeBackendEvidence:
+    """Detached closed evidence normalized from SciPy's DE result."""
+
+    success: bool
+    message: str
+    generation_count: int
+    backend_evaluation_count: int
+    population_size: int
+    finite_population_energies: int
+    returned_solver_vector: tuple[float, ...]
+    returned_objective: float | None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-backend-evidence",
+                (
+                    self.success,
+                    self.message,
+                    self.generation_count,
+                    self.backend_evaluation_count,
+                    self.population_size,
+                    self.finite_population_energies,
+                    tuple(_float_token(value) for value in self.returned_solver_vector),
+                    None
+                    if self.returned_objective is None
+                    else _float_token(self.returned_objective),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DeSearchExecution:
+    """Immutable accounting and candidate evidence for one DE attempt."""
+
+    occurrence_identity: str = field(compare=False)
+    problem_identity: str
+    workflow_invocation_identity: str
+    terminal: DeSearchTerminal
+    counters: AttemptCounters
+    population_identity: str
+    candidate_ordering_policy: str
+    preflight_evaluation_identity: str | None
+    valid_candidate_count: int
+    rejected_trial_count: int
+    best_candidate: DeSearchCandidate | None
+    backend: DeBackendEvidence | None
+    failure: TerminalFailure | None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.valid_candidate_count < 0 or self.rejected_trial_count < 0:
+            raise ValueError("DE candidate counts cannot be negative")
+        if (self.best_candidate is None) != (self.valid_candidate_count == 0):
+            raise ValueError("DE best-candidate evidence disagrees with its count")
+        if self.restart_eligible and self.best_candidate is None:
+            raise ValueError("Restart-eligible DE outcome lacks a candidate")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-search-execution",
+                (
+                    self.problem_identity,
+                    self.workflow_invocation_identity,
+                    self.terminal.value,
+                    (
+                        self.counters.solver_requests_received,
+                        self.counters.objective_requests_accepted,
+                        self.counters.objective_evaluations_completed,
+                    ),
+                    self.population_identity,
+                    self.candidate_ordering_policy,
+                    self.preflight_evaluation_identity,
+                    self.valid_candidate_count,
+                    self.rejected_trial_count,
+                    None
+                    if self.best_candidate is None
+                    else self.best_candidate.identity,
+                    None if self.backend is None else self.backend.identity,
+                    None if self.failure is None else self.failure.identity,
+                ),
+            ),
+        )
+
+    @property
+    def restart_eligible(self) -> bool:
+        return (
+            self.terminal.value in _DE_RESTART_TERMINALS
+            and self.best_candidate is not None
+        )
+
+
+class _DeAttemptStop(RuntimeError):
+    def __init__(self, terminal: DeSearchTerminal, failure: TerminalFailure) -> None:
+        self.terminal = terminal
+        self.failure = failure
+        super().__init__(failure.message or failure.category)
+
+
+class _LiveDeAttempt:
+    def __init__(
+        self,
+        root_problem: OptimizationProblem,
+        invocation: DeDirectTrfInvocation,
+        parameterization: ActiveParameterization,
+        engine: EvaluationEngine,
+        cancellation: CancellationToken,
+    ) -> None:
+        self.root_problem = root_problem
+        self.invocation = invocation
+        self.parameterization = parameterization
+        self.evaluator = engine.new_evaluator()
+        self.cancellation = cancellation
+        self.received = 0
+        self.accepted = 0
+        self.completed = 0
+        self.rejected = 0
+        self.candidates: list[DeSearchCandidate] = []
+        self.best: DeSearchCandidate | None = None
+
+    @property
+    def counters(self) -> AttemptCounters:
+        return AttemptCounters(self.received, self.accepted, self.completed)
+
+    def map_solver_vector(
+        self, solver_vector: Sequence[float] | Array
+    ) -> tuple[float, ...]:
+        values = tuple(float(value) for value in solver_vector)
+        if len(values) != len(self.invocation.search_coordinates):
+            raise ValueError("DE solver vector has the wrong dimension")
+        return tuple(
+            coordinate.to_physical(value)
+            for coordinate, value in zip(
+                self.invocation.search_coordinates,
+                values,
+                strict=True,
+            )
+        )
+
+    def objective(self, solver_vector: Array) -> float:
+        self.received += 1
+        if self.cancellation.is_cancelled:
+            raise _DeAttemptStop(
+                DeSearchTerminal.CANCELLED,
+                TerminalFailure("cancelled", "Cancellation observed before DE request"),
+            )
+        if self.accepted >= self.invocation.de_objective_request_budget:
+            raise _DeAttemptStop(
+                DeSearchTerminal.BUDGET_EXHAUSTED,
+                TerminalFailure(
+                    "de_objective_budget_exhausted",
+                    "DE objective-request budget exhausted",
+                ),
+            )
+        self.accepted += 1
+        try:
+            selected = self.map_solver_vector(solver_vector)
+            lifecycle = self.invocation.search_problem.lifecycle_frame(
+                selected,
+                self.parameterization,
+            )
+            frame = EvaluationFrame.from_lifecycle_frame(
+                self.parameterization,
+                lifecycle,
+            )
+        except Exception as error:
+            raise _DeAttemptStop(
+                DeSearchTerminal.IMPLEMENTATION_FAILURE,
+                TerminalFailure(
+                    "de_candidate_contract_failure",
+                    f"{type(error).__name__}: {error}",
+                ),
+            ) from error
+        evaluated = self.evaluator.evaluate(frame)
+        self.completed += 1
+        if isinstance(evaluated, EvaluationFailure):
+            if evaluated.validity == "INVALID_TRIAL":
+                self.rejected += 1
+                return math.inf
+            raise _DeAttemptStop(
+                DeSearchTerminal.IMPLEMENTATION_FAILURE,
+                TerminalFailure(evaluated.category, evaluated.message, evaluated),
+            )
+        try:
+            objective = canonical_chi_square(evaluated.residuals)
+        except (TypeError, ValueError, ObjectiveScalarizationError):
+            self.rejected += 1
+            return math.inf
+        try:
+            full_vector = tuple(
+                evaluated.resolved_values[param_id]
+                for param_id in self.root_problem.controlled_ids
+            )
+            candidate = DeSearchCandidate(
+                tuple(float(value) for value in solver_vector),
+                selected,
+                full_vector,
+                objective,
+                self.received,
+                evaluated.identity,
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise _DeAttemptStop(
+                DeSearchTerminal.IMPLEMENTATION_FAILURE,
+                TerminalFailure(
+                    "de_candidate_evidence_failure",
+                    f"{type(error).__name__}: {error}",
+                ),
+            ) from error
+        self.candidates.append(candidate)
+        if self.best is None or candidate.ordering_key() < self.best.ordering_key():
+            self.best = candidate
+        if self.cancellation.is_cancelled:
+            raise _DeAttemptStop(
+                DeSearchTerminal.CANCELLED,
+                TerminalFailure("cancelled", "Cancellation observed after DE request"),
+            )
+        return objective
+
+
+def _validate_de_context(
+    problem: OptimizationProblem,
+    invocation: DeDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+) -> None:
+    if (
+        not problem.acceptance_authority
+        or invocation.root_problem_identity != problem.identity
+        or engine.plan.identity != problem.evaluation_plan_identity
+        or engine.plan.identity != invocation.search_problem.evaluation_plan_identity
+    ):
+        raise DirectTrfConstructionError(
+            "DE invocation, root problem, and evaluator context differ"
+        )
+    problem.validate_parameterization(parameterization)
+    invocation.search_problem.validate_parameterization(parameterization)
+
+
+def _de_preflight(live: _LiveDeAttempt) -> EvaluationResult | TerminalFailure:
+    try:
+        lifecycle = live.invocation.search_problem.lifecycle_frame(
+            live.invocation.search_problem.start,
+            live.parameterization,
+        )
+        frame = EvaluationFrame.from_lifecycle_frame(live.parameterization, lifecycle)
+        evaluated = live.evaluator.evaluate(frame)
+    except Exception as error:  # noqa: BLE001 - preflight fails closed
+        return TerminalFailure(
+            "de_preflight_frame_failure",
+            f"{type(error).__name__}: {error}",
+        )
+    if isinstance(evaluated, EvaluationFailure):
+        return TerminalFailure(evaluated.category, evaluated.message, evaluated)
+    try:
+        canonical_chi_square(evaluated.residuals)
+    except (TypeError, ValueError, ObjectiveScalarizationError) as error:
+        return TerminalFailure(
+            "de_preflight_scalarization_failure",
+            f"{type(error).__name__}: {error}",
+        )
+    return evaluated
+
+
+def _normalize_de_backend(
+    result: object,
+    *,
+    dimension: int,
+    population_size: int,
+) -> DeBackendEvidence:
+    backend = cast("_DeBackendResult", result)
+    success = backend.success
+    if not isinstance(success, (bool, np.bool_)):
+        raise TypeError("DE backend success must be Boolean")
+    message = backend.message
+    if not isinstance(message, str):
+        raise TypeError("DE backend message must be text")
+    generation_count = backend.nit
+    backend_count = backend.nfev
+    if (
+        isinstance(generation_count, bool)
+        or not isinstance(generation_count, (int, np.integer))
+        or int(generation_count) < 0
+        or isinstance(backend_count, bool)
+        or not isinstance(backend_count, (int, np.integer))
+        or int(backend_count) < 0
+    ):
+        raise ValueError("DE backend counters must be non-negative integers")
+    returned = np.asarray(backend.x, dtype=np.float64)
+    population = np.asarray(backend.population, dtype=np.float64)
+    energies = np.asarray(backend.population_energies, dtype=np.float64)
+    if (
+        returned.shape != (dimension,)
+        or not np.all(np.isfinite(returned))
+        or population.shape != (population_size, dimension)
+        or energies.shape != (population_size,)
+    ):
+        raise ValueError("DE backend returned malformed population evidence")
+    raw_objective = float(cast("Real", backend.fun))
+    objective = raw_objective if math.isfinite(raw_objective) else None
+    return DeBackendEvidence(
+        bool(success),
+        message,
+        int(generation_count),
+        int(backend_count),
+        population_size,
+        int(np.count_nonzero(np.isfinite(energies))),
+        tuple(float(value) for value in returned),
+        objective,
+    )
+
+
+class _DeBackendResult(Protocol):
+    success: object
+    message: object
+    nit: object
+    nfev: object
+    x: object
+    population: object
+    population_energies: object
+    fun: object
+
+
+def _search_execution(
+    live: _LiveDeAttempt,
+    terminal: DeSearchTerminal,
+    preflight_identity: str | None,
+    *,
+    backend: DeBackendEvidence | None = None,
+    failure: TerminalFailure | None = None,
+) -> DeSearchExecution:
+    effective_terminal = terminal
+    effective_failure = failure
+    if (
+        terminal
+        in {
+            DeSearchTerminal.POPULATION_CONVERGED,
+            DeSearchTerminal.GENERATION_LIMIT,
+            DeSearchTerminal.BUDGET_EXHAUSTED,
+        }
+        and live.best is None
+    ):
+        effective_terminal = DeSearchTerminal.NO_VALID_CANDIDATE
+        effective_failure = TerminalFailure(
+            "de_no_valid_candidate",
+            "DE completed without a valid finite objective evaluation",
+        )
+    return DeSearchExecution(
+        uuid4().hex,
+        live.invocation.search_problem.identity,
+        live.invocation.identity,
+        effective_terminal,
+        live.counters,
+        live.invocation.population.identity,
+        _DE_CANDIDATE_ORDER_VERSION,
+        preflight_identity,
+        len(live.candidates),
+        live.rejected,
+        live.best,
+        backend,
+        effective_failure,
+    )
+
+
+def _invoke_de_backend(
+    live: _LiveDeAttempt,
+    invocation: DeDirectTrfInvocation,
+    solver_start: Array,
+) -> object:
+    return differential_evolution(
+        live.objective,
+        Bounds(
+            np.asarray(
+                tuple(item.solver_bounds[0] for item in invocation.search_coordinates),
+                dtype=np.float64,
+            ),
+            np.asarray(
+                tuple(item.solver_bounds[1] for item in invocation.search_coordinates),
+                dtype=np.float64,
+            ),
+        ),
+        strategy="best1bin",
+        maxiter=invocation.population.maximum_generations,
+        popsize=invocation.population.multiplier,
+        tol=invocation.tol,
+        mutation=invocation.mutation,
+        recombination=invocation.recombination,
+        rng=np.random.Generator(np.random.PCG64(invocation.root_seed)),
+        callback=None,
+        disp=False,
+        polish=False,
+        init="latinhypercube",
+        atol=invocation.atol,
+        updating="deferred",
+        workers=1,
+        constraints=(),
+        x0=solver_start,
+        integrality=None,
+        vectorized=False,
+    )
+
+
+def _finish_de_backend(
+    live: _LiveDeAttempt,
+    result: object,
+    preflight_identity: str,
+) -> DeSearchExecution:
+    try:
+        backend = _normalize_de_backend(
+            result,
+            dimension=len(live.invocation.search_coordinates),
+            population_size=live.invocation.population.size,
+        )
+    except Exception as error:  # noqa: BLE001 - mutable backend boundary
+        return _search_execution(
+            live,
+            DeSearchTerminal.IMPLEMENTATION_FAILURE,
+            preflight_identity,
+            failure=TerminalFailure(
+                "malformed_de_backend_result",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    if backend.success:
+        terminal = DeSearchTerminal.POPULATION_CONVERGED
+        failure = None
+    elif "maximum number of iterations" in backend.message.lower():
+        terminal = DeSearchTerminal.GENERATION_LIMIT
+        failure = TerminalFailure("de_generation_limit", backend.message)
+    else:
+        terminal = DeSearchTerminal.BACKEND_FAILURE
+        failure = TerminalFailure("de_backend_failure", backend.message)
+    return _search_execution(
+        live,
+        terminal,
+        preflight_identity,
+        backend=backend,
+        failure=failure,
+    )
+
+
+def _unstarted_search_execution(
+    invocation: DeDirectTrfInvocation,
+    terminal: DeSearchTerminal,
+    failure: TerminalFailure,
+) -> DeSearchExecution:
+    """Freeze typed zero-counter evidence when DE cannot acquire an evaluator."""
+    return DeSearchExecution(
+        uuid4().hex,
+        invocation.search_problem.identity,
+        invocation.identity,
+        terminal,
+        AttemptCounters(0, 0, 0),
+        invocation.population.identity,
+        _DE_CANDIDATE_ORDER_VERSION,
+        None,
+        0,
+        0,
+        None,
+        None,
+        failure,
+    )
+
+
+def _start_live_de_attempt(
+    problem: OptimizationProblem,
+    invocation: DeDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    cancellation: CancellationToken,
+) -> _LiveDeAttempt | DeSearchExecution:
+    if cancellation.is_cancelled:
+        return _unstarted_search_execution(
+            invocation,
+            DeSearchTerminal.CANCELLED,
+            TerminalFailure("cancelled", "Cancellation before DE evaluator binding"),
+        )
+    try:
+        live = _LiveDeAttempt(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            cancellation,
+        )
+    except KeyboardInterrupt:
+        return _unstarted_search_execution(
+            invocation,
+            DeSearchTerminal.INTERRUPTED,
+            TerminalFailure(
+                "interrupted",
+                "KeyboardInterrupt during DE evaluator binding",
+            ),
+        )
+    except Exception as error:  # noqa: BLE001 - binding failure is typed evidence
+        return _unstarted_search_execution(
+            invocation,
+            DeSearchTerminal.IMPLEMENTATION_FAILURE,
+            TerminalFailure(
+                "de_evaluator_binding_failure",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    return live
+
+
+def _run_de_search(
+    problem: OptimizationProblem,
+    invocation: DeDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    cancellation: CancellationToken,
+) -> DeSearchExecution:
+    started = _start_live_de_attempt(
+        problem,
+        invocation,
+        parameterization,
+        engine,
+        cancellation,
+    )
+    if isinstance(started, DeSearchExecution):
+        return started
+    live = started
+    try:
+        preflight = _de_preflight(live)
+    except KeyboardInterrupt:
+        return _search_execution(
+            live,
+            DeSearchTerminal.INTERRUPTED,
+            None,
+            failure=TerminalFailure(
+                "interrupted",
+                "KeyboardInterrupt during DE preflight",
+            ),
+        )
+    if isinstance(preflight, TerminalFailure):
+        return _search_execution(
+            live,
+            DeSearchTerminal.PREFLIGHT_INVALID,
+            None,
+            failure=preflight,
+        )
+    if cancellation.is_cancelled:
+        return _search_execution(
+            live,
+            DeSearchTerminal.CANCELLED,
+            preflight.identity,
+            failure=TerminalFailure("cancelled", "Cancellation after DE preflight"),
+        )
+    solver_start = np.asarray(
+        tuple(
+            coordinate.to_solver(value)
+            for coordinate, value in zip(
+                invocation.search_coordinates,
+                invocation.search_problem.start,
+                strict=True,
+            )
+        ),
+        dtype=np.float64,
+    )
+    try:
+        result = _invoke_de_backend(live, invocation, solver_start)
+    except _DeAttemptStop as stop:
+        return _search_execution(
+            live,
+            stop.terminal,
+            preflight.identity,
+            failure=stop.failure,
+        )
+    except KeyboardInterrupt:
+        return _search_execution(
+            live,
+            DeSearchTerminal.INTERRUPTED,
+            preflight.identity,
+            failure=TerminalFailure("interrupted", "KeyboardInterrupt during DE"),
+        )
+    except Exception as error:  # noqa: BLE001 - undeclared backend errors fail closed
+        return _search_execution(
+            live,
+            DeSearchTerminal.IMPLEMENTATION_FAILURE,
+            preflight.identity,
+            failure=TerminalFailure(
+                "unexpected_de_backend_exception",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    if cancellation.is_cancelled:
+        return _search_execution(
+            live,
+            DeSearchTerminal.CANCELLED,
+            preflight.identity,
+            failure=TerminalFailure("cancelled", "Cancellation after DE backend"),
+        )
+    return _finish_de_backend(live, result, preflight.identity)
+
+
+def _derive_polish_problem(
+    problem: OptimizationProblem,
+    invocation: DeDirectTrfInvocation,
+    search: DeSearchExecution,
+) -> tuple[OptimizationProblem, DirectTrfInvocation]:
+    candidate = search.best_candidate
+    if not search.restart_eligible or candidate is None:
+        raise DirectTrfConstructionError(
+            "Only a restart-eligible DE outcome may create a TRF polish"
+        )
+    derivation = DePolishProblemDerivation(
+        problem.identity,
+        invocation.identity,
+        invocation.search_problem.identity,
+        search.identity,
+        candidate.identity,
+        problem.controlled_ids,
+        candidate.full_vector,
+    )
+    child = OptimizationProblem(
+        problem.evaluation_plan_identity,
+        problem.parameterization_identity,
+        problem.evaluator_parameterization_identity,
+        problem.constraint_program_identity,
+        problem.configuration_identity,
+        problem.source_snapshot,
+        problem.independent_items,
+        problem.controlled_ids,
+        problem.held_items,
+        candidate.full_vector,
+        problem.lower_bounds,
+        problem.upper_bounds,
+        problem.commit_scope,
+        derivation,
+        problem.scalarization_version,
+    )
+    polish = DirectTrfInvocation.for_problem(
+        child,
+        objective_request_budget=invocation.polish_objective_request_budget,
+        x_scale=invocation.polish_x_scale,
+        ftol=invocation.polish_ftol,
+        xtol=invocation.polish_xtol,
+        gtol=invocation.polish_gtol,
+    )
+    return child, polish
+
+
+@dataclass(frozen=True, slots=True)
+class DeTrfTransitionAccounting:
+    """Explicit non-fungible accounting owned by the DE→TRF transition."""
+
+    de_budget: int
+    de_counters: AttemptCounters
+    polish_budget: int
+    polish_counters: AttemptCounters | None
+    search_to_polish_transfers: int
+    root_materializations: int
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.search_to_polish_transfers not in {
+            0,
+            1,
+        } or self.root_materializations not in {
+            0,
+            1,
+        }:
+            raise ValueError("DE→TRF transition counts must be zero or one")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-trf-transition-accounting",
+                (
+                    self.de_budget,
+                    (
+                        self.de_counters.solver_requests_received,
+                        self.de_counters.objective_requests_accepted,
+                        self.de_counters.objective_evaluations_completed,
+                    ),
+                    self.polish_budget,
+                    None
+                    if self.polish_counters is None
+                    else (
+                        self.polish_counters.solver_requests_received,
+                        self.polish_counters.objective_requests_accepted,
+                        self.polish_counters.objective_evaluations_completed,
+                    ),
+                    self.search_to_polish_transfers,
+                    self.root_materializations,
+                ),
+            ),
+        )
+
+
+class DeDirectTrfTerminal(StrEnum):
+    """Closed workflow outcomes; only ACCEPTED can expose fit authority."""
+
+    ACCEPTED = "accepted"
+    SEARCH_UNSUCCESSFUL = "search_unsuccessful"
+    POLISH_UNSUCCESSFUL = "polish_unsuccessful"
+    MATERIALIZATION_FAILURE = "materialization_failure"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+    EXECUTION_FAILURE = "execution_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class DePolishProvenance:
+    """Exact selected-restart and one-polish lineage for accepted evidence."""
+
+    workflow_invocation_identity: str
+    root_problem_identity: str
+    search_execution_identity: str
+    search_candidate_identity: str
+    search_terminal: DeSearchTerminal
+    polish_problem_identity: str
+    polish_invocation_identity: str
+    polish_execution_identity: str
+    polished_candidate_identity: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-polish-provenance",
+                (
+                    self.workflow_invocation_identity,
+                    self.root_problem_identity,
+                    self.search_execution_identity,
+                    self.search_candidate_identity,
+                    self.search_terminal.value,
+                    self.polish_problem_identity,
+                    self.polish_invocation_identity,
+                    self.polish_execution_identity,
+                    self.polished_candidate_identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedDeDirectTrfResult(AcceptedFitResult):
+    """Accepted root evidence retaining exact DE search and TRF polish lineage."""
+
+    de_polish_provenance: DePolishProvenance
+    workflow_invocation: DeDirectTrfInvocation = field(repr=False, compare=False)
+    search_execution: DeSearchExecution = field(repr=False, compare=False)
+    polish_problem: OptimizationProblem = field(repr=False, compare=False)
+    polish_invocation: DirectTrfInvocation = field(repr=False, compare=False)
+    polish_outcome: DirectTrfCandidateOutcome = field(repr=False, compare=False)
+    fresh_candidate: MaterializedDirectTrfCandidate = field(
+        repr=False,
+        compare=False,
+    )
+
+    @classmethod
+    def from_accepted(
+        cls,
+        accepted: AcceptedFitResult,
+        provenance: DePolishProvenance,
+        workflow_invocation: DeDirectTrfInvocation,
+        search_execution: DeSearchExecution,
+        polish_problem: OptimizationProblem,
+        polish_invocation: DirectTrfInvocation,
+        polish_outcome: DirectTrfCandidateOutcome,
+        fresh_candidate: MaterializedDirectTrfCandidate,
+    ) -> AcceptedDeDirectTrfResult:
+        return cls(
+            accepted.occurrence_identity,
+            accepted.problem_identity,
+            accepted.invocation_identity,
+            accepted.execution_identity,
+            accepted.materialization_identity,
+            accepted.parameterization_identity,
+            accepted.evaluator_parameterization_identity,
+            accepted.source_occurrence_identity,
+            accepted.source_revision,
+            accepted.controlled_ids,
+            accepted.vector,
+            accepted.chi_square,
+            accepted.evaluation_result,
+            accepted.commit_scope,
+            accepted.commit_items,
+            accepted.origin_context_identity,
+            provenance,
+            workflow_invocation,
+            search_execution,
+            polish_problem,
+            polish_invocation,
+            polish_outcome,
+            fresh_candidate,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DeDirectTrfOutcome:
+    """Complete DE→TRF occurrence with separated stage and authority evidence."""
+
+    terminal: DeDirectTrfTerminal
+    search: DeSearchExecution
+    accounting: DeTrfTransitionAccounting
+    polish_problem: OptimizationProblem | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    polish_invocation: DirectTrfInvocation | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    polish: DirectTrfCandidateOutcome | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    root_materialization: CandidateMaterialization | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    accepted_result: AcceptedDeDirectTrfResult | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    commit_authority: LiveFitCommitAuthority | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    failure: TerminalFailure | None = None
+
+    def __post_init__(self) -> None:
+        accepted = self.terminal is DeDirectTrfTerminal.ACCEPTED
+        if accepted != (
+            self.accepted_result is not None and self.commit_authority is not None
+        ):
+            raise ValueError("Only accepted DE→TRF exposes fit commit authority")
+        if self.polish is None and (
+            self.polish_problem is not None or self.polish_invocation is not None
+        ):
+            raise ValueError("Unstarted TRF polish cannot expose partial topology")
+
+
+class DeDirectTrfInterrupted(KeyboardInterrupt):
+    """Propagated interruption carrying the frozen DE→TRF workflow outcome."""
+
+    def __init__(self, outcome: DeDirectTrfOutcome) -> None:
+        self.outcome = outcome
+        super().__init__("Native DE→TRF was interrupted")
+
+
+def _transition_accounting(
+    invocation: DeDirectTrfInvocation,
+    search: DeSearchExecution,
+    polish: DirectTrfCandidateOutcome | None,
+    *,
+    transferred: bool,
+    materialized: bool,
+) -> DeTrfTransitionAccounting:
+    return DeTrfTransitionAccounting(
+        invocation.de_objective_request_budget,
+        search.counters,
+        invocation.polish_objective_request_budget,
+        None if polish is None else polish.execution.counters,
+        int(transferred),
+        int(materialized),
+    )
+
+
+def _failed_root_materialization(
+    problem: OptimizationProblem,
+    polish_invocation: DirectTrfInvocation,
+    polish: DirectTrfCandidateOutcome,
+    candidate: MaterializedDirectTrfCandidate,
+    compatibility_identity: str,
+    evaluation_count: int,
+    cache_hits: int,
+    cache_misses: int,
+    failure: TerminalFailure,
+    *,
+    terminal: MaterializationTerminal = MaterializationTerminal.FAILURE,
+) -> CandidateMaterialization:
+    return CandidateMaterialization(
+        uuid4().hex,
+        problem.identity,
+        polish_invocation.identity,
+        polish.execution.identity,
+        CandidateSummary(candidate.vector, candidate.chi_square, 0),
+        terminal,
+        evaluation_count,
+        compatibility_identity,
+        None,
+        cache_hits,
+        cache_misses,
+        failure,
+    )
+
+
+def _bind_root_materialization_evaluator(
+    problem: OptimizationProblem,
+    polish_invocation: DirectTrfInvocation,
+    polish: DirectTrfCandidateOutcome,
+    candidate: MaterializedDirectTrfCandidate,
+    engine: EvaluationEngine,
+) -> BoundEvaluator | CandidateMaterialization:
+    try:
+        return engine.new_evaluator()
+    except KeyboardInterrupt:
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            engine.compatibility_identity,
+            0,
+            0,
+            0,
+            TerminalFailure(
+                "interrupted",
+                "KeyboardInterrupt while binding root materialization",
+            ),
+            terminal=MaterializationTerminal.INTERRUPTED,
+        )
+    except Exception as error:  # noqa: BLE001 - root binding fails closed
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            engine.compatibility_identity,
+            0,
+            0,
+            0,
+            TerminalFailure(
+                "de_polish_materialization_binding_failure",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+
+
+def _materialize_polished_candidate_for_root(
+    problem: OptimizationProblem,
+    polish_invocation: DirectTrfInvocation,
+    polish: DirectTrfCandidateOutcome,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    cancellation: CancellationToken,
+) -> MaterializedDirectTrfCandidate | CandidateMaterialization:
+    candidate = polish.candidate
+    if (
+        polish.terminal is not DirectTrfCandidateTerminal.SUCCESS
+        or polish.execution.terminal is not DirectTrfTerminal.CONVERGED
+        or candidate is None
+    ):
+        raise DirectTrfConstructionError(
+            "Only a converged materialized TRF polish may reach root validation"
+        )
+    bound = _bind_root_materialization_evaluator(
+        problem,
+        polish_invocation,
+        polish,
+        candidate,
+        engine,
+    )
+    if isinstance(bound, CandidateMaterialization):
+        return bound
+    evaluator = bound
+    if cancellation.is_cancelled:
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            evaluator.compatibility_identity,
+            0,
+            0,
+            0,
+            TerminalFailure("cancelled", "Cancellation before root materialization"),
+            terminal=MaterializationTerminal.CANCELLED,
+        )
+    try:
+        lifecycle = problem.lifecycle_frame(candidate.vector, parameterization)
+        frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
+        evaluated = evaluator.evaluate(frame)
+    except KeyboardInterrupt:
+        statistics = evaluator.cache_statistics
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure("interrupted", "KeyboardInterrupt in root materialization"),
+            terminal=MaterializationTerminal.INTERRUPTED,
+        )
+    except Exception as error:  # noqa: BLE001 - root materialization fails closed
+        statistics = evaluator.cache_statistics
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(
+                "de_polish_materialization_exception",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    statistics = evaluator.cache_statistics
+    if cancellation.is_cancelled:
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(
+                "cancelled",
+                "Cancellation after fresh root evaluation",
+            ),
+            terminal=MaterializationTerminal.CANCELLED,
+        )
+    if isinstance(evaluated, EvaluationFailure):
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(evaluated.category, evaluated.message, evaluated),
+        )
+    try:
+        objective = canonical_chi_square(evaluated.residuals)
+        vector = tuple(
+            evaluated.resolved_values[param_id] for param_id in problem.controlled_ids
+        )
+    except Exception as error:  # noqa: BLE001 - malformed evidence fails closed
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(
+                "de_polish_materialization_validation_failure",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    if (
+        vector != candidate.vector
+        or objective != candidate.chi_square
+        or evaluated.plan_identity != problem.evaluation_plan_identity
+        or evaluated.parameterization_identity
+        != problem.evaluator_parameterization_identity
+        or tuple(evaluated.resolved_values) != problem.commit_scope
+    ):
+        return _failed_root_materialization(
+            problem,
+            polish_invocation,
+            polish,
+            candidate,
+            evaluator.compatibility_identity,
+            1,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(
+                "de_polish_materialization_mismatch",
+                "Fresh root evidence differs from the polished candidate",
+            ),
+        )
+    materialization = CandidateMaterialization(
+        uuid4().hex,
+        problem.identity,
+        polish_invocation.identity,
+        polish.execution.identity,
+        CandidateSummary(candidate.vector, objective, 0),
+        MaterializationTerminal.SUCCESS,
+        1,
+        evaluator.compatibility_identity,
+        evaluated.identity,
+        statistics.hits,
+        statistics.misses,
+    )
+    return MaterializedDirectTrfCandidate(
+        problem.identity,
+        polish_invocation.identity,
+        polish.execution.identity,
+        materialization,
+        candidate.vector,
+        objective,
+        evaluated,
+    )
+
+
+def execute_de_direct_trf(
+    problem: OptimizationProblem,
+    invocation: DeDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> DeDirectTrfOutcome:
+    """Run one selected-coordinate DE stage and at most one native TRF polish."""
+    _validate_de_context(problem, invocation, parameterization, engine)
+    token = CancellationToken() if cancellation is None else cancellation
+    search = _run_de_search(problem, invocation, parameterization, engine, token)
+    if not search.restart_eligible:
+        terminal = {
+            DeSearchTerminal.CANCELLED: DeDirectTrfTerminal.CANCELLED,
+            DeSearchTerminal.INTERRUPTED: DeDirectTrfTerminal.INTERRUPTED,
+            DeSearchTerminal.BACKEND_FAILURE: DeDirectTrfTerminal.EXECUTION_FAILURE,
+            DeSearchTerminal.IMPLEMENTATION_FAILURE: (
+                DeDirectTrfTerminal.EXECUTION_FAILURE
+            ),
+        }.get(search.terminal, DeDirectTrfTerminal.SEARCH_UNSUCCESSFUL)
+        outcome = DeDirectTrfOutcome(
+            terminal,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                None,
+                transferred=False,
+                materialized=False,
+            ),
+            failure=search.failure,
+        )
+        if terminal is DeDirectTrfTerminal.INTERRUPTED:
+            raise DeDirectTrfInterrupted(outcome)
+        return outcome
+    polish_problem, polish_invocation = _derive_polish_problem(
+        problem,
+        invocation,
+        search,
+    )
+    try:
+        polish = execute_direct_trf_candidate(
+            polish_problem,
+            polish_invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+    except DirectTrfInterrupted as error:
+        polish = DirectTrfCandidateOutcome(
+            DirectTrfCandidateTerminal.CANCELLED,
+            error.execution,
+            error.materialization,
+        )
+        outcome = DeDirectTrfOutcome(
+            DeDirectTrfTerminal.INTERRUPTED,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                polish,
+                transferred=True,
+                materialized=False,
+            ),
+            polish_problem,
+            polish_invocation,
+            polish,
+            failure=TerminalFailure(
+                "interrupted", "KeyboardInterrupt during TRF polish"
+            ),
+        )
+        raise DeDirectTrfInterrupted(outcome) from error
+    if polish.terminal is not DirectTrfCandidateTerminal.SUCCESS:
+        terminal = (
+            DeDirectTrfTerminal.CANCELLED
+            if polish.terminal is DirectTrfCandidateTerminal.CANCELLED
+            else DeDirectTrfTerminal.POLISH_UNSUCCESSFUL
+        )
+        return DeDirectTrfOutcome(
+            terminal,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                polish,
+                transferred=True,
+                materialized=False,
+            ),
+            polish_problem,
+            polish_invocation,
+            polish,
+            failure=polish.execution.failure,
+        )
+    fresh = _materialize_polished_candidate_for_root(
+        problem,
+        polish_invocation,
+        polish,
+        parameterization,
+        engine,
+        token,
+    )
+    if isinstance(fresh, CandidateMaterialization):
+        terminal = {
+            MaterializationTerminal.CANCELLED: DeDirectTrfTerminal.CANCELLED,
+            MaterializationTerminal.INTERRUPTED: DeDirectTrfTerminal.INTERRUPTED,
+        }.get(fresh.terminal, DeDirectTrfTerminal.MATERIALIZATION_FAILURE)
+        outcome = DeDirectTrfOutcome(
+            terminal,
+            search,
+            _transition_accounting(
+                invocation,
+                search,
+                polish,
+                transferred=True,
+                materialized=True,
+            ),
+            polish_problem,
+            polish_invocation,
+            polish,
+            fresh,
+            failure=fresh.failure,
+        )
+        if terminal is DeDirectTrfTerminal.INTERRUPTED:
+            raise DeDirectTrfInterrupted(outcome)
+        return outcome
+    search_candidate = cast("DeSearchCandidate", search.best_candidate)
+    polished_candidate = cast("MaterializedDirectTrfCandidate", polish.candidate)
+    provenance = DePolishProvenance(
+        invocation.identity,
+        problem.identity,
+        search.identity,
+        search_candidate.identity,
+        search.terminal,
+        polish_problem.identity,
+        polish_invocation.identity,
+        polish.execution.identity,
+        polished_candidate.identity,
+    )
+    accepted_base = _accept_materialized_fit_for_derived_workflow(
+        problem=problem,
+        invocation_identity=polish_invocation.identity,
+        execution_identity=polish.execution.identity,
+        materialization=fresh.materialization,
+        vector=fresh.vector,
+        chi_square=fresh.chi_square,
+        evaluation_result=fresh.evaluation_result,
+        authority_context_identity=provenance.identity,
+    )
+    accepted = AcceptedDeDirectTrfResult.from_accepted(
+        accepted_base,
+        provenance,
+        invocation,
+        search,
+        polish_problem,
+        polish_invocation,
+        polish,
+        fresh,
+    )
+    authority = _grant_derived_fit_commit_authority(accepted, problem)
+    return DeDirectTrfOutcome(
+        DeDirectTrfTerminal.ACCEPTED,
+        search,
+        _transition_accounting(
+            invocation,
+            search,
+            polish,
+            transferred=True,
+            materialized=True,
+        ),
+        polish_problem,
+        polish_invocation,
+        polish,
+        fresh.materialization,
+        accepted,
+        authority,
+    )
+
+
+def validate_de_commit_lineage(
+    accepted: AcceptedDeDirectTrfResult,
+    problem: OptimizationProblem,
+) -> None:
+    """Fail closed unless accepted evidence retains exact DE→TRF lineage."""
+    provenance = accepted.de_polish_provenance
+    invocation = accepted.workflow_invocation
+    search = accepted.search_execution
+    polish_problem = accepted.polish_problem
+    polish_invocation = accepted.polish_invocation
+    polish = accepted.polish_outcome
+    fresh = accepted.fresh_candidate
+    search_candidate = search.best_candidate
+    polished_candidate = polish.candidate
+    derivation = polish_problem.derivation
+    if (
+        accepted.problem_identity != problem.identity
+        or accepted.origin_context_identity != provenance.identity
+        or provenance.workflow_invocation_identity != invocation.identity
+        or provenance.root_problem_identity != problem.identity
+        or provenance.search_execution_identity != search.identity
+        or search_candidate is None
+        or provenance.search_candidate_identity != search_candidate.identity
+        or provenance.search_terminal is not search.terminal
+        or not search.restart_eligible
+        or not isinstance(derivation, DePolishProblemDerivation)
+        or derivation.root_problem_identity != problem.identity
+        or derivation.workflow_invocation_identity != invocation.identity
+        or derivation.search_execution_identity != search.identity
+        or derivation.search_candidate_identity != search_candidate.identity
+        or provenance.polish_problem_identity != polish_problem.identity
+        or provenance.polish_invocation_identity != polish_invocation.identity
+        or provenance.polish_execution_identity != polish.execution.identity
+        or polish.terminal is not DirectTrfCandidateTerminal.SUCCESS
+        or polished_candidate is None
+        or provenance.polished_candidate_identity != polished_candidate.identity
+        or fresh.problem_identity != problem.identity
+        or accepted.invocation_identity != polish_invocation.identity
+        or accepted.execution_identity != polish.execution.identity
+        or accepted.materialization_identity != fresh.materialization.identity
+        or accepted.vector != fresh.vector
+        or accepted.chi_square != fresh.chi_square
+        or accepted.evaluation_result is not fresh.evaluation_result
+    ):
+        raise DirectTrfConstructionError(
+            "Accepted DE→TRF result lacks exact canonical polish authority"
+        )
+
+
+def commit_de_accepted_fit(
+    accepted: AcceptedDeDirectTrfResult,
+    authority: LiveFitCommitAuthority,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    analysis_values: AnalysisValues,
+) -> CommitReceipt:
+    """Commit one exact accepted DE→TRF result through the native boundary."""
+    if not isinstance(accepted, AcceptedDeDirectTrfResult):
+        raise DirectTrfConstructionError(
+            "DE→TRF commit requires accepted workflow evidence"
+        )
+    validate_de_commit_lineage(accepted, problem)
+    return commit_accepted_fit(
+        accepted,
+        authority,
+        problem=problem,
+        parameterization=parameterization,
+        analysis_values=analysis_values,
+    )

--- a/src/chemex/optimize/de_direct_trf.py
+++ b/src/chemex/optimize/de_direct_trf.py
@@ -40,6 +40,7 @@ from chemex.optimize.direct_trf import (
     DirectTrfConstructionError,
     DirectTrfInterrupted,
     DirectTrfInvocation,
+    DirectTrfTerminal,
     LiveFitCommitAuthority,
     MaterializationTerminal,
     MaterializedDirectTrfCandidate,
@@ -1629,8 +1630,10 @@ def _validate_de_polish_transition_lineage(
     if (
         search_candidate is None
         or polish.terminal is not DirectTrfCandidateTerminal.SUCCESS
+        or polish.execution.terminal is not DirectTrfTerminal.CONVERGED
         or polished_candidate is None
         or materialization is None
+        or materialization.terminal is not MaterializationTerminal.SUCCESS
         or not isinstance(derivation, DePolishProblemDerivation)
         or derivation != expected_derivation
         or polish_problem.evaluation_plan_identity != problem.evaluation_plan_identity

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -2476,81 +2476,34 @@ def execute_direct_trf_candidate(
     )
 
 
-def _materialize_direct_trf_candidate_for_root(
+def _validate_derived_candidate_for_root(
     problem: OptimizationProblem,
-    candidate_problem: OptimizationProblem,
-    invocation: DirectTrfInvocation,
-    outcome: DirectTrfCandidateOutcome,
+    candidate: MaterializedDirectTrfCandidate,
     parameterization: ActiveParameterization,
     engine: EvaluationEngine,
-    *,
-    cancellation: CancellationToken | None = None,
-) -> MaterializedDirectTrfCandidate | DirectTrfOutcome:
-    """Freshly materialize one derived full-coordinate candidate at its root."""
-    derivation = candidate_problem.derivation
-    if (
-        not problem.acceptance_authority
-        or candidate_problem.acceptance_authority
-        or not isinstance(derivation, GridSeedProblemDerivation)
-        or derivation.root_problem_identity != problem.identity
-    ):
+) -> _CompletedRequest:
+    if not problem.acceptance_authority:
         raise DirectTrfConstructionError(
-            "Selected candidate is not derived from this GRID root problem"
+            "Derived root materialization requires an authoritative root problem"
         )
-    _validate_execution_context(
-        candidate_problem,
-        invocation,
-        parameterization,
-        engine,
-    )
-    candidate = outcome.candidate
-    materialization = outcome.materialization
-    if (
-        outcome.terminal is not DirectTrfCandidateTerminal.SUCCESS
-        or outcome.execution.terminal is not DirectTrfTerminal.CONVERGED
-        or candidate is None
-        or materialization is None
-        or materialization.terminal is not MaterializationTerminal.SUCCESS
-    ):
+    problem.validate_parameterization(parameterization)
+    if engine.plan.identity != problem.evaluation_plan_identity:
         raise DirectTrfConstructionError(
-            "Only a successful converged GRID candidate may be selected"
+            "Derived root materialization evaluator belongs to another plan"
         )
-    unchanged_root_semantics = (
-        candidate_problem.evaluation_plan_identity == problem.evaluation_plan_identity
-        and candidate_problem.parameterization_identity
-        == problem.parameterization_identity
-        and candidate_problem.evaluator_parameterization_identity
-        == problem.evaluator_parameterization_identity
-        and candidate_problem.constraint_program_identity
-        == problem.constraint_program_identity
-        and candidate_problem.configuration_identity == problem.configuration_identity
-        and candidate_problem.source_snapshot == problem.source_snapshot
-        and candidate_problem.independent_items == problem.independent_items
-        and candidate_problem.controlled_ids == problem.controlled_ids
-        and candidate_problem.held_items == problem.held_items
-        and candidate_problem.lower_bounds == problem.lower_bounds
-        and candidate_problem.upper_bounds == problem.upper_bounds
-        and candidate_problem.commit_scope == problem.commit_scope
-        and candidate_problem.scalarization_version == problem.scalarization_version
-    )
+    materialization = candidate.materialization
     evaluation = candidate.evaluation_result
     try:
         candidate_chi_square = canonical_chi_square(evaluation.residuals)
     except (TypeError, ValueError, ObjectiveScalarizationError) as error:
         raise DirectTrfConstructionError(
-            "Selected GRID candidate has invalid objective evidence"
+            "Derived candidate has invalid objective evidence"
         ) from error
     if (
-        not unchanged_root_semantics
-        or outcome.execution.problem_identity != candidate_problem.identity
-        or outcome.execution.invocation_identity != invocation.identity
-        or candidate.problem_identity != candidate_problem.identity
-        or candidate.invocation_identity != invocation.identity
-        or candidate.execution_identity != outcome.execution.identity
-        or candidate.materialization is not materialization
-        or materialization.problem_identity != candidate_problem.identity
-        or materialization.invocation_identity != invocation.identity
-        or materialization.execution_identity != outcome.execution.identity
+        materialization.terminal is not MaterializationTerminal.SUCCESS
+        or materialization.problem_identity != candidate.problem_identity
+        or materialization.invocation_identity != candidate.invocation_identity
+        or materialization.execution_identity != candidate.execution_identity
         or materialization.candidate.vector != candidate.vector
         or materialization.candidate.chi_square != candidate.chi_square
         or materialization.evaluation_identity != evaluation.identity
@@ -2566,31 +2519,198 @@ def _materialize_direct_trf_candidate_for_root(
         or candidate.chi_square != candidate_chi_square
     ):
         raise DirectTrfConstructionError(
-            "Selected GRID candidate provenance is incompatible with its root"
+            "Derived candidate provenance is incompatible with its root"
         )
-    token = CancellationToken() if cancellation is None else cancellation
-    if token.is_cancelled:
-        return DirectTrfOutcome(
-            DirectTrfOutcomeTerminal.CANCELLED,
-            outcome.execution,
-        )
-    request = _CompletedRequest(
+    return _CompletedRequest(
         materialization.candidate,
         tuple(float(value) for value in evaluation.residuals),
         evaluation.identity,
     )
-    fresh = _materialize_candidate(
-        outcome.execution,
+
+
+def _bind_derived_root_evaluator(
+    problem: OptimizationProblem,
+    candidate: MaterializedDirectTrfCandidate,
+    engine: EvaluationEngine,
+) -> BoundEvaluator | CandidateMaterialization:
+    try:
+        return engine.new_evaluator()
+    except KeyboardInterrupt:
+        return CandidateMaterialization(
+            uuid4().hex,
+            problem.identity,
+            candidate.invocation_identity,
+            candidate.execution_identity,
+            CandidateSummary(candidate.vector, candidate.chi_square, 0),
+            MaterializationTerminal.INTERRUPTED,
+            0,
+            engine.compatibility_identity,
+            None,
+            0,
+            0,
+            TerminalFailure(
+                "interrupted",
+                "KeyboardInterrupt during root evaluator binding",
+            ),
+        )
+    except Exception as error:  # noqa: BLE001 - root binding fails closed
+        return CandidateMaterialization(
+            uuid4().hex,
+            problem.identity,
+            candidate.invocation_identity,
+            candidate.execution_identity,
+            CandidateSummary(candidate.vector, candidate.chi_square, 0),
+            MaterializationTerminal.FAILURE,
+            0,
+            engine.compatibility_identity,
+            None,
+            0,
+            0,
+            TerminalFailure(
+                "materialization_binding_failure",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+
+
+def _materialize_derived_direct_trf_candidate_for_root(
+    problem: OptimizationProblem,
+    candidate: MaterializedDirectTrfCandidate,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> MaterializedDirectTrfCandidate | CandidateMaterialization:
+    """Freshly evaluate workflow-validated candidate evidence at its root."""
+    request = _validate_derived_candidate_for_root(
         problem,
-        invocation,
+        candidate,
         parameterization,
         engine,
-        request,
-        token,
     )
-    if isinstance(fresh, DirectTrfOutcome):
-        return fresh
-    return fresh
+    token = CancellationToken() if cancellation is None else cancellation
+    bound = _bind_derived_root_evaluator(problem, candidate, engine)
+    if isinstance(bound, CandidateMaterialization):
+        return bound
+    fresh_evaluator = bound
+    if token.is_cancelled:
+        return CandidateMaterialization(
+            uuid4().hex,
+            problem.identity,
+            candidate.invocation_identity,
+            candidate.execution_identity,
+            CandidateSummary(candidate.vector, candidate.chi_square, 0),
+            MaterializationTerminal.CANCELLED,
+            0,
+            fresh_evaluator.compatibility_identity,
+            None,
+            0,
+            0,
+            TerminalFailure("cancelled", "Cancellation before root materialization"),
+        )
+    try:
+        lifecycle = problem.lifecycle_frame(candidate.vector, parameterization)
+        frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
+        evaluated = fresh_evaluator.evaluate(frame)
+    except KeyboardInterrupt:
+        statistics = fresh_evaluator.cache_statistics
+        return CandidateMaterialization(
+            uuid4().hex,
+            problem.identity,
+            candidate.invocation_identity,
+            candidate.execution_identity,
+            CandidateSummary(candidate.vector, candidate.chi_square, 0),
+            MaterializationTerminal.INTERRUPTED,
+            1,
+            fresh_evaluator.compatibility_identity,
+            None,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure("interrupted", "KeyboardInterrupt during materialization"),
+        )
+    except Exception as error:  # noqa: BLE001 - root evaluation fails closed
+        statistics = fresh_evaluator.cache_statistics
+        return CandidateMaterialization(
+            uuid4().hex,
+            problem.identity,
+            candidate.invocation_identity,
+            candidate.execution_identity,
+            CandidateSummary(candidate.vector, candidate.chi_square, 0),
+            MaterializationTerminal.FAILURE,
+            1,
+            fresh_evaluator.compatibility_identity,
+            None,
+            statistics.hits,
+            statistics.misses,
+            TerminalFailure(
+                "materialization_exception",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    statistics = fresh_evaluator.cache_statistics
+    terminal: MaterializationTerminal | None = None
+    failure: TerminalFailure | None = None
+    if token.is_cancelled:
+        terminal = MaterializationTerminal.CANCELLED
+        failure = TerminalFailure(
+            "cancelled",
+            "Cancellation observed during root materialization",
+        )
+    elif isinstance(evaluated, EvaluationFailure):
+        terminal = MaterializationTerminal.FAILURE
+        failure = TerminalFailure(evaluated.category, evaluated.message, evaluated)
+    else:
+        try:
+            _validate_materialized_result(
+                evaluated,
+                request,
+                problem,
+                fresh_evaluator,
+            )
+        except Exception as error:  # noqa: BLE001 - aggregate validation fails closed
+            terminal = MaterializationTerminal.FAILURE
+            failure = TerminalFailure(
+                "materialization_validation_failure",
+                f"{type(error).__name__}: {error}",
+            )
+    if terminal is not None:
+        return CandidateMaterialization(
+            uuid4().hex,
+            problem.identity,
+            candidate.invocation_identity,
+            candidate.execution_identity,
+            CandidateSummary(candidate.vector, candidate.chi_square, 0),
+            terminal,
+            1,
+            fresh_evaluator.compatibility_identity,
+            None,
+            statistics.hits,
+            statistics.misses,
+            failure,
+        )
+    successful = cast("EvaluationResult", evaluated)
+    fresh_materialization = CandidateMaterialization(
+        uuid4().hex,
+        problem.identity,
+        candidate.invocation_identity,
+        candidate.execution_identity,
+        CandidateSummary(candidate.vector, candidate.chi_square, 0),
+        MaterializationTerminal.SUCCESS,
+        1,
+        fresh_evaluator.compatibility_identity,
+        successful.identity,
+        statistics.hits,
+        statistics.misses,
+    )
+    return MaterializedDirectTrfCandidate(
+        problem.identity,
+        candidate.invocation_identity,
+        candidate.execution_identity,
+        fresh_materialization,
+        candidate.vector,
+        candidate.chi_square,
+        successful,
+    )
 
 
 def _consume_fit_commit_authority(

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -353,6 +353,120 @@ class GridSeedProblemDerivation:
 
 
 @dataclass(frozen=True, slots=True)
+class DeSearchProblemDerivation:
+    """Exact lineage for one selected-coordinate DE search problem."""
+
+    root_problem_identity: str
+    search_specification_identity: str
+    selected_ids: tuple[str, ...]
+    captured_held_items: tuple[tuple[str, float], ...]
+    start: tuple[float, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            not self.root_problem_identity
+            or not self.search_specification_identity
+            or not self.selected_ids
+            or len(set(self.selected_ids)) != len(self.selected_ids)
+            or self.selected_ids
+            != tuple(sorted(self.selected_ids, key=lambda item: item.encode("utf-8")))
+        ):
+            raise DirectTrfConstructionError(
+                "DE search derivation requires unique canonical selected IDs"
+            )
+        held_items = tuple(
+            (
+                param_id,
+                _finite_binary64(value, name=f"DE held value {param_id!r}"),
+            )
+            for param_id, value in self.captured_held_items
+        )
+        held_ids = tuple(param_id for param_id, _value in held_items)
+        if len(set(held_ids)) != len(held_ids) or set(held_ids) & set(
+            self.selected_ids
+        ):
+            raise DirectTrfConstructionError(
+                "DE search derivation has inconsistent held coordinates"
+            )
+        start = tuple(
+            _finite_binary64(value, name=f"DE search start[{index}]")
+            for index, value in enumerate(self.start)
+        )
+        if len(start) != len(self.selected_ids):
+            raise DirectTrfConstructionError("DE search start has the wrong dimension")
+        object.__setattr__(self, "captured_held_items", held_items)
+        object.__setattr__(self, "start", start)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-search-problem-derivation",
+                (
+                    self.root_problem_identity,
+                    self.search_specification_identity,
+                    self.selected_ids,
+                    tuple(
+                        (param_id, _float_token(value))
+                        for param_id, value in held_items
+                    ),
+                    _vector_tokens(start),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DePolishProblemDerivation:
+    """Exact lineage for the one full-coordinate TRF polish after DE."""
+
+    root_problem_identity: str
+    workflow_invocation_identity: str
+    search_problem_identity: str
+    search_execution_identity: str
+    search_candidate_identity: str
+    controlled_ids: tuple[str, ...]
+    start: tuple[float, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            not self.root_problem_identity
+            or not self.workflow_invocation_identity
+            or not self.search_problem_identity
+            or not self.search_execution_identity
+            or not self.search_candidate_identity
+            or not self.controlled_ids
+        ):
+            raise DirectTrfConstructionError(
+                "DE polish derivation requires complete transition lineage"
+            )
+        start = tuple(
+            _finite_binary64(value, name=f"DE polish start[{index}]")
+            for index, value in enumerate(self.start)
+        )
+        if len(start) != len(self.controlled_ids):
+            raise DirectTrfConstructionError("DE polish start has the wrong dimension")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-de-polish-problem-derivation",
+                (
+                    self.root_problem_identity,
+                    self.workflow_invocation_identity,
+                    self.search_problem_identity,
+                    self.search_execution_identity,
+                    self.search_candidate_identity,
+                    self.controlled_ids,
+                    _vector_tokens(start),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class OptimizationProblem:
     """One immutable canonical external-coordinate fit and commit context."""
 
@@ -369,7 +483,13 @@ class OptimizationProblem:
     lower_bounds: tuple[float, ...]
     upper_bounds: tuple[float, ...]
     commit_scope: tuple[str, ...]
-    derivation: ComponentProblemDerivation | GridSeedProblemDerivation | None = None
+    derivation: (
+        ComponentProblemDerivation
+        | GridSeedProblemDerivation
+        | DeSearchProblemDerivation
+        | DePolishProblemDerivation
+        | None
+    ) = None
     scalarization_version: str = _SCALARIZATION_VERSION
     identity: str = field(init=False)
 
@@ -402,6 +522,21 @@ class OptimizationProblem:
             raise DirectTrfConstructionError(
                 "GRID seed problem differs from its derivation record"
             )
+        elif isinstance(self.derivation, DeSearchProblemDerivation) and (
+            self.derivation.selected_ids != self.controlled_ids
+            or self.derivation.captured_held_items != self.held_items
+            or self.derivation.start != normalized_start
+        ):
+            raise DirectTrfConstructionError(
+                "DE search problem differs from its derivation record"
+            )
+        elif isinstance(self.derivation, DePolishProblemDerivation) and (
+            self.derivation.controlled_ids != self.controlled_ids
+            or self.derivation.start != normalized_start
+        ):
+            raise DirectTrfConstructionError(
+                "DE polish problem differs from its derivation record"
+            )
         object.__setattr__(self, "start", normalized_start)
         object.__setattr__(self, "lower_bounds", lower)
         object.__setattr__(self, "upper_bounds", upper)
@@ -409,8 +544,12 @@ class OptimizationProblem:
             derivation_record: tuple[tuple[str, str], ...] = ()
         elif isinstance(self.derivation, ComponentProblemDerivation):
             derivation_record = (("derived-fit-component", self.derivation.identity),)
-        else:
+        elif isinstance(self.derivation, GridSeedProblemDerivation):
             derivation_record = (("derived-grid-seed", self.derivation.identity),)
+        elif isinstance(self.derivation, DeSearchProblemDerivation):
+            derivation_record = (("derived-de-search", self.derivation.identity),)
+        else:
+            derivation_record = (("derived-de-polish", self.derivation.identity),)
         object.__setattr__(
             self,
             "identity",

--- a/src/chemex/optimize/grid_direct_trf.py
+++ b/src/chemex/optimize/grid_direct_trf.py
@@ -16,18 +16,12 @@ from enum import StrEnum
 from itertools import product
 from numbers import Real
 from typing import Protocol, cast
-from uuid import uuid4
 
-from chemex.evaluation.native import (
-    EvaluationEngine,
-    EvaluationFailure,
-    EvaluationFrame,
-)
+from chemex.evaluation.native import EvaluationEngine
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     CancellationToken,
     CandidateMaterialization,
-    CandidateSummary,
     CommitReceipt,
     DirectTrfCandidateOutcome,
     DirectTrfCandidateTerminal,
@@ -44,6 +38,7 @@ from chemex.optimize.direct_trf import (
     TerminalFailure,
     _accept_materialized_fit_for_derived_workflow,
     _grant_derived_fit_commit_authority,
+    _materialize_derived_direct_trf_candidate_for_root,
     canonical_chi_square,
     commit_accepted_fit,
     execute_direct_trf_candidate,
@@ -1377,157 +1372,6 @@ def _grid_finalization_gate(
         return GridDirectTrfTerminal.INTERRUPTED
 
 
-def _failed_root_materialization(
-    problem: OptimizationProblem,
-    candidate: MaterializedDirectTrfCandidate,
-    evaluator_compatibility_identity: str,
-    evaluation_count: int,
-    cache_hits: int,
-    cache_misses: int,
-    failure: TerminalFailure,
-    *,
-    terminal: MaterializationTerminal = MaterializationTerminal.FAILURE,
-) -> CandidateMaterialization:
-    return CandidateMaterialization(
-        uuid4().hex,
-        problem.identity,
-        candidate.invocation_identity,
-        candidate.execution_identity,
-        CandidateSummary(candidate.vector, candidate.chi_square, 0),
-        terminal,
-        evaluation_count,
-        evaluator_compatibility_identity,
-        None,
-        cache_hits,
-        cache_misses,
-        failure,
-    )
-
-
-def _materialize_grid_candidate_for_root(
-    problem: OptimizationProblem,
-    candidate: MaterializedDirectTrfCandidate,
-    parameterization: ActiveParameterization,
-    engine: EvaluationEngine,
-    cancellation: CancellationToken,
-) -> MaterializedDirectTrfCandidate | CandidateMaterialization:
-    """Freshly evaluate one selected GRID vector against the complete root."""
-    try:
-        evaluator = engine.new_evaluator()
-    except Exception as error:  # noqa: BLE001 - binding failure is typed evidence
-        return _failed_root_materialization(
-            problem,
-            candidate,
-            engine.compatibility_identity,
-            0,
-            0,
-            0,
-            TerminalFailure(
-                "grid_selection_materialization_binding_failure",
-                f"{type(error).__name__}: {error}",
-            ),
-        )
-    if cancellation.is_cancelled:
-        return _failed_root_materialization(
-            problem,
-            candidate,
-            evaluator.compatibility_identity,
-            0,
-            0,
-            0,
-            TerminalFailure("cancelled", "Cancellation before GRID promotion"),
-            terminal=MaterializationTerminal.CANCELLED,
-        )
-    try:
-        lifecycle = problem.lifecycle_frame(candidate.vector, parameterization)
-        frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
-        evaluated = evaluator.evaluate(frame)
-    except KeyboardInterrupt:
-        statistics = evaluator.cache_statistics
-        return _failed_root_materialization(
-            problem,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure("interrupted", "KeyboardInterrupt during GRID promotion"),
-            terminal=MaterializationTerminal.INTERRUPTED,
-        )
-    except Exception as error:  # noqa: BLE001 - root evaluation fails closed
-        statistics = evaluator.cache_statistics
-        return _failed_root_materialization(
-            problem,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure(
-                "grid_selection_materialization_exception",
-                f"{type(error).__name__}: {error}",
-            ),
-        )
-    statistics = evaluator.cache_statistics
-    if cancellation.is_cancelled:
-        return _failed_root_materialization(
-            problem,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure("cancelled", "Cancellation after GRID promotion"),
-            terminal=MaterializationTerminal.CANCELLED,
-        )
-    if isinstance(evaluated, EvaluationFailure):
-        return _failed_root_materialization(
-            problem,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure(evaluated.category, evaluated.message, evaluated),
-        )
-    chi_square = canonical_chi_square(evaluated.residuals)
-    if chi_square != candidate.chi_square:
-        return _failed_root_materialization(
-            problem,
-            candidate,
-            evaluator.compatibility_identity,
-            1,
-            statistics.hits,
-            statistics.misses,
-            TerminalFailure(
-                "grid_selection_objective_mismatch",
-                "Fresh root objective differs from the selected aggregate candidate",
-            ),
-        )
-    materialization = CandidateMaterialization(
-        uuid4().hex,
-        problem.identity,
-        candidate.invocation_identity,
-        candidate.execution_identity,
-        CandidateSummary(candidate.vector, chi_square, 0),
-        MaterializationTerminal.SUCCESS,
-        1,
-        evaluator.compatibility_identity,
-        evaluated.identity,
-        statistics.hits,
-        statistics.misses,
-    )
-    return MaterializedDirectTrfCandidate(
-        problem.identity,
-        candidate.invocation_identity,
-        candidate.execution_identity,
-        materialization,
-        candidate.vector,
-        chi_square,
-        evaluated,
-    )
-
-
 def _finalize_grid_candidates(
     problem: OptimizationProblem,
     invocation: GridDirectTrfInvocation,
@@ -1570,12 +1414,12 @@ def _finalize_grid_candidates(
     selection, selected = _selection(eligible)
     selected_seed = invocation.seeds[selected.seed_ordinal]
     selected_candidate = cast("GridCandidate", selected.candidate)
-    promoted = _materialize_grid_candidate_for_root(
+    promoted = _materialize_derived_direct_trf_candidate_for_root(
         problem,
         selected_candidate.candidate,
         parameterization,
         engine,
-        cancellation,
+        cancellation=cancellation,
     )
     if isinstance(promoted, CandidateMaterialization):
         terminal = {

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -31,12 +31,15 @@ from chemex.evaluation.native import (
     EvaluationResult,
 )
 from chemex.experiments.builder import build_experiments
+from chemex.optimize import de_direct_trf as de_workflow
 from chemex.optimize.de_direct_trf import (
     DeCoordinateSemantics,
     DeDirectTrfInterrupted,
     DeDirectTrfInvocation,
     DeDirectTrfTerminal,
+    DePopulation,
     DeSearchCoordinate,
+    DeSearchExecution,
     DeSearchTerminal,
     commit_de_accepted_fit,
     execute_de_direct_trf,
@@ -166,6 +169,131 @@ def test_de_requires_an_explicit_unsigned_64_bit_root_seed(root_seed: object) ->
             de_objective_request_budget=5,
             polish_objective_request_budget=5,
         )
+
+
+def _two_coordinate_invocation(
+    problem: OptimizationProblem,
+) -> DeDirectTrfInvocation:
+    coordinates = tuple(
+        (
+            param_id,
+            max(
+                problem.lower_bounds[index],
+                (
+                    problem.start[index] * 0.5
+                    if problem.start[index] > 0.0
+                    else problem.start[index] - 1.0
+                ),
+            ),
+            min(
+                problem.upper_bounds[index],
+                (
+                    problem.start[index] * 1.5
+                    if problem.start[index] > 0.0
+                    else problem.start[index] + 1.0
+                ),
+            ),
+            DeCoordinateSemantics.LINEAR,
+        )
+        for index, param_id in enumerate(problem.controlled_ids)
+    )
+    return DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=coordinates,
+        root_seed=597,
+        de_objective_request_budget=10,
+        polish_objective_request_budget=10,
+        population_multiplier=4,
+        maximum_generations=2,
+    )
+
+
+def test_reconstructed_invocation_rejects_retargeted_coordinates() -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    invocation = _two_coordinate_invocation(problem)
+    first, second = invocation.search_coordinates
+    foreign = dataclasses.replace(first, param_id="foreign")
+    duplicate = dataclasses.replace(second, param_id=first.param_id)
+    swapped_records = (
+        dataclasses.replace(
+            first,
+            physical_lower=second.physical_lower,
+            physical_upper=second.physical_upper,
+        ),
+        dataclasses.replace(
+            second,
+            physical_lower=first.physical_lower,
+            physical_upper=first.physical_upper,
+        ),
+    )
+    positive_index = next(
+        index
+        for index, coordinate in enumerate(invocation.search_coordinates)
+        if coordinate.physical_lower > 0.0
+    )
+    altered_transform = dataclasses.replace(
+        invocation.search_coordinates[positive_index],
+        semantics="log",
+    )
+    altered_bounds = dataclasses.replace(
+        first,
+        physical_lower=first.physical_lower + 0.01,
+    )
+
+    attacks = (
+        tuple(reversed(invocation.search_coordinates)),
+        swapped_records,
+        (first, duplicate),
+        (foreign, second),
+        tuple(
+            altered_transform if index == positive_index else coordinate
+            for index, coordinate in enumerate(invocation.search_coordinates)
+        ),
+        (altered_bounds, second),
+    )
+    for coordinates in attacks:
+        with pytest.raises(DirectTrfConstructionError):
+            dataclasses.replace(invocation, search_coordinates=coordinates)
+
+
+@pytest.mark.parametrize("root_seed", (True, -1, 2**64))
+def test_reconstructed_invocation_rejects_invalid_root_seed(root_seed: object) -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    invocation = _two_coordinate_invocation(problem)
+
+    with pytest.raises(DirectTrfConstructionError, match="unsigned 64-bit root seed"):
+        dataclasses.replace(invocation, root_seed=root_seed)
+
+
+def test_reconstructed_invocation_rejects_malformed_topology_budgets_and_settings() -> (
+    None
+):
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    invocation = _two_coordinate_invocation(problem)
+    wrong_dimension = DePopulation(1, 5, 5, 2)
+
+    attacks = (
+        {"population": wrong_dimension},
+        {"de_objective_request_budget": True},
+        {"polish_objective_request_budget": 0},
+        {"mutation": 2.0},
+        {"recombination": 1.1},
+        {"tol": -0.1},
+        {"polish_x_scale": (-1.0, 1.0)},
+        {"polish_ftol": None, "polish_xtol": None, "polish_gtol": None},
+    )
+    for changes in attacks:
+        with pytest.raises(DirectTrfConstructionError):
+            dataclasses.replace(invocation, **changes)
+
+    with pytest.raises(DirectTrfConstructionError):
+        dataclasses.replace(invocation.population, size=6)
 
 
 def test_log_coordinate_map_has_exact_endpoints_and_stable_interior_round_trip() -> (
@@ -827,6 +955,191 @@ def test_de_cancellation_stops_before_polish_without_fallback() -> None:
     polish_backend.assert_not_called()
 
 
+def test_cancellation_after_de_eligibility_prevents_polish_transfer() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    token = CancellationToken()
+    run_search = de_workflow._run_de_search
+
+    def eligible_then_cancel(
+        root_problem: OptimizationProblem,
+        workflow_invocation: DeDirectTrfInvocation,
+        active_parameterization: ActiveParameterization,
+        evaluation_engine: EvaluationEngine,
+        cancellation: CancellationToken,
+    ) -> DeSearchExecution:
+        search = run_search(
+            root_problem,
+            workflow_invocation,
+            active_parameterization,
+            evaluation_engine,
+            cancellation,
+        )
+        assert search.restart_eligible
+        token.cancel()
+        return search
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf._run_de_search",
+            side_effect=eligible_then_cancel,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf.execute_direct_trf_candidate"
+        ) as polish_entry,
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.CANCELLED
+    assert outcome.search.restart_eligible
+    assert outcome.accounting.search_to_polish_transfers == 0
+    assert outcome.accounting.root_materializations == 0
+    assert outcome.polish_problem is None
+    assert outcome.polish_invocation is None
+    assert outcome.polish is None
+    assert outcome.root_materialization is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    polish_entry.assert_not_called()
+
+
+def test_interruption_after_de_eligibility_prevents_polish_transfer() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+
+    class InterruptAtTransition(CancellationToken):
+        ready = False
+
+        @property
+        def is_cancelled(self) -> bool:
+            if self.ready:
+                raise KeyboardInterrupt
+            return False
+
+    token = InterruptAtTransition()
+    run_search = de_workflow._run_de_search
+
+    def eligible_then_interrupt(
+        root_problem: OptimizationProblem,
+        workflow_invocation: DeDirectTrfInvocation,
+        active_parameterization: ActiveParameterization,
+        evaluation_engine: EvaluationEngine,
+        cancellation: CancellationToken,
+    ) -> DeSearchExecution:
+        search = run_search(
+            root_problem,
+            workflow_invocation,
+            active_parameterization,
+            evaluation_engine,
+            cancellation,
+        )
+        assert search.restart_eligible
+        token.ready = True
+        return search
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf._run_de_search",
+            side_effect=eligible_then_interrupt,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf.execute_direct_trf_candidate"
+        ) as polish_entry,
+        pytest.raises(DeDirectTrfInterrupted) as interrupted,
+    ):
+        execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+
+    outcome = interrupted.value.outcome
+    assert outcome.terminal is DeDirectTrfTerminal.INTERRUPTED
+    assert outcome.accounting.search_to_polish_transfers == 0
+    assert outcome.accounting.root_materializations == 0
+    assert outcome.polish is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    polish_entry.assert_not_called()
+
+
+def test_retargeted_de_candidate_lineage_fails_before_polish_transfer() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    run_search = de_workflow._run_de_search
+
+    def retarget_eligible_candidate(
+        root_problem: OptimizationProblem,
+        workflow_invocation: DeDirectTrfInvocation,
+        active_parameterization: ActiveParameterization,
+        evaluation_engine: EvaluationEngine,
+        cancellation: CancellationToken,
+    ) -> DeSearchExecution:
+        search = run_search(
+            root_problem,
+            workflow_invocation,
+            active_parameterization,
+            evaluation_engine,
+            cancellation,
+        )
+        candidate = search.best_candidate
+        assert candidate is not None
+        retargeted = dataclasses.replace(
+            candidate,
+            full_vector=(candidate.full_vector[0] + 0.01,),
+        )
+        return dataclasses.replace(search, best_candidate=retargeted)
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf._run_de_search",
+            side_effect=retarget_eligible_candidate,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf.execute_direct_trf_candidate"
+        ) as polish_entry,
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.EXECUTION_FAILURE
+    assert outcome.accounting.search_to_polish_transfers == 0
+    assert outcome.polish is None
+    assert outcome.failure is not None
+    assert outcome.failure.category == "de_search_lineage_failure"
+    polish_entry.assert_not_called()
+
+
 def test_non_converged_polish_is_terminal_and_never_falls_back_to_de_candidate() -> (
     None
 ):
@@ -1099,3 +1412,87 @@ def test_real_scipy_de_is_deterministic_for_the_same_root_seed() -> None:
     assert first.search.best_candidate == second.search.best_candidate
     assert first.search.backend == second.search.backend
     assert first.search.identity == second.search.identity
+
+
+def test_real_de_and_real_trf_match_analytical_boundary_optimum() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        Method(fit=["PB"], fix=["KEX_AB"])
+    )
+    selected_id, unselected_id = problem.controlled_ids
+    selected_index = problem.controlled_ids.index(selected_id)
+    unselected_index = problem.controlled_ids.index(unselected_id)
+    expected_vector = (0.0, 6.87922079444668)
+    assert problem.controlled_ids == ("__PB", "__R1A_A_G2N_H_800_0MHZ")
+    assert problem.start == expected_vector
+    lower = problem.lower_bounds[selected_index]
+    upper = min(
+        problem.upper_bounds[selected_index],
+        problem.start[selected_index] + max(abs(problem.start[selected_index]), 1.0),
+    )
+    assert math.isfinite(lower) and math.isfinite(upper) and lower < upper
+    target_below_bound = -1.0
+    unselected_target = expected_vector[unselected_index]
+    invocation = DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=((selected_id, lower, upper, "linear"),),
+        root_seed=597,
+        de_objective_request_budget=25,
+        polish_objective_request_budget=100,
+        population_multiplier=5,
+        maximum_generations=4,
+        polish_ftol=1.0e-12,
+        polish_xtol=1.0e-12,
+        polish_gtol=1.0e-12,
+    )
+    original_new_evaluator = engine.new_evaluator
+
+    class AnalyticalBoundaryEvaluator:
+        def __init__(self, delegate: BoundEvaluator) -> None:
+            self._delegate = delegate
+            self.compatibility_identity = delegate.compatibility_identity
+
+        @property
+        def cache_statistics(self) -> object:
+            return self._delegate.cache_statistics
+
+        def evaluate(
+            self,
+            frame: EvaluationFrame,
+        ) -> EvaluationResult | EvaluationFailure:
+            evaluated = self._delegate.evaluate(frame)
+            if isinstance(evaluated, EvaluationFailure):
+                return evaluated
+            residuals = np.zeros(
+                engine.plan.retained_observation_count,
+                dtype=np.float64,
+            )
+            residuals[0] = evaluated.resolved_values[selected_id] - target_below_bound
+            residuals[1] = evaluated.resolved_values[unselected_id] - unselected_target
+            return dataclasses.replace(evaluated, residuals=residuals)
+
+    def analytical_new_evaluator() -> AnalyticalBoundaryEvaluator:
+        return AnalyticalBoundaryEvaluator(original_new_evaluator())
+
+    with patch.object(engine, "new_evaluator", analytical_new_evaluator):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.ACCEPTED
+    assert outcome.search.best_candidate is not None
+    search_candidate = outcome.search.best_candidate
+    assert search_candidate.selected_vector == (
+        search_candidate.full_vector[selected_index],
+    )
+    assert search_candidate.full_vector[unselected_index] == unselected_target
+    assert outcome.accepted_result is not None
+    fitted = outcome.accepted_result.vector
+    # The exact constrained solution is (lower, unselected_target), with
+    # residual vector (1, 0, ...), hence chi-square 1.  The 1e-7 vector and
+    # 2e-7 chi-square tolerances cover TRF's interior representation of an
+    # active bound while remaining much tighter than the one-unit scale.
+    assert fitted == pytest.approx(expected_vector, abs=1.0e-7)
+    assert outcome.accepted_result.chi_square == pytest.approx(1.0, abs=2.0e-7)

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -46,7 +46,10 @@ from chemex.optimize.de_direct_trf import (
 )
 from chemex.optimize.direct_trf import (
     CancellationToken,
+    DePolishProblemDerivation,
+    DirectTrfCandidateOutcome,
     DirectTrfConstructionError,
+    DirectTrfInvocation,
     OptimizationProblem,
 )
 from chemex.parameters.parameterization import ActiveParameterization
@@ -206,6 +209,182 @@ def _two_coordinate_invocation(
         population_multiplier=4,
         maximum_generations=2,
     )
+
+
+def _one_of_two_coordinate_invocation(
+    problem: OptimizationProblem,
+    *,
+    polish_x_scale: float | tuple[float, ...] | None = None,
+) -> DeDirectTrfInvocation:
+    selected_id = problem.controlled_ids[0]
+    selected_index = problem.controlled_ids.index(selected_id)
+    return DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=(
+            (
+                selected_id,
+                problem.lower_bounds[selected_index],
+                problem.upper_bounds[selected_index],
+                DeCoordinateSemantics.LINEAR,
+            ),
+        ),
+        root_seed=597,
+        de_objective_request_budget=6,
+        polish_objective_request_budget=10,
+        population_multiplier=4,
+        maximum_generations=2,
+        polish_x_scale=polish_x_scale,
+    )
+
+
+def _replace_item_value(
+    items: tuple[tuple[str, float], ...],
+    param_id: str,
+    value: float,
+) -> tuple[tuple[str, float], ...]:
+    return tuple(
+        (item_id, value if item_id == param_id else item_value)
+        for item_id, item_value in items
+    )
+
+
+def _forged_search_child(
+    invocation: DeDirectTrfInvocation,
+    attack: str,
+) -> OptimizationProblem:
+    child = invocation.search_problem
+    derivation = child.derivation
+    assert derivation is not None
+    held_ids = tuple(param_id for param_id, _value in child.held_items)
+    first_held = held_ids[0]
+    first_value = dict(child.held_items)[first_held]
+    independent_items = child.independent_items
+    held_items = child.held_items
+    source_snapshot = child.source_snapshot
+    if attack in {"one_unselected", "multiple_unselected"}:
+        independent_items = _replace_item_value(
+            independent_items,
+            first_held,
+            first_value + 1.0,
+        )
+        held_items = _replace_item_value(held_items, first_held, first_value + 1.0)
+        if attack == "multiple_unselected":
+            second_held = held_ids[1]
+            second_value = dict(child.held_items)[second_held]
+            independent_items = _replace_item_value(
+                independent_items,
+                second_held,
+                second_value + 2.0,
+            )
+            held_items = _replace_item_value(
+                held_items,
+                second_held,
+                second_value + 2.0,
+            )
+    elif attack == "snapshot_revision":
+        source_snapshot = dataclasses.replace(
+            source_snapshot,
+            revision=source_snapshot.revision + 1,
+        )
+    elif attack == "selected_independent_frame":
+        selected_id = child.controlled_ids[0]
+        selected_value = dict(child.independent_items)[selected_id]
+        independent_items = _replace_item_value(
+            independent_items,
+            selected_id,
+            selected_value + 0.25,
+        )
+    elif attack == "held_only":
+        held_items = _replace_item_value(held_items, first_held, first_value + 1.0)
+    else:
+        raise AssertionError(f"Unknown forged search-child attack: {attack}")
+    forged_derivation = dataclasses.replace(
+        derivation,
+        captured_held_items=held_items,
+    )
+    return dataclasses.replace(
+        child,
+        source_snapshot=source_snapshot,
+        independent_items=independent_items,
+        held_items=held_items,
+        derivation=forged_derivation,
+    )
+
+
+@pytest.mark.parametrize(
+    "attack",
+    (
+        "one_unselected",
+        "multiple_unselected",
+        "snapshot_revision",
+        "selected_independent_frame",
+        "held_only",
+    ),
+)
+def test_reconstructed_invocation_rejects_forged_search_root_projection(
+    attack: str,
+) -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    invocation = _one_of_two_coordinate_invocation(problem)
+    forged = _forged_search_child(invocation, attack)
+
+    with (
+        patch("chemex.optimize.de_direct_trf.differential_evolution") as backend,
+        pytest.raises(DirectTrfConstructionError, match="root projection"),
+    ):
+        dataclasses.replace(invocation, search_problem=forged)
+
+    backend.assert_not_called()
+
+
+def test_polish_scale_uses_the_complete_root_trf_dimension() -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    scalar = _one_of_two_coordinate_invocation(problem, polish_x_scale=2.0)
+    vector = _one_of_two_coordinate_invocation(
+        problem,
+        polish_x_scale=(2.0, 3.0),
+    )
+
+    assert scalar.polish_x_scale == (2.0, 2.0)
+    assert vector.polish_x_scale == (2.0, 3.0)
+    assert dataclasses.replace(vector, polish_x_scale=(3.0, 2.0)).polish_x_scale == (
+        3.0,
+        2.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "polish_x_scale",
+    (
+        (1.0,),
+        (),
+        (1.0, 1.0, 1.0),
+        (1.0, math.nan),
+        (1.0, -1.0),
+    ),
+)
+def test_reconstructed_invocation_rejects_non_full_polish_scale(
+    polish_x_scale: tuple[float, ...],
+) -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    invocation = _one_of_two_coordinate_invocation(
+        problem,
+        polish_x_scale=(1.0, 1.0),
+    )
+
+    with (
+        patch("chemex.optimize.de_direct_trf.differential_evolution") as backend,
+        pytest.raises((DirectTrfConstructionError, ValueError)),
+    ):
+        dataclasses.replace(invocation, polish_x_scale=polish_x_scale)
+
+    backend.assert_not_called()
 
 
 def test_reconstructed_invocation_rejects_retargeted_coordinates() -> None:
@@ -1138,6 +1317,146 @@ def test_retargeted_de_candidate_lineage_fails_before_polish_transfer() -> None:
     assert outcome.failure is not None
     assert outcome.failure.category == "de_search_lineage_failure"
     polish_entry.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "attack",
+    (
+        "another_de_invocation",
+        "another_polish_problem",
+        "same_root_foreign_polish_invocation",
+        "foreign_execution_materialization",
+    ),
+)
+def test_foreign_self_consistent_polish_lineage_fails_before_root_promotion(
+    attack: str,
+) -> None:
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    execute_polish = de_workflow.execute_direct_trf_candidate
+    before = session.analysis_values.snapshot()
+
+    def foreign_polish(
+        polish_problem: OptimizationProblem,
+        polish_invocation: DirectTrfInvocation,
+        active_parameterization: ActiveParameterization,
+        evaluation_engine: EvaluationEngine,
+        *,
+        cancellation: CancellationToken | None = None,
+    ) -> DirectTrfCandidateOutcome:
+        derivation = polish_problem.derivation
+        assert isinstance(derivation, DePolishProblemDerivation)
+        if attack in {"another_de_invocation", "another_polish_problem"}:
+            replacement = (
+                {"workflow_invocation_identity": "foreign-de-invocation"}
+                if attack == "another_de_invocation"
+                else {"search_candidate_identity": "foreign-de-candidate"}
+            )
+            foreign_derivation = dataclasses.replace(derivation, **replacement)
+            foreign_problem = dataclasses.replace(
+                polish_problem,
+                derivation=foreign_derivation,
+            )
+            foreign_invocation = DirectTrfInvocation.for_problem(
+                foreign_problem,
+                objective_request_budget=polish_invocation.objective_request_budget,
+                x_scale=polish_invocation.x_scale,
+                ftol=polish_invocation.ftol,
+                xtol=polish_invocation.xtol,
+                gtol=polish_invocation.gtol,
+            )
+            result = execute_polish(
+                foreign_problem,
+                foreign_invocation,
+                active_parameterization,
+                evaluation_engine,
+                cancellation=cancellation,
+            )
+            assert result.candidate is not None
+            assert result.candidate.vector == polish_problem.start
+            return result
+        if attack == "same_root_foreign_polish_invocation":
+            foreign_invocation = dataclasses.replace(
+                polish_invocation,
+                objective_request_budget=(
+                    polish_invocation.objective_request_budget + 1
+                ),
+            )
+            return execute_polish(
+                polish_problem,
+                foreign_invocation,
+                active_parameterization,
+                evaluation_engine,
+                cancellation=cancellation,
+            )
+        result = execute_polish(
+            polish_problem,
+            polish_invocation,
+            active_parameterization,
+            evaluation_engine,
+            cancellation=cancellation,
+        )
+        assert result.materialization is not None
+        assert result.candidate is not None
+        foreign_execution = dataclasses.replace(
+            result.execution,
+            invocation_identity="foreign-polish-invocation",
+        )
+        foreign_materialization = dataclasses.replace(
+            result.materialization,
+            invocation_identity="foreign-polish-invocation",
+            execution_identity=foreign_execution.identity,
+        )
+        foreign_candidate = dataclasses.replace(
+            result.candidate,
+            invocation_identity="foreign-polish-invocation",
+            execution_identity=foreign_execution.identity,
+            materialization=foreign_materialization,
+        )
+        return dataclasses.replace(
+            result,
+            execution=foreign_execution,
+            materialization=foreign_materialization,
+            candidate=foreign_candidate,
+        )
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            _successful_polish_backend,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf.execute_direct_trf_candidate",
+            side_effect=foreign_polish,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf."
+            "_materialize_derived_direct_trf_candidate_for_root"
+        ) as root_promotion,
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.EXECUTION_FAILURE
+    assert outcome.failure is not None
+    assert outcome.failure.category == "de_polish_lineage_failure"
+    assert outcome.accounting.search_to_polish_transfers == 1
+    assert outcome.accounting.root_materializations == 0
+    assert outcome.root_materialization is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    assert session.analysis_values.snapshot() == before
+    root_promotion.assert_not_called()
 
 
 def test_non_converged_polish_is_terminal_and_never_falls_back_to_de_candidate() -> (

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -1,0 +1,1101 @@
+"""Behavioral qualification for selected-coordinate native DE -> TRF (#597).
+
+The public seams are the immutable two-stage workflow invocation, typed search
+and polish outcomes, and the existing revision-checked Direct TRF commit
+boundary.  Legacy optimizer dispatch remains outside this qualification.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from scipy.optimize import Bounds
+
+from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.parameters import read_defaults
+from chemex.containers.experiments import Experiments
+from chemex.evaluation.native import (
+    BoundEvaluator,
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationResult,
+)
+from chemex.experiments.builder import build_experiments
+from chemex.optimize.de_direct_trf import (
+    DeCoordinateSemantics,
+    DeDirectTrfInterrupted,
+    DeDirectTrfInvocation,
+    DeDirectTrfTerminal,
+    DeSearchCoordinate,
+    DeSearchTerminal,
+    commit_de_accepted_fit,
+    execute_de_direct_trf,
+)
+from chemex.optimize.direct_trf import (
+    CancellationToken,
+    DirectTrfConstructionError,
+    OptimizationProblem,
+)
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+from chemex.typing import Array
+
+ROOT = Path(__file__).parent.parent
+EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
+METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+def _qualification_problem(
+    method: Method,
+) -> tuple[
+    AnalysisSession,
+    Experiments,
+    ActiveParameterization,
+    EvaluationEngine,
+    OptimizationProblem,
+]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    return session, experiments, parameterization, engine, problem
+
+
+def test_selected_coordinate_plan_is_bounded_seeded_and_non_authoritative() -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    pb_id, r1_id = problem.controlled_ids
+    pb_index = problem.controlled_ids.index(pb_id)
+    search_lower = problem.lower_bounds[pb_index]
+    search_upper = problem.upper_bounds[pb_index]
+
+    invocation = DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=(
+            (pb_id, search_lower, search_upper, DeCoordinateSemantics.LINEAR),
+        ),
+        root_seed=597,
+        de_objective_request_budget=6,
+        polish_objective_request_budget=5,
+        population_multiplier=4,
+        maximum_generations=3,
+    )
+
+    assert invocation.root_problem_identity == problem.identity
+    assert tuple(item.param_id for item in invocation.search_coordinates) == (pb_id,)
+    assert invocation.search_coordinates[0].physical_bounds == (
+        search_lower,
+        search_upper,
+    )
+    assert invocation.search_problem.controlled_ids == (pb_id,)
+    assert dict(invocation.search_problem.held_items)[r1_id] == problem.start[1]
+    assert invocation.search_problem.lower_bounds == (problem.lower_bounds[0],)
+    assert invocation.search_problem.upper_bounds == (problem.upper_bounds[0],)
+    assert not invocation.search_problem.acceptance_authority
+    assert invocation.root_seed == 597
+    assert invocation.population.dimension == 1
+    assert invocation.population.multiplier == 4
+    assert invocation.population.size == 5
+    assert invocation.population.maximum_generations == 3
+    assert invocation.de_objective_request_budget == 6
+    assert invocation.polish_objective_request_budget == 5
+    assert (
+        invocation.identity
+        == DeDirectTrfInvocation.for_problem(
+            problem,
+            search_coordinates=((pb_id, search_lower, search_upper, "linear"),),
+            root_seed=597,
+            de_objective_request_budget=6,
+            polish_objective_request_budget=5,
+            population_multiplier=4,
+            maximum_generations=3,
+        ).identity
+    )
+
+
+@pytest.mark.parametrize("root_seed", (-1, 2**64, True, None))
+def test_de_requires_an_explicit_unsigned_64_bit_root_seed(root_seed: object) -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    param_id = problem.controlled_ids[0]
+    index = problem.controlled_ids.index(param_id)
+
+    with pytest.raises(DirectTrfConstructionError, match="unsigned 64-bit root seed"):
+        DeDirectTrfInvocation.for_problem(
+            problem,
+            search_coordinates=(
+                (
+                    param_id,
+                    problem.lower_bounds[index],
+                    problem.upper_bounds[index],
+                    "linear",
+                ),
+            ),
+            root_seed=root_seed,
+            de_objective_request_budget=5,
+            polish_objective_request_budget=5,
+        )
+
+
+def test_log_coordinate_map_has_exact_endpoints_and_stable_interior_round_trip() -> (
+    None
+):
+    coordinate = DeSearchCoordinate("log-rate", 0.1, 10.0, "log", 0)
+    solver_lower, solver_upper = coordinate.solver_bounds
+
+    assert coordinate.to_physical(solver_lower) == 0.1
+    assert coordinate.to_physical(solver_upper) == 10.0
+    assert coordinate.to_physical(coordinate.to_solver(2.5)) == pytest.approx(
+        2.5,
+        rel=2.0e-15,
+        abs=0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("lower", "upper"),
+    ((0.0, 1.0), (-1.0, 1.0), (1.0, math.inf), (1.0, 1.0)),
+)
+def test_log_coordinate_rejects_non_positive_non_finite_or_empty_bounds(
+    lower: float,
+    upper: float,
+) -> None:
+    with pytest.raises(DirectTrfConstructionError):
+        DeSearchCoordinate("log-rate", lower, upper, "log", 0)
+
+
+def test_log_coordinate_rejects_a_start_outside_the_declared_search_range() -> None:
+    coordinate = DeSearchCoordinate("log-rate", 0.1, 10.0, "log", 0)
+
+    with pytest.raises(DirectTrfConstructionError, match="outside its search range"):
+        coordinate.to_solver(10.1)
+
+
+def _trf_backend_result(candidate: Array, residuals: Array) -> SimpleNamespace:
+    return SimpleNamespace(
+        x=candidate,
+        fun=residuals,
+        status=1,
+        success=True,
+        message="qualified TRF polish",
+        nfev=1,
+        njev=0,
+        cost=0.5 * float(np.dot(residuals, residuals)),
+        optimality=0.0,
+        active_mask=np.zeros_like(candidate, dtype=np.int64),
+    )
+
+
+def _bounded_de_invocation(
+    problem: OptimizationProblem,
+    *,
+    de_budget: int = 6,
+) -> DeDirectTrfInvocation:
+    (param_id,) = problem.controlled_ids
+    lower = max(problem.lower_bounds[0], problem.start[0] * 0.5)
+    upper = min(problem.upper_bounds[0], problem.start[0] * 1.5)
+    return DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=((param_id, lower, upper, "linear"),),
+        root_seed=597,
+        de_objective_request_budget=de_budget,
+        polish_objective_request_budget=5,
+        population_multiplier=4,
+        maximum_generations=2,
+    )
+
+
+def _eligible_search_backend(
+    fun: Callable[[Array], float],
+    _bounds: Bounds,
+    **kwargs: object,
+) -> object:
+    candidate = np.asarray(kwargs["x0"], dtype=np.float64)
+    objective = fun(candidate)
+    population = np.repeat(candidate[None, :], 5, axis=0)
+    return SimpleNamespace(
+        x=candidate,
+        fun=objective,
+        success=True,
+        message="Optimization terminated successfully.",
+        nit=1,
+        nfev=1,
+        population=population,
+        population_energies=np.full(5, objective),
+    )
+
+
+def _successful_polish_backend(
+    fun: Callable[[Array], Array],
+    x0: Array,
+    **_kwargs: object,
+) -> object:
+    candidate = np.asarray(x0, dtype=np.float64)
+    return _trf_backend_result(candidate, fun(candidate))
+
+
+def test_de_selects_canonical_restart_then_runs_one_full_trf_polish_and_commit() -> (
+    None
+):
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    search_lower = max(problem.lower_bounds[0], problem.start[0] * 0.5)
+    search_upper = min(problem.upper_bounds[0], problem.start[0] * 1.5)
+    invocation = DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=((param_id, search_lower, search_upper, "linear"),),
+        root_seed=597,
+        de_objective_request_budget=6,
+        polish_objective_request_budget=5,
+        population_multiplier=4,
+        maximum_generations=1,
+    )
+    de_calls = 0
+    polish_starts: list[tuple[float, ...]] = []
+
+    def bounded_search_backend(
+        fun: Callable[[Array], float],
+        bounds: Bounds,
+        **kwargs: object,
+    ) -> object:
+        nonlocal de_calls
+        de_calls += 1
+        assert kwargs["strategy"] == "best1bin"
+        assert kwargs["init"] == "latinhypercube"
+        assert kwargs["updating"] == "deferred"
+        assert kwargs["polish"] is False
+        assert kwargs["workers"] == 1
+        assert kwargs["vectorized"] is False
+        assert isinstance(kwargs["rng"], np.random.Generator)
+        assert kwargs["x0"] is not None
+        lower = float(bounds.lb[0])
+        upper = float(bounds.ub[0])
+        first = np.asarray(kwargs["x0"], dtype=np.float64)
+        second = np.asarray(((lower + upper) * 0.5,), dtype=np.float64)
+        first_objective = fun(first)
+        second_objective = fun(second)
+        # Deliberately return the worse backend x: ChemEx owns restart ordering.
+        returned = first if first_objective >= second_objective else second
+        return SimpleNamespace(
+            x=returned,
+            fun=max(first_objective, second_objective),
+            success=False,
+            message="Maximum number of iterations has been exceeded.",
+            nit=1,
+            nfev=2,
+            population=np.asarray((first, second, first, second, first)),
+            population_energies=np.asarray(
+                (
+                    first_objective,
+                    second_objective,
+                    first_objective,
+                    second_objective,
+                    first_objective,
+                )
+            ),
+        )
+
+    def polishing_backend(
+        fun: Callable[[Array], Array],
+        x0: Array,
+        **_kwargs: object,
+    ) -> object:
+        polish_starts.append(tuple(float(value) for value in x0))
+        candidate = np.asarray(x0, dtype=np.float64)
+        residuals = fun(candidate)
+        return _trf_backend_result(candidate, residuals)
+
+    before = session.analysis_values.snapshot()
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            bounded_search_backend,
+        ),
+        patch("chemex.optimize.direct_trf.least_squares", polishing_backend),
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert de_calls == 1
+    assert outcome.terminal is DeDirectTrfTerminal.ACCEPTED
+    assert outcome.search.terminal is DeSearchTerminal.GENERATION_LIMIT
+    assert outcome.search.restart_eligible
+    assert outcome.search.best_candidate is not None
+    assert polish_starts == [outcome.search.best_candidate.full_vector]
+    assert outcome.polish_problem is not None
+    assert outcome.polish_problem.controlled_ids == problem.controlled_ids
+    assert outcome.polish_problem.start == outcome.search.best_candidate.full_vector
+    assert not outcome.polish_problem.acceptance_authority
+    assert outcome.polish is not None
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    assert outcome.accounting.de_budget == 6
+    assert outcome.accounting.de_counters.objective_requests_accepted == 2
+    assert outcome.accounting.polish_budget == 5
+    assert outcome.accounting.polish_counters is not None
+    assert outcome.accounting.search_to_polish_transfers == 1
+    assert outcome.accounting.root_materializations == 1
+    assert session.analysis_values.snapshot() == before
+
+    receipt = commit_de_accepted_fit(
+        outcome.accepted_result,
+        outcome.commit_authority,
+        problem=problem,
+        parameterization=parameterization,
+        analysis_values=session.analysis_values,
+    )
+
+    assert receipt.old_revision == before.revision
+    assert receipt.new_revision == before.revision + 1
+
+
+def test_de_interruption_freezes_typed_evidence_and_never_starts_polish() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    search_lower = max(problem.lower_bounds[0], problem.start[0] * 0.5)
+    search_upper = min(problem.upper_bounds[0], problem.start[0] * 1.5)
+    invocation = DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=((param_id, search_lower, search_upper, "linear"),),
+        root_seed=597,
+        de_objective_request_budget=6,
+        polish_objective_request_budget=5,
+        population_multiplier=4,
+    )
+
+    def interrupted_backend(
+        fun: Callable[[Array], float],
+        _bounds: Bounds,
+        **kwargs: object,
+    ) -> object:
+        fun(np.asarray(kwargs["x0"], dtype=np.float64))
+        raise KeyboardInterrupt
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            interrupted_backend,
+        ),
+        patch("chemex.optimize.direct_trf.least_squares") as polish_backend,
+        pytest.raises(DeDirectTrfInterrupted) as interrupted,
+    ):
+        execute_de_direct_trf(problem, invocation, parameterization, engine)
+
+    outcome = interrupted.value.outcome
+    assert outcome.terminal is DeDirectTrfTerminal.INTERRUPTED
+    assert outcome.search.terminal is DeSearchTerminal.INTERRUPTED
+    assert outcome.search.counters.objective_requests_accepted == 1
+    assert outcome.polish is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    assert outcome.accounting.search_to_polish_transfers == 0
+    polish_backend.assert_not_called()
+
+
+def test_de_preflight_interruption_is_typed_before_backend_entry() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+
+    with (
+        patch.object(BoundEvaluator, "evaluate", side_effect=KeyboardInterrupt),
+        patch("chemex.optimize.de_direct_trf.differential_evolution") as search_backend,
+        pytest.raises(DeDirectTrfInterrupted) as interrupted,
+    ):
+        execute_de_direct_trf(problem, invocation, parameterization, engine)
+
+    outcome = interrupted.value.outcome
+    assert outcome.terminal is DeDirectTrfTerminal.INTERRUPTED
+    assert outcome.search.terminal is DeSearchTerminal.INTERRUPTED
+    assert outcome.search.preflight_evaluation_identity is None
+    assert outcome.search.counters.objective_requests_accepted == 0
+    assert outcome.polish is None
+    assert outcome.commit_authority is None
+    search_backend.assert_not_called()
+
+
+def test_initial_de_evaluator_binding_interruption_is_typed() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+
+    with (
+        patch.object(engine, "new_evaluator", side_effect=KeyboardInterrupt),
+        patch("chemex.optimize.de_direct_trf.differential_evolution") as search_backend,
+        pytest.raises(DeDirectTrfInterrupted) as interrupted,
+    ):
+        execute_de_direct_trf(problem, invocation, parameterization, engine)
+
+    outcome = interrupted.value.outcome
+    assert outcome.terminal is DeDirectTrfTerminal.INTERRUPTED
+    assert outcome.search.terminal is DeSearchTerminal.INTERRUPTED
+    assert outcome.search.counters.objective_requests_accepted == 0
+    assert outcome.search.preflight_evaluation_identity is None
+    assert outcome.polish is None
+    search_backend.assert_not_called()
+
+
+def test_initial_de_evaluator_binding_failure_is_typed_without_backend_entry() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+
+    with (
+        patch.object(
+            engine,
+            "new_evaluator",
+            side_effect=RuntimeError("binding failed"),
+        ),
+        patch("chemex.optimize.de_direct_trf.differential_evolution") as search_backend,
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.EXECUTION_FAILURE
+    assert outcome.search.terminal is DeSearchTerminal.IMPLEMENTATION_FAILURE
+    assert outcome.search.failure is not None
+    assert outcome.search.failure.category == "de_evaluator_binding_failure"
+    assert outcome.search.counters.objective_requests_accepted == 0
+    assert outcome.polish is None
+    search_backend.assert_not_called()
+
+
+def test_root_materialization_binding_interruption_is_typed() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    original_new_evaluator = engine.new_evaluator
+    evaluator_count = 0
+
+    def interrupted_root_binding() -> BoundEvaluator:
+        nonlocal evaluator_count
+        evaluator_count += 1
+        if evaluator_count == 4:
+            raise KeyboardInterrupt
+        return original_new_evaluator()
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            _successful_polish_backend,
+        ),
+        patch.object(engine, "new_evaluator", interrupted_root_binding),
+        pytest.raises(DeDirectTrfInterrupted) as interrupted,
+    ):
+        execute_de_direct_trf(problem, invocation, parameterization, engine)
+
+    outcome = interrupted.value.outcome
+    assert evaluator_count == 4
+    assert outcome.terminal is DeDirectTrfTerminal.INTERRUPTED
+    assert outcome.root_materialization is not None
+    assert outcome.root_materialization.terminal.value == "interrupted"
+    assert outcome.root_materialization.evaluation_count == 0
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+
+
+def test_trf_polish_interruption_has_no_acceptance_or_backend_fallback() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    (param_id,) = problem.controlled_ids
+    search_lower = max(problem.lower_bounds[0], problem.start[0] * 0.5)
+    search_upper = min(problem.upper_bounds[0], problem.start[0] * 1.5)
+    invocation = DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=((param_id, search_lower, search_upper, "linear"),),
+        root_seed=597,
+        de_objective_request_budget=6,
+        polish_objective_request_budget=5,
+        population_multiplier=4,
+    )
+    polish_calls = 0
+
+    def eligible_search(
+        fun: Callable[[Array], float],
+        _bounds: Bounds,
+        **kwargs: object,
+    ) -> object:
+        candidate = np.asarray(kwargs["x0"], dtype=np.float64)
+        objective = fun(candidate)
+        population = np.repeat(candidate[None, :], 5, axis=0)
+        return SimpleNamespace(
+            x=candidate,
+            fun=objective,
+            success=True,
+            message="Optimization terminated successfully.",
+            nit=1,
+            nfev=1,
+            population=population,
+            population_energies=np.full(5, objective),
+        )
+
+    def interrupted_polish(
+        fun: Callable[[Array], Array],
+        x0: Array,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal polish_calls
+        polish_calls += 1
+        fun(np.asarray(x0, dtype=np.float64))
+        raise KeyboardInterrupt
+
+    with (
+        patch("chemex.optimize.de_direct_trf.differential_evolution", eligible_search),
+        patch("chemex.optimize.direct_trf.least_squares", interrupted_polish),
+        pytest.raises(DeDirectTrfInterrupted) as interrupted,
+    ):
+        execute_de_direct_trf(problem, invocation, parameterization, engine)
+
+    outcome = interrupted.value.outcome
+    assert polish_calls == 1
+    assert outcome.terminal is DeDirectTrfTerminal.INTERRUPTED
+    assert outcome.search.restart_eligible
+    assert outcome.polish is not None
+    assert outcome.polish.execution.terminal.value == "interrupted"
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    assert outcome.accounting.search_to_polish_transfers == 1
+    assert outcome.accounting.root_materializations == 0
+
+
+def test_all_invalid_de_population_has_no_restart_or_polish_authority() -> None:
+    _session, experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    original = cast("Callable[..., Array]", pulse_type.calculate)
+    reject_trials = False
+
+    def controlled_calculate(*args: object, **kwargs: object) -> Array:
+        calculated = original(*args, **kwargs)
+        if reject_trials:
+            return np.full_like(calculated, np.nan)
+        return calculated
+
+    def rejected_population(
+        fun: Callable[[Array], float],
+        bounds: Bounds,
+        **kwargs: object,
+    ) -> object:
+        nonlocal reject_trials
+        candidate = np.asarray(bounds.ub, dtype=np.float64)
+        reject_trials = True
+        objectives = tuple(fun(candidate) for _ in range(5))
+        assert all(math.isinf(value) for value in objectives)
+        population = np.repeat(candidate[None, :], 5, axis=0)
+        return SimpleNamespace(
+            x=candidate,
+            fun=math.inf,
+            success=False,
+            message="Maximum number of iterations has been exceeded.",
+            nit=1,
+            nfev=5,
+            population=population,
+            population_energies=np.full(5, math.inf),
+        )
+
+    with (
+        patch.object(pulse_type, "calculate", controlled_calculate),
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            rejected_population,
+        ),
+        patch("chemex.optimize.direct_trf.least_squares") as polish_backend,
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.SEARCH_UNSUCCESSFUL
+    assert outcome.search.terminal is DeSearchTerminal.NO_VALID_CANDIDATE
+    assert outcome.search.best_candidate is None
+    assert outcome.search.valid_candidate_count == 0
+    assert outcome.search.rejected_trial_count == 5
+    assert outcome.search.counters.objective_evaluations_completed == 5
+    assert outcome.polish is None
+    assert outcome.commit_authority is None
+    polish_backend.assert_not_called()
+
+
+def test_corrupt_successful_evaluation_is_fatal_not_a_rejected_trial() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    original_new_evaluator = engine.new_evaluator
+
+    class CorruptingEvaluator:
+        def __init__(self, delegate: BoundEvaluator) -> None:
+            self._delegate = delegate
+            self.compatibility_identity = delegate.compatibility_identity
+            self.calls = 0
+
+        @property
+        def cache_statistics(self) -> object:
+            return self._delegate.cache_statistics
+
+        def evaluate(self, frame: EvaluationFrame) -> object:
+            self.calls += 1
+            evaluated = self._delegate.evaluate(frame)
+            if self.calls == 2 and isinstance(evaluated, EvaluationResult):
+                return SimpleNamespace(
+                    residuals=evaluated.residuals,
+                    resolved_values={},
+                    identity="corrupt-successful-evaluation",
+                )
+            return evaluated
+
+    evaluator_count = 0
+
+    def staged_evaluator() -> BoundEvaluator | CorruptingEvaluator:
+        nonlocal evaluator_count
+        evaluator_count += 1
+        evaluator = original_new_evaluator()
+        return CorruptingEvaluator(evaluator) if evaluator_count == 1 else evaluator
+
+    def one_corrupt_request(
+        fun: Callable[[Array], float],
+        _bounds: Bounds,
+        **kwargs: object,
+    ) -> object:
+        fun(np.asarray(kwargs["x0"], dtype=np.float64))
+        raise AssertionError("Corrupt evidence must terminate the DE stage")
+
+    with (
+        patch.object(engine, "new_evaluator", staged_evaluator),
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            one_corrupt_request,
+        ),
+        patch("chemex.optimize.direct_trf.least_squares") as polish_backend,
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.EXECUTION_FAILURE
+    assert outcome.search.terminal is DeSearchTerminal.IMPLEMENTATION_FAILURE
+    assert outcome.search.failure is not None
+    assert outcome.search.failure.category == "de_candidate_evidence_failure"
+    assert outcome.search.rejected_trial_count == 0
+    assert outcome.polish is None
+    polish_backend.assert_not_called()
+
+
+def test_de_budget_refusal_is_uncharged_and_best_partial_candidate_is_polished() -> (
+    None
+):
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem, de_budget=6)
+
+    def exhaust_after_valid_candidates(
+        fun: Callable[[Array], float],
+        _bounds: Bounds,
+        **kwargs: object,
+    ) -> object:
+        candidate = np.asarray(kwargs["x0"], dtype=np.float64)
+        for _ in range(7):
+            fun(candidate)
+        raise AssertionError("The seventh request must stop the DE backend")
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            exhaust_after_valid_candidates,
+        ),
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            _successful_polish_backend,
+        ),
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.ACCEPTED
+    assert outcome.search.terminal is DeSearchTerminal.BUDGET_EXHAUSTED
+    assert outcome.search.restart_eligible
+    assert outcome.search.counters.solver_requests_received == 7
+    assert outcome.search.counters.objective_requests_accepted == 6
+    assert outcome.search.counters.objective_evaluations_completed == 6
+    assert outcome.accounting.search_to_polish_transfers == 1
+
+
+def test_de_cancellation_stops_before_polish_without_fallback() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    token = CancellationToken()
+
+    def cancel_after_one_candidate(
+        fun: Callable[[Array], float],
+        _bounds: Bounds,
+        **kwargs: object,
+    ) -> object:
+        candidate = np.asarray(kwargs["x0"], dtype=np.float64)
+        fun(candidate)
+        token.cancel()
+        fun(candidate)
+        raise AssertionError("Cancellation must stop the DE backend")
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            cancel_after_one_candidate,
+        ),
+        patch("chemex.optimize.direct_trf.least_squares") as polish_backend,
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.CANCELLED
+    assert outcome.search.terminal is DeSearchTerminal.CANCELLED
+    assert outcome.search.best_candidate is not None
+    assert not outcome.search.restart_eligible
+    assert outcome.polish is None
+    assert outcome.accepted_result is None
+    polish_backend.assert_not_called()
+
+
+def test_non_converged_polish_is_terminal_and_never_falls_back_to_de_candidate() -> (
+    None
+):
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    polish_calls = 0
+
+    def non_converged_polish(
+        fun: Callable[[Array], Array],
+        x0: Array,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal polish_calls
+        polish_calls += 1
+        candidate = np.asarray(x0, dtype=np.float64)
+        residuals = fun(candidate)
+        result = _trf_backend_result(candidate, residuals)
+        result.status = 0
+        result.success = False
+        return result
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch("chemex.optimize.direct_trf.least_squares", non_converged_polish),
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert polish_calls == 1
+    assert outcome.terminal is DeDirectTrfTerminal.POLISH_UNSUCCESSFUL
+    assert outcome.search.restart_eligible
+    assert outcome.polish is not None
+    assert outcome.polish.execution.terminal.value == "non_converged"
+    assert outcome.root_materialization is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    assert outcome.accounting.root_materializations == 0
+
+
+def test_root_materialization_failure_never_accepts_or_retries_polish() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    original_new_evaluator = engine.new_evaluator
+    evaluator_count = 0
+    polish_calls = 0
+
+    class FailingEvaluator:
+        def __init__(self, delegate: BoundEvaluator) -> None:
+            self.compatibility_identity = delegate.compatibility_identity
+            self.cache_statistics = delegate.cache_statistics
+
+        def evaluate(self, _frame: object) -> EvaluationFailure:
+            return EvaluationFailure(
+                engine.plan.identity,
+                parameterization.evaluator_identity,
+                "kernel",
+                "non_finite_calculation",
+                "INVALID_TRIAL",
+            )
+
+    def staged_evaluator() -> BoundEvaluator | FailingEvaluator:
+        nonlocal evaluator_count
+        evaluator_count += 1
+        evaluator = original_new_evaluator()
+        return FailingEvaluator(evaluator) if evaluator_count == 4 else evaluator
+
+    def counted_polish(
+        fun: Callable[[Array], Array],
+        x0: Array,
+        **kwargs: object,
+    ) -> object:
+        nonlocal polish_calls
+        polish_calls += 1
+        return _successful_polish_backend(fun, x0, **kwargs)
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch("chemex.optimize.direct_trf.least_squares", counted_polish),
+        patch.object(engine, "new_evaluator", staged_evaluator),
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert evaluator_count == 4
+    assert polish_calls == 1
+    assert outcome.terminal is DeDirectTrfTerminal.MATERIALIZATION_FAILURE
+    assert outcome.root_materialization is not None
+    assert outcome.root_materialization.terminal.value == "failure"
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    assert outcome.accounting.root_materializations == 1
+
+
+def test_cancellation_after_root_evaluation_suppresses_acceptance() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    token = CancellationToken()
+    original_new_evaluator = engine.new_evaluator
+    evaluator_count = 0
+
+    class CancellingEvaluator:
+        def __init__(self, delegate: BoundEvaluator) -> None:
+            self._delegate = delegate
+            self.compatibility_identity = delegate.compatibility_identity
+
+        @property
+        def cache_statistics(self) -> object:
+            return self._delegate.cache_statistics
+
+        def evaluate(
+            self,
+            frame: EvaluationFrame,
+        ) -> EvaluationResult | EvaluationFailure:
+            evaluated = self._delegate.evaluate(frame)
+            token.cancel()
+            return evaluated
+
+    def staged_evaluator() -> BoundEvaluator | CancellingEvaluator:
+        nonlocal evaluator_count
+        evaluator_count += 1
+        evaluator = original_new_evaluator()
+        return CancellingEvaluator(evaluator) if evaluator_count == 4 else evaluator
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            _successful_polish_backend,
+        ),
+        patch.object(engine, "new_evaluator", staged_evaluator),
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            cancellation=token,
+        )
+
+    assert evaluator_count == 4
+    assert outcome.terminal is DeDirectTrfTerminal.CANCELLED
+    assert outcome.root_materialization is not None
+    assert outcome.root_materialization.terminal.value == "cancelled"
+    assert outcome.root_materialization.evaluation_count == 1
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+
+
+def test_invocation_is_serializable_and_commit_rejects_tampered_lineage() -> None:
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    record = invocation.to_record()
+    restored = json.loads(json.dumps(record, allow_nan=False, sort_keys=True))
+    assert restored == record
+    assert restored["identity"] == invocation.identity
+    search_record = cast("dict[str, object]", restored["search_problem"])
+    assert search_record["controlled_ids"] == list(
+        invocation.search_problem.controlled_ids
+    )
+    assert search_record["captured_held_items"] == [
+        [param_id, value] for param_id, value in invocation.search_problem.held_items
+    ]
+    assert search_record["physical_start"] == list(invocation.search_problem.start)
+    assert search_record["solver_x0"] == [
+        coordinate.to_solver(value)
+        for coordinate, value in zip(
+            invocation.search_coordinates,
+            invocation.search_problem.start,
+            strict=True,
+        )
+    ]
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            _successful_polish_backend,
+        ),
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    accepted = outcome.accepted_result
+    invalid_provenance = dataclasses.replace(
+        accepted.de_polish_provenance,
+        search_candidate_identity="foreign-de-candidate",
+    )
+    invalid = dataclasses.replace(
+        accepted,
+        de_polish_provenance=invalid_provenance,
+    )
+    before = session.analysis_values.snapshot()
+
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="canonical polish authority",
+    ):
+        commit_de_accepted_fit(
+            invalid,
+            outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+
+    assert session.analysis_values.snapshot() == before
+
+
+def test_real_scipy_de_is_deterministic_for_the_same_root_seed() -> None:
+    _session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem, de_budget=10)
+
+    with patch(
+        "chemex.optimize.direct_trf.least_squares",
+        _successful_polish_backend,
+    ):
+        first = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+        second = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert first.terminal is second.terminal is DeDirectTrfTerminal.ACCEPTED
+    assert first.search.terminal is second.search.terminal
+    assert first.search.counters == second.search.counters
+    assert first.search.counters.objective_requests_accepted == 10
+    assert first.search.best_candidate == second.search.best_candidate
+    assert first.search.backend == second.search.backend
+    assert first.search.identity == second.search.identity

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -50,6 +50,7 @@ from chemex.optimize.direct_trf import (
     DirectTrfCandidateOutcome,
     DirectTrfConstructionError,
     DirectTrfInvocation,
+    DirectTrfTerminal,
     OptimizationProblem,
 )
 from chemex.parameters.parameterization import ActiveParameterization
@@ -1451,6 +1452,87 @@ def test_foreign_self_consistent_polish_lineage_fails_before_root_promotion(
     assert outcome.failure is not None
     assert outcome.failure.category == "de_polish_lineage_failure"
     assert outcome.accounting.search_to_polish_transfers == 1
+    assert outcome.accounting.root_materializations == 0
+    assert outcome.root_materialization is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_authority is None
+    assert session.analysis_values.snapshot() == before
+    root_promotion.assert_not_called()
+
+
+def test_successful_looking_non_converged_polish_cannot_reach_root_promotion() -> None:
+    session, _experiments, parameterization, engine, problem = _qualification_problem(
+        read_methods([METHOD])["DEFAULT"]
+    )
+    invocation = _bounded_de_invocation(problem)
+    execute_polish = de_workflow.execute_direct_trf_candidate
+    before = session.analysis_values.snapshot()
+
+    def successful_non_converged_polish(
+        polish_problem: OptimizationProblem,
+        polish_invocation: DirectTrfInvocation,
+        active_parameterization: ActiveParameterization,
+        evaluation_engine: EvaluationEngine,
+        *,
+        cancellation: CancellationToken | None = None,
+    ) -> DirectTrfCandidateOutcome:
+        result = execute_polish(
+            polish_problem,
+            polish_invocation,
+            active_parameterization,
+            evaluation_engine,
+            cancellation=cancellation,
+        )
+        assert result.materialization is not None
+        assert result.candidate is not None
+        non_converged_execution = dataclasses.replace(
+            result.execution,
+            terminal=DirectTrfTerminal.NON_CONVERGED,
+        )
+        rebound_materialization = dataclasses.replace(
+            result.materialization,
+            execution_identity=non_converged_execution.identity,
+        )
+        rebound_candidate = dataclasses.replace(
+            result.candidate,
+            execution_identity=non_converged_execution.identity,
+            materialization=rebound_materialization,
+        )
+        return dataclasses.replace(
+            result,
+            execution=non_converged_execution,
+            materialization=rebound_materialization,
+            candidate=rebound_candidate,
+        )
+
+    with (
+        patch(
+            "chemex.optimize.de_direct_trf.differential_evolution",
+            _eligible_search_backend,
+        ),
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            _successful_polish_backend,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf.execute_direct_trf_candidate",
+            side_effect=successful_non_converged_polish,
+        ),
+        patch(
+            "chemex.optimize.de_direct_trf."
+            "_materialize_derived_direct_trf_candidate_for_root"
+        ) as root_promotion,
+    ):
+        outcome = execute_de_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DeDirectTrfTerminal.EXECUTION_FAILURE
+    assert outcome.failure is not None
+    assert outcome.failure.category == "de_polish_lineage_failure"
     assert outcome.accounting.root_materializations == 0
     assert outcome.root_materialization is None
     assert outcome.accepted_result is None


### PR DESCRIPTION
Closes #597.

## Summary

Adds an isolated native selected-coordinate differential-evolution → TRF
qualification path.

Differential evolution searches only explicitly selected bounded physical
coordinates using a deterministic root seed and explicit topology/budgets.
An eligible DE result supplies exactly one complete physical start to native
Direct TRF polishing.

DE itself has no acceptance or commit authority. Only successful TRF polishing
followed by fresh root materialization can produce accepted evidence and the
existing Direct-TRF live commit authority.

## Behavior

- Explicit selected-coordinate ownership and canonical ordering.
- Finite strictly ordered physical bounds.
- Deterministic root seed and serializable DE topology.
- Explicit population, budget, mutation, recombination, tolerance, and accounting
  contracts.
- Unselected root coordinates remain exactly fixed.
- Search children are exact canonical projections of the authoritative root
  problem.
- Coordinate transforms are bound to their exact parameter IDs and physical
  bounds.
- An eligible DE result starts exactly one native TRF polish.
- No fallback or implicit retry after DE failure, interruption, ineligibility,
  or failed polish.
- Cancellation before transition prevents any TRF occurrence from starting.
- Successful polish evidence must belong to the exact DE-derived problem,
  invocation, execution, materialization, and evaluation lineage.
- Only `SUCCESS + CONVERGED` polish evidence may reach root promotion.

## Root materialization

Generic derived-candidate root materialization is centralized in Direct TRF.

Direct TRF owns:

- evaluator binding;
- fresh root evaluation;
- compatibility validation;
- typed materialization evidence;
- acceptance and live commit authority.

DE retains only search and transition-specific lineage policy.

The shared root-materialization seam is also used by the existing GRID derived
workflow without introducing DE or GRID policy into Direct TRF.

## Numerical qualification

A real-SciPy analytical DE → TRF reference test exercises both optimizers.

Independent expected result:

- fitted vector: `(0.0, 6.87922079444668)`
- χ²: `1.0`
- `__PB = 0.0` is the finite lower-bound optimum

Tolerances:

- vector: `1e-7`
- χ²: `2e-7`

The tolerance covers TRF's interior representation of an active bound while
remaining narrow relative to the controlled analytical reference.

## Adversarial qualification

Coverage includes:

- coordinate transposition and retargeting;
- forged/unselected root values;
- rebuilt forged search-child derivations;
- invalid deterministic seeds;
- malformed DE topology and budgets;
- incorrect polish scale dimensions;
- cancellation immediately before polishing;
- foreign polish problem/invocation/execution/materialization/evaluation;
- forged successful polish with non-converged execution;
- failure and interruption without fallback;
- exact transition accounting;
- acceptance/authority isolation.

## Scope

Qualification path only.

No changes to:

- production dispatch;
- CLI or TOML;
- output formats;
- supported user-facing Python APIs;
- documentation;
- existing scientific behavior.

## Validation

Implementation validation:

- Full suite: 684+ tests passed during the final implementation cycles
- Focused DE → TRF qualification: 52 tests passed in final independent review
- `uv run ty check`: passed
- Ruff lint: passed
- Ruff format check: passed
- `git diff --check`: passed
- Graphify refreshed

One existing non-failing `emcee` autocorrelation warning remains.

Independent adversarial review: **MERGE**

- Standards: 0 Blocking/Important findings
- Spec: 0 Blocking/Important findings