### PR TITLE
Add native covariance and constrained-uncertainty evidence

### DIFF
--- a/src/chemex/optimize/de_direct_trf.py
+++ b/src/chemex/optimize/de_direct_trf.py
@@ -364,6 +364,7 @@ def _expected_search_projection(
         ),
         DeSearchProblemDerivation(
             root_problem.identity,
+            root_problem.affine_feasibility_identity,
             specification_identity,
             selected_ids,
             held_items,
@@ -397,6 +398,8 @@ def _validate_exact_search_projection(
         or search_problem.upper_bounds != expected.upper_bounds
         or search_problem.commit_scope != root_problem.commit_scope
         or search_problem.scalarization_version != root_problem.scalarization_version
+        or search_problem.affine_half_spaces != root_problem.affine_half_spaces
+        or search_problem.affine_equalities != root_problem.affine_equalities
         or derivation != expected.derivation
     ):
         raise DirectTrfConstructionError(
@@ -699,6 +702,7 @@ class DeDirectTrfInvocation:
         )
         derivation = DeSearchProblemDerivation(
             problem.identity,
+            problem.affine_feasibility_identity,
             search_specification_identity,
             canonical_selected_ids,
             held_items,
@@ -726,6 +730,8 @@ class DeDirectTrfInvocation:
             problem.commit_scope,
             derivation,
             problem.scalarization_version,
+            problem.affine_half_spaces,
+            problem.affine_equalities,
         )
         population = DePopulation(
             len(coordinates),
@@ -1514,6 +1520,7 @@ def _derive_polish_problem(
         )
     derivation = DePolishProblemDerivation(
         problem.identity,
+        problem.affine_feasibility_identity,
         invocation.identity,
         invocation.search_problem.identity,
         search.identity,
@@ -1537,6 +1544,8 @@ def _derive_polish_problem(
         problem.commit_scope,
         derivation,
         problem.scalarization_version,
+        problem.affine_half_spaces,
+        problem.affine_equalities,
     )
     polish = DirectTrfInvocation.for_problem(
         child,
@@ -1620,6 +1629,7 @@ def _validate_de_polish_transition_lineage(
     if search_candidate is not None:
         expected_derivation = DePolishProblemDerivation(
             problem.identity,
+            problem.affine_feasibility_identity,
             invocation.identity,
             invocation.search_problem.identity,
             search.identity,
@@ -1652,6 +1662,8 @@ def _validate_de_polish_transition_lineage(
         or polish_problem.upper_bounds != problem.upper_bounds
         or polish_problem.commit_scope != problem.commit_scope
         or polish_problem.scalarization_version != problem.scalarization_version
+        or polish_problem.affine_half_spaces != problem.affine_half_spaces
+        or polish_problem.affine_equalities != problem.affine_equalities
         or polish_invocation.problem_identity != polish_problem.identity
         or polish_invocation.objective_request_budget
         != invocation.polish_objective_request_budget

--- a/src/chemex/optimize/de_direct_trf.py
+++ b/src/chemex/optimize/de_direct_trf.py
@@ -1823,6 +1823,7 @@ class AcceptedDeDirectTrfResult(AcceptedFitResult):
             polish_invocation,
             polish_outcome,
             fresh_candidate,
+            occurrence_witness=accepted.occurrence_witness,
         )
 
 

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1189,21 +1189,70 @@ class GridSelectionProvenance:
         )
 
 
-@dataclass(frozen=True, slots=True)
 class _AcceptedOccurrenceWitness:
-    occurrence_identity: str
-    accepted_result_identity: str
-    identity: str = field(init=False)
+    """Opaque process-local witness for one accepted-result occurrence."""
 
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "identity",
-            _identity(
-                "native-accepted-occurrence-witness",
-                (self.occurrence_identity, self.accepted_result_identity),
-            ),
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls) -> _AcceptedOccurrenceWitness:
+        raise TypeError(
+            "Accepted occurrence witnesses are minted only by Direct TRF or "
+            "the isolated qualification constructor"
         )
+
+    def __copy__(self) -> _AcceptedOccurrenceWitness:
+        raise TypeError("Accepted occurrence witnesses cannot be copied")
+
+    def __deepcopy__(self, _memo: object) -> _AcceptedOccurrenceWitness:
+        raise TypeError("Accepted occurrence witnesses cannot be copied")
+
+    def __reduce__(self) -> tuple[object, ...]:
+        raise TypeError("Accepted occurrence witnesses cannot be serialized")
+
+    def __reduce_ex__(self, _protocol: SupportsIndex, /) -> tuple[object, ...]:
+        raise TypeError("Accepted occurrence witnesses cannot be serialized")
+
+
+@dataclass(frozen=True, slots=True)
+class _AcceptedOccurrenceBinding:
+    occurrence_identity: str
+    accepted_result_identity: str | None = None
+
+
+_ACCEPTED_OCCURRENCE_WITNESSES: WeakKeyDictionary[
+    _AcceptedOccurrenceWitness,
+    _AcceptedOccurrenceBinding,
+] = WeakKeyDictionary()
+_ACCEPTED_OCCURRENCE_WITNESSES_LOCK = RLock()
+
+
+def _mint_accepted_occurrence_witness(
+    occurrence_identity: str,
+) -> _AcceptedOccurrenceWitness:
+    witness = object.__new__(_AcceptedOccurrenceWitness)
+    with _ACCEPTED_OCCURRENCE_WITNESSES_LOCK:
+        _ACCEPTED_OCCURRENCE_WITNESSES[witness] = _AcceptedOccurrenceBinding(
+            occurrence_identity
+        )
+    return witness
+
+
+def _bind_accepted_occurrence_witness(
+    witness: _AcceptedOccurrenceWitness,
+    occurrence_identity: str,
+    accepted_result_identity: str,
+) -> bool:
+    with _ACCEPTED_OCCURRENCE_WITNESSES_LOCK:
+        binding = _ACCEPTED_OCCURRENCE_WITNESSES.get(witness)
+        if binding is None or binding.occurrence_identity != occurrence_identity:
+            return False
+        if binding.accepted_result_identity is None:
+            _ACCEPTED_OCCURRENCE_WITNESSES[witness] = _AcceptedOccurrenceBinding(
+                occurrence_identity,
+                accepted_result_identity,
+            )
+            return True
+        return binding.accepted_result_identity == accepted_result_identity
 
 
 @dataclass(frozen=True, slots=True)
@@ -1227,7 +1276,6 @@ class AcceptedFitResult:
     commit_items: tuple[tuple[str, float], ...]
     origin_context_identity: str
     occurrence_witness: _AcceptedOccurrenceWitness | None = field(
-        default=None,
         compare=False,
         repr=False,
         kw_only=True,
@@ -1262,21 +1310,65 @@ class AcceptedFitResult:
                 self.origin_context_identity,
             ),
         )
-        if self.occurrence_witness is None:
-            object.__setattr__(
-                self,
-                "occurrence_witness",
-                _AcceptedOccurrenceWitness(self.occurrence_identity, identity),
-            )
         object.__setattr__(self, "identity", identity)
+        if self.occurrence_witness is not None:
+            _bind_accepted_occurrence_witness(
+                self.occurrence_witness,
+                self.occurrence_identity,
+                identity,
+            )
+
+    @classmethod
+    def for_qualification(
+        cls,
+        occurrence_identity: str,
+        problem_identity: str,
+        invocation_identity: str,
+        execution_identity: str,
+        materialization_identity: str,
+        parameterization_identity: str,
+        evaluator_parameterization_identity: str,
+        source_occurrence_identity: str,
+        source_revision: int,
+        controlled_ids: tuple[str, ...],
+        vector: tuple[float, ...],
+        chi_square: float,
+        evaluation_result: EvaluationResult,
+        commit_scope: tuple[str, ...],
+        commit_items: tuple[tuple[str, float], ...],
+        origin_context_identity: str,
+    ) -> AcceptedFitResult:
+        """Construct an authoritative anchor only for isolated qualification."""
+        return cls(
+            occurrence_identity,
+            problem_identity,
+            invocation_identity,
+            execution_identity,
+            materialization_identity,
+            parameterization_identity,
+            evaluator_parameterization_identity,
+            source_occurrence_identity,
+            source_revision,
+            controlled_ids,
+            vector,
+            chi_square,
+            evaluation_result,
+            commit_scope,
+            commit_items,
+            origin_context_identity,
+            occurrence_witness=_mint_accepted_occurrence_witness(occurrence_identity),
+        )
 
 
 def accepted_occurrence_is_authoritative(accepted: AcceptedFitResult) -> bool:
     """Report whether this object retains its exact construction occurrence."""
-    witness = accepted.occurrence_witness
-    return witness is not None and (
-        witness.occurrence_identity == accepted.occurrence_identity
-        and witness.accepted_result_identity == accepted.identity
+    if accepted.occurrence_witness is None:
+        return False
+    with _ACCEPTED_OCCURRENCE_WITNESSES_LOCK:
+        binding = _ACCEPTED_OCCURRENCE_WITNESSES.get(accepted.occurrence_witness)
+    return binding == _AcceptedOccurrenceBinding(
+        accepted.occurrence_identity,
+        accepted.identity,
     )
 
 
@@ -2265,8 +2357,9 @@ def _accepted_fit_evidence(
         (param_id, evaluation_result.resolved_values[param_id])
         for param_id in problem.commit_scope
     )
+    occurrence_identity = uuid4().hex
     return AcceptedFitResult(
-        uuid4().hex,
+        occurrence_identity,
         problem.identity,
         invocation_identity,
         execution_identity,
@@ -2282,6 +2375,7 @@ def _accepted_fit_evidence(
         problem.commit_scope,
         commit_items,
         origin_context_identity,
+        occurrence_witness=_mint_accepted_occurrence_witness(occurrence_identity),
     )
 
 

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -466,6 +466,25 @@ class DePolishProblemDerivation:
         )
 
 
+def _normalize_affine_restriction(
+    restriction_id: str,
+    coefficients: tuple[float, ...],
+    scalar: float,
+    *,
+    scalar_name: str,
+) -> tuple[tuple[float, ...], float]:
+    normalized_coefficients = tuple(
+        _finite_binary64(value, name=f"affine coefficient[{index}]")
+        for index, value in enumerate(coefficients)
+    )
+    normalized_scalar = _finite_binary64(scalar, name=scalar_name)
+    if not restriction_id or not normalized_coefficients:
+        raise DirectTrfConstructionError(
+            "Affine restrictions require an ID and full-frame coefficients"
+        )
+    return normalized_coefficients, normalized_scalar
+
+
 @dataclass(frozen=True, slots=True)
 class AffineHalfSpace:
     """One canonical full independent-frame restriction ``a^T x <= b``."""
@@ -476,18 +495,12 @@ class AffineHalfSpace:
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        coefficients = tuple(
-            _finite_binary64(value, name=f"affine coefficient[{index}]")
-            for index, value in enumerate(self.coefficients)
-        )
-        upper_bound = _finite_binary64(
+        coefficients, upper_bound = _normalize_affine_restriction(
+            self.restriction_id,
+            self.coefficients,
             self.upper_bound,
-            name="affine upper bound",
+            scalar_name="affine upper bound",
         )
-        if not self.restriction_id or not coefficients:
-            raise DirectTrfConstructionError(
-                "Affine restrictions require an ID and full-frame coefficients"
-            )
         object.__setattr__(self, "coefficients", coefficients)
         object.__setattr__(self, "upper_bound", upper_bound)
         object.__setattr__(
@@ -514,15 +527,12 @@ class AffineEquality:
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        coefficients = tuple(
-            _finite_binary64(value, name=f"equality coefficient[{index}]")
-            for index, value in enumerate(self.coefficients)
+        coefficients, value = _normalize_affine_restriction(
+            self.restriction_id,
+            self.coefficients,
+            self.value,
+            scalar_name="affine equality value",
         )
-        value = _finite_binary64(self.value, name="affine equality value")
-        if not self.restriction_id or not coefficients:
-            raise DirectTrfConstructionError(
-                "Affine equalities require an ID and full-frame coefficients"
-            )
         object.__setattr__(self, "coefficients", coefficients)
         object.__setattr__(self, "value", value)
         object.__setattr__(
@@ -1179,8 +1189,21 @@ class GridSelectionProvenance:
         )
 
 
-_ACCEPTED_SEMANTIC_OCCURRENCES: dict[str, str] = {}
-_ACCEPTED_SEMANTIC_OCCURRENCES_LOCK = RLock()
+@dataclass(frozen=True, slots=True)
+class _AcceptedOccurrenceWitness:
+    occurrence_identity: str
+    accepted_result_identity: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-accepted-occurrence-witness",
+                (self.occurrence_identity, self.accepted_result_identity),
+            ),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1203,6 +1226,12 @@ class AcceptedFitResult:
     commit_scope: tuple[str, ...]
     commit_items: tuple[tuple[str, float], ...]
     origin_context_identity: str
+    occurrence_witness: _AcceptedOccurrenceWitness | None = field(
+        default=None,
+        compare=False,
+        repr=False,
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -1233,21 +1262,22 @@ class AcceptedFitResult:
                 self.origin_context_identity,
             ),
         )
-        with _ACCEPTED_SEMANTIC_OCCURRENCES_LOCK:
-            _ACCEPTED_SEMANTIC_OCCURRENCES.setdefault(
-                identity,
-                self.occurrence_identity,
+        if self.occurrence_witness is None:
+            object.__setattr__(
+                self,
+                "occurrence_witness",
+                _AcceptedOccurrenceWitness(self.occurrence_identity, identity),
             )
         object.__setattr__(self, "identity", identity)
 
 
 def accepted_occurrence_is_authoritative(accepted: AcceptedFitResult) -> bool:
-    """Report whether this object carries the first established lifecycle occurrence."""
-    with _ACCEPTED_SEMANTIC_OCCURRENCES_LOCK:
-        return (
-            _ACCEPTED_SEMANTIC_OCCURRENCES.get(accepted.identity)
-            == accepted.occurrence_identity
-        )
+    """Report whether this object retains its exact construction occurrence."""
+    witness = accepted.occurrence_witness
+    return witness is not None and (
+        witness.occurrence_identity == accepted.occurrence_identity
+        and witness.accepted_result_identity == accepted.identity
+    )
 
 
 class LiveFitCommitAuthority:

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1321,6 +1321,7 @@ class AcceptedFitResult:
     @classmethod
     def for_qualification(
         cls,
+        *,
         occurrence_identity: str,
         problem_identity: str,
         invocation_identity: str,

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -467,6 +467,106 @@ class DePolishProblemDerivation:
 
 
 @dataclass(frozen=True, slots=True)
+class AffineHalfSpace:
+    """One canonical full independent-frame restriction ``a^T x <= b``."""
+
+    restriction_id: str
+    coefficients: tuple[float, ...]
+    upper_bound: float
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        coefficients = tuple(
+            _finite_binary64(value, name=f"affine coefficient[{index}]")
+            for index, value in enumerate(self.coefficients)
+        )
+        upper_bound = _finite_binary64(
+            self.upper_bound,
+            name="affine upper bound",
+        )
+        if not self.restriction_id or not coefficients:
+            raise DirectTrfConstructionError(
+                "Affine restrictions require an ID and full-frame coefficients"
+            )
+        object.__setattr__(self, "coefficients", coefficients)
+        object.__setattr__(self, "upper_bound", upper_bound)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-affine-half-space",
+                (
+                    self.restriction_id,
+                    _vector_tokens(coefficients),
+                    _float_token(upper_bound),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AffineEquality:
+    """One canonical full independent-frame restriction ``a^T x == b``."""
+
+    restriction_id: str
+    coefficients: tuple[float, ...]
+    value: float
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        coefficients = tuple(
+            _finite_binary64(value, name=f"equality coefficient[{index}]")
+            for index, value in enumerate(self.coefficients)
+        )
+        value = _finite_binary64(self.value, name="affine equality value")
+        if not self.restriction_id or not coefficients:
+            raise DirectTrfConstructionError(
+                "Affine equalities require an ID and full-frame coefficients"
+            )
+        object.__setattr__(self, "coefficients", coefficients)
+        object.__setattr__(self, "value", value)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-affine-equality",
+                (
+                    self.restriction_id,
+                    _vector_tokens(coefficients),
+                    _float_token(value),
+                ),
+            ),
+        )
+
+
+def _validate_affine_feasibility(
+    independent_items: tuple[tuple[str, float], ...],
+    half_spaces: tuple[AffineHalfSpace, ...],
+    equalities: tuple[AffineEquality, ...],
+) -> None:
+    restrictions = (*half_spaces, *equalities)
+    restriction_ids = tuple(item.restriction_id for item in restrictions)
+    if len(set(restriction_ids)) != len(restriction_ids) or any(
+        len(item.coefficients) != len(independent_items) for item in restrictions
+    ):
+        raise DirectTrfConstructionError(
+            "Affine feasibility must use unique IDs and full independent-frame coefficients"
+        )
+
+
+def _affine_feasibility_identity_record(
+    half_spaces: tuple[AffineHalfSpace, ...],
+    equalities: tuple[AffineEquality, ...],
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    if not half_spaces and not equalities:
+        return ()
+    return (
+        ("affine-half-spaces", tuple(item.identity for item in half_spaces)),
+        ("affine-equalities", tuple(item.identity for item in equalities)),
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class OptimizationProblem:
     """One immutable canonical external-coordinate fit and commit context."""
 
@@ -491,6 +591,8 @@ class OptimizationProblem:
         | None
     ) = None
     scalarization_version: str = _SCALARIZATION_VERSION
+    affine_half_spaces: tuple[AffineHalfSpace, ...] = ()
+    affine_equalities: tuple[AffineEquality, ...] = ()
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -505,6 +607,11 @@ class OptimizationProblem:
             self.start,
             self.lower_bounds,
             self.upper_bounds,
+        )
+        _validate_affine_feasibility(
+            self.independent_items,
+            self.affine_half_spaces,
+            self.affine_equalities,
         )
         if isinstance(self.derivation, ComponentProblemDerivation):
             if (
@@ -550,6 +657,11 @@ class OptimizationProblem:
             derivation_record = (("derived-de-search", self.derivation.identity),)
         else:
             derivation_record = (("derived-de-polish", self.derivation.identity),)
+        # Preserve the established box-only problem identity exactly.
+        feasibility_record = _affine_feasibility_identity_record(
+            self.affine_half_spaces,
+            self.affine_equalities,
+        )
         object.__setattr__(
             self,
             "identity",
@@ -579,6 +691,7 @@ class OptimizationProblem:
                     self.commit_scope,
                     *derivation_record,
                     self.scalarization_version,
+                    *feasibility_record,
                 ),
             ),
         )
@@ -1066,6 +1179,10 @@ class GridSelectionProvenance:
         )
 
 
+_ACCEPTED_SEMANTIC_OCCURRENCES: dict[str, str] = {}
+_ACCEPTED_SEMANTIC_OCCURRENCES_LOCK = RLock()
+
+
 @dataclass(frozen=True, slots=True)
 class AcceptedFitResult:
     """Fresh-materialized immutable evidence with no live commit authority."""
@@ -1093,32 +1210,43 @@ class AcceptedFitResult:
             raise ValueError("Accepted result cannot have an empty residual objective")
         if not self.origin_context_identity:
             raise ValueError("Accepted result requires an origin context identity")
-        object.__setattr__(
-            self,
-            "identity",
-            _identity(
-                "native-accepted-fit-result",
-                (
-                    self.problem_identity,
-                    self.invocation_identity,
-                    self.execution_identity,
-                    self.materialization_identity,
-                    self.parameterization_identity,
-                    self.evaluator_parameterization_identity,
-                    self.source_occurrence_identity,
-                    self.source_revision,
-                    self.controlled_ids,
-                    _vector_tokens(self.vector),
-                    _float_token(self.chi_square),
-                    self.evaluation_result.identity,
-                    self.commit_scope,
-                    tuple(
-                        (param_id, _float_token(value))
-                        for param_id, value in self.commit_items
-                    ),
-                    self.origin_context_identity,
+        identity = _identity(
+            "native-accepted-fit-result",
+            (
+                self.problem_identity,
+                self.invocation_identity,
+                self.execution_identity,
+                self.materialization_identity,
+                self.parameterization_identity,
+                self.evaluator_parameterization_identity,
+                self.source_occurrence_identity,
+                self.source_revision,
+                self.controlled_ids,
+                _vector_tokens(self.vector),
+                _float_token(self.chi_square),
+                self.evaluation_result.identity,
+                self.commit_scope,
+                tuple(
+                    (param_id, _float_token(value))
+                    for param_id, value in self.commit_items
                 ),
+                self.origin_context_identity,
             ),
+        )
+        with _ACCEPTED_SEMANTIC_OCCURRENCES_LOCK:
+            _ACCEPTED_SEMANTIC_OCCURRENCES.setdefault(
+                identity,
+                self.occurrence_identity,
+            )
+        object.__setattr__(self, "identity", identity)
+
+
+def accepted_occurrence_is_authoritative(accepted: AcceptedFitResult) -> bool:
+    """Report whether this object carries the first established lifecycle occurrence."""
+    with _ACCEPTED_SEMANTIC_OCCURRENCES_LOCK:
+        return (
+            _ACCEPTED_SEMANTIC_OCCURRENCES.get(accepted.identity)
+            == accepted.occurrence_identity
         )
 
 

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -264,6 +264,7 @@ class ComponentProblemDerivation:
     """Exact immutable derivation of one non-authoritative child problem."""
 
     root_problem_identity: str
+    root_affine_feasibility_identity: str
     component_identity: str
     projection_policy: str
     projected_plan_identity: str
@@ -279,6 +280,7 @@ class ComponentProblemDerivation:
                 "native-component-problem-derivation",
                 (
                     self.root_problem_identity,
+                    self.root_affine_feasibility_identity,
                     self.component_identity,
                     self.projection_policy,
                     self.projected_plan_identity,
@@ -297,6 +299,7 @@ class GridSeedProblemDerivation:
     """Exact lineage for one full-coordinate GRID seed child problem."""
 
     root_problem_identity: str
+    root_affine_feasibility_identity: str
     seed_identity: str
     seed_ordinal: int
     axis_items: tuple[tuple[str, float], ...]
@@ -339,6 +342,7 @@ class GridSeedProblemDerivation:
                 "native-grid-seed-problem-derivation",
                 (
                     self.root_problem_identity,
+                    self.root_affine_feasibility_identity,
                     self.seed_identity,
                     self.seed_ordinal,
                     tuple(
@@ -357,6 +361,7 @@ class DeSearchProblemDerivation:
     """Exact lineage for one selected-coordinate DE search problem."""
 
     root_problem_identity: str
+    root_affine_feasibility_identity: str
     search_specification_identity: str
     selected_ids: tuple[str, ...]
     captured_held_items: tuple[tuple[str, float], ...]
@@ -404,6 +409,7 @@ class DeSearchProblemDerivation:
                 "native-de-search-problem-derivation",
                 (
                     self.root_problem_identity,
+                    self.root_affine_feasibility_identity,
                     self.search_specification_identity,
                     self.selected_ids,
                     tuple(
@@ -421,6 +427,7 @@ class DePolishProblemDerivation:
     """Exact lineage for the one full-coordinate TRF polish after DE."""
 
     root_problem_identity: str
+    root_affine_feasibility_identity: str
     workflow_invocation_identity: str
     search_problem_identity: str
     search_execution_identity: str
@@ -455,6 +462,7 @@ class DePolishProblemDerivation:
                 "native-de-polish-problem-derivation",
                 (
                     self.root_problem_identity,
+                    self.root_affine_feasibility_identity,
                     self.workflow_invocation_identity,
                     self.search_problem_identity,
                     self.search_execution_identity,
@@ -549,6 +557,48 @@ class AffineEquality:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class CoordinateLineFeasibility:
+    """Exact feasible displacement interval along one controlled coordinate."""
+
+    param_id: str
+    minimum_displacement: float
+    maximum_displacement: float
+    lower_limiters: tuple[str, ...]
+    upper_limiters: tuple[str, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        minimum = _bound_binary64(
+            self.minimum_displacement,
+            name="minimum feasible displacement",
+        )
+        maximum = _bound_binary64(
+            self.maximum_displacement,
+            name="maximum feasible displacement",
+        )
+        if not minimum <= 0.0 <= maximum:
+            raise DirectTrfConstructionError(
+                "Coordinate line feasibility must contain the accepted point"
+            )
+        object.__setattr__(self, "minimum_displacement", minimum)
+        object.__setattr__(self, "maximum_displacement", maximum)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-coordinate-line-feasibility",
+                (
+                    self.param_id,
+                    _float_token(minimum),
+                    _float_token(maximum),
+                    self.lower_limiters,
+                    self.upper_limiters,
+                ),
+            ),
+        )
+
+
 def _validate_affine_feasibility(
     independent_items: tuple[tuple[str, float], ...],
     half_spaces: tuple[AffineHalfSpace, ...],
@@ -574,6 +624,93 @@ def _affine_feasibility_identity_record(
         ("affine-half-spaces", tuple(item.identity for item in half_spaces)),
         ("affine-equalities", tuple(item.identity for item in equalities)),
     )
+
+
+def _affine_feasibility_identity(
+    half_spaces: tuple[AffineHalfSpace, ...],
+    equalities: tuple[AffineEquality, ...],
+) -> str:
+    return _identity(
+        "native-affine-feasibility",
+        _affine_feasibility_identity_record(half_spaces, equalities),
+    )
+
+
+def _pairwise_feasibility_sum(values: Sequence[float]) -> float:
+    terms = list(values)
+    while len(terms) > 1:
+        reduced = [
+            terms[index] + terms[index + 1] for index in range(0, len(terms) - 1, 2)
+        ]
+        if len(terms) % 2:
+            reduced.append(terms[-1])
+        terms = reduced
+    result = terms[0] if terms else 0.0
+    return 0.0 if result == 0.0 else result
+
+
+def _full_frame_candidate(
+    independent_items: tuple[tuple[str, float], ...],
+    controlled_ids: tuple[str, ...],
+    candidate: tuple[float, ...],
+) -> tuple[float, ...]:
+    updates = dict(zip(controlled_ids, candidate, strict=True))
+    return tuple(updates.get(param_id, value) for param_id, value in independent_items)
+
+
+def _affine_total(
+    coefficients: tuple[float, ...],
+    full_values: tuple[float, ...],
+) -> float:
+    products = tuple(
+        coefficient * value
+        for coefficient, value in zip(coefficients, full_values, strict=True)
+    )
+    return _pairwise_feasibility_sum(products)
+
+
+def _validate_candidate_feasibility(
+    independent_items: tuple[tuple[str, float], ...],
+    controlled_ids: tuple[str, ...],
+    candidate: tuple[float, ...],
+    lower_bounds: tuple[float, ...],
+    upper_bounds: tuple[float, ...],
+    half_spaces: tuple[AffineHalfSpace, ...],
+    equalities: tuple[AffineEquality, ...],
+) -> tuple[float, ...]:
+    if any(
+        not lower <= value <= upper
+        for value, lower, upper in zip(
+            candidate,
+            lower_bounds,
+            upper_bounds,
+            strict=True,
+        )
+    ):
+        raise DirectTrfConstructionError(
+            "External candidate is outside exact box bounds"
+        )
+    full_values = _full_frame_candidate(
+        independent_items,
+        controlled_ids,
+        candidate,
+    )
+    for restriction in half_spaces:
+        total = _affine_total(restriction.coefficients, full_values)
+        slack = restriction.upper_bound - total
+        if not math.isfinite(total) or not math.isfinite(slack) or slack < 0.0:
+            raise DirectTrfConstructionError(
+                f"External candidate violates affine half-space "
+                f"{restriction.restriction_id!r}"
+            )
+    for restriction in equalities:
+        total = _affine_total(restriction.coefficients, full_values)
+        if not math.isfinite(total) or total != restriction.value:
+            raise DirectTrfConstructionError(
+                f"External candidate violates affine equality "
+                f"{restriction.restriction_id!r}"
+            )
+    return full_values
 
 
 @dataclass(frozen=True, slots=True)
@@ -605,7 +742,7 @@ class OptimizationProblem:
     affine_equalities: tuple[AffineEquality, ...] = ()
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: C901 - complete problem invariant
         _validate_problem_ordering(
             self.controlled_ids,
             self.independent_items,
@@ -623,7 +760,28 @@ class OptimizationProblem:
             self.affine_half_spaces,
             self.affine_equalities,
         )
+        affine_feasibility_identity = _affine_feasibility_identity(
+            self.affine_half_spaces,
+            self.affine_equalities,
+        )
+        _validate_candidate_feasibility(
+            self.independent_items,
+            self.controlled_ids,
+            normalized_start,
+            lower,
+            upper,
+            self.affine_half_spaces,
+            self.affine_equalities,
+        )
         if isinstance(self.derivation, ComponentProblemDerivation):
+            if (
+                self.derivation.root_affine_feasibility_identity
+                != affine_feasibility_identity
+            ):
+                raise DirectTrfConstructionError(
+                    "Component problem affine feasibility differs from its "
+                    "derivation record"
+                )
             if (
                 self.derivation.projected_plan_identity != self.evaluation_plan_identity
                 or self.derivation.controlled_ids != self.controlled_ids
@@ -632,28 +790,52 @@ class OptimizationProblem:
                 raise DirectTrfConstructionError(
                     "Component problem differs from its derivation record"
                 )
-        elif isinstance(self.derivation, GridSeedProblemDerivation) and (
-            self.derivation.controlled_ids != self.controlled_ids
-            or self.derivation.start != normalized_start
-        ):
-            raise DirectTrfConstructionError(
-                "GRID seed problem differs from its derivation record"
-            )
-        elif isinstance(self.derivation, DeSearchProblemDerivation) and (
-            self.derivation.selected_ids != self.controlled_ids
-            or self.derivation.captured_held_items != self.held_items
-            or self.derivation.start != normalized_start
-        ):
-            raise DirectTrfConstructionError(
-                "DE search problem differs from its derivation record"
-            )
-        elif isinstance(self.derivation, DePolishProblemDerivation) and (
-            self.derivation.controlled_ids != self.controlled_ids
-            or self.derivation.start != normalized_start
-        ):
-            raise DirectTrfConstructionError(
-                "DE polish problem differs from its derivation record"
-            )
+        elif isinstance(self.derivation, GridSeedProblemDerivation):
+            if (
+                self.derivation.root_affine_feasibility_identity
+                != affine_feasibility_identity
+            ):
+                raise DirectTrfConstructionError(
+                    "GRID seed affine feasibility differs from its derivation record"
+                )
+            if (
+                self.derivation.controlled_ids != self.controlled_ids
+                or self.derivation.start != normalized_start
+            ):
+                raise DirectTrfConstructionError(
+                    "GRID seed problem differs from its derivation record"
+                )
+        elif isinstance(self.derivation, DeSearchProblemDerivation):
+            if (
+                self.derivation.root_affine_feasibility_identity
+                != affine_feasibility_identity
+            ):
+                raise DirectTrfConstructionError(
+                    "DE search affine feasibility differs from its derivation record"
+                )
+            if (
+                self.derivation.selected_ids != self.controlled_ids
+                or self.derivation.captured_held_items != self.held_items
+                or self.derivation.start != normalized_start
+            ):
+                raise DirectTrfConstructionError(
+                    "DE search problem differs from its derivation record"
+                )
+        elif isinstance(self.derivation, DePolishProblemDerivation):
+            if (
+                self.derivation.root_affine_feasibility_identity
+                != affine_feasibility_identity
+            ):
+                raise DirectTrfConstructionError(
+                    "DE polish affine feasibility differs from its derivation record"
+                )
+            if (
+                self.derivation.controlled_ids != self.controlled_ids
+                or self.derivation.start != normalized_start
+            ):
+                raise DirectTrfConstructionError(
+                    "DE polish problem differs from its derivation record"
+                )
         object.__setattr__(self, "start", normalized_start)
         object.__setattr__(self, "lower_bounds", lower)
         object.__setattr__(self, "upper_bounds", upper)
@@ -795,6 +977,87 @@ class OptimizationProblem:
         """Whether this is the complete root rather than a derived component."""
         return self.derivation is None
 
+    @property
+    def affine_feasibility_identity(self) -> str:
+        """Return the canonical box-independent affine feasibility identity."""
+        return _affine_feasibility_identity(
+            self.affine_half_spaces,
+            self.affine_equalities,
+        )
+
+    def coordinate_line_feasibility(  # noqa: C901 - exact interval intersection
+        self,
+        vector: Sequence[float] | Array,
+        column: int,
+    ) -> CoordinateLineFeasibility:
+        """Intersect exact box and affine feasibility along one coordinate line."""
+        candidate = _canonical_vector(
+            vector,
+            dimension=len(self.controlled_ids),
+            name="coordinate-line center",
+        )
+        full_values = _validate_candidate_feasibility(
+            self.independent_items,
+            self.controlled_ids,
+            candidate,
+            self.lower_bounds,
+            self.upper_bounds,
+            self.affine_half_spaces,
+            self.affine_equalities,
+        )
+        if not 0 <= column < len(self.controlled_ids):
+            raise IndexError("Controlled coordinate column is out of range")
+        param_id = self.controlled_ids[column]
+        independent_index = next(
+            index
+            for index, (independent_id, _value) in enumerate(self.independent_items)
+            if independent_id == param_id
+        )
+        minimum = self.lower_bounds[column] - candidate[column]
+        maximum = self.upper_bounds[column] - candidate[column]
+        lower_limiters = (f"box-lower:{param_id}",) if math.isfinite(minimum) else ()
+        upper_limiters = (f"box-upper:{param_id}",) if math.isfinite(maximum) else ()
+        for restriction in self.affine_half_spaces:
+            coefficient = restriction.coefficients[independent_index]
+            if coefficient == 0.0:
+                continue
+            slack = restriction.upper_bound - _affine_total(
+                restriction.coefficients,
+                full_values,
+            )
+            boundary = _bound_binary64(
+                slack / coefficient,
+                name=f"affine line boundary {restriction.restriction_id!r}",
+            )
+            limiter = f"affine:{restriction.restriction_id}"
+            if coefficient > 0.0:
+                if boundary < maximum:
+                    maximum = boundary
+                    upper_limiters = (limiter,)
+                elif boundary == maximum:
+                    upper_limiters += (limiter,)
+            elif boundary > minimum:
+                minimum = boundary
+                lower_limiters = (limiter,)
+            elif boundary == minimum:
+                lower_limiters += (limiter,)
+        for restriction in self.affine_equalities:
+            coefficient = restriction.coefficients[independent_index]
+            if coefficient == 0.0:
+                continue
+            minimum = 0.0
+            maximum = 0.0
+            limiter = f"equality:{restriction.restriction_id}"
+            lower_limiters = (limiter,)
+            upper_limiters = (limiter,)
+        return CoordinateLineFeasibility(
+            param_id,
+            minimum,
+            maximum,
+            lower_limiters,
+            upper_limiters,
+        )
+
     def lifecycle_frame(
         self,
         vector: Sequence[float] | Array,
@@ -806,6 +1069,15 @@ class OptimizationProblem:
             vector,
             dimension=len(self.controlled_ids),
             name="external candidate",
+        )
+        _validate_candidate_feasibility(
+            self.independent_items,
+            self.controlled_ids,
+            candidate,
+            self.lower_bounds,
+            self.upper_bounds,
+            self.affine_half_spaces,
+            self.affine_equalities,
         )
         updates = dict(zip(self.controlled_ids, candidate, strict=True))
         return IndependentValueFrame(

--- a/src/chemex/optimize/grid_direct_trf.py
+++ b/src/chemex/optimize/grid_direct_trf.py
@@ -898,6 +898,7 @@ class AcceptedGridDirectTrfResult(AcceptedFitResult):
             selected_seed,
             selected_outcome,
             fresh_candidate,
+            occurrence_witness=accepted.occurrence_witness,
         )
 
 

--- a/src/chemex/optimize/grid_direct_trf.py
+++ b/src/chemex/optimize/grid_direct_trf.py
@@ -410,6 +410,7 @@ class GridDirectTrfInvocation:
                 continue
             derivation = GridSeedProblemDerivation(
                 problem.identity,
+                problem.affine_feasibility_identity,
                 seed_identity,
                 ordinal,
                 finite_axis_items,
@@ -432,6 +433,8 @@ class GridDirectTrfInvocation:
                 problem.commit_scope,
                 derivation,
                 problem.scalarization_version,
+                problem.affine_half_spaces,
+                problem.affine_equalities,
             )
             child_invocation = DirectTrfInvocation.for_problem(
                 child,
@@ -669,6 +672,8 @@ def _validate_direct_grid_record(
         and child_problem.upper_bounds == problem.upper_bounds
         and child_problem.commit_scope == problem.commit_scope
         and child_problem.scalarization_version == problem.scalarization_version
+        and child_problem.affine_half_spaces == problem.affine_half_spaces
+        and child_problem.affine_equalities == problem.affine_equalities
     )
     if (
         invocation.root_problem_identity != problem.identity

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -260,6 +260,7 @@ def _build_component(
     )
     derivation = ComponentProblemDerivation(
         problem.identity,
+        problem.affine_feasibility_identity,
         component_identity,
         _PROJECTION_POLICY,
         child_engine.plan.identity,
@@ -281,6 +282,9 @@ def _build_component(
         upper,
         problem.commit_scope,
         derivation,
+        problem.scalarization_version,
+        problem.affine_half_spaces,
+        problem.affine_equalities,
     )
     return FitComponent(
         component_ids,

--- a/src/chemex/optimize/grouped_grid_direct_trf.py
+++ b/src/chemex/optimize/grouped_grid_direct_trf.py
@@ -607,6 +607,8 @@ def _validate_grouped_grid_seed(
         or seed_problem.upper_bounds != problem.upper_bounds
         or seed_problem.commit_scope != problem.commit_scope
         or seed_problem.scalarization_version != problem.scalarization_version
+        or seed_problem.affine_half_spaces != problem.affine_half_spaces
+        or seed_problem.affine_equalities != problem.affine_equalities
         or seed_decomposition is None
         or seed_decomposition.root_problem_identity != seed_problem.identity
         or seed_decomposition.root_plan_identity
@@ -718,6 +720,8 @@ def _validate_grouped_grid_seed(
             or component_problem.commit_scope != seed_problem.commit_scope
             or component_problem.scalarization_version
             != seed_problem.scalarization_version
+            or component_problem.affine_half_spaces != seed_problem.affine_half_spaces
+            or component_problem.affine_equalities != seed_problem.affine_equalities
             or direct.problem_identity != component_problem.identity
             or component_candidate.problem_identity != direct.problem_identity
             or component_candidate.invocation_identity != direct.identity

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -944,6 +944,17 @@ class ResidualJacobianEvidence:
             != self.accepted_anchor.source_occurrence_identity
             or self.source_revision != self.accepted_anchor.source_revision
             or self.controlled_ids != self.accepted_anchor.controlled_ids
+            or self.source_problem.identity != self.problem_identity
+            or self.source_parameterization.identity != self.parameterization_identity
+            or self.source_parameterization.evaluator_identity
+            != self.evaluator_parameterization_identity
+            or self.source_parameterization.program.fingerprint
+            != self.constraint_program_identity
+            or self.source_engine.plan.identity != self.evaluation_plan_identity
+            or self.source_policy.identity != self.policy_identity
+            or self.source_policy.calibration_identity != self.calibration_identity
+            or self.source_policy.numerical_compatibility_requirement
+            != self.numerical_compatibility_requirement
             or tuple(item.param_id for item in self.columns) != self.controlled_ids
             or any(value <= 0.0 for value in self.coordinate_scales)
             or any(len(item.fine_estimate) != residual_count for item in self.columns)
@@ -1171,6 +1182,13 @@ class RankDiagnostic:
         ):
             raise ValueError("SVD/rank evidence has inconsistent lineage or spectrum")
         largest = self.singular_values[0] if self.singular_values else 0.0
+        expected_weak_threshold = _finite(
+            max(
+                self.threshold,
+                self.source_policy.weak_relative_tolerance * largest,
+            ),
+            name="weak-subspace threshold",
+        )
         expected_normalized = tuple(
             0.0 if largest == 0.0 else value / largest for value in self.singular_values
         )
@@ -1187,6 +1205,8 @@ class RankDiagnostic:
         tolerance = 512.0 * _EPSILON * max(1, dimension)
         if (
             self.normalized_singular_values != expected_normalized
+            or self.weak_threshold != expected_weak_threshold
+            or self.source_policy.identity != source.source_policy.identity
             or not np.allclose(
                 self.scaled_column_norms, expected_norms, rtol=tolerance, atol=0.0
             )
@@ -1272,6 +1292,21 @@ class RankDiagnostic:
             atol=tolerance,
         ):
             raise ValueError("Singular invariant-subspace projectors are incomplete")
+        expected_weak = sum(
+            (
+                np.asarray(item.projector)
+                for item in self.subspaces
+                if item.classification.endswith("_weak")
+            ),
+            start=np.zeros((dimension, dimension), dtype=np.float64),
+        )
+        if not np.allclose(
+            weak,
+            expected_weak,
+            rtol=0.0,
+            atol=tolerance,
+        ):
+            raise ValueError("Weak-subspace projector is inconsistent")
         object.__setattr__(self, "identifiable_projector", identifiable)
         object.__setattr__(self, "null_projector", null)
         object.__setattr__(self, "weak_projector", weak)
@@ -3465,6 +3500,14 @@ def _affine_feasibility_claim(
         )
         for item in problem.affine_equalities
     )
+    restrictions.extend(
+        (
+            f"{item.restriction_id}:negative",
+            -np.asarray(item.coefficients, dtype=np.float64),
+            -item.value,
+        )
+        for item in problem.affine_equalities
+    )
     if controlled_only:
         restrictions = [
             item
@@ -3477,14 +3520,6 @@ def _affine_feasibility_claim(
             ClaimState.NOT_APPLICABLE,
             "No affine restriction has a controlled-coordinate coefficient",
         )
-    restrictions.extend(
-        (
-            f"{item.restriction_id}:negative",
-            -np.asarray(item.coefficients, dtype=np.float64),
-            -item.value,
-        )
-        for item in problem.affine_equalities
-    )
     assessments = tuple(
         _classify_affine_restriction(
             label,

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -1,0 +1,3947 @@
+"""ChemEx-owned accepted-point uncertainty evidence qualification (#598).
+
+This module is deliberately separate from backend execution evidence.  It
+linearizes the complete native residual map again at one accepted external
+coordinate vector, constructs full-rank scaled-SVD covariance, and derives
+typed marginal, correlation, and constrained-propagation artifacts.
+
+The entry point remains an isolated qualification seam; production fitting and
+reporting do not consume these artifacts yet.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field, fields, is_dataclass
+from enum import StrEnum
+from itertools import pairwise
+from numbers import Real
+from typing import Literal, Protocol, cast
+from uuid import uuid4
+
+import numpy as np
+from scipy.linalg import svd
+
+from chemex.evaluation.native import (
+    BoundEvaluator,
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationResult,
+)
+from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    BinaryExpression,
+    CompiledConstraint,
+    FunctionExpression,
+    LiteralExpression,
+    ParameterRole,
+    ReferenceExpression,
+    ScalarExpression,
+    UnaryExpression,
+)
+
+_SCHEMA_VERSION = 1
+_RESIDUAL_LINEARIZATION_VERSION = "external-real-finite-difference-v1"
+_CONSTRAINT_LINEARIZATION_VERSION = "constraint-forward-chain-v1"
+_COVARIANCE_VERSION = "full-rank-scaled-svd-v1"
+_FACTOR_VERSION = "scaled-svd-gram-v1"
+_REDUCTION_VERSION = "fixed-pairwise-binary64-v1"
+_MARGINAL_VERSION = "covariance-diagonal-square-root-v1"
+_CORRELATION_VERSION = "ordered-double-division-v1"
+_PROPAGATION_VERSION = "constraint-gram-factor-v1"
+_EPSILON = float(np.finfo(np.float64).eps)
+_NOMINAL_STEP_FACTOR = _EPSILON ** (1.0 / 3.0)
+_BOUNDARY_THRESHOLD = 3.0
+
+
+class UncertaintyConstructionError(ValueError):
+    """Raised only for malformed policy or artifact construction."""
+
+
+class FunctionPartialFailure(UncertaintyConstructionError):
+    """Typed failure retaining a scientific-function partial trajectory."""
+
+    def __init__(
+        self,
+        category: str,
+        message: str,
+        trajectory_fingerprint: str,
+        termination_details: tuple[str, ...],
+    ) -> None:
+        super().__init__(message)
+        self.category = category
+        self.trajectory_fingerprint = trajectory_fingerprint
+        self.termination_details = termination_details
+
+
+class DerivationTermination(RuntimeError):
+    """Internal cooperative cancellation/interruption checkpoint signal."""
+
+    def __init__(self, terminal: OperationTerminal) -> None:
+        super().__init__(terminal.value)
+        self.terminal = terminal
+
+
+class ResidualVarianceScaling(StrEnum):
+    """Closed interpretation of supplied observation uncertainties."""
+
+    ABSOLUTE_OBSERVATION_UNCERTAINTIES = "absolute_observation_uncertainties"
+    ESTIMATED_COMMON_RESIDUAL_VARIANCE = "estimated_common_residual_variance"
+
+
+class ClaimState(StrEnum):
+    """One closed scientific-claim assessment."""
+
+    SATISFIED = "satisfied"
+    VIOLATED = "violated"
+    INDETERMINATE = "indeterminate"
+    NOT_APPLICABLE = "not_applicable"
+
+
+class OperationTerminal(StrEnum):
+    """Lifecycle result of one evidence derivation operation."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+
+
+class ParameterUnit(StrEnum):
+    """Closed unit vocabulary carried by uncertainty evidence."""
+
+    DIMENSIONLESS = "dimensionless"
+    FRACTION = "fraction"
+    RATE_PER_SECOND = "s^-1"
+    FREQUENCY_HZ = "Hz"
+    CHEMICAL_SHIFT_PPM = "ppm"
+    TIME_SECONDS = "s"
+    TEMPERATURE_CELSIUS = "degC"
+    CONCENTRATION_MOLAR = "mol/L"
+    ENERGY_PER_MOLE = "J/mol"
+    ENTROPY_PER_MOLE_KELVIN = "J/mol/K"
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "record": record, "schema_version": _SCHEMA_VERSION},
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _record_value(value: object) -> object:
+    """Encode typed immutable evidence with canonical binary64 values."""
+    if isinstance(value, StrEnum):
+        return value.value
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return {"binary64": _float_token(value)}
+    if isinstance(value, tuple):
+        return [_record_value(item) for item in value]
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            "artifact_type": type(value).__name__,
+            **{
+                item.name: _record_value(getattr(value, item.name))
+                for item in fields(value)
+            },
+        }
+    raise TypeError(f"Unsupported uncertainty record value {type(value).__name__}")
+
+
+def _finite(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{name} must be a real binary64 scalar")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return 0.0 if result == 0.0 else result
+
+
+def _float_token(value: float) -> str:
+    return float(value).hex()
+
+
+def _vector_tokens(values: Sequence[float]) -> tuple[str, ...]:
+    return tuple(_float_token(value) for value in values)
+
+
+def _matrix_tokens(
+    matrix: Sequence[Sequence[float]],
+) -> tuple[tuple[str, ...], ...]:
+    return tuple(_vector_tokens(row) for row in matrix)
+
+
+def _canonical_matrix(
+    values: Sequence[Sequence[float]],
+    *,
+    rows: int,
+    columns: int,
+    name: str,
+) -> tuple[tuple[float, ...], ...]:
+    matrix = tuple(
+        tuple(
+            _finite(value, name=f"{name}[{row_index},{column_index}]")
+            for column_index, value in enumerate(row)
+        )
+        for row_index, row in enumerate(values)
+    )
+    if len(matrix) != rows or any(len(row) != columns for row in matrix):
+        raise ValueError(f"{name} must have shape ({rows}, {columns})")
+    return matrix
+
+
+def _validated_extent(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise UncertaintyConstructionError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _validated_coordinate_contract(
+    raw_scales: Sequence[tuple[str, float]],
+    raw_units: Sequence[tuple[str, ParameterUnit]],
+) -> tuple[
+    tuple[tuple[str, float], ...],
+    tuple[tuple[str, ParameterUnit], ...],
+]:
+    scales = tuple(
+        (param_id, _finite(value, name=f"scale {param_id!r}"))
+        for param_id, value in raw_scales
+    )
+    ids = tuple(param_id for param_id, _value in scales)
+    if (
+        not ids
+        or any(not param_id for param_id in ids)
+        or len(set(ids)) != len(ids)
+        or any(value <= 0.0 for _param_id, value in scales)
+    ):
+        raise UncertaintyConstructionError(
+            "Coordinate scales must be unique positive finite ID/value pairs"
+        )
+    units = tuple(raw_units)
+    if tuple(param_id for param_id, _unit in units) != ids or any(
+        not unit for _param_id, unit in units
+    ):
+        raise UncertaintyConstructionError(
+            "Coordinate units must explicitly match coordinate-scale order"
+        )
+    return scales, units
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionFiniteDifferenceCapability:
+    """Explicit numerical partial capability for one scientific function output."""
+
+    function_id: str
+    component: str | None
+    argument_scales: tuple[float, ...]
+    output_scale: float
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        scales = tuple(
+            _finite(value, name=f"function argument scale[{index}]")
+            for index, value in enumerate(self.argument_scales)
+        )
+        output_scale = _finite(self.output_scale, name="function output scale")
+        if (
+            not self.function_id
+            or not scales
+            or any(value <= 0.0 for value in scales)
+            or output_scale <= 0.0
+        ):
+            raise UncertaintyConstructionError(
+                "Function finite-difference scales must be positive and explicit"
+            )
+        object.__setattr__(self, "argument_scales", scales)
+        object.__setattr__(self, "output_scale", output_scale)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-function-finite-difference-capability",
+                (
+                    self.function_id,
+                    self.component,
+                    _vector_tokens(scales),
+                    _float_token(output_scale),
+                    _CONSTRAINT_LINEARIZATION_VERSION,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionAnalyticPartialCapability:
+    """Versioned analytic partials selected for one scientific function output."""
+
+    function_id: str
+    component: str | None
+    implementation_identity: str
+    partials: tuple[Callable[..., float], ...] = field(compare=False, repr=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            not self.function_id
+            or not self.implementation_identity
+            or not self.partials
+            or any(not callable(partial) for partial in self.partials)
+        ):
+            raise UncertaintyConstructionError(
+                "Analytic scientific-function capability is incomplete"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-function-analytic-partial-capability",
+                (
+                    self.function_id,
+                    self.component,
+                    self.implementation_identity,
+                    len(self.partials),
+                    _CONSTRAINT_LINEARIZATION_VERSION,
+                ),
+            ),
+        )
+
+
+FunctionLinearizationCapability = (
+    FunctionFiniteDifferenceCapability | FunctionAnalyticPartialCapability
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledConstraintLinearizationCapabilities:
+    """Capability selection frozen against one constraint program and scope."""
+
+    parameterization_identity: str
+    constraint_program_identity: str
+    output_scope: tuple[str, ...]
+    capabilities: tuple[FunctionLinearizationCapability, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        keys = tuple((item.function_id, item.component) for item in self.capabilities)
+        if len(set(keys)) != len(keys):
+            raise UncertaintyConstructionError(
+                "Compiled function capabilities must be unique"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "compiled-constraint-linearization-capabilities",
+                (
+                    self.parameterization_identity,
+                    self.constraint_program_identity,
+                    self.output_scope,
+                    tuple(item.identity for item in self.capabilities),
+                ),
+            ),
+        )
+
+
+def _expression_function_keys(
+    expression: ScalarExpression,
+) -> tuple[tuple[str, str | None], ...]:
+    if isinstance(expression, FunctionExpression):
+        nested = tuple(
+            key
+            for argument in expression.arguments
+            for key in _expression_function_keys(argument)
+        )
+        return ((expression.function_id, expression.component), *nested)
+    if isinstance(expression, UnaryExpression):
+        return _expression_function_keys(expression.operand)
+    if isinstance(expression, BinaryExpression):
+        return _expression_function_keys(expression.left) + _expression_function_keys(
+            expression.right
+        )
+    return ()
+
+
+def _required_function_keys(
+    parameterization: ActiveParameterization,
+    scope: tuple[str, ...],
+) -> set[tuple[str, str | None]]:
+    constraints = {
+        item.target_id: item for item in parameterization.program.constraints
+    }
+    required: set[tuple[str, str | None]] = set()
+    visited: set[str] = set()
+
+    def visit(target_id: str) -> None:
+        if target_id in visited or target_id not in constraints:
+            return
+        visited.add(target_id)
+        constraint = constraints[target_id]
+        for dependency in constraint.dependencies:
+            visit(dependency)
+        required.update(_expression_function_keys(constraint.expression))
+
+    for target_id in scope:
+        visit(target_id)
+    return required
+
+
+def compile_constraint_linearization_capabilities(
+    parameterization: ActiveParameterization,
+    output_scope: Sequence[str],
+    capabilities: Sequence[FunctionLinearizationCapability],
+) -> CompiledConstraintLinearizationCapabilities:
+    """Freeze scientific-function capability selection before derivation."""
+    scope = tuple(output_scope)
+    if len(set(scope)) != len(scope) or any(
+        param_id not in parameterization.scope_ids for param_id in scope
+    ):
+        raise UncertaintyConstructionError(
+            "Compiled constraint-linearization scope is invalid"
+        )
+    selected = tuple(capabilities)
+    selected_keys = {(item.function_id, item.component) for item in selected}
+
+    required_keys = _required_function_keys(parameterization, scope)
+    missing = required_keys - selected_keys
+    if missing:
+        raise UncertaintyConstructionError(
+            "Compiled constraint linearization lacks capabilities for "
+            f"{sorted(missing, key=repr)!r}"
+        )
+    return CompiledConstraintLinearizationCapabilities(
+        parameterization.identity,
+        parameterization.program.fingerprint,
+        scope,
+        selected,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class UncertaintyPolicy:
+    """Explicit resolved v1 numerical policy; no defaults are inferred."""
+
+    calibration_identity: str
+    numerical_compatibility_requirement: str
+    coordinate_scales: tuple[tuple[str, float], ...]
+    coordinate_units: tuple[tuple[str, ParameterUnit], ...]
+    residual_variance_scaling: ResidualVarianceScaling
+    relative_step_tolerance: float
+    roundoff_multiplier: float
+    smaller_step_extent: int
+    larger_step_extent: int
+    svd_driver: Literal["gesdd", "gesvd"]
+    rank_absolute_tolerance: float
+    rank_relative_tolerance: float
+    weak_relative_tolerance: float
+    conditioning_limit: float
+    correlation_roundoff_multiplier: float
+    affine_feasibility_policy: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.calibration_identity:
+            raise UncertaintyConstructionError(
+                "Uncertainty policy requires a calibration identity"
+            )
+        if not self.numerical_compatibility_requirement:
+            raise UncertaintyConstructionError(
+                "Uncertainty policy requires numerical compatibility semantics"
+            )
+        scales, units = _validated_coordinate_contract(
+            self.coordinate_scales,
+            self.coordinate_units,
+        )
+        relative = _finite(
+            self.relative_step_tolerance,
+            name="relative step tolerance",
+        )
+        roundoff = _finite(
+            self.roundoff_multiplier,
+            name="roundoff multiplier",
+        )
+        rank_absolute = _finite(
+            self.rank_absolute_tolerance,
+            name="absolute rank tolerance",
+        )
+        rank_relative = _finite(
+            self.rank_relative_tolerance,
+            name="relative rank tolerance",
+        )
+        weak_relative = _finite(
+            self.weak_relative_tolerance,
+            name="weak-subspace relative tolerance",
+        )
+        conditioning = _finite(
+            self.conditioning_limit,
+            name="conditioning limit",
+        )
+        correlation_roundoff = _finite(
+            self.correlation_roundoff_multiplier,
+            name="correlation roundoff multiplier",
+        )
+        if relative < 0.0 or roundoff < 0.0:
+            raise UncertaintyConstructionError(
+                "Finite-difference tolerances must be non-negative"
+            )
+        if rank_absolute < 0.0 or rank_relative < 0.0 or weak_relative < rank_relative:
+            raise UncertaintyConstructionError("Rank thresholds must be non-negative")
+        if conditioning <= 0.0 or correlation_roundoff < 0.0:
+            raise UncertaintyConstructionError(
+                "Conditioning and correlation policies are invalid"
+            )
+        _validated_extent(
+            self.smaller_step_extent,
+            name="smaller step extent",
+        )
+        _validated_extent(
+            self.larger_step_extent,
+            name="larger step extent",
+        )
+        if self.svd_driver not in {"gesdd", "gesvd"}:
+            raise UncertaintyConstructionError(
+                "SVD driver must be explicitly 'gesdd' or 'gesvd'"
+            )
+        if not self.affine_feasibility_policy:
+            raise UncertaintyConstructionError(
+                "Affine-feasibility semantics must be explicit"
+            )
+        object.__setattr__(self, "coordinate_scales", scales)
+        object.__setattr__(self, "coordinate_units", units)
+        object.__setattr__(self, "relative_step_tolerance", relative)
+        object.__setattr__(self, "roundoff_multiplier", roundoff)
+        object.__setattr__(self, "rank_absolute_tolerance", rank_absolute)
+        object.__setattr__(self, "rank_relative_tolerance", rank_relative)
+        object.__setattr__(self, "weak_relative_tolerance", weak_relative)
+        object.__setattr__(self, "conditioning_limit", conditioning)
+        object.__setattr__(
+            self,
+            "correlation_roundoff_multiplier",
+            correlation_roundoff,
+        )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-uncertainty-policy",
+                (
+                    self.calibration_identity,
+                    self.numerical_compatibility_requirement,
+                    tuple(
+                        (param_id, _float_token(value)) for param_id, value in scales
+                    ),
+                    units,
+                    self.residual_variance_scaling.value,
+                    _float_token(relative),
+                    _float_token(roundoff),
+                    self.smaller_step_extent,
+                    self.larger_step_extent,
+                    self.svd_driver,
+                    _float_token(rank_absolute),
+                    _float_token(rank_relative),
+                    _float_token(weak_relative),
+                    _float_token(conditioning),
+                    _float_token(correlation_roundoff),
+                    self.affine_feasibility_policy,
+                    _float_token(_BOUNDARY_THRESHOLD),
+                    _RESIDUAL_LINEARIZATION_VERSION,
+                    _CONSTRAINT_LINEARIZATION_VERSION,
+                    _COVARIANCE_VERSION,
+                    _REDUCTION_VERSION,
+                    _MARGINAL_VERSION,
+                    _CORRELATION_VERSION,
+                    _PROPAGATION_VERSION,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimAssessment:
+    name: str
+    state: ClaimState
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceFailure:
+    stage: str
+    category: str
+    message: str
+    source_identity: str
+    trajectory_fingerprint: str | None = None
+    termination_details: tuple[str, ...] = ()
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-uncertainty-failure",
+                (
+                    self.stage,
+                    self.category,
+                    self.message,
+                    self.source_identity,
+                    self.trajectory_fingerprint,
+                    self.termination_details,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DerivationOperation:
+    occurrence_identity: str = field(compare=False)
+    resolved_environment_identity: str = field(compare=False)
+    stage: str
+    request_identity: str
+    terminal: OperationTerminal
+    artifact_identity: str | None = None
+    failure: EvidenceFailure | None = None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.resolved_environment_identity:
+            raise ValueError("Derivation operation requires resolved environment")
+        if self.terminal is OperationTerminal.COMPLETED:
+            if self.artifact_identity is None or self.failure is not None:
+                raise ValueError("Completed operation lacks one exact artifact")
+        elif self.artifact_identity is not None or self.failure is None:
+            raise ValueError("Non-completed operation has inconsistent evidence")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-uncertainty-operation",
+                (
+                    self.stage,
+                    self.request_identity,
+                    self.terminal.value,
+                    self.artifact_identity,
+                    None if self.failure is None else self.failure.identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LinearizationColumn:
+    param_id: str
+    orientation: str
+    nominal_step: float
+    represented_displacements: tuple[float, ...]
+    fine_estimate: tuple[float, ...]
+    companion_estimate: tuple[float, ...]
+    discrepancy: float
+    derivative_scale: float
+    roundoff_allowance: float
+    attempt_count: int
+    termination: str
+    trajectory_fingerprint: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-linearization-column",
+                (
+                    self.param_id,
+                    self.orientation,
+                    _float_token(self.nominal_step),
+                    _vector_tokens(self.represented_displacements),
+                    _vector_tokens(self.fine_estimate),
+                    _vector_tokens(self.companion_estimate),
+                    _float_token(self.discrepancy),
+                    _float_token(self.derivative_scale),
+                    _float_token(self.roundoff_allowance),
+                    self.attempt_count,
+                    self.termination,
+                    self.trajectory_fingerprint,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionPartialDiagnostic:
+    """Separate reliability evidence for one scientific-function partial."""
+
+    capability_identity: str
+    function_id: str
+    component: str | None
+    argument_index: int
+    method: str
+    estimate: float
+    companion_estimate: float | None
+    represented_displacements: tuple[float, ...]
+    discrepancy: float
+    derivative_scale: float
+    roundoff_allowance: float
+    attempt_count: int
+    trajectory_fingerprint: str
+    claims: tuple[ClaimAssessment, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-function-partial-diagnostic",
+                (
+                    self.capability_identity,
+                    self.function_id,
+                    self.component,
+                    self.argument_index,
+                    self.method,
+                    _float_token(self.estimate),
+                    None
+                    if self.companion_estimate is None
+                    else _float_token(self.companion_estimate),
+                    _vector_tokens(self.represented_displacements),
+                    _float_token(self.discrepancy),
+                    _float_token(self.derivative_scale),
+                    _float_token(self.roundoff_allowance),
+                    self.attempt_count,
+                    self.trajectory_fingerprint,
+                    tuple(
+                        (item.name, item.state.value, item.detail)
+                        for item in self.claims
+                    ),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResidualJacobianEvidence:
+    request_identity: str
+    accepted_result_identity: str
+    accepted_evaluation_identity: str
+    problem_identity: str
+    source_snapshot_occurrence_identity: str
+    source_revision: int
+    parameterization_identity: str
+    evaluator_parameterization_identity: str
+    constraint_program_identity: str
+    evaluation_plan_identity: str
+    policy_identity: str
+    calibration_identity: str
+    numerical_compatibility_requirement: str
+    controlled_ids: tuple[str, ...]
+    accepted_vector: tuple[float, ...]
+    coordinate_scales: tuple[float, ...]
+    matrix: tuple[tuple[float, ...], ...]
+    columns: tuple[LinearizationColumn, ...]
+    trajectory_fingerprint: str
+    complete_reliable: bool = True
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        residual_count = len(self.matrix)
+        coordinate_count = len(self.controlled_ids)
+        matrix = _canonical_matrix(
+            self.matrix,
+            rows=residual_count,
+            columns=coordinate_count,
+            name="residual Jacobian",
+        )
+        if (
+            residual_count < 1
+            or coordinate_count < 1
+            or len(self.columns) != coordinate_count
+            or len(self.coordinate_scales) != coordinate_count
+        ):
+            raise ValueError("Residual Jacobian has inconsistent scope")
+        object.__setattr__(self, "matrix", matrix)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-residual-jacobian-evidence",
+                (
+                    self.request_identity,
+                    self.accepted_result_identity,
+                    self.accepted_evaluation_identity,
+                    self.problem_identity,
+                    self.source_snapshot_occurrence_identity,
+                    self.source_revision,
+                    self.parameterization_identity,
+                    self.evaluator_parameterization_identity,
+                    self.constraint_program_identity,
+                    self.evaluation_plan_identity,
+                    self.policy_identity,
+                    self.calibration_identity,
+                    self.numerical_compatibility_requirement,
+                    self.controlled_ids,
+                    _vector_tokens(self.accepted_vector),
+                    _vector_tokens(self.coordinate_scales),
+                    _matrix_tokens(matrix),
+                    tuple(column.identity for column in self.columns),
+                    self.trajectory_fingerprint,
+                    self.complete_reliable,
+                    _RESIDUAL_LINEARIZATION_VERSION,
+                ),
+            ),
+        )
+
+    @property
+    def residual_count(self) -> int:
+        return len(self.matrix)
+
+    @property
+    def coordinate_count(self) -> int:
+        return len(self.controlled_ids)
+
+
+@dataclass(frozen=True, slots=True)
+class RankDiagnostic:
+    source_jacobian_identity: str
+    controlled_ids: tuple[str, ...]
+    singular_values: tuple[float, ...]
+    normalized_singular_values: tuple[float, ...]
+    scaled_column_norms: tuple[float, ...]
+    threshold: float
+    weak_threshold: float
+    rank: int
+    identifiable_projector: tuple[tuple[float, ...], ...]
+    null_projector: tuple[tuple[float, ...], ...]
+    weak_projector: tuple[tuple[float, ...], ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        dimension = len(self.controlled_ids)
+        identifiable = _canonical_matrix(
+            self.identifiable_projector,
+            rows=dimension,
+            columns=dimension,
+            name="identifiable-subspace projector",
+        )
+        null = _canonical_matrix(
+            self.null_projector,
+            rows=dimension,
+            columns=dimension,
+            name="null-subspace projector",
+        )
+        weak = _canonical_matrix(
+            self.weak_projector,
+            rows=dimension,
+            columns=dimension,
+            name="weak-subspace projector",
+        )
+        object.__setattr__(self, "identifiable_projector", identifiable)
+        object.__setattr__(self, "null_projector", null)
+        object.__setattr__(self, "weak_projector", weak)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-rank-diagnostic",
+                (
+                    self.source_jacobian_identity,
+                    self.controlled_ids,
+                    _vector_tokens(self.singular_values),
+                    _vector_tokens(self.normalized_singular_values),
+                    _vector_tokens(self.scaled_column_norms),
+                    _float_token(self.threshold),
+                    _float_token(self.weak_threshold),
+                    self.rank,
+                    _matrix_tokens(identifiable),
+                    _matrix_tokens(null),
+                    _matrix_tokens(weak),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CovarianceEvidence:
+    request_identity: str
+    source_jacobian_identity: str
+    accepted_result_identity: str
+    problem_identity: str
+    parameterization_identity: str
+    evaluation_plan_identity: str
+    policy_identity: str
+    calibration_identity: str
+    numerical_compatibility_requirement: str
+    controlled_ids: tuple[str, ...]
+    units: tuple[ParameterUnit, ...]
+    accepted_vector: tuple[float, ...]
+    coordinate_scales: tuple[float, ...]
+    residual_variance_scaling: ResidualVarianceScaling
+    retained_residual_count: int
+    controlled_coordinate_count: int
+    profiled_normalization_count: int
+    nominal_residual_degrees_of_freedom: int
+    chi_square: float
+    residual_variance_scale: float
+    rank: int
+    singular_values: tuple[float, ...]
+    rank_threshold: float
+    jacobian_condition: float
+    information_condition: float
+    unscaled_covariance: tuple[tuple[float, ...], ...]
+    factor: tuple[tuple[float, ...], ...]
+    covariance: tuple[tuple[float, ...], ...]
+    claims: tuple[ClaimAssessment, ...]
+    factorization: str = _FACTOR_VERSION
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        dimension = len(self.controlled_ids)
+        unscaled = _canonical_matrix(
+            self.unscaled_covariance,
+            rows=dimension,
+            columns=dimension,
+            name="unscaled covariance",
+        )
+        factor = _canonical_matrix(
+            self.factor,
+            rows=dimension,
+            columns=dimension,
+            name="covariance factor",
+        )
+        covariance = _canonical_matrix(
+            self.covariance,
+            rows=dimension,
+            columns=dimension,
+            name="scaled covariance",
+        )
+        if self.rank != dimension or self.controlled_coordinate_count != dimension:
+            raise ValueError("Covariance requires full controlled-coordinate rank")
+        if (
+            tuple(item.name for item in self.claims).count("USABLE_LOCAL_COVARIANCE")
+            != 1
+        ):
+            raise ValueError("Covariance lacks its named usability conjunction")
+        object.__setattr__(self, "unscaled_covariance", unscaled)
+        object.__setattr__(self, "factor", factor)
+        object.__setattr__(self, "covariance", covariance)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-local-covariance-evidence",
+                (
+                    self.request_identity,
+                    self.source_jacobian_identity,
+                    self.accepted_result_identity,
+                    self.problem_identity,
+                    self.parameterization_identity,
+                    self.evaluation_plan_identity,
+                    self.policy_identity,
+                    self.calibration_identity,
+                    self.numerical_compatibility_requirement,
+                    self.controlled_ids,
+                    self.units,
+                    _vector_tokens(self.accepted_vector),
+                    _vector_tokens(self.coordinate_scales),
+                    self.residual_variance_scaling.value,
+                    self.retained_residual_count,
+                    self.controlled_coordinate_count,
+                    self.profiled_normalization_count,
+                    self.nominal_residual_degrees_of_freedom,
+                    _float_token(self.chi_square),
+                    _float_token(self.residual_variance_scale),
+                    self.rank,
+                    _vector_tokens(self.singular_values),
+                    _float_token(self.rank_threshold),
+                    _float_token(self.jacobian_condition),
+                    _float_token(self.information_condition),
+                    _matrix_tokens(unscaled),
+                    _matrix_tokens(factor),
+                    _matrix_tokens(covariance),
+                    tuple(
+                        (item.name, item.state.value, item.detail)
+                        for item in self.claims
+                    ),
+                    self.factorization,
+                    _COVARIANCE_VERSION,
+                    _REDUCTION_VERSION,
+                ),
+            ),
+        )
+
+    def claim(self, name: str) -> ClaimState:
+        return next(item.state for item in self.claims if item.name == name)
+
+    @property
+    def usable(self) -> bool:
+        return self.claim("USABLE_LOCAL_COVARIANCE") is ClaimState.SATISFIED
+
+
+@dataclass(frozen=True, slots=True)
+class ScalarEvidenceEntry:
+    param_id: str
+    value: float | None
+    outcome: str
+    raw_value: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MarginalErrorEvidence:
+    source_identity: str
+    source_family: str
+    output_ids: tuple[str, ...]
+    units: tuple[ParameterUnit, ...]
+    entries: tuple[ScalarEvidenceEntry, ...]
+    claims: tuple[ClaimAssessment, ...]
+    scope_reportable: bool
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-marginal-error-evidence",
+                (
+                    self.source_identity,
+                    self.source_family,
+                    self.output_ids,
+                    self.units,
+                    tuple(
+                        (
+                            item.param_id,
+                            None if item.value is None else _float_token(item.value),
+                            item.outcome,
+                            None
+                            if item.raw_value is None
+                            else _float_token(item.raw_value),
+                        )
+                        for item in self.entries
+                    ),
+                    tuple(
+                        (item.name, item.state.value, item.detail)
+                        for item in self.claims
+                    ),
+                    self.scope_reportable,
+                    _MARGINAL_VERSION,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationEntry:
+    value: float | None
+    outcome: str
+    raw_value: float | None = None
+    excess: float | None = None
+    tolerance: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationEvidence:
+    source_identity: str
+    source_family: str
+    output_ids: tuple[str, ...]
+    units: tuple[ParameterUnit, ...]
+    entries: tuple[tuple[CorrelationEntry, ...], ...]
+    claims: tuple[ClaimAssessment, ...]
+    scope_reportable: bool
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-correlation-evidence",
+                (
+                    self.source_identity,
+                    self.source_family,
+                    self.output_ids,
+                    self.units,
+                    tuple(
+                        tuple(
+                            (
+                                None
+                                if item.value is None
+                                else _float_token(item.value),
+                                item.outcome,
+                                None
+                                if item.raw_value is None
+                                else _float_token(item.raw_value),
+                                None
+                                if item.excess is None
+                                else _float_token(item.excess),
+                                None
+                                if item.tolerance is None
+                                else _float_token(item.tolerance),
+                            )
+                            for item in row
+                        )
+                        for row in self.entries
+                    ),
+                    tuple(
+                        (item.name, item.state.value, item.detail)
+                        for item in self.claims
+                    ),
+                    self.scope_reportable,
+                    _CORRELATION_VERSION,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConstraintJacobianEvidence:
+    request_identity: str
+    accepted_result_identity: str
+    accepted_evaluation_identity: str
+    problem_identity: str
+    parameterization_identity: str
+    constraint_program_identity: str
+    capability_selection_identity: str
+    controlled_ids: tuple[str, ...]
+    output_ids: tuple[str, ...]
+    output_units: tuple[ParameterUnit, ...]
+    output_scales: tuple[float, ...]
+    matrix: tuple[tuple[float, ...], ...]
+    structural_dependencies: tuple[tuple[str, ...], ...]
+    function_partial_diagnostics: tuple[FunctionPartialDiagnostic, ...]
+    claims: tuple[ClaimAssessment, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if len(self.output_scales) != len(self.output_ids) or any(
+            value <= 0.0 or not math.isfinite(value) for value in self.output_scales
+        ):
+            raise ValueError("Constraint-output scales must be positive and complete")
+        matrix = _canonical_matrix(
+            self.matrix,
+            rows=len(self.output_ids),
+            columns=len(self.controlled_ids),
+            name="constraint-output Jacobian",
+        )
+        object.__setattr__(self, "matrix", matrix)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-constraint-jacobian-evidence",
+                (
+                    self.request_identity,
+                    self.accepted_result_identity,
+                    self.accepted_evaluation_identity,
+                    self.problem_identity,
+                    self.parameterization_identity,
+                    self.constraint_program_identity,
+                    self.capability_selection_identity,
+                    self.controlled_ids,
+                    self.output_ids,
+                    self.output_units,
+                    _vector_tokens(self.output_scales),
+                    _matrix_tokens(matrix),
+                    self.structural_dependencies,
+                    tuple(item.identity for item in self.function_partial_diagnostics),
+                    tuple(
+                        (item.name, item.state.value, item.detail)
+                        for item in self.claims
+                    ),
+                    _CONSTRAINT_LINEARIZATION_VERSION,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConstrainedPropagationEvidence:
+    request_identity: str
+    source_covariance_identity: str
+    source_constraint_jacobian_identity: str
+    accepted_result_identity: str
+    controlled_ids: tuple[str, ...]
+    output_ids: tuple[str, ...]
+    output_units: tuple[ParameterUnit, ...]
+    output_scales: tuple[float, ...]
+    factor: tuple[tuple[float, ...], ...]
+    covariance: tuple[tuple[float, ...], ...]
+    claims: tuple[ClaimAssessment, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        rows = len(self.output_ids)
+        columns = len(self.controlled_ids)
+        if len(self.output_scales) != rows or any(
+            value <= 0.0 or not math.isfinite(value) for value in self.output_scales
+        ):
+            raise ValueError("Propagated-output scales must be positive and complete")
+        factor = _canonical_matrix(
+            self.factor,
+            rows=rows,
+            columns=columns,
+            name="propagated covariance factor",
+        )
+        covariance = _canonical_matrix(
+            self.covariance,
+            rows=rows,
+            columns=rows,
+            name="propagated covariance",
+        )
+        object.__setattr__(self, "factor", factor)
+        object.__setattr__(self, "covariance", covariance)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-constrained-propagation-evidence",
+                (
+                    self.request_identity,
+                    self.source_covariance_identity,
+                    self.source_constraint_jacobian_identity,
+                    self.accepted_result_identity,
+                    self.controlled_ids,
+                    self.output_ids,
+                    self.output_units,
+                    _vector_tokens(self.output_scales),
+                    _matrix_tokens(factor),
+                    _matrix_tokens(covariance),
+                    tuple(
+                        (item.name, item.state.value, item.detail)
+                        for item in self.claims
+                    ),
+                    _PROPAGATION_VERSION,
+                    _REDUCTION_VERSION,
+                ),
+            ),
+        )
+
+    def claim(self, name: str) -> ClaimState:
+        return next(item.state for item in self.claims if item.name == name)
+
+
+@dataclass(frozen=True, slots=True)
+class UncertaintyEvidence:
+    accepted_result_identity: str
+    request_identity: str
+    policy_identity: str
+    resolved_environment_identity: str = field(compare=False)
+    operations: tuple[DerivationOperation, ...]
+    failures: tuple[EvidenceFailure, ...]
+    residual_jacobian: ResidualJacobianEvidence | None = None
+    rank_diagnostic: RankDiagnostic | None = None
+    covariance: CovarianceEvidence | None = None
+    marginal_errors: MarginalErrorEvidence | None = None
+    correlations: CorrelationEvidence | None = None
+    constraint_jacobian: ConstraintJacobianEvidence | None = None
+    constrained_propagation: ConstrainedPropagationEvidence | None = None
+    constrained_marginal_errors: MarginalErrorEvidence | None = None
+    constrained_correlations: CorrelationEvidence | None = None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-uncertainty-evidence-bundle",
+                (
+                    self.accepted_result_identity,
+                    self.request_identity,
+                    self.policy_identity,
+                    tuple(item.identity for item in self.operations),
+                    tuple(item.identity for item in self.failures),
+                    None
+                    if self.residual_jacobian is None
+                    else self.residual_jacobian.identity,
+                    None
+                    if self.rank_diagnostic is None
+                    else self.rank_diagnostic.identity,
+                    None if self.covariance is None else self.covariance.identity,
+                    None
+                    if self.marginal_errors is None
+                    else self.marginal_errors.identity,
+                    None if self.correlations is None else self.correlations.identity,
+                    None
+                    if self.constraint_jacobian is None
+                    else self.constraint_jacobian.identity,
+                    None
+                    if self.constrained_propagation is None
+                    else self.constrained_propagation.identity,
+                    None
+                    if self.constrained_marginal_errors is None
+                    else self.constrained_marginal_errors.identity,
+                    None
+                    if self.constrained_correlations is None
+                    else self.constrained_correlations.identity,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize the closed typed bundle without runtime machinery."""
+        return {
+            "artifact_type": "native_uncertainty_evidence_bundle",
+            "schema_version": _SCHEMA_VERSION,
+            "payload": _record_value(self),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _DerivativeValue:
+    value: float
+    gradient: tuple[float, ...]
+    structural_dependencies: frozenset[str]
+    function_partial_diagnostics: tuple[FunctionPartialDiagnostic, ...] = ()
+
+
+class _IdentityBearing(Protocol):
+    @property
+    def identity(self) -> str: ...
+
+
+def _pairwise_sum(values: Sequence[float]) -> float:
+    terms = [0.0 if value == 0.0 else value for value in values]
+    while len(terms) > 1:
+        reduced: list[float] = []
+        for index in range(0, len(terms) - 1, 2):
+            partial = terms[index] + terms[index + 1]
+            if not math.isfinite(partial):
+                raise ArithmeticError("fixed pairwise reduction became non-finite")
+            reduced.append(0.0 if partial == 0.0 else partial)
+        if len(terms) % 2:
+            reduced.append(terms[-1])
+        terms = reduced
+    return terms[0] if terms else 0.0
+
+
+def _gram_matrix(factor: Sequence[Sequence[float]]) -> tuple[tuple[float, ...], ...]:
+    rows = len(factor)
+    result = [[0.0] * rows for _index in range(rows)]
+    for left in range(rows):
+        for right in range(left, rows):
+            value = _pairwise_sum(
+                tuple(
+                    factor[left][column] * factor[right][column]
+                    for column in range(len(factor[left]))
+                )
+            )
+            value = _finite(value, name="Gram matrix entry")
+            result[left][right] = value
+            result[right][left] = value
+    return tuple(tuple(row) for row in result)
+
+
+def _has_positive_scale_zero_variance(
+    covariance: Sequence[Sequence[float]],
+    residual_variance_scale: float,
+) -> bool:
+    return residual_variance_scale > 0.0 and any(
+        row[index] == 0.0 for index, row in enumerate(covariance)
+    )
+
+
+def _canonical_right_singular_vectors(values: np.ndarray) -> np.ndarray:
+    """Fix each isolated right-singular direction by its first max-magnitude entry."""
+    canonical = np.array(values, dtype=np.float64, copy=True)
+    for column in range(canonical.shape[1]):
+        pivot = int(np.argmax(np.abs(canonical[:, column])))
+        if canonical[pivot, column] < 0.0:
+            canonical[:, column] *= -1.0
+    return canonical
+
+
+def _singular_spectrum_error(
+    values: Sequence[float],
+    expected_count: int,
+) -> tuple[str, str] | None:
+    if len(values) != expected_count:
+        return (
+            "incomplete_singular_spectrum",
+            "Economical SVD did not produce one value per coordinate",
+        )
+    if any(value < 0.0 for value in values) or any(
+        left < right for left, right in pairwise(values)
+    ):
+        return (
+            "invalid_singular_spectrum",
+            "SVD singular spectrum must be non-negative and descending",
+        )
+    return None
+
+
+def _max_norm(values: Sequence[float]) -> float:
+    return max((abs(value) for value in values), default=0.0)
+
+
+def _three_point_derivative(
+    first: Sequence[float],
+    center: Sequence[float],
+    second: Sequence[float],
+    first_displacement: float,
+    second_displacement: float,
+) -> tuple[float, ...]:
+    first_coefficient = -second_displacement / (
+        first_displacement * (first_displacement - second_displacement)
+    )
+    center_coefficient = -(first_displacement + second_displacement) / (
+        first_displacement * second_displacement
+    )
+    second_coefficient = -first_displacement / (
+        second_displacement * (second_displacement - first_displacement)
+    )
+    result = tuple(
+        _finite(
+            _pairwise_sum(
+                (
+                    first_coefficient * left,
+                    center_coefficient * middle,
+                    second_coefficient * right,
+                )
+            ),
+            name="finite-difference derivative",
+        )
+        for left, middle, right in zip(first, center, second, strict=True)
+    )
+    return result
+
+
+def _step_candidates(
+    nominal: float,
+    maximum: float,
+    policy: UncertaintyPolicy,
+) -> tuple[float, ...]:
+    candidates: list[tuple[float, float]] = []
+    for exponent in range(-policy.smaller_step_extent, policy.larger_step_extent + 1):
+        candidate = nominal * math.ldexp(1.0, exponent)
+        if math.isfinite(candidate) and 0.0 < candidate <= maximum:
+            candidates.append((abs(float(exponent)), candidate))
+    if math.isfinite(maximum) and maximum > 0.0:
+        distance = abs(math.log2(maximum / nominal)) if nominal > 0.0 else math.inf
+        candidates.append((distance, maximum))
+    unique: dict[str, tuple[float, float]] = {}
+    for distance, candidate in candidates:
+        token = _float_token(candidate)
+        current = unique.get(token)
+        if current is None or (distance, candidate) < current:
+            unique[token] = (distance, candidate)
+    return tuple(
+        candidate
+        for _distance, candidate in sorted(unique.values(), key=lambda item: item)
+    )
+
+
+def _lineage_failure(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    policy: UncertaintyPolicy,
+) -> str | None:
+    scales = tuple(param_id for param_id, _value in policy.coordinate_scales)
+    if scales != problem.controlled_ids:
+        return "coordinate_scale_scope_mismatch"
+    if (
+        accepted.problem_identity != problem.identity
+        or accepted.parameterization_identity != problem.parameterization_identity
+        or accepted.evaluator_parameterization_identity
+        != problem.evaluator_parameterization_identity
+        or accepted.controlled_ids != problem.controlled_ids
+        or accepted.source_occurrence_identity
+        != problem.source_snapshot.occurrence_identity
+        or accepted.source_revision != problem.source_snapshot.revision
+        or accepted.evaluation_result.plan_identity != problem.evaluation_plan_identity
+    ):
+        return "accepted_result_lineage_mismatch"
+    try:
+        problem.validate_parameterization(parameterization)
+    except ValueError:
+        return "parameterization_lineage_mismatch"
+    if (
+        engine.plan.identity != problem.evaluation_plan_identity
+        or engine.plan.parameterization_identity
+        != problem.evaluator_parameterization_identity
+        or engine.plan.constraint_program_identity
+        != problem.constraint_program_identity
+    ):
+        return "evaluation_engine_lineage_mismatch"
+    return None
+
+
+def _evaluate_vector(
+    vector: tuple[float, ...],
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    evaluator: BoundEvaluator,
+) -> EvaluationResult | EvaluationFailure:
+    lifecycle = problem.lifecycle_frame(vector, parameterization)
+    frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
+    return evaluator.evaluate(frame)
+
+
+def _column_orientations(
+    value: float,
+    lower: float,
+    upper: float,
+) -> tuple[tuple[str, float], ...]:
+    negative_distance = value - lower
+    positive_distance = upper - value
+    central_distance = min(negative_distance, positive_distance) / 2.0
+    candidates: list[tuple[str, float]] = []
+    if central_distance > 0.0:
+        candidates.append(("centered", central_distance))
+    negative_maximum = negative_distance / 4.0
+    positive_maximum = positive_distance / 4.0
+    one_sided = (
+        (
+            ("one_sided_positive", positive_maximum),
+            ("one_sided_negative", negative_maximum),
+        )
+        if positive_maximum >= negative_maximum
+        else (
+            ("one_sided_negative", negative_maximum),
+            ("one_sided_positive", positive_maximum),
+        )
+    )
+    candidates.extend(item for item in one_sided if item[1] > 0.0)
+    return tuple(candidates)
+
+
+def _stencil_vectors(
+    vector: tuple[float, ...],
+    column: int,
+    step: float,
+    orientation: str,
+) -> tuple[tuple[float, ...], ...] | None:
+    center = vector[column]
+    multipliers = (
+        (-2.0, -1.0, 1.0, 2.0)
+        if orientation == "centered"
+        else (
+            (1.0, 2.0, 4.0)
+            if orientation == "one_sided_positive"
+            else (-1.0, -2.0, -4.0)
+        )
+    )
+    vectors: list[tuple[float, ...]] = []
+    represented: set[float] = {center}
+    for multiplier in multipliers:
+        updated = center + multiplier * step
+        if not math.isfinite(updated) or updated in represented:
+            return None
+        represented.add(updated)
+        values = list(vector)
+        values[column] = updated
+        vectors.append(tuple(values))
+    return tuple(vectors)
+
+
+def _evaluate_stencil(
+    vectors: tuple[tuple[float, ...], ...],
+    *,
+    column: int,
+    center: float,
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    evaluator: BoundEvaluator,
+) -> tuple[
+    list[tuple[float, ...]] | None,
+    list[float] | None,
+    EvidenceFailure | None,
+]:
+    results: list[tuple[float, ...]] = []
+    displacements: list[float] = []
+    for trial in vectors:
+        result = _evaluate_vector(
+            trial,
+            problem=problem,
+            parameterization=parameterization,
+            evaluator=evaluator,
+        )
+        if isinstance(result, EvaluationFailure):
+            if result.validity == "INVALID_TRIAL":
+                return None, None, None
+            return (
+                None,
+                None,
+                EvidenceFailure(
+                    "residual_linearization",
+                    "fatal_stencil_evaluation_failure",
+                    result.category,
+                    accepted.identity,
+                ),
+            )
+        results.append(tuple(float(item) for item in result.residuals))
+        displacements.append(trial[column] - center)
+    return results, displacements, None
+
+
+def _stencil_estimates(
+    orientation: str,
+    results: Sequence[Sequence[float]],
+    base_residuals: tuple[float, ...],
+    displacements: Sequence[float],
+) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    if orientation == "centered":
+        coarse = _three_point_derivative(
+            results[0],
+            base_residuals,
+            results[3],
+            displacements[0],
+            displacements[3],
+        )
+        fine = _three_point_derivative(
+            results[1],
+            base_residuals,
+            results[2],
+            displacements[1],
+            displacements[2],
+        )
+        return fine, coarse
+    fine = _three_point_derivative(
+        results[0],
+        base_residuals,
+        results[1],
+        displacements[0],
+        displacements[1],
+    )
+    coarse = _three_point_derivative(
+        results[1],
+        base_residuals,
+        results[2],
+        displacements[1],
+        displacements[2],
+    )
+    return fine, coarse
+
+
+def _assess_stencil(
+    fine: tuple[float, ...],
+    coarse: tuple[float, ...],
+    results: Sequence[Sequence[float]],
+    base_residuals: tuple[float, ...],
+    displacements: Sequence[float],
+    policy: UncertaintyPolicy,
+    output_scale: float,
+) -> tuple[float, float, float, bool]:
+    discrepancy = _max_norm(
+        tuple(left - right for left, right in zip(fine, coarse, strict=True))
+    )
+    derivative_scale = max(_max_norm(fine), _max_norm(coarse))
+    function_scale = max(
+        output_scale,
+        _max_norm(base_residuals),
+        *(_max_norm(result) for result in results),
+    )
+    minimum_displacement = min(abs(item) for item in displacements)
+    roundoff = (
+        policy.roundoff_multiplier * _EPSILON * function_scale / minimum_displacement
+    )
+    threshold = policy.relative_step_tolerance * derivative_scale + roundoff
+    return discrepancy, derivative_scale, roundoff, discrepancy <= threshold
+
+
+def _linearize_residual_column(
+    accepted: AcceptedFitResult,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    evaluator: BoundEvaluator,
+    policy: UncertaintyPolicy,
+    base_residuals: tuple[float, ...],
+    column: int,
+    param_id: str,
+    scale: float,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
+) -> tuple[LinearizationColumn | None, tuple[object, ...], EvidenceFailure | None]:
+    center = accepted.vector[column]
+    orientations = _column_orientations(
+        center,
+        problem.lower_bounds[column],
+        problem.upper_bounds[column],
+    )
+    nominal = _NOMINAL_STEP_FACTOR * scale
+    trajectory: list[object] = []
+    if not orientations:
+        return (
+            None,
+            tuple(trajectory),
+            EvidenceFailure(
+                "residual_linearization",
+                "exhausted_exact_feasible_distance",
+                f"No nonzero feasible displacement exists for {param_id}",
+                accepted.identity,
+                _identity("residual-column-trajectory", trajectory),
+                ("exhausted_exact_feasible_distance",),
+            ),
+        )
+    attempt = 0
+    for orientation, maximum in orientations:
+        orientation_had_feasible_stencil = False
+        for step in _step_candidates(nominal, maximum, policy):
+            _raise_if_terminated(cancellation_probe)
+            attempt += 1
+            vectors = _stencil_vectors(accepted.vector, column, step, orientation)
+            if vectors is None:
+                trajectory.append((orientation, _float_token(step), "not_distinct"))
+                continue
+            results, displacements, failure = _evaluate_stencil(
+                vectors,
+                column=column,
+                center=center,
+                accepted=accepted,
+                problem=problem,
+                parameterization=parameterization,
+                evaluator=evaluator,
+            )
+            if failure is not None:
+                trajectory.append(
+                    (
+                        orientation,
+                        _float_token(step),
+                        "fatal_evaluation_failure",
+                        failure.identity,
+                    )
+                )
+                return (
+                    None,
+                    tuple(trajectory),
+                    EvidenceFailure(
+                        failure.stage,
+                        failure.category,
+                        failure.message,
+                        failure.source_identity,
+                        _identity("residual-column-trajectory", trajectory),
+                        ("fatal_stencil_evaluation_termination",),
+                    ),
+                )
+            if results is None or displacements is None:
+                trajectory.append((orientation, _float_token(step), "invalid_trial"))
+                continue
+            orientation_had_feasible_stencil = True
+            fine, coarse = _stencil_estimates(
+                orientation,
+                results,
+                base_residuals,
+                displacements,
+            )
+            discrepancy, derivative_scale, roundoff, reliable = _assess_stencil(
+                fine,
+                coarse,
+                results,
+                base_residuals,
+                displacements,
+                policy,
+                1.0,
+            )
+            trajectory.append(
+                (
+                    orientation,
+                    _float_token(step),
+                    tuple(_float_token(item) for item in displacements),
+                    _float_token(discrepancy),
+                    _float_token(derivative_scale),
+                    _float_token(roundoff),
+                    reliable,
+                )
+            )
+            if reliable:
+                fingerprint = _identity("residual-column-trajectory", trajectory)
+                return (
+                    LinearizationColumn(
+                        param_id,
+                        orientation,
+                        nominal,
+                        tuple(displacements),
+                        fine,
+                        coarse,
+                        discrepancy,
+                        derivative_scale,
+                        roundoff,
+                        attempt,
+                        "successful_reliable_estimate",
+                        fingerprint,
+                    ),
+                    tuple(trajectory),
+                    None,
+                )
+        if orientation == "centered" and orientation_had_feasible_stencil:
+            break
+    category = (
+        "loss_of_distinct_binary64_representation"
+        if trajectory
+        and all(
+            len(item) == 3 and item[2] == "not_distinct"
+            for item in trajectory
+            if isinstance(item, tuple)
+        )
+        else "exhausted_declared_step_search_extent"
+    )
+    return (
+        None,
+        tuple(trajectory),
+        EvidenceFailure(
+            "residual_linearization",
+            category,
+            f"No reliable feasible stencil for {param_id}",
+            accepted.identity,
+            _identity("residual-column-trajectory", trajectory),
+            (
+                "exhausted_declared_smaller_step_extent",
+                "exhausted_declared_larger_step_extent",
+            ),
+        ),
+    )
+
+
+def _linearize_residuals(
+    accepted: AcceptedFitResult,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    policy: UncertaintyPolicy,
+    request_identity: str,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
+) -> tuple[ResidualJacobianEvidence | None, EvidenceFailure | None]:
+    _raise_if_terminated(cancellation_probe)
+    evaluator = engine.new_evaluator()
+    base = _evaluate_vector(
+        accepted.vector,
+        problem=problem,
+        parameterization=parameterization,
+        evaluator=evaluator,
+    )
+    if isinstance(base, EvaluationFailure):
+        return None, EvidenceFailure(
+            "residual_linearization",
+            "accepted_point_evaluation_failed",
+            base.category,
+            accepted.identity,
+        )
+    if base.identity != accepted.evaluation_result.identity:
+        return None, EvidenceFailure(
+            "residual_linearization",
+            "fresh_accepted_point_mismatch",
+            "Fresh uncertainty baseline differs from accepted materialization",
+            accepted.identity,
+        )
+    base_residuals = tuple(float(value) for value in base.residuals)
+    scales = tuple(value for _param_id, value in policy.coordinate_scales)
+    column_values: list[tuple[float, ...]] = []
+    column_evidence: list[LinearizationColumn] = []
+    aggregate_trajectory: list[object] = []
+    for column, (param_id, scale) in enumerate(policy.coordinate_scales):
+        _raise_if_terminated(cancellation_probe)
+        accepted_column, trajectory, failure = _linearize_residual_column(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            evaluator=evaluator,
+            policy=policy,
+            base_residuals=base_residuals,
+            column=column,
+            param_id=param_id,
+            scale=scale,
+            cancellation_probe=cancellation_probe,
+        )
+        aggregate_trajectory.append((param_id, tuple(trajectory)))
+        if failure is not None:
+            return None, failure
+        if accepted_column is None:
+            return None, EvidenceFailure(
+                "residual_linearization",
+                "reliable_stencil_unavailable",
+                f"No reliable feasible stencil for {param_id}",
+                accepted.identity,
+            )
+        column_evidence.append(accepted_column)
+        column_values.append(accepted_column.fine_estimate)
+    matrix = tuple(
+        tuple(column[row] for column in column_values)
+        for row in range(len(base_residuals))
+    )
+    trajectory_fingerprint = _identity(
+        "residual-linearization-trajectory",
+        aggregate_trajectory,
+    )
+    return (
+        ResidualJacobianEvidence(
+            request_identity,
+            accepted.identity,
+            accepted.evaluation_result.identity,
+            problem.identity,
+            problem.source_snapshot.occurrence_identity,
+            problem.source_snapshot.revision,
+            parameterization.identity,
+            parameterization.evaluator_identity,
+            parameterization.program.fingerprint,
+            engine.plan.identity,
+            policy.identity,
+            policy.calibration_identity,
+            policy.numerical_compatibility_requirement,
+            problem.controlled_ids,
+            accepted.vector,
+            scales,
+            matrix,
+            tuple(column_evidence),
+            trajectory_fingerprint,
+        ),
+        None,
+    )
+
+
+def _profiled_normalization_regular(
+    accepted: AcceptedFitResult,
+    engine: EvaluationEngine,
+) -> bool:
+    for descriptor, profile in zip(
+        engine.plan.profiles,
+        accepted.evaluation_result.profiles,
+        strict=True,
+    ):
+        if not descriptor.is_scaled:
+            continue
+        retained = descriptor.retained_observation_indices
+        denominator = _pairwise_sum(
+            tuple(
+                (
+                    float(
+                        accepted.evaluation_result.unscaled_calculations[
+                            descriptor.observation_offset + index
+                        ]
+                    )
+                    / descriptor.uncertainties[index]
+                )
+                ** 2
+                for index in retained
+            )
+        )
+        if denominator <= 0.0 or not math.isfinite(profile.normalization_factor):
+            return False
+    return True
+
+
+def _boundary_claims(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    covariance: tuple[tuple[float, ...], ...],
+    residual_variance_scale: float,
+    affine_feasibility_policy: str,
+) -> tuple[ClaimAssessment, ClaimAssessment, ClaimAssessment]:
+    strict_interior = True
+    separation = ClaimState.SATISFIED
+    details: list[str] = []
+    for index, (value, lower, upper) in enumerate(
+        zip(
+            accepted.vector,
+            problem.lower_bounds,
+            problem.upper_bounds,
+            strict=True,
+        )
+    ):
+        if not lower <= value <= upper:
+            return (
+                ClaimAssessment("INTERIOR_POINT", ClaimState.VIOLATED),
+                ClaimAssessment("BOUNDARY_SEPARATION", ClaimState.VIOLATED),
+                ClaimAssessment(
+                    "AFFINE_FEASIBILITY",
+                    ClaimState.VIOLATED,
+                    "Accepted point is outside its box",
+                ),
+            )
+        if value in (lower, upper):
+            strict_interior = False
+        for label, slack in (
+            ("lower", value - lower),
+            ("upper", upper - value),
+        ):
+            if math.isinf(slack):
+                continue
+            variance = covariance[index][index]
+            if residual_variance_scale == 0.0 or variance == 0.0:
+                separation = ClaimState.INDETERMINATE
+                details.append(f"{label}[{index}]: zero scaled variance")
+                continue
+            if variance < 0.0 or not math.isfinite(variance):
+                separation = ClaimState.INDETERMINATE
+                details.append(f"{label}[{index}]: invalid directional variance")
+                continue
+            zeta = float(slack / math.sqrt(variance))
+            details.append(f"{label}[{index}] zeta={zeta.hex()}")
+            if not math.isfinite(zeta):
+                separation = ClaimState.INDETERMINATE
+            elif zeta <= _BOUNDARY_THRESHOLD:
+                separation = ClaimState.VIOLATED
+    return (
+        ClaimAssessment(
+            "INTERIOR_POINT",
+            ClaimState.SATISFIED if strict_interior else ClaimState.VIOLATED,
+        ),
+        ClaimAssessment("BOUNDARY_SEPARATION", separation, "; ".join(details)),
+        ClaimAssessment(
+            "AFFINE_FEASIBILITY",
+            ClaimState.NOT_APPLICABLE,
+            affine_feasibility_policy,
+        ),
+    )
+
+
+def _residual_variance_scale(
+    accepted: AcceptedFitResult,
+    *,
+    degrees_of_freedom: int,
+    policy: UncertaintyPolicy,
+) -> tuple[float | None, EvidenceFailure | None]:
+    if not math.isfinite(accepted.chi_square):
+        return None, EvidenceFailure(
+            "covariance",
+            "non_finite_chi_square",
+            "Accepted chi-square is non-finite",
+            accepted.identity,
+        )
+    if accepted.chi_square < 0.0:
+        return None, EvidenceFailure(
+            "covariance",
+            "negative_chi_square",
+            "Accepted chi-square is negative",
+            accepted.identity,
+        )
+    if (
+        policy.residual_variance_scaling
+        is ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+    ):
+        return 1.0, None
+    scale = accepted.chi_square / degrees_of_freedom
+    if not math.isfinite(scale) or scale < 0.0:
+        return None, EvidenceFailure(
+            "covariance",
+            "invalid_residual_variance_scale",
+            "Estimated residual variance is negative or non-finite",
+            accepted.identity,
+        )
+    return float(scale), None
+
+
+def _covariance_from_jacobian(
+    accepted: AcceptedFitResult,
+    jacobian: ResidualJacobianEvidence,
+    *,
+    problem: OptimizationProblem,
+    engine: EvaluationEngine,
+    policy: UncertaintyPolicy,
+    request_identity: str,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
+) -> tuple[CovarianceEvidence | None, RankDiagnostic | None, EvidenceFailure | None]:
+    _raise_if_terminated(cancellation_probe)
+    residual_count = jacobian.residual_count
+    coordinate_count = jacobian.coordinate_count
+    normalization_count = sum(
+        1 for profile in engine.plan.profiles if profile.is_scaled
+    )
+    degrees_of_freedom = residual_count - coordinate_count - normalization_count
+    if residual_count - normalization_count < coordinate_count:
+        return (
+            None,
+            None,
+            EvidenceFailure(
+                "covariance",
+                "insufficient_effective_observations",
+                "m - g is smaller than the controlled-coordinate count",
+                jacobian.identity,
+            ),
+        )
+    if (
+        policy.residual_variance_scaling
+        is ResidualVarianceScaling.ESTIMATED_COMMON_RESIDUAL_VARIANCE
+        and degrees_of_freedom <= 0
+    ):
+        return (
+            None,
+            None,
+            EvidenceFailure(
+                "covariance",
+                "non_positive_nominal_residual_degrees_of_freedom",
+                "Estimated common residual variance requires positive nu",
+                jacobian.identity,
+            ),
+        )
+    matrix = np.asarray(jacobian.matrix, dtype=np.float64)
+    scales = np.asarray(jacobian.coordinate_scales, dtype=np.float64)
+    scaled = matrix * scales[np.newaxis, :]
+    _raise_if_terminated(cancellation_probe)
+    try:
+        _left, singular_array, right_transpose = svd(
+            scaled,
+            full_matrices=False,
+            compute_uv=True,
+            overwrite_a=False,
+            check_finite=True,
+            lapack_driver=policy.svd_driver,
+        )
+    except Exception as error:  # noqa: BLE001 - declared third-party kernel fence
+        return (
+            None,
+            None,
+            EvidenceFailure(
+                "covariance",
+                "svd_failure",
+                str(error),
+                jacobian.identity,
+            ),
+        )
+    _raise_if_terminated(cancellation_probe)
+    singular_values = tuple(
+        _finite(value, name=f"singular value[{index}]")
+        for index, value in enumerate(singular_array)
+    )
+    spectrum_error = _singular_spectrum_error(singular_values, coordinate_count)
+    if spectrum_error is not None:
+        return (
+            None,
+            None,
+            EvidenceFailure(
+                "covariance",
+                spectrum_error[0],
+                spectrum_error[1],
+                jacobian.identity,
+            ),
+        )
+    largest = singular_values[0] if singular_values else 0.0
+    threshold = (
+        policy.rank_absolute_tolerance + policy.rank_relative_tolerance * largest
+    )
+    threshold = _finite(threshold, name="rank threshold")
+    rank = sum(value > threshold for value in singular_values)
+    normalized = tuple(
+        0.0 if largest == 0.0 else value / largest for value in singular_values
+    )
+    column_norms = tuple(
+        _finite(
+            math.sqrt(
+                _pairwise_sum(tuple(float(value) ** 2 for value in scaled[:, index]))
+            ),
+            name=f"scaled column norm[{index}]",
+        )
+        for index in range(coordinate_count)
+    )
+    right = _canonical_right_singular_vectors(right_transpose.T)
+    weak_threshold = _finite(
+        max(threshold, policy.weak_relative_tolerance * largest),
+        name="weak-subspace threshold",
+    )
+
+    def projector(indices: Sequence[int]) -> tuple[tuple[float, ...], ...]:
+        factor = tuple(
+            tuple(
+                _finite(right[row, column], name="right singular vector")
+                for column in indices
+            )
+            for row in range(coordinate_count)
+        )
+        return _gram_matrix(factor)
+
+    identifiable_projector = projector(tuple(range(rank)))
+    null_projector = projector(tuple(range(rank, coordinate_count)))
+    weak_projector = projector(
+        tuple(
+            index
+            for index, value in enumerate(singular_values)
+            if threshold < value <= weak_threshold
+        )
+    )
+    rank_diagnostic = RankDiagnostic(
+        jacobian.identity,
+        jacobian.controlled_ids,
+        singular_values,
+        normalized,
+        column_norms,
+        threshold,
+        weak_threshold,
+        rank,
+        identifiable_projector,
+        null_projector,
+        weak_projector,
+    )
+    if rank != coordinate_count:
+        return (
+            None,
+            rank_diagnostic,
+            EvidenceFailure(
+                "covariance",
+                "rank_deficient",
+                f"Scaled Jacobian rank {rank} is below {coordinate_count}",
+                jacobian.identity,
+            ),
+        )
+    smallest = singular_values[-1]
+    jacobian_condition = _finite(largest / smallest, name="Jacobian condition")
+    information_condition = jacobian_condition * jacobian_condition
+    if not math.isfinite(information_condition):
+        return (
+            None,
+            rank_diagnostic,
+            EvidenceFailure(
+                "covariance",
+                "non_finite_information_condition",
+                "Squared Jacobian condition is non-finite",
+                jacobian.identity,
+            ),
+        )
+    residual_variance_scale, variance_failure = _residual_variance_scale(
+        accepted,
+        degrees_of_freedom=degrees_of_freedom,
+        policy=policy,
+    )
+    if variance_failure is not None or residual_variance_scale is None:
+        return None, rank_diagnostic, variance_failure
+    chi_square = _finite(accepted.chi_square, name="accepted chi-square")
+    unscaled_factor = tuple(
+        tuple(
+            _finite(
+                scales[row] * right[row, column] / singular_values[column],
+                name=f"unscaled covariance factor[{row},{column}]",
+            )
+            for column in range(coordinate_count)
+        )
+        for row in range(coordinate_count)
+    )
+    unscaled_covariance = _gram_matrix(unscaled_factor)
+    scale_root = math.sqrt(residual_variance_scale)
+    factor = tuple(
+        tuple(
+            _finite(scale_root * value, name="scaled covariance factor")
+            for value in row
+        )
+        for row in unscaled_factor
+    )
+    covariance = _gram_matrix(factor)
+    if _has_positive_scale_zero_variance(covariance, residual_variance_scale):
+        return (
+            None,
+            rank_diagnostic,
+            EvidenceFailure(
+                "covariance",
+                "covariance_factor_underflow",
+                "Positive-scale full-rank covariance factor produced zero variance",
+                jacobian.identity,
+            ),
+        )
+    interior, boundary, affine = _boundary_claims(
+        accepted,
+        problem,
+        covariance,
+        residual_variance_scale,
+        policy.affine_feasibility_policy,
+    )
+    conditioning = ClaimAssessment(
+        "CONDITIONING_ADEQUACY",
+        ClaimState.SATISFIED
+        if jacobian_condition <= policy.conditioning_limit
+        else ClaimState.VIOLATED,
+        f"kappa_J={float(jacobian_condition).hex()}",
+    )
+    normalization = ClaimAssessment(
+        "PROFILED_NORMALIZATION_REGULARITY",
+        ClaimState.SATISFIED
+        if _profiled_normalization_regular(accepted, engine)
+        else ClaimState.VIOLATED,
+    )
+    variance_nondegeneracy = ClaimAssessment(
+        "RESIDUAL_VARIANCE_NONDEGENERACY",
+        ClaimState.NOT_APPLICABLE
+        if policy.residual_variance_scaling
+        is ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+        else (
+            ClaimState.SATISFIED
+            if residual_variance_scale > 0.0
+            else ClaimState.VIOLATED
+        ),
+    )
+    required = (
+        conditioning.state,
+        ClaimState.SATISFIED,
+        interior.state,
+        boundary.state,
+        normalization.state,
+        variance_nondegeneracy.state
+        if variance_nondegeneracy.state is not ClaimState.NOT_APPLICABLE
+        else ClaimState.SATISFIED,
+    )
+    claims = (
+        ClaimAssessment("AUTHORITATIVE_LINEAGE", ClaimState.SATISFIED),
+        ClaimAssessment("LOCAL_LINEARIZATION_REGULARITY", ClaimState.SATISFIED),
+        ClaimAssessment("EFFECTIVE_OBSERVATION_SUFFICIENCY", ClaimState.SATISFIED),
+        ClaimAssessment("FULL_COLUMN_RANK", ClaimState.SATISFIED),
+        conditioning,
+        ClaimAssessment(
+            "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
+            ClaimState.SATISFIED,
+            "OptimizationProblem v1 represents a box domain with a nonempty interior",
+        ),
+        interior,
+        boundary,
+        affine,
+        variance_nondegeneracy,
+        normalization,
+        ClaimAssessment("COVARIANCE_ARITHMETIC_INTEGRITY", ClaimState.SATISFIED),
+        ClaimAssessment(
+            "USABLE_LOCAL_COVARIANCE",
+            ClaimState.SATISFIED
+            if all(state is ClaimState.SATISFIED for state in required)
+            else (
+                ClaimState.INDETERMINATE
+                if ClaimState.INDETERMINATE in required
+                else ClaimState.VIOLATED
+            ),
+        ),
+    )
+    covariance_evidence = CovarianceEvidence(
+        request_identity,
+        jacobian.identity,
+        accepted.identity,
+        problem.identity,
+        accepted.parameterization_identity,
+        accepted.evaluation_result.plan_identity,
+        policy.identity,
+        policy.calibration_identity,
+        policy.numerical_compatibility_requirement,
+        accepted.controlled_ids,
+        tuple(unit for _param_id, unit in policy.coordinate_units),
+        accepted.vector,
+        jacobian.coordinate_scales,
+        policy.residual_variance_scaling,
+        residual_count,
+        coordinate_count,
+        normalization_count,
+        degrees_of_freedom,
+        chi_square,
+        residual_variance_scale,
+        rank,
+        singular_values,
+        threshold,
+        jacobian_condition,
+        information_condition,
+        unscaled_covariance,
+        factor,
+        covariance,
+        claims,
+    )
+    return covariance_evidence, rank_diagnostic, None
+
+
+def _marginal_errors(
+    *,
+    source_identity: str,
+    source_family: str,
+    output_ids: tuple[str, ...],
+    units: tuple[ParameterUnit, ...],
+    covariance: tuple[tuple[float, ...], ...],
+    residual_variance_degenerate: bool,
+    source_reportable: bool,
+    inherited_claims: tuple[ClaimAssessment, ...],
+) -> MarginalErrorEvidence:
+    entries: list[ScalarEvidenceEntry] = []
+    for index, param_id in enumerate(output_ids):
+        variance = covariance[index][index]
+        if residual_variance_degenerate and variance == 0.0:
+            entries.append(
+                ScalarEvidenceEntry(
+                    param_id,
+                    None,
+                    "RESIDUAL_VARIANCE_DEGENERACY",
+                    0.0,
+                )
+            )
+        elif variance > 0.0 and math.isfinite(variance):
+            entries.append(
+                ScalarEvidenceEntry(param_id, math.sqrt(variance), "AVAILABLE")
+            )
+        else:
+            entries.append(
+                ScalarEvidenceEntry(
+                    param_id,
+                    None,
+                    "INVALID_VARIANCE",
+                    variance if math.isfinite(variance) else None,
+                )
+            )
+    complete = all(item.value is not None for item in entries)
+    reportable = source_reportable and complete
+    claims = (
+        *inherited_claims,
+        ClaimAssessment(
+            "MARGINAL_VARIANCE_VALIDITY",
+            ClaimState.SATISFIED if complete else ClaimState.VIOLATED,
+        ),
+        ClaimAssessment(
+            "MARGINAL_SCOPE_REPORTABILITY",
+            ClaimState.SATISFIED if reportable else ClaimState.VIOLATED,
+        ),
+    )
+    return MarginalErrorEvidence(
+        source_identity,
+        source_family,
+        output_ids,
+        units,
+        tuple(entries),
+        claims,
+        reportable,
+    )
+
+
+def _correlations(
+    *,
+    source_identity: str,
+    source_family: str,
+    output_ids: tuple[str, ...],
+    units: tuple[ParameterUnit, ...],
+    covariance: tuple[tuple[float, ...], ...],
+    residual_variance_degenerate: bool,
+    source_reportable: bool,
+    policy: UncertaintyPolicy,
+    inherited_claims: tuple[ClaimAssessment, ...],
+) -> CorrelationEvidence:
+    dimension = len(output_ids)
+    entries: list[list[CorrelationEntry]] = [
+        [CorrelationEntry(None, "UNAVAILABLE") for _right in range(dimension)]
+        for _left in range(dimension)
+    ]
+    standard_errors = tuple(
+        math.sqrt(covariance[index][index]) if covariance[index][index] > 0.0 else None
+        for index in range(dimension)
+    )
+    tolerance = policy.correlation_roundoff_multiplier * _EPSILON
+    for left in range(dimension):
+        if standard_errors[left] is not None and not residual_variance_degenerate:
+            entries[left][left] = CorrelationEntry(1.0, "AVAILABLE", 1.0)
+        else:
+            entries[left][left] = CorrelationEntry(
+                None,
+                "RESIDUAL_VARIANCE_DEGENERACY"
+                if residual_variance_degenerate
+                else "INVALID_VARIANCE",
+            )
+        for right in range(left + 1, dimension):
+            left_error = standard_errors[left]
+            right_error = standard_errors[right]
+            if residual_variance_degenerate:
+                entry = CorrelationEntry(None, "RESIDUAL_VARIANCE_DEGENERACY")
+            elif left_error is None or right_error is None:
+                entry = CorrelationEntry(None, "INVALID_VARIANCE")
+            else:
+                raw = (covariance[left][right] / left_error) / right_error
+                if not math.isfinite(raw):
+                    entry = CorrelationEntry(None, "NON_FINITE_CORRELATION")
+                else:
+                    excess = max(0.0, abs(raw) - 1.0)
+                    if abs(raw) <= 1.0:
+                        entry = CorrelationEntry(
+                            raw, "AVAILABLE", raw, excess, tolerance
+                        )
+                    elif excess <= tolerance:
+                        canonical = math.copysign(1.0, raw)
+                        entry = CorrelationEntry(
+                            canonical,
+                            "ENDPOINT_CANONICALIZED",
+                            raw,
+                            excess,
+                            tolerance,
+                        )
+                    else:
+                        entry = CorrelationEntry(
+                            None,
+                            "CORRELATION_RANGE_VIOLATION",
+                            raw,
+                            excess,
+                            tolerance,
+                        )
+            entries[left][right] = entry
+            entries[right][left] = entry
+    complete = all(item.value is not None for row in entries for item in row)
+    reportable = source_reportable and complete
+    claims = (
+        *inherited_claims,
+        ClaimAssessment(
+            "CORRELATION_ENTRY_VALIDITY",
+            ClaimState.SATISFIED if complete else ClaimState.VIOLATED,
+        ),
+        ClaimAssessment(
+            "CORRELATION_SCOPE_REPORTABILITY",
+            ClaimState.SATISFIED if reportable else ClaimState.VIOLATED,
+        ),
+    )
+    return CorrelationEvidence(
+        source_identity,
+        source_family,
+        output_ids,
+        units,
+        tuple(tuple(row) for row in entries),
+        claims,
+        reportable,
+    )
+
+
+def _combine_gradients(
+    left: tuple[float, ...],
+    right: tuple[float, ...],
+    operation: str,
+    left_value: float,
+    right_value: float,
+) -> tuple[float, ...]:
+    if operation == "add":
+        return tuple(a + b for a, b in zip(left, right, strict=True))
+    if operation == "subtract":
+        return tuple(a - b for a, b in zip(left, right, strict=True))
+    if operation == "multiply":
+        return tuple(
+            a * right_value + left_value * b for a, b in zip(left, right, strict=True)
+        )
+    if right_value == 0.0:
+        raise ArithmeticError("constraint derivative divides by zero")
+    return tuple(
+        (a * right_value - left_value * b) / (right_value * right_value)
+        for a, b in zip(left, right, strict=True)
+    )
+
+
+def _scientific_function_output(
+    expression: FunctionExpression,
+    function: Callable[..., object],
+    arguments: Sequence[float],
+) -> float:
+    result = function(*arguments)
+    if expression.component is None:
+        return _finite(result, name=f"function {expression.function_id!r} output")
+    if not isinstance(result, Mapping) or expression.component not in result:
+        raise ValueError(
+            f"Scientific function {expression.function_id!r} lacks component "
+            f"{expression.component!r}"
+        )
+    return _finite(
+        cast("Mapping[str, object]", result)[expression.component],
+        name=(
+            f"function {expression.function_id!r} component {expression.component!r}"
+        ),
+    )
+
+
+def _scientific_function_partial(
+    expression: FunctionExpression,
+    function: Callable[..., object],
+    arguments: tuple[float, ...],
+    argument_index: int,
+    capability: FunctionFiniteDifferenceCapability,
+    policy: UncertaintyPolicy,
+) -> tuple[float, FunctionPartialDiagnostic]:
+    center = arguments[argument_index]
+    nominal = _NOMINAL_STEP_FACTOR * capability.argument_scales[argument_index]
+    base = (_scientific_function_output(expression, function, arguments),)
+    trajectory: list[object] = []
+    for attempt, step in enumerate(
+        _step_candidates(nominal, math.inf, policy),
+        start=1,
+    ):
+        trial_arguments: list[tuple[float, ...]] = []
+        displacements: list[float] = []
+        represented = {center}
+        for multiplier in (-2.0, -1.0, 1.0, 2.0):
+            updated = center + multiplier * step
+            if not math.isfinite(updated) or updated in represented:
+                break
+            represented.add(updated)
+            trial = list(arguments)
+            trial[argument_index] = updated
+            trial_arguments.append(tuple(trial))
+            displacements.append(updated - center)
+        if len(trial_arguments) != 4:
+            trajectory.append((_float_token(step), "not_distinct"))
+            continue
+        try:
+            results = tuple(
+                (_scientific_function_output(expression, function, trial),)
+                for trial in trial_arguments
+            )
+        except (ArithmeticError, FloatingPointError, TypeError, ValueError):
+            trajectory.append((_float_token(step), "domain_failure"))
+            continue
+        fine, coarse = _stencil_estimates(
+            "centered",
+            results,
+            base,
+            displacements,
+        )
+        discrepancy, derivative_scale, roundoff, reliable = _assess_stencil(
+            fine,
+            coarse,
+            results,
+            base,
+            displacements,
+            policy,
+            capability.output_scale,
+        )
+        trajectory.append(
+            (
+                _float_token(step),
+                tuple(_float_token(item) for item in displacements),
+                _float_token(discrepancy),
+                _float_token(derivative_scale),
+                _float_token(roundoff),
+                reliable,
+            )
+        )
+        if reliable:
+            fingerprint = _identity(
+                "scientific-function-partial-trajectory", trajectory
+            )
+            return (
+                fine[0],
+                FunctionPartialDiagnostic(
+                    capability.identity,
+                    expression.function_id,
+                    expression.component,
+                    argument_index,
+                    "centered_two_scale_numerical",
+                    fine[0],
+                    coarse[0],
+                    tuple(displacements),
+                    discrepancy,
+                    derivative_scale,
+                    roundoff,
+                    attempt,
+                    fingerprint,
+                    (
+                        ClaimAssessment(
+                            "FUNCTION_PARTIAL_RELIABILITY",
+                            ClaimState.SATISFIED,
+                        ),
+                    ),
+                ),
+            )
+    fingerprint = _identity("scientific-function-partial-trajectory", trajectory)
+    if trajectory and all(
+        isinstance(item, tuple) and len(item) == 2 and item[1] == "not_distinct"
+        for item in trajectory
+    ):
+        category = "function_partial_representation_loss"
+    elif trajectory and all(
+        isinstance(item, tuple)
+        and len(item) == 2
+        and item[1] in {"not_distinct", "domain_failure"}
+        for item in trajectory
+    ):
+        category = "function_partial_active_domain_failure"
+    else:
+        category = "unreliable_or_nondifferentiable_function_partial"
+    raise FunctionPartialFailure(
+        category,
+        f"No reliable numerical partial for function {expression.function_id!r} "
+        f"argument {argument_index}",
+        fingerprint,
+        (
+            "exhausted_declared_smaller_step_extent",
+            "exhausted_declared_larger_step_extent",
+        ),
+    )
+
+
+def _analytic_function_partials(
+    expression: FunctionExpression,
+    arguments: tuple[float, ...],
+    capability: FunctionAnalyticPartialCapability,
+) -> tuple[tuple[float, ...], tuple[FunctionPartialDiagnostic, ...]]:
+    if len(capability.partials) != len(arguments):
+        raise UncertaintyConstructionError(
+            f"Scientific function {expression.function_id!r} capability has the "
+            "wrong arity"
+        )
+    estimates: list[float] = []
+    diagnostics: list[FunctionPartialDiagnostic] = []
+    for index, partial in enumerate(capability.partials):
+        try:
+            estimate = _finite(
+                partial(*arguments),
+                name=f"analytic scientific-function partial[{index}]",
+            )
+        except (ArithmeticError, FloatingPointError, TypeError, ValueError) as error:
+            raise FunctionPartialFailure(
+                "analytic_function_partial_domain_failure",
+                str(error),
+                capability.implementation_identity,
+                ("versioned_analytic_partial_failed",),
+            ) from error
+        estimates.append(estimate)
+        diagnostics.append(
+            FunctionPartialDiagnostic(
+                capability.identity,
+                expression.function_id,
+                expression.component,
+                index,
+                "versioned_analytic_partial",
+                estimate,
+                None,
+                (),
+                0.0,
+                abs(estimate),
+                0.0,
+                1,
+                capability.implementation_identity,
+                (
+                    ClaimAssessment(
+                        "FUNCTION_PARTIAL_RELIABILITY",
+                        ClaimState.SATISFIED,
+                        capability.implementation_identity,
+                    ),
+                ),
+            )
+        )
+    return tuple(estimates), tuple(diagnostics)
+
+
+def _differentiate_function(
+    expression: FunctionExpression,
+    values: Mapping[str, _DerivativeValue],
+    dimension: int,
+    parameterization: ActiveParameterization,
+    policy: UncertaintyPolicy,
+    compiled_capabilities: CompiledConstraintLinearizationCapabilities,
+) -> _DerivativeValue:
+    arguments = tuple(
+        _differentiate_expression(
+            argument,
+            values,
+            dimension,
+            parameterization,
+            policy,
+            compiled_capabilities,
+        )
+        for argument in expression.arguments
+    )
+    capability = next(
+        (
+            item
+            for item in compiled_capabilities.capabilities
+            if (item.function_id, item.component)
+            == (expression.function_id, expression.component)
+        ),
+        None,
+    )
+    if capability is None:
+        raise UncertaintyConstructionError(
+            f"Scientific function {expression.function_id!r} lacks an explicitly "
+            "declared linearization capability"
+        )
+    function = parameterization.binder[expression.function_id]
+    argument_values = tuple(item.value for item in arguments)
+    if isinstance(capability, FunctionFiniteDifferenceCapability):
+        if len(capability.argument_scales) != len(arguments):
+            raise UncertaintyConstructionError(
+                f"Scientific function {expression.function_id!r} capability has the "
+                "wrong arity"
+            )
+        partial_results = tuple(
+            _scientific_function_partial(
+                expression,
+                function,
+                argument_values,
+                index,
+                capability,
+                policy,
+            )
+            for index in range(len(arguments))
+        )
+        partials = tuple(item[0] for item in partial_results)
+        diagnostics = tuple(item[1] for item in partial_results)
+    else:
+        partials, diagnostics = _analytic_function_partials(
+            expression,
+            argument_values,
+            capability,
+        )
+    value = _scientific_function_output(expression, function, argument_values)
+    gradient = tuple(
+        _finite(
+            _pairwise_sum(
+                tuple(
+                    partial * arguments[index].gradient[coordinate]
+                    for index, partial in enumerate(partials)
+                )
+            ),
+            name="scientific-function constraint derivative",
+        )
+        for coordinate in range(dimension)
+    )
+    structural = frozenset().union(
+        *(item.structural_dependencies for item in arguments)
+    )
+    inherited_diagnostics = tuple(
+        diagnostic
+        for argument in arguments
+        for diagnostic in argument.function_partial_diagnostics
+    )
+    return _DerivativeValue(
+        value,
+        gradient,
+        structural,
+        inherited_diagnostics + diagnostics,
+    )
+
+
+def _differentiate_expression(
+    expression: ScalarExpression,
+    values: Mapping[str, _DerivativeValue],
+    dimension: int,
+    parameterization: ActiveParameterization,
+    policy: UncertaintyPolicy,
+    compiled_capabilities: CompiledConstraintLinearizationCapabilities,
+) -> _DerivativeValue:
+    zero = (0.0,) * dimension
+    if isinstance(expression, LiteralExpression):
+        return _DerivativeValue(expression.value, zero, frozenset())
+    if isinstance(expression, ReferenceExpression):
+        return values[expression.param_id]
+    if isinstance(expression, UnaryExpression):
+        operand = _differentiate_expression(
+            expression.operand,
+            values,
+            dimension,
+            parameterization,
+            policy,
+            compiled_capabilities,
+        )
+        if expression.operator == "positive":
+            return operand
+        return _DerivativeValue(
+            -operand.value,
+            tuple(-item for item in operand.gradient),
+            operand.structural_dependencies,
+            operand.function_partial_diagnostics,
+        )
+    if isinstance(expression, BinaryExpression):
+        left = _differentiate_expression(
+            expression.left,
+            values,
+            dimension,
+            parameterization,
+            policy,
+            compiled_capabilities,
+        )
+        right = _differentiate_expression(
+            expression.right,
+            values,
+            dimension,
+            parameterization,
+            policy,
+            compiled_capabilities,
+        )
+        if expression.operator == "add":
+            value = left.value + right.value
+        elif expression.operator == "subtract":
+            value = left.value - right.value
+        elif expression.operator == "multiply":
+            value = left.value * right.value
+        else:
+            value = left.value / right.value
+        return _DerivativeValue(
+            _finite(value, name="constraint linearization value"),
+            tuple(
+                _finite(item, name="constraint derivative")
+                for item in _combine_gradients(
+                    left.gradient,
+                    right.gradient,
+                    expression.operator,
+                    left.value,
+                    right.value,
+                )
+            ),
+            left.structural_dependencies | right.structural_dependencies,
+            left.function_partial_diagnostics + right.function_partial_diagnostics,
+        )
+    if isinstance(expression, FunctionExpression):
+        return _differentiate_function(
+            expression,
+            values,
+            dimension,
+            parameterization,
+            policy,
+            compiled_capabilities,
+        )
+    raise TypeError("Unknown constraint expression")
+
+
+def _constraint_scope_failure(
+    accepted: AcceptedFitResult,
+    parameterization: ActiveParameterization,
+    output_scope: tuple[str, ...],
+) -> EvidenceFailure | None:
+    if len(set(output_scope)) != len(output_scope):
+        return EvidenceFailure(
+            "constraint_linearization",
+            "duplicate_output_scope",
+            "Constraint-output scope must contain unique stable IDs",
+            accepted.identity,
+        )
+    if any(param_id not in parameterization.scope_ids for param_id in output_scope):
+        return EvidenceFailure(
+            "constraint_linearization",
+            "unknown_output_scope",
+            "Constraint-output scope contains an unknown stable ID",
+            accepted.identity,
+        )
+    return None
+
+
+def _initial_derivative_values(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+) -> dict[str, _DerivativeValue]:
+    controlled_index = {
+        param_id: index for index, param_id in enumerate(problem.controlled_ids)
+    }
+    dimension = len(problem.controlled_ids)
+    zero = (0.0,) * dimension
+    resolved = accepted.evaluation_result.resolved_values
+    values: dict[str, _DerivativeValue] = {}
+    for param_id in parameterization.independent_ids:
+        if param_id in controlled_index:
+            gradient = tuple(
+                1.0 if index == controlled_index[param_id] else 0.0
+                for index in range(dimension)
+            )
+            structural = frozenset((param_id,))
+        else:
+            gradient = zero
+            structural = frozenset()
+        values[param_id] = _DerivativeValue(resolved[param_id], gradient, structural)
+    return values
+
+
+def _differentiate_target(
+    target_id: str,
+    *,
+    values: dict[str, _DerivativeValue],
+    constraints: Mapping[str, CompiledConstraint],
+    resolved: Mapping[str, float],
+    dimension: int,
+    parameterization: ActiveParameterization,
+    policy: UncertaintyPolicy,
+    compiled_capabilities: CompiledConstraintLinearizationCapabilities,
+) -> _DerivativeValue:
+    existing = values.get(target_id)
+    if existing is not None:
+        return existing
+    constraint = constraints[target_id]
+    dependencies = constraint.dependencies
+    for dependency in dependencies:
+        _differentiate_target(
+            dependency,
+            values=values,
+            constraints=constraints,
+            resolved=resolved,
+            dimension=dimension,
+            parameterization=parameterization,
+            policy=policy,
+            compiled_capabilities=compiled_capabilities,
+        )
+    differentiated = _differentiate_expression(
+        constraint.expression,
+        values,
+        dimension,
+        parameterization,
+        policy,
+        compiled_capabilities,
+    )
+    if differentiated.value != resolved[target_id]:
+        raise UncertaintyConstructionError(
+            f"Constraint linearization value differs for {target_id}"
+        )
+    values[target_id] = differentiated
+    return differentiated
+
+
+def _constraint_rows(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    policy: UncertaintyPolicy,
+    compiled_capabilities: CompiledConstraintLinearizationCapabilities,
+    output_scope: tuple[str, ...],
+) -> tuple[
+    tuple[tuple[float, ...], ...] | None,
+    tuple[tuple[str, ...], ...] | None,
+    tuple[FunctionPartialDiagnostic, ...] | None,
+    EvidenceFailure | None,
+]:
+    values = _initial_derivative_values(accepted, problem, parameterization)
+    constraints = {
+        constraint.target_id: constraint
+        for constraint in parameterization.program.constraints
+    }
+    resolved = accepted.evaluation_result.resolved_values
+    rows: list[tuple[float, ...]] = []
+    dependencies: list[tuple[str, ...]] = []
+    diagnostics: dict[str, FunctionPartialDiagnostic] = {}
+    try:
+        for param_id in output_scope:
+            role = parameterization.role(param_id)
+            if (
+                param_id in parameterization.independent_ids
+                and param_id not in problem.controlled_ids
+            ):
+                return (
+                    None,
+                    None,
+                    None,
+                    EvidenceFailure(
+                        "constraint_linearization",
+                        "held_independent_outside_uncertainty_basis",
+                        f"Held parameter {param_id} cannot be requested",
+                        accepted.identity,
+                    ),
+                )
+            value = _differentiate_target(
+                param_id,
+                values=values,
+                constraints=constraints,
+                resolved=resolved,
+                dimension=len(problem.controlled_ids),
+                parameterization=parameterization,
+                policy=policy,
+                compiled_capabilities=compiled_capabilities,
+            )
+            if role is ParameterRole.DERIVED and not value.structural_dependencies:
+                return (
+                    None,
+                    None,
+                    None,
+                    EvidenceFailure(
+                        "constraint_linearization",
+                        "derived_output_outside_controlled_basis",
+                        f"Derived parameter {param_id} has no controlled dependency path",
+                        accepted.identity,
+                    ),
+                )
+            rows.append(value.gradient)
+            dependencies.append(
+                tuple(
+                    item
+                    for item in problem.controlled_ids
+                    if item in value.structural_dependencies
+                )
+            )
+            diagnostics.update(
+                (item.identity, item) for item in value.function_partial_diagnostics
+            )
+    except FunctionPartialFailure as error:
+        return (
+            None,
+            None,
+            None,
+            EvidenceFailure(
+                "constraint_linearization",
+                error.category,
+                str(error),
+                accepted.identity,
+                error.trajectory_fingerprint,
+                error.termination_details,
+            ),
+        )
+    except (ArithmeticError, KeyError, TypeError, ValueError) as error:
+        return (
+            None,
+            None,
+            None,
+            EvidenceFailure(
+                "constraint_linearization",
+                "constraint_linearization_failure",
+                str(error),
+                accepted.identity,
+            ),
+        )
+    return tuple(rows), tuple(dependencies), tuple(diagnostics.values()), None
+
+
+def _linearize_constraints(
+    accepted: AcceptedFitResult,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    policy: UncertaintyPolicy,
+    compiled_capabilities: CompiledConstraintLinearizationCapabilities,
+    output_scope: tuple[str, ...],
+    output_units: tuple[ParameterUnit, ...],
+    output_scales: tuple[float, ...],
+    request_identity: str,
+) -> tuple[ConstraintJacobianEvidence | None, EvidenceFailure | None]:
+    if not output_scope:
+        return None, None
+    scope_failure = _constraint_scope_failure(
+        accepted,
+        parameterization,
+        output_scope,
+    )
+    if scope_failure is not None:
+        return None, scope_failure
+    rows, dependencies, diagnostics, row_failure = _constraint_rows(
+        accepted,
+        problem,
+        parameterization,
+        policy,
+        compiled_capabilities,
+        output_scope,
+    )
+    if (
+        row_failure is not None
+        or rows is None
+        or dependencies is None
+        or diagnostics is None
+    ):
+        return None, row_failure
+    return (
+        ConstraintJacobianEvidence(
+            request_identity,
+            accepted.identity,
+            accepted.evaluation_result.identity,
+            problem.identity,
+            parameterization.identity,
+            parameterization.program.fingerprint,
+            compiled_capabilities.identity,
+            problem.controlled_ids,
+            output_scope,
+            output_units,
+            output_scales,
+            rows,
+            dependencies,
+            diagnostics,
+            (
+                ClaimAssessment(
+                    "CONSTRAINT_OUTPUT_LINEARIZATION_COMPLETE",
+                    ClaimState.SATISFIED,
+                ),
+                ClaimAssessment(
+                    "CONSTRAINT_OUTPUT_LINEARIZATION_RELIABLE",
+                    ClaimState.SATISFIED,
+                ),
+            ),
+        ),
+        None,
+    )
+
+
+def _propagate_constraints(
+    accepted: AcceptedFitResult,
+    covariance: CovarianceEvidence,
+    constraint_jacobian: ConstraintJacobianEvidence,
+    *,
+    request_identity: str,
+    policy: UncertaintyPolicy,
+) -> ConstrainedPropagationEvidence:
+    gradient = constraint_jacobian.matrix
+    factor = tuple(
+        tuple(
+            _finite(
+                _pairwise_sum(
+                    tuple(
+                        gradient[row][inner] * covariance.factor[inner][column]
+                        for inner in range(len(covariance.controlled_ids))
+                    )
+                ),
+                name=f"propagated factor[{row},{column}]",
+            )
+            for column in range(len(covariance.controlled_ids))
+        )
+        for row in range(len(constraint_jacobian.output_ids))
+    )
+    propagated = _gram_matrix(factor)
+    per_output_degeneracy = tuple(
+        all(value == 0.0 for value in constraint_jacobian.matrix[index])
+        and bool(constraint_jacobian.structural_dependencies[index])
+        for index in range(len(factor))
+    )
+    local_degeneracy = any(per_output_degeneracy)
+    residual_variance_degenerate = covariance.residual_variance_scale == 0.0
+    if not residual_variance_degenerate:
+        for index, row in enumerate(factor):
+            if any(value != 0.0 for value in gradient[index]) and all(
+                value == 0.0 for value in row
+            ):
+                raise ArithmeticError(
+                    "Nonzero constraint-gradient row collapsed to a zero propagated factor"
+                )
+            if any(value != 0.0 for value in row) and propagated[index][index] == 0.0:
+                raise ArithmeticError(
+                    "Nonzero propagated factor row underflowed to zero variance"
+                )
+    scaled_gradient = (
+        np.asarray(gradient, dtype=np.float64)
+        * np.asarray(covariance.coordinate_scales, dtype=np.float64)[np.newaxis, :]
+        / np.asarray(constraint_jacobian.output_scales, dtype=np.float64)[:, np.newaxis]
+    )
+    output_rank_claim: ClaimAssessment
+    try:
+        gradient_singular = tuple(
+            _finite(value, name="constraint-output singular value")
+            for value in svd(
+                scaled_gradient,
+                full_matrices=False,
+                compute_uv=False,
+                overwrite_a=False,
+                check_finite=True,
+                lapack_driver=policy.svd_driver,
+            )
+        )
+        if any(value < 0.0 for value in gradient_singular) or any(
+            left < right for left, right in pairwise(gradient_singular)
+        ):
+            raise ValueError("invalid scaled constraint-output singular spectrum")
+        largest = gradient_singular[0] if gradient_singular else 0.0
+        rank_threshold = _finite(
+            policy.rank_absolute_tolerance + policy.rank_relative_tolerance * largest,
+            name="constraint-output rank threshold",
+        )
+        output_rank = sum(value > rank_threshold for value in gradient_singular)
+        output_rank_deficient = output_rank < len(constraint_jacobian.output_ids)
+        output_rank_claim = ClaimAssessment(
+            "OUTPUT_RANK_DEFICIENCY_EXPECTED",
+            ClaimState.SATISFIED
+            if output_rank_deficient
+            else ClaimState.NOT_APPLICABLE,
+            f"scaled-rank={output_rank}; rows={len(constraint_jacobian.output_ids)}; "
+            f"threshold={float(rank_threshold).hex()}",
+        )
+    except Exception as error:  # noqa: BLE001 - diagnostic kernel fence
+        output_rank_claim = ClaimAssessment(
+            "OUTPUT_RANK_DEFICIENCY_EXPECTED",
+            ClaimState.INDETERMINATE,
+            f"diagnostic scaled-SVD unavailable: {error}",
+        )
+    inherited_claims = tuple(
+        ClaimAssessment(
+            f"SOURCE_COVARIANCE::{item.name}",
+            item.state,
+            item.detail,
+        )
+        for item in covariance.claims
+    ) + tuple(
+        ClaimAssessment(
+            f"SOURCE_CONSTRAINT_LINEARIZATION::{item.name}",
+            item.state,
+            item.detail,
+        )
+        for item in constraint_jacobian.claims
+    )
+    output_claims = tuple(
+        ClaimAssessment(
+            f"OUTPUT_FIRST_ORDER_NONDEGENERACY::{param_id}",
+            ClaimState.VIOLATED
+            if per_output_degeneracy[index]
+            else ClaimState.SATISFIED,
+        )
+        for index, param_id in enumerate(constraint_jacobian.output_ids)
+    )
+    claims = (
+        *inherited_claims,
+        ClaimAssessment("EXACT_LINEAGE", ClaimState.SATISFIED),
+        ClaimAssessment(
+            "CONSTRAINT_LINEARIZATION_REGULARITY",
+            ClaimState.SATISFIED,
+        ),
+        ClaimAssessment("GRAM_ARITHMETIC_INTEGRITY", ClaimState.SATISFIED),
+        output_rank_claim,
+        ClaimAssessment(
+            "LOCAL_FIRST_ORDER_DEGENERACY",
+            ClaimState.VIOLATED if local_degeneracy else ClaimState.SATISFIED,
+        ),
+        ClaimAssessment(
+            "RESIDUAL_VARIANCE_NONDEGENERACY",
+            ClaimState.VIOLATED
+            if residual_variance_degenerate
+            else ClaimState.SATISFIED,
+        ),
+        ClaimAssessment(
+            "SOURCE_COVARIANCE_USABILITY",
+            covariance.claim("USABLE_LOCAL_COVARIANCE"),
+        ),
+        *output_claims,
+    )
+    return ConstrainedPropagationEvidence(
+        request_identity,
+        covariance.identity,
+        constraint_jacobian.identity,
+        accepted.identity,
+        covariance.controlled_ids,
+        constraint_jacobian.output_ids,
+        constraint_jacobian.output_units,
+        constraint_jacobian.output_scales,
+        factor,
+        propagated,
+        claims,
+    )
+
+
+def _operation(
+    stage: str,
+    request_identity: str,
+    artifact: _IdentityBearing | None,
+    failure: EvidenceFailure | None,
+    *,
+    resolved_environment_identity: str,
+    terminal_override: OperationTerminal | None = None,
+) -> DerivationOperation:
+    if terminal_override in {
+        OperationTerminal.CANCELLED,
+        OperationTerminal.INTERRUPTED,
+    }:
+        terminal_failure = EvidenceFailure(
+            stage,
+            terminal_override.value,
+            f"Derivation operation {terminal_override.value}",
+            request_identity,
+        )
+        return DerivationOperation(
+            uuid4().hex,
+            resolved_environment_identity,
+            stage,
+            request_identity,
+            terminal_override,
+            failure=terminal_failure,
+        )
+    if artifact is not None:
+        return DerivationOperation(
+            uuid4().hex,
+            resolved_environment_identity,
+            stage,
+            request_identity,
+            OperationTerminal.COMPLETED,
+            artifact.identity,
+        )
+    if failure is None:
+        failure = EvidenceFailure(
+            stage,
+            "source_artifact_unavailable",
+            "A required source artifact was unavailable",
+            request_identity,
+        )
+    return DerivationOperation(
+        uuid4().hex,
+        resolved_environment_identity,
+        stage,
+        request_identity,
+        OperationTerminal.FAILED,
+        failure=failure,
+    )
+
+
+def _record_operation(
+    operations: list[DerivationOperation],
+    failures: list[EvidenceFailure],
+    operation: DerivationOperation,
+) -> None:
+    operations.append(operation)
+    if operation.failure is not None:
+        failures.append(operation.failure)
+
+
+def _cancellation_terminal(
+    probe: Callable[[], OperationTerminal | None] | None,
+) -> OperationTerminal | None:
+    if probe is None:
+        return None
+    terminal = probe()
+    if terminal not in {
+        None,
+        OperationTerminal.CANCELLED,
+        OperationTerminal.INTERRUPTED,
+    }:
+        raise UncertaintyConstructionError(
+            "Cancellation probe may return only cancelled, interrupted, or None"
+        )
+    return terminal
+
+
+def _raise_if_terminated(
+    probe: Callable[[], OperationTerminal | None] | None,
+) -> None:
+    terminal = _cancellation_terminal(probe)
+    if terminal is not None:
+        raise DerivationTermination(terminal)
+
+
+@dataclass(frozen=True, slots=True)
+class _CovarianceBranch:
+    operations: tuple[DerivationOperation, ...]
+    failures: tuple[EvidenceFailure, ...]
+    residual_jacobian: ResidualJacobianEvidence | None
+    rank_diagnostic: RankDiagnostic | None
+    covariance: CovarianceEvidence | None
+    marginal_errors: MarginalErrorEvidence | None
+    correlations: CorrelationEvidence | None
+
+
+def _derive_covariance_branch(
+    accepted: AcceptedFitResult,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    policy: UncertaintyPolicy,
+    request_identity: str,
+    resolved_environment_identity: str,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
+) -> _CovarianceBranch:
+    operations: list[DerivationOperation] = []
+    failures: list[EvidenceFailure] = []
+    residual_request = _identity(
+        "native-residual-linearization-request",
+        (request_identity, accepted.identity, engine.plan.identity, policy.identity),
+    )
+    residual_jacobian: ResidualJacobianEvidence | None = None
+    residual_failure: EvidenceFailure | None = None
+    residual_terminal: OperationTerminal | None = None
+    try:
+        residual_jacobian, residual_failure = _linearize_residuals(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=policy,
+            request_identity=residual_request,
+            cancellation_probe=cancellation_probe,
+        )
+    except DerivationTermination as termination:
+        residual_terminal = termination.terminal
+    except (ArithmeticError, TypeError, ValueError) as error:
+        residual_failure = EvidenceFailure(
+            "residual_linearization",
+            "invalid_linearization_arithmetic",
+            str(error),
+            accepted.identity,
+        )
+    _record_operation(
+        operations,
+        failures,
+        _operation(
+            "residual_linearization",
+            residual_request,
+            residual_jacobian,
+            residual_failure,
+            resolved_environment_identity=resolved_environment_identity,
+            terminal_override=residual_terminal,
+        ),
+    )
+    if residual_terminal is not None:
+        return _CovarianceBranch(
+            tuple(operations),
+            tuple(failures),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    covariance_request = _identity(
+        "native-covariance-request",
+        (
+            request_identity,
+            None if residual_jacobian is None else residual_jacobian.identity,
+            policy.identity,
+        ),
+    )
+    covariance: CovarianceEvidence | None = None
+    rank_diagnostic: RankDiagnostic | None = None
+    covariance_failure: EvidenceFailure | None = None
+    covariance_terminal: OperationTerminal | None = None
+    if residual_jacobian is not None:
+        try:
+            covariance, rank_diagnostic, covariance_failure = _covariance_from_jacobian(
+                accepted,
+                residual_jacobian,
+                problem=problem,
+                engine=engine,
+                policy=policy,
+                request_identity=covariance_request,
+                cancellation_probe=cancellation_probe,
+            )
+        except DerivationTermination as termination:
+            covariance_terminal = termination.terminal
+        except (ArithmeticError, TypeError, ValueError) as error:
+            covariance_failure = EvidenceFailure(
+                "covariance",
+                "invalid_covariance_arithmetic",
+                str(error),
+                residual_jacobian.identity,
+            )
+    _record_operation(
+        operations,
+        failures,
+        _operation(
+            "covariance",
+            covariance_request,
+            covariance,
+            covariance_failure,
+            resolved_environment_identity=resolved_environment_identity,
+            terminal_override=covariance_terminal,
+        ),
+    )
+    if covariance_terminal is not None:
+        return _CovarianceBranch(
+            tuple(operations),
+            tuple(failures),
+            residual_jacobian,
+            None,
+            None,
+            None,
+            None,
+        )
+    marginal_errors: MarginalErrorEvidence | None = None
+    correlations: CorrelationEvidence | None = None
+    if covariance is not None:
+        variance_degenerate = covariance.residual_variance_scale == 0.0
+        marginal_errors = _marginal_errors(
+            source_identity=covariance.identity,
+            source_family="local_covariance",
+            output_ids=covariance.controlled_ids,
+            units=covariance.units,
+            covariance=covariance.covariance,
+            residual_variance_degenerate=variance_degenerate,
+            source_reportable=covariance.usable,
+            inherited_claims=covariance.claims,
+        )
+        correlations = _correlations(
+            source_identity=covariance.identity,
+            source_family="local_covariance",
+            output_ids=covariance.controlled_ids,
+            units=covariance.units,
+            covariance=covariance.covariance,
+            residual_variance_degenerate=variance_degenerate,
+            source_reportable=covariance.usable,
+            policy=policy,
+            inherited_claims=covariance.claims,
+        )
+        marginal_request = _identity(
+            "native-marginal-error-request",
+            (covariance.identity, _MARGINAL_VERSION),
+        )
+        correlation_request = _identity(
+            "native-correlation-request",
+            (covariance.identity, policy.identity, _CORRELATION_VERSION),
+        )
+        _record_operation(
+            operations,
+            failures,
+            _operation(
+                "marginal_errors",
+                marginal_request,
+                marginal_errors,
+                None,
+                resolved_environment_identity=resolved_environment_identity,
+            ),
+        )
+        _record_operation(
+            operations,
+            failures,
+            _operation(
+                "correlations",
+                correlation_request,
+                correlations,
+                None,
+                resolved_environment_identity=resolved_environment_identity,
+            ),
+        )
+    return _CovarianceBranch(
+        tuple(operations),
+        tuple(failures),
+        residual_jacobian,
+        rank_diagnostic,
+        covariance,
+        marginal_errors,
+        correlations,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _ConstraintBranch:
+    operations: tuple[DerivationOperation, ...]
+    failures: tuple[EvidenceFailure, ...]
+    jacobian: ConstraintJacobianEvidence | None
+    propagation: ConstrainedPropagationEvidence | None
+    marginal_errors: MarginalErrorEvidence | None
+    correlations: CorrelationEvidence | None
+
+
+def _derive_constraint_branch(
+    accepted: AcceptedFitResult,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    policy: UncertaintyPolicy,
+    compiled_capabilities: CompiledConstraintLinearizationCapabilities,
+    request_identity: str,
+    output_scope: tuple[str, ...],
+    output_units: tuple[ParameterUnit, ...],
+    output_scales: tuple[float, ...],
+    covariance: CovarianceEvidence | None,
+    resolved_environment_identity: str,
+) -> _ConstraintBranch:
+    if not output_scope:
+        return _ConstraintBranch((), (), None, None, None, None)
+    operations: list[DerivationOperation] = []
+    failures: list[EvidenceFailure] = []
+    constraint_request = _identity(
+        "native-constraint-linearization-request",
+        (
+            request_identity,
+            accepted.identity,
+            output_scope,
+            output_units,
+            _vector_tokens(output_scales),
+            policy.identity,
+        ),
+    )
+    jacobian, constraint_failure = _linearize_constraints(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        policy=policy,
+        compiled_capabilities=compiled_capabilities,
+        output_scope=output_scope,
+        output_units=output_units,
+        output_scales=output_scales,
+        request_identity=constraint_request,
+    )
+    _record_operation(
+        operations,
+        failures,
+        _operation(
+            "constraint_linearization",
+            constraint_request,
+            jacobian,
+            constraint_failure,
+            resolved_environment_identity=resolved_environment_identity,
+        ),
+    )
+    propagation_request = _identity(
+        "native-constrained-propagation-request",
+        (
+            request_identity,
+            None if covariance is None else covariance.identity,
+            None if jacobian is None else jacobian.identity,
+            output_scope,
+            policy.identity,
+        ),
+    )
+    propagation: ConstrainedPropagationEvidence | None = None
+    propagation_failure: EvidenceFailure | None = None
+    if covariance is not None and jacobian is not None:
+        try:
+            propagation = _propagate_constraints(
+                accepted,
+                covariance,
+                jacobian,
+                request_identity=propagation_request,
+                policy=policy,
+            )
+        except (ArithmeticError, TypeError, ValueError) as error:
+            propagation_failure = EvidenceFailure(
+                "constrained_propagation",
+                "gram_propagation_failure",
+                str(error),
+                propagation_request,
+            )
+    _record_operation(
+        operations,
+        failures,
+        _operation(
+            "constrained_propagation",
+            propagation_request,
+            propagation,
+            propagation_failure,
+            resolved_environment_identity=resolved_environment_identity,
+        ),
+    )
+    marginal: MarginalErrorEvidence | None = None
+    correlations: CorrelationEvidence | None = None
+    if propagation is not None and covariance is not None:
+        variance_degenerate = covariance.residual_variance_scale == 0.0
+        source_reportable = (
+            covariance.usable
+            and propagation.claim("LOCAL_FIRST_ORDER_DEGENERACY")
+            is ClaimState.SATISFIED
+        )
+        marginal = _marginal_errors(
+            source_identity=propagation.identity,
+            source_family="constrained_propagation",
+            output_ids=propagation.output_ids,
+            units=propagation.output_units,
+            covariance=propagation.covariance,
+            residual_variance_degenerate=variance_degenerate,
+            source_reportable=source_reportable,
+            inherited_claims=propagation.claims,
+        )
+        correlations = _correlations(
+            source_identity=propagation.identity,
+            source_family="constrained_propagation",
+            output_ids=propagation.output_ids,
+            units=propagation.output_units,
+            covariance=propagation.covariance,
+            residual_variance_degenerate=variance_degenerate,
+            source_reportable=source_reportable,
+            policy=policy,
+            inherited_claims=propagation.claims,
+        )
+        marginal_request = _identity(
+            "native-constrained-marginal-error-request",
+            (propagation.identity, _MARGINAL_VERSION),
+        )
+        correlation_request = _identity(
+            "native-constrained-correlation-request",
+            (propagation.identity, policy.identity, _CORRELATION_VERSION),
+        )
+        _record_operation(
+            operations,
+            failures,
+            _operation(
+                "constrained_marginal_errors",
+                marginal_request,
+                marginal,
+                None,
+                resolved_environment_identity=resolved_environment_identity,
+            ),
+        )
+        _record_operation(
+            operations,
+            failures,
+            _operation(
+                "constrained_correlations",
+                correlation_request,
+                correlations,
+                None,
+                resolved_environment_identity=resolved_environment_identity,
+            ),
+        )
+    return _ConstraintBranch(
+        tuple(operations),
+        tuple(failures),
+        jacobian,
+        propagation,
+        marginal,
+        correlations,
+    )
+
+
+def derive_uncertainty_evidence(
+    accepted: AcceptedFitResult,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    policy: UncertaintyPolicy,
+    constrained_scope: Sequence[str] = (),
+    constrained_units: Sequence[tuple[str, ParameterUnit]] = (),
+    constrained_scales: Sequence[tuple[str, float]] = (),
+    compiled_constraint_linearization: (
+        CompiledConstraintLinearizationCapabilities | None
+    ) = None,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None = None,
+    resolved_environment_identity: str,
+) -> UncertaintyEvidence:
+    """Derive one closed immutable evidence bundle from an exact accepted fit."""
+    if not resolved_environment_identity:
+        raise UncertaintyConstructionError(
+            "Uncertainty evidence requires a resolved environment identity"
+        )
+    output_scope = tuple(constrained_scope)
+    compiled_capabilities = (
+        compile_constraint_linearization_capabilities(
+            parameterization,
+            (),
+            (),
+        )
+        if compiled_constraint_linearization is None and not output_scope
+        else compiled_constraint_linearization
+    )
+    if compiled_capabilities is None or (
+        compiled_capabilities.parameterization_identity != parameterization.identity
+        or compiled_capabilities.constraint_program_identity
+        != parameterization.program.fingerprint
+        or compiled_capabilities.output_scope != output_scope
+    ):
+        raise UncertaintyConstructionError(
+            "Constraint linearization requires an exact compiled capability selection"
+        )
+    unit_pairs = tuple(constrained_units)
+    if tuple(param_id for param_id, _unit in unit_pairs) != output_scope or any(
+        not unit for _param_id, unit in unit_pairs
+    ):
+        raise UncertaintyConstructionError(
+            "Constrained-output units must explicitly match requested scope order"
+        )
+    output_units = tuple(unit for _param_id, unit in unit_pairs)
+    scale_pairs = tuple(
+        (param_id, _finite(value, name=f"constrained scale {param_id!r}"))
+        for param_id, value in constrained_scales
+    )
+    if tuple(param_id for param_id, _value in scale_pairs) != output_scope or any(
+        value <= 0.0 for _param_id, value in scale_pairs
+    ):
+        raise UncertaintyConstructionError(
+            "Constrained-output scales must explicitly match requested scope order"
+        )
+    output_scales = tuple(value for _param_id, value in scale_pairs)
+    request_identity = _identity(
+        "native-uncertainty-request",
+        (
+            accepted.identity,
+            problem.identity,
+            parameterization.identity,
+            engine.plan.identity,
+            policy.identity,
+            output_scope,
+            output_units,
+            _vector_tokens(output_scales),
+            compiled_capabilities.identity,
+        ),
+    )
+    initial_terminal = _cancellation_terminal(cancellation_probe)
+    if initial_terminal is not None:
+        operation = _operation(
+            "residual_linearization",
+            request_identity,
+            None,
+            None,
+            resolved_environment_identity=resolved_environment_identity,
+            terminal_override=initial_terminal,
+        )
+        terminal_failure = cast("EvidenceFailure", operation.failure)
+        return UncertaintyEvidence(
+            accepted.identity,
+            request_identity,
+            policy.identity,
+            resolved_environment_identity,
+            (operation,),
+            (terminal_failure,),
+        )
+    lineage_category = _lineage_failure(
+        accepted,
+        problem,
+        parameterization,
+        engine,
+        policy,
+    )
+    if lineage_category is not None:
+        failure = EvidenceFailure(
+            "residual_linearization",
+            lineage_category,
+            "Uncertainty inputs do not have exact accepted-fit lineage",
+            accepted.identity,
+        )
+        operation = _operation(
+            "residual_linearization",
+            request_identity,
+            None,
+            failure,
+            resolved_environment_identity=resolved_environment_identity,
+        )
+        return UncertaintyEvidence(
+            accepted.identity,
+            request_identity,
+            policy.identity,
+            resolved_environment_identity,
+            (operation,),
+            (failure,),
+        )
+
+    covariance_branch = _derive_covariance_branch(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        request_identity=request_identity,
+        resolved_environment_identity=resolved_environment_identity,
+        cancellation_probe=cancellation_probe,
+    )
+    if covariance_branch.operations[-1].terminal in {
+        OperationTerminal.CANCELLED,
+        OperationTerminal.INTERRUPTED,
+    }:
+        return UncertaintyEvidence(
+            accepted.identity,
+            request_identity,
+            policy.identity,
+            resolved_environment_identity,
+            covariance_branch.operations,
+            covariance_branch.failures,
+            covariance_branch.residual_jacobian,
+            covariance_branch.rank_diagnostic,
+            covariance_branch.covariance,
+            covariance_branch.marginal_errors,
+            covariance_branch.correlations,
+        )
+    branch_terminal = (
+        _cancellation_terminal(cancellation_probe) if output_scope else None
+    )
+    if branch_terminal is not None:
+        operation = _operation(
+            "constraint_linearization",
+            request_identity,
+            None,
+            None,
+            resolved_environment_identity=resolved_environment_identity,
+            terminal_override=branch_terminal,
+        )
+        terminal_failure = cast("EvidenceFailure", operation.failure)
+        return UncertaintyEvidence(
+            accepted.identity,
+            request_identity,
+            policy.identity,
+            resolved_environment_identity,
+            covariance_branch.operations + (operation,),
+            covariance_branch.failures + (terminal_failure,),
+            covariance_branch.residual_jacobian,
+            covariance_branch.rank_diagnostic,
+            covariance_branch.covariance,
+            covariance_branch.marginal_errors,
+            covariance_branch.correlations,
+        )
+    constraint_branch = _derive_constraint_branch(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        policy=policy,
+        compiled_capabilities=compiled_capabilities,
+        request_identity=request_identity,
+        output_scope=output_scope,
+        output_units=output_units,
+        output_scales=output_scales,
+        covariance=covariance_branch.covariance,
+        resolved_environment_identity=resolved_environment_identity,
+    )
+
+    return UncertaintyEvidence(
+        accepted.identity,
+        request_identity,
+        policy.identity,
+        resolved_environment_identity,
+        covariance_branch.operations + constraint_branch.operations,
+        covariance_branch.failures + constraint_branch.failures,
+        covariance_branch.residual_jacobian,
+        covariance_branch.rank_diagnostic,
+        covariance_branch.covariance,
+        covariance_branch.marginal_errors,
+        covariance_branch.correlations,
+        constraint_branch.jacobian,
+        constraint_branch.propagation,
+        constraint_branch.marginal_errors,
+        constraint_branch.correlations,
+    )

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -12,6 +12,7 @@ reporting do not consume these artifacts yet.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import math
 from collections.abc import Callable, Mapping, Sequence
@@ -32,7 +33,11 @@ from chemex.evaluation.native import (
     EvaluationFrame,
     EvaluationResult,
 )
-from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    OptimizationProblem,
+    accepted_occurrence_is_authoritative,
+)
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     BinaryExpression,
@@ -43,13 +48,14 @@ from chemex.parameters.parameterization import (
     ReferenceExpression,
     ScalarExpression,
     UnaryExpression,
+    scientific_callable_fingerprint,
 )
 
 _SCHEMA_VERSION = 1
 _RESIDUAL_LINEARIZATION_VERSION = "external-real-finite-difference-v1"
 _CONSTRAINT_LINEARIZATION_VERSION = "constraint-forward-chain-v1"
-_COVARIANCE_VERSION = "full-rank-scaled-svd-v1"
-_FACTOR_VERSION = "scaled-svd-gram-v1"
+_COVARIANCE_VERSION = "full-rank-scaled-svd-cholesky-v2"
+_FACTOR_VERSION = "canonical-information-cholesky-gram-v2"
 _REDUCTION_VERSION = "fixed-pairwise-binary64-v1"
 _MARGINAL_VERSION = "covariance-diagonal-square-root-v1"
 _CORRELATION_VERSION = "ordered-double-division-v1"
@@ -82,9 +88,14 @@ class FunctionPartialFailure(UncertaintyConstructionError):
 class DerivationTermination(RuntimeError):
     """Internal cooperative cancellation/interruption checkpoint signal."""
 
-    def __init__(self, terminal: OperationTerminal) -> None:
+    def __init__(
+        self,
+        terminal: OperationTerminal,
+        partial_artifact: object | None = None,
+    ) -> None:
         super().__init__(terminal.value)
         self.terminal = terminal
+        self.partial_artifact = partial_artifact
 
 
 class ResidualVarianceScaling(StrEnum):
@@ -154,6 +165,7 @@ def _record_value(value: object) -> object:
             **{
                 item.name: _record_value(getattr(value, item.name))
                 for item in fields(value)
+                if item.metadata.get("record", True)
             },
         }
     raise TypeError(f"Unsupported uncertainty record value {type(value).__name__}")
@@ -289,6 +301,7 @@ class FunctionAnalyticPartialCapability:
     component: str | None
     implementation_identity: str
     partials: tuple[Callable[..., float], ...] = field(compare=False, repr=False)
+    implementation_fingerprints: tuple[str, ...] = field(init=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -301,6 +314,10 @@ class FunctionAnalyticPartialCapability:
             raise UncertaintyConstructionError(
                 "Analytic scientific-function capability is incomplete"
             )
+        fingerprints = tuple(
+            scientific_callable_fingerprint(partial) for partial in self.partials
+        )
+        object.__setattr__(self, "implementation_fingerprints", fingerprints)
         object.__setattr__(
             self,
             "identity",
@@ -310,11 +327,21 @@ class FunctionAnalyticPartialCapability:
                     self.function_id,
                     self.component,
                     self.implementation_identity,
-                    len(self.partials),
+                    fingerprints,
                     _CONSTRAINT_LINEARIZATION_VERSION,
                 ),
             ),
         )
+
+    def validate_implementations(self) -> None:
+        """Reject a mutable/rebound analytic implementation after compilation."""
+        current = tuple(
+            scientific_callable_fingerprint(partial) for partial in self.partials
+        )
+        if current != self.implementation_fingerprints:
+            raise UncertaintyConstructionError(
+                "Analytic partial implementation changed after capability compilation"
+            )
 
 
 FunctionLinearizationCapability = (
@@ -372,6 +399,28 @@ def _expression_function_keys(
     return ()
 
 
+def _expression_function_arities(
+    expression: ScalarExpression,
+) -> tuple[tuple[tuple[str, str | None], int], ...]:
+    if isinstance(expression, FunctionExpression):
+        nested = tuple(
+            item
+            for argument in expression.arguments
+            for item in _expression_function_arities(argument)
+        )
+        return (
+            ((expression.function_id, expression.component), len(expression.arguments)),
+            *nested,
+        )
+    if isinstance(expression, UnaryExpression):
+        return _expression_function_arities(expression.operand)
+    if isinstance(expression, BinaryExpression):
+        return _expression_function_arities(
+            expression.left
+        ) + _expression_function_arities(expression.right)
+    return ()
+
+
 def _required_function_keys(
     parameterization: ActiveParameterization,
     scope: tuple[str, ...],
@@ -390,6 +439,35 @@ def _required_function_keys(
         for dependency in constraint.dependencies:
             visit(dependency)
         required.update(_expression_function_keys(constraint.expression))
+
+    for target_id in scope:
+        visit(target_id)
+    return required
+
+
+def _required_function_arities(
+    parameterization: ActiveParameterization,
+    scope: tuple[str, ...],
+) -> dict[tuple[str, str | None], int]:
+    constraints = {
+        item.target_id: item for item in parameterization.program.constraints
+    }
+    required: dict[tuple[str, str | None], int] = {}
+    visited: set[str] = set()
+
+    def visit(target_id: str) -> None:
+        if target_id in visited or target_id not in constraints:
+            return
+        visited.add(target_id)
+        constraint = constraints[target_id]
+        for dependency in constraint.dependencies:
+            visit(dependency)
+        for key, arity in _expression_function_arities(constraint.expression):
+            previous = required.setdefault(key, arity)
+            if previous != arity:
+                raise UncertaintyConstructionError(
+                    f"Scientific function {key!r} has inconsistent compiled arity"
+                )
 
     for target_id in scope:
         visit(target_id)
@@ -419,6 +497,30 @@ def compile_constraint_linearization_capabilities(
             "Compiled constraint linearization lacks capabilities for "
             f"{sorted(missing, key=repr)!r}"
         )
+    required_arities = _required_function_arities(parameterization, scope)
+    for capability in selected:
+        key = (capability.function_id, capability.component)
+        arity = required_arities.get(key)
+        if arity is None:
+            continue
+        if isinstance(capability, FunctionFiniteDifferenceCapability):
+            if len(capability.argument_scales) != arity:
+                raise UncertaintyConstructionError(
+                    f"Numerical capability {key!r} has incompatible arity"
+                )
+        else:
+            capability.validate_implementations()
+            if len(capability.partials) != arity:
+                raise UncertaintyConstructionError(
+                    f"Analytic capability {key!r} has incompatible arity"
+                )
+            for partial in capability.partials:
+                try:
+                    inspect.signature(partial).bind(*((0.0,) * arity))
+                except TypeError as error:
+                    raise UncertaintyConstructionError(
+                        f"Analytic partial for {key!r} has incompatible domain arity"
+                    ) from error
     return CompiledConstraintLinearizationCapabilities(
         parameterization.identity,
         parameterization.program.fingerprint,
@@ -444,6 +546,7 @@ class UncertaintyPolicy:
     rank_absolute_tolerance: float
     rank_relative_tolerance: float
     weak_relative_tolerance: float
+    singular_value_cluster_relative_tolerance: float
     conditioning_limit: float
     correlation_roundoff_multiplier: float
     affine_feasibility_policy: str
@@ -482,6 +585,10 @@ class UncertaintyPolicy:
             self.weak_relative_tolerance,
             name="weak-subspace relative tolerance",
         )
+        cluster_relative = _finite(
+            self.singular_value_cluster_relative_tolerance,
+            name="singular-value cluster relative tolerance",
+        )
         conditioning = _finite(
             self.conditioning_limit,
             name="conditioning limit",
@@ -494,7 +601,12 @@ class UncertaintyPolicy:
             raise UncertaintyConstructionError(
                 "Finite-difference tolerances must be non-negative"
             )
-        if rank_absolute < 0.0 or rank_relative < 0.0 or weak_relative < rank_relative:
+        if (
+            rank_absolute < 0.0
+            or rank_relative < 0.0
+            or weak_relative < rank_relative
+            or cluster_relative < 0.0
+        ):
             raise UncertaintyConstructionError("Rank thresholds must be non-negative")
         if conditioning <= 0.0 or correlation_roundoff < 0.0:
             raise UncertaintyConstructionError(
@@ -523,6 +635,11 @@ class UncertaintyPolicy:
         object.__setattr__(self, "rank_absolute_tolerance", rank_absolute)
         object.__setattr__(self, "rank_relative_tolerance", rank_relative)
         object.__setattr__(self, "weak_relative_tolerance", weak_relative)
+        object.__setattr__(
+            self,
+            "singular_value_cluster_relative_tolerance",
+            cluster_relative,
+        )
         object.__setattr__(self, "conditioning_limit", conditioning)
         object.__setattr__(
             self,
@@ -550,6 +667,7 @@ class UncertaintyPolicy:
                     _float_token(rank_absolute),
                     _float_token(rank_relative),
                     _float_token(weak_relative),
+                    _float_token(cluster_relative),
                     _float_token(conditioning),
                     _float_token(correlation_roundoff),
                     self.affine_feasibility_policy,
@@ -727,10 +845,32 @@ class FunctionPartialDiagnostic:
         )
 
 
+def _validate_accepted_anchor(
+    accepted: AcceptedFitResult,
+    semantic_identity: str,
+    occurrence_identity: str,
+) -> None:
+    if (
+        semantic_identity != accepted.identity
+        or occurrence_identity != accepted.occurrence_identity
+    ):
+        raise ValueError(
+            "Uncertainty artifact differs from its exact accepted occurrence"
+        )
+
+
+def _named_claim(claims: Sequence[ClaimAssessment], name: str) -> ClaimAssessment:
+    matches = tuple(item for item in claims if item.name == name)
+    if len(matches) != 1:
+        raise ValueError(f"Evidence must contain exactly one {name!r} claim")
+    return matches[0]
+
+
 @dataclass(frozen=True, slots=True)
 class ResidualJacobianEvidence:
     request_identity: str
     accepted_result_identity: str
+    accepted_occurrence_identity: str
     accepted_evaluation_identity: str
     problem_identity: str
     source_snapshot_occurrence_identity: str
@@ -749,9 +889,20 @@ class ResidualJacobianEvidence:
     columns: tuple[LinearizationColumn, ...]
     trajectory_fingerprint: str
     complete_reliable: bool = True
+    accepted_anchor: AcceptedFitResult = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        _validate_accepted_anchor(
+            self.accepted_anchor,
+            self.accepted_result_identity,
+            self.accepted_occurrence_identity,
+        )
         residual_count = len(self.matrix)
         coordinate_count = len(self.controlled_ids)
         matrix = _canonical_matrix(
@@ -767,6 +918,43 @@ class ResidualJacobianEvidence:
             or len(self.coordinate_scales) != coordinate_count
         ):
             raise ValueError("Residual Jacobian has inconsistent scope")
+        if (
+            self.accepted_vector != self.accepted_anchor.vector
+            or self.accepted_evaluation_identity
+            != self.accepted_anchor.evaluation_result.identity
+            or self.parameterization_identity
+            != self.accepted_anchor.parameterization_identity
+            or self.evaluator_parameterization_identity
+            != self.accepted_anchor.evaluator_parameterization_identity
+            or self.problem_identity != self.accepted_anchor.problem_identity
+            or self.source_snapshot_occurrence_identity
+            != self.accepted_anchor.source_occurrence_identity
+            or self.source_revision != self.accepted_anchor.source_revision
+            or self.controlled_ids != self.accepted_anchor.controlled_ids
+            or tuple(item.param_id for item in self.columns) != self.controlled_ids
+            or any(value <= 0.0 for value in self.coordinate_scales)
+            or any(len(item.fine_estimate) != residual_count for item in self.columns)
+            or any(
+                len(item.companion_estimate) != residual_count for item in self.columns
+            )
+        ):
+            raise ValueError("Residual Jacobian provenance is internally inconsistent")
+        derived_matrix = tuple(
+            tuple(column.fine_estimate[row] for column in self.columns)
+            for row in range(residual_count)
+        )
+        expected_trajectory = _identity(
+            "residual-linearization-trajectory",
+            tuple(
+                (item.param_id, item.trajectory_fingerprint) for item in self.columns
+            ),
+        )
+        if (
+            matrix != derived_matrix
+            or not self.complete_reliable
+            or self.trajectory_fingerprint != expected_trajectory
+        ):
+            raise ValueError("Residual Jacobian differs from its accepted columns")
         object.__setattr__(self, "matrix", matrix)
         object.__setattr__(
             self,
@@ -776,6 +964,7 @@ class ResidualJacobianEvidence:
                 (
                     self.request_identity,
                     self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
                     self.accepted_evaluation_identity,
                     self.problem_identity,
                     self.source_snapshot_occurrence_identity,
@@ -809,7 +998,56 @@ class ResidualJacobianEvidence:
 
 
 @dataclass(frozen=True, slots=True)
+class SingularSubspaceEvidence:
+    indices: tuple[int, ...]
+    singular_values: tuple[float, ...]
+    classification: Literal[
+        "isolated_identifiable",
+        "isolated_weak",
+        "isolated_null",
+        "clustered_identifiable",
+        "clustered_weak",
+        "clustered_null",
+    ]
+    projector: tuple[tuple[float, ...], ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        dimension = len(self.projector)
+        projector = _canonical_matrix(
+            self.projector,
+            rows=dimension,
+            columns=dimension,
+            name="singular subspace projector",
+        )
+        if (
+            not self.indices
+            or len(self.indices) != len(self.singular_values)
+            or tuple(sorted(self.indices)) != self.indices
+            or (len(self.indices) == 1) != self.classification.startswith("isolated")
+        ):
+            raise ValueError("Singular subspace evidence has inconsistent membership")
+        object.__setattr__(self, "projector", projector)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-singular-invariant-subspace",
+                (
+                    self.indices,
+                    _vector_tokens(self.singular_values),
+                    self.classification,
+                    _matrix_tokens(projector),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class RankDiagnostic:
+    request_identity: str
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
     source_jacobian_identity: str
     controlled_ids: tuple[str, ...]
     singular_values: tuple[float, ...]
@@ -821,9 +1059,28 @@ class RankDiagnostic:
     identifiable_projector: tuple[tuple[float, ...], ...]
     null_projector: tuple[tuple[float, ...], ...]
     weak_projector: tuple[tuple[float, ...], ...]
+    subspaces: tuple[SingularSubspaceEvidence, ...]
+    source_jacobian: ResidualJacobianEvidence = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    source_policy: UncertaintyPolicy = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: C901 - complete SVD integrity chain
+        source = self.source_jacobian
+        _validate_accepted_anchor(
+            source.accepted_anchor,
+            self.accepted_result_identity,
+            self.accepted_occurrence_identity,
+        )
         dimension = len(self.controlled_ids)
         identifiable = _canonical_matrix(
             self.identifiable_projector,
@@ -843,6 +1100,118 @@ class RankDiagnostic:
             columns=dimension,
             name="weak-subspace projector",
         )
+        if (
+            self.source_jacobian_identity != source.identity
+            or self.controlled_ids != source.controlled_ids
+            or len(self.singular_values) != dimension
+            or len(self.normalized_singular_values) != dimension
+            or len(self.scaled_column_norms) != dimension
+            or not 0 <= self.rank <= dimension
+            or any(
+                value < 0.0 or not math.isfinite(value)
+                for value in self.singular_values
+            )
+            or any(left < right for left, right in pairwise(self.singular_values))
+            or self.rank
+            != sum(value > self.threshold for value in self.singular_values)
+            or self.threshold
+            != self.source_policy.rank_absolute_tolerance
+            + self.source_policy.rank_relative_tolerance
+            * (self.singular_values[0] if self.singular_values else 0.0)
+        ):
+            raise ValueError("SVD/rank evidence has inconsistent lineage or spectrum")
+        largest = self.singular_values[0] if self.singular_values else 0.0
+        expected_normalized = tuple(
+            0.0 if largest == 0.0 else value / largest for value in self.singular_values
+        )
+        scaled = (
+            np.asarray(source.matrix)
+            * np.asarray(source.coordinate_scales)[np.newaxis, :]
+        )
+        expected_norms = tuple(
+            float(np.linalg.norm(scaled[:, index])) for index in range(dimension)
+        )
+        information_eigenvalues = np.linalg.eigvalsh(scaled.T @ scaled)[::-1]
+        with np.errstate(over="ignore", invalid="ignore"):
+            expected_squared = np.square(np.asarray(self.singular_values))
+        tolerance = 512.0 * _EPSILON * max(1, dimension)
+        if (
+            self.normalized_singular_values != expected_normalized
+            or not np.allclose(
+                self.scaled_column_norms, expected_norms, rtol=tolerance, atol=0.0
+            )
+            or not np.allclose(
+                expected_squared,
+                information_eigenvalues,
+                rtol=tolerance,
+                atol=tolerance,
+            )
+        ):
+            raise ValueError("SVD/rank numerical evidence does not derive from J_z")
+        identity_matrix = np.eye(dimension)
+        for name, candidate in (
+            ("identifiable", identifiable),
+            ("null", null),
+            ("weak", weak),
+        ):
+            array = np.asarray(candidate)
+            if not (
+                np.allclose(array, array.T, rtol=0.0, atol=tolerance)
+                and np.allclose(array @ array, array, rtol=0.0, atol=tolerance)
+            ):
+                raise ValueError(f"{name} subspace evidence is not a projector")
+        if not np.allclose(
+            np.asarray(identifiable) + np.asarray(null),
+            identity_matrix,
+            rtol=0.0,
+            atol=tolerance,
+        ):
+            raise ValueError("Identifiable and null projectors are not complementary")
+        covered = tuple(index for item in self.subspaces for index in item.indices)
+        if covered != tuple(range(dimension)):
+            raise ValueError("Singular subspaces do not partition parameter order")
+        expected_groups = _singular_cluster_indices(
+            self.singular_values,
+            rank_threshold=self.threshold,
+            weak_threshold=self.weak_threshold,
+            cluster_relative_tolerance=(
+                self.source_policy.singular_value_cluster_relative_tolerance
+            ),
+        )
+        if tuple(item.indices for item in self.subspaces) != expected_groups:
+            raise ValueError(
+                "Singular subspaces violate the declared clustering policy"
+            )
+        subspace_sum = np.zeros((dimension, dimension), dtype=np.float64)
+        information = scaled.T @ scaled
+        for item in self.subspaces:
+            if item.singular_values != tuple(
+                self.singular_values[index] for index in item.indices
+            ):
+                raise ValueError("Singular subspace spectrum is inconsistent")
+            item_projector = np.asarray(item.projector)
+            if not np.allclose(
+                item_projector @ information,
+                information @ item_projector,
+                rtol=tolerance,
+                atol=tolerance,
+            ) or not np.allclose(
+                np.trace(item_projector @ information),
+                sum(value * value for value in item.singular_values),
+                rtol=tolerance,
+                atol=tolerance,
+            ):
+                raise ValueError(
+                    "Singular projector does not match its invariant spectrum"
+                )
+            subspace_sum += item_projector
+        if not np.allclose(
+            subspace_sum,
+            identity_matrix,
+            rtol=0.0,
+            atol=tolerance,
+        ):
+            raise ValueError("Singular invariant-subspace projectors are incomplete")
         object.__setattr__(self, "identifiable_projector", identifiable)
         object.__setattr__(self, "null_projector", null)
         object.__setattr__(self, "weak_projector", weak)
@@ -852,6 +1221,9 @@ class RankDiagnostic:
             _identity(
                 "native-rank-diagnostic",
                 (
+                    self.request_identity,
+                    self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
                     self.source_jacobian_identity,
                     self.controlled_ids,
                     _vector_tokens(self.singular_values),
@@ -863,6 +1235,7 @@ class RankDiagnostic:
                     _matrix_tokens(identifiable),
                     _matrix_tokens(null),
                     _matrix_tokens(weak),
+                    tuple(item.identity for item in self.subspaces),
                 ),
             ),
         )
@@ -873,6 +1246,7 @@ class CovarianceEvidence:
     request_identity: str
     source_jacobian_identity: str
     accepted_result_identity: str
+    accepted_occurrence_identity: str
     problem_identity: str
     parameterization_identity: str
     evaluation_plan_identity: str
@@ -899,10 +1273,52 @@ class CovarianceEvidence:
     factor: tuple[tuple[float, ...], ...]
     covariance: tuple[tuple[float, ...], ...]
     claims: tuple[ClaimAssessment, ...]
+    rank_diagnostic_identity: str
+    source_jacobian: ResidualJacobianEvidence = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    source_rank_diagnostic: RankDiagnostic = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    accepted_anchor: AcceptedFitResult = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    source_problem: OptimizationProblem = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    source_policy: UncertaintyPolicy = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    source_engine: EvaluationEngine = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     factorization: str = _FACTOR_VERSION
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        _validate_accepted_anchor(
+            self.accepted_anchor,
+            self.accepted_result_identity,
+            self.accepted_occurrence_identity,
+        )
         dimension = len(self.controlled_ids)
         unscaled = _canonical_matrix(
             self.unscaled_covariance,
@@ -924,11 +1340,143 @@ class CovarianceEvidence:
         )
         if self.rank != dimension or self.controlled_coordinate_count != dimension:
             raise ValueError("Covariance requires full controlled-coordinate rank")
+        source = self.source_jacobian
+        rank_source = self.source_rank_diagnostic
+        accepted = self.accepted_anchor
+        problem = self.source_problem
+        policy = self.source_policy
+        engine = self.source_engine
+        expected_residual_count = source.residual_count
+        expected_normalization_count = sum(
+            1 for profile in engine.plan.profiles if profile.is_scaled
+        )
+        expected_degrees = (
+            expected_residual_count - dimension - expected_normalization_count
+        )
+        expected_scale, scale_failure = _residual_variance_scale(
+            accepted,
+            degrees_of_freedom=expected_degrees,
+            policy=policy,
+        )
+        if scale_failure is not None or expected_scale is None:
+            raise ValueError("Covariance has no valid residual-variance derivation")
         if (
-            tuple(item.name for item in self.claims).count("USABLE_LOCAL_COVARIANCE")
-            != 1
+            self.source_jacobian_identity != source.identity
+            or self.rank_diagnostic_identity != rank_source.identity
+            or rank_source.source_jacobian_identity != source.identity
+            or self.request_identity != rank_source.request_identity
+            or self.problem_identity != problem.identity
+            or self.problem_identity != accepted.problem_identity
+            or self.parameterization_identity != accepted.parameterization_identity
+            or self.evaluation_plan_identity != accepted.evaluation_result.plan_identity
+            or self.policy_identity != policy.identity
+            or self.calibration_identity != policy.calibration_identity
+            or self.numerical_compatibility_requirement
+            != policy.numerical_compatibility_requirement
+            or self.controlled_ids != source.controlled_ids
+            or self.controlled_ids != accepted.controlled_ids
+            or self.accepted_vector != accepted.vector
+            or self.coordinate_scales != source.coordinate_scales
+            or self.units != tuple(unit for _param_id, unit in policy.coordinate_units)
+            or self.residual_variance_scaling is not policy.residual_variance_scaling
+            or self.retained_residual_count != expected_residual_count
+            or self.profiled_normalization_count != expected_normalization_count
+            or self.nominal_residual_degrees_of_freedom != expected_degrees
+            or self.chi_square != accepted.chi_square
+            or self.residual_variance_scale != expected_scale
+            or self.rank != rank_source.rank
+            or self.singular_values != rank_source.singular_values
+            or self.rank_threshold != rank_source.threshold
+            or self.factorization != _FACTOR_VERSION
         ):
-            raise ValueError("Covariance lacks its named usability conjunction")
+            raise ValueError("Covariance derivation lineage is internally inconsistent")
+        expected_unscaled, expected_factor, expected_covariance = (
+            _canonical_covariance_reduction(
+                source.matrix,
+                source.coordinate_scales,
+                expected_scale,
+            )
+        )
+        if (
+            unscaled != expected_unscaled
+            or factor != expected_factor
+            or covariance != expected_covariance
+        ):
+            raise ValueError("Covariance arrays do not match the canonical reduction")
+        expected_jacobian_condition = self.singular_values[0] / self.singular_values[-1]
+        if (
+            self.jacobian_condition != expected_jacobian_condition
+            or self.information_condition
+            != expected_jacobian_condition * expected_jacobian_condition
+        ):
+            raise ValueError("Covariance conditioning claims do not match the spectrum")
+        expected_interior, expected_boundary, expected_affine = _boundary_claims(
+            accepted,
+            problem,
+            covariance,
+            expected_scale,
+            policy.affine_feasibility_policy,
+        )
+        expected_full_dimensional = _full_dimensional_feasible_interior_claim(
+            accepted,
+            problem,
+            expected_interior,
+        )
+        expected_claim_states = {
+            "AUTHORITATIVE_LINEAGE": ClaimState.SATISFIED,
+            "LOCAL_LINEARIZATION_REGULARITY": ClaimState.SATISFIED,
+            "EFFECTIVE_OBSERVATION_SUFFICIENCY": ClaimState.SATISFIED,
+            "FULL_COLUMN_RANK": ClaimState.SATISFIED,
+            "COVARIANCE_ARITHMETIC_INTEGRITY": ClaimState.SATISFIED,
+            "FULL_DIMENSIONAL_FEASIBLE_INTERIOR": expected_full_dimensional.state,
+            "INTERIOR_POINT": expected_interior.state,
+            "BOUNDARY_SEPARATION": expected_boundary.state,
+            "AFFINE_FEASIBILITY": expected_affine.state,
+            "CONDITIONING_ADEQUACY": (
+                ClaimState.SATISFIED
+                if expected_jacobian_condition <= policy.conditioning_limit
+                else ClaimState.VIOLATED
+            ),
+            "PROFILED_NORMALIZATION_REGULARITY": (
+                ClaimState.SATISFIED
+                if _profiled_normalization_regular(accepted, engine)
+                else ClaimState.VIOLATED
+            ),
+        }
+        for name, state in expected_claim_states.items():
+            if _named_claim(self.claims, name).state is not state:
+                raise ValueError(f"Covariance claim {name!r} is inconsistent")
+        usable_inputs = (
+            expected_claim_states["CONDITIONING_ADEQUACY"],
+            expected_full_dimensional.state,
+            expected_interior.state,
+            expected_boundary.state,
+            expected_affine.state
+            if expected_affine.state is not ClaimState.NOT_APPLICABLE
+            else ClaimState.SATISFIED,
+            expected_claim_states["PROFILED_NORMALIZATION_REGULARITY"],
+            (
+                ClaimState.SATISFIED
+                if policy.residual_variance_scaling
+                is ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+                or expected_scale > 0.0
+                else ClaimState.VIOLATED
+            ),
+        )
+        expected_usable = (
+            ClaimState.SATISFIED
+            if all(state is ClaimState.SATISFIED for state in usable_inputs)
+            else (
+                ClaimState.INDETERMINATE
+                if ClaimState.INDETERMINATE in usable_inputs
+                else ClaimState.VIOLATED
+            )
+        )
+        if (
+            _named_claim(self.claims, "USABLE_LOCAL_COVARIANCE").state
+            is not expected_usable
+        ):
+            raise ValueError("Covariance usability claim is inconsistent")
         object.__setattr__(self, "unscaled_covariance", unscaled)
         object.__setattr__(self, "factor", factor)
         object.__setattr__(self, "covariance", covariance)
@@ -941,6 +1489,7 @@ class CovarianceEvidence:
                     self.request_identity,
                     self.source_jacobian_identity,
                     self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
                     self.problem_identity,
                     self.parameterization_identity,
                     self.evaluation_plan_identity,
@@ -970,6 +1519,7 @@ class CovarianceEvidence:
                         (item.name, item.state.value, item.detail)
                         for item in self.claims
                     ),
+                    self.rank_diagnostic_identity,
                     self.factorization,
                     _COVARIANCE_VERSION,
                     _REDUCTION_VERSION,
@@ -996,15 +1546,98 @@ class ScalarEvidenceEntry:
 @dataclass(frozen=True, slots=True)
 class MarginalErrorEvidence:
     source_identity: str
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
     source_family: str
     output_ids: tuple[str, ...]
     units: tuple[ParameterUnit, ...]
     entries: tuple[ScalarEvidenceEntry, ...]
     claims: tuple[ClaimAssessment, ...]
     scope_reportable: bool
+    source_artifact: CovarianceEvidence | ConstrainedPropagationEvidence = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        source = self.source_artifact
+        source_output_ids = (
+            source.output_ids
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else source.controlled_ids
+        )
+        if (
+            self.source_identity != source.identity
+            or self.accepted_result_identity != source.accepted_result_identity
+            or self.accepted_occurrence_identity != source.accepted_occurrence_identity
+            or self.output_ids != source_output_ids
+        ):
+            raise ValueError("Marginal-error evidence has inconsistent source lineage")
+        source_units = (
+            source.output_units
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else source.units
+        )
+        expected_family = (
+            "constrained_propagation"
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else "local_covariance"
+        )
+        if (
+            self.units != source_units
+            or self.source_family != expected_family
+            or len(self.entries) != len(self.output_ids)
+            or self.claims[: len(source.claims)] != source.claims
+        ):
+            raise ValueError("Marginal-error scope differs from its covariance source")
+        source_covariance = source.covariance
+        residual_degenerate = (
+            source.source_covariance.residual_variance_scale == 0.0
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else source.residual_variance_scale == 0.0
+        )
+        expected_entries: list[ScalarEvidenceEntry] = []
+        for index, param_id in enumerate(self.output_ids):
+            variance = source_covariance[index][index]
+            if residual_degenerate and variance == 0.0:
+                expected_entries.append(
+                    ScalarEvidenceEntry(
+                        param_id, None, "RESIDUAL_VARIANCE_DEGENERACY", 0.0
+                    )
+                )
+            elif variance > 0.0 and math.isfinite(variance):
+                expected_entries.append(
+                    ScalarEvidenceEntry(param_id, math.sqrt(variance), "AVAILABLE")
+                )
+            else:
+                expected_entries.append(
+                    ScalarEvidenceEntry(
+                        param_id,
+                        None,
+                        "INVALID_VARIANCE",
+                        variance if math.isfinite(variance) else None,
+                    )
+                )
+        if self.entries != tuple(expected_entries):
+            raise ValueError("Marginal errors do not derive from the source covariance")
+        complete = all(item.value is not None for item in expected_entries)
+        if _named_claim(self.claims, "MARGINAL_VARIANCE_VALIDITY").state is not (
+            ClaimState.SATISFIED if complete else ClaimState.VIOLATED
+        ):
+            raise ValueError("Marginal validity claim is inconsistent")
+        report_claim = _named_claim(self.claims, "MARGINAL_SCOPE_REPORTABILITY")
+        if (
+            report_claim.state
+            is not (
+                ClaimState.SATISFIED if self.scope_reportable else ClaimState.VIOLATED
+            )
+            or self.scope_reportable
+            and not complete
+        ):
+            raise ValueError("Marginal reportability claim is inconsistent")
         object.__setattr__(
             self,
             "identity",
@@ -1012,6 +1645,8 @@ class MarginalErrorEvidence:
                 "native-marginal-error-evidence",
                 (
                     self.source_identity,
+                    self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
                     self.source_family,
                     self.output_ids,
                     self.units,
@@ -1046,18 +1681,150 @@ class CorrelationEntry:
     tolerance: float | None = None
 
 
+def _expected_correlation_entries(
+    covariance: tuple[tuple[float, ...], ...],
+    *,
+    residual_variance_degenerate: bool,
+    policy: UncertaintyPolicy,
+) -> tuple[tuple[CorrelationEntry, ...], ...]:
+    dimension = len(covariance)
+    entries: list[list[CorrelationEntry]] = [
+        [CorrelationEntry(None, "UNAVAILABLE") for _right in range(dimension)]
+        for _left in range(dimension)
+    ]
+    standard_errors = tuple(
+        math.sqrt(covariance[index][index]) if covariance[index][index] > 0.0 else None
+        for index in range(dimension)
+    )
+    tolerance = policy.correlation_roundoff_multiplier * _EPSILON
+    for left in range(dimension):
+        if standard_errors[left] is not None and not residual_variance_degenerate:
+            entries[left][left] = CorrelationEntry(1.0, "AVAILABLE", 1.0)
+        else:
+            entries[left][left] = CorrelationEntry(
+                None,
+                "RESIDUAL_VARIANCE_DEGENERACY"
+                if residual_variance_degenerate
+                else "INVALID_VARIANCE",
+            )
+        for right in range(left + 1, dimension):
+            left_error = standard_errors[left]
+            right_error = standard_errors[right]
+            if residual_variance_degenerate:
+                entry = CorrelationEntry(None, "RESIDUAL_VARIANCE_DEGENERACY")
+            elif left_error is None or right_error is None:
+                entry = CorrelationEntry(None, "INVALID_VARIANCE")
+            else:
+                raw = (covariance[left][right] / left_error) / right_error
+                if not math.isfinite(raw):
+                    entry = CorrelationEntry(None, "NON_FINITE_CORRELATION")
+                else:
+                    excess = max(0.0, abs(raw) - 1.0)
+                    if abs(raw) <= 1.0:
+                        entry = CorrelationEntry(
+                            raw, "AVAILABLE", raw, excess, tolerance
+                        )
+                    elif excess <= tolerance:
+                        entry = CorrelationEntry(
+                            math.copysign(1.0, raw),
+                            "ENDPOINT_CANONICALIZED",
+                            raw,
+                            excess,
+                            tolerance,
+                        )
+                    else:
+                        entry = CorrelationEntry(
+                            None,
+                            "CORRELATION_RANGE_VIOLATION",
+                            raw,
+                            excess,
+                            tolerance,
+                        )
+            entries[left][right] = entry
+            entries[right][left] = entry
+    return tuple(tuple(row) for row in entries)
+
+
 @dataclass(frozen=True, slots=True)
 class CorrelationEvidence:
     source_identity: str
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
     source_family: str
     output_ids: tuple[str, ...]
     units: tuple[ParameterUnit, ...]
     entries: tuple[tuple[CorrelationEntry, ...], ...]
     claims: tuple[ClaimAssessment, ...]
     scope_reportable: bool
+    source_artifact: CovarianceEvidence | ConstrainedPropagationEvidence = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    source_policy: UncertaintyPolicy = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        source = self.source_artifact
+        source_output_ids = (
+            source.output_ids
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else source.controlled_ids
+        )
+        source_units = (
+            source.output_units
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else source.units
+        )
+        source_covariance = source.covariance
+        residual_degenerate = (
+            source.source_covariance.residual_variance_scale == 0.0
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else source.residual_variance_scale == 0.0
+        )
+        expected_entries = _expected_correlation_entries(
+            source_covariance,
+            residual_variance_degenerate=residual_degenerate,
+            policy=self.source_policy,
+        )
+        if (
+            self.source_identity != source.identity
+            or self.accepted_result_identity != source.accepted_result_identity
+            or self.accepted_occurrence_identity != source.accepted_occurrence_identity
+            or self.output_ids != source_output_ids
+            or self.units != source_units
+            or self.entries != expected_entries
+            or self.source_family
+            != (
+                "constrained_propagation"
+                if isinstance(source, ConstrainedPropagationEvidence)
+                else "local_covariance"
+            )
+            or self.claims[: len(source.claims)] != source.claims
+        ):
+            raise ValueError("Correlation evidence does not derive from its source")
+        complete = all(
+            item.value is not None for row in expected_entries for item in row
+        )
+        if _named_claim(self.claims, "CORRELATION_ENTRY_VALIDITY").state is not (
+            ClaimState.SATISFIED if complete else ClaimState.VIOLATED
+        ):
+            raise ValueError("Correlation validity claim is inconsistent")
+        if (
+            _named_claim(self.claims, "CORRELATION_SCOPE_REPORTABILITY").state
+            is not (
+                ClaimState.SATISFIED if self.scope_reportable else ClaimState.VIOLATED
+            )
+            or self.scope_reportable
+            and not complete
+        ):
+            raise ValueError("Correlation reportability claim is inconsistent")
         object.__setattr__(
             self,
             "identity",
@@ -1065,6 +1832,8 @@ class CorrelationEvidence:
                 "native-correlation-evidence",
                 (
                     self.source_identity,
+                    self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
                     self.source_family,
                     self.output_ids,
                     self.units,
@@ -1104,6 +1873,7 @@ class CorrelationEvidence:
 class ConstraintJacobianEvidence:
     request_identity: str
     accepted_result_identity: str
+    accepted_occurrence_identity: str
     accepted_evaluation_identity: str
     problem_identity: str
     parameterization_identity: str
@@ -1117,9 +1887,32 @@ class ConstraintJacobianEvidence:
     structural_dependencies: tuple[tuple[str, ...], ...]
     function_partial_diagnostics: tuple[FunctionPartialDiagnostic, ...]
     claims: tuple[ClaimAssessment, ...]
+    accepted_anchor: AcceptedFitResult = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    source_problem: OptimizationProblem = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_parameterization: ActiveParameterization = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_policy: UncertaintyPolicy = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_capabilities: CompiledConstraintLinearizationCapabilities = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        _validate_accepted_anchor(
+            self.accepted_anchor,
+            self.accepted_result_identity,
+            self.accepted_occurrence_identity,
+        )
         if len(self.output_scales) != len(self.output_ids) or any(
             value <= 0.0 or not math.isfinite(value) for value in self.output_scales
         ):
@@ -1130,6 +1923,59 @@ class ConstraintJacobianEvidence:
             columns=len(self.controlled_ids),
             name="constraint-output Jacobian",
         )
+        if (
+            self.accepted_evaluation_identity
+            != self.accepted_anchor.evaluation_result.identity
+            or self.problem_identity != self.accepted_anchor.problem_identity
+            or self.parameterization_identity
+            != self.accepted_anchor.parameterization_identity
+            or self.controlled_ids != self.accepted_anchor.controlled_ids
+            or len(set(self.output_ids)) != len(self.output_ids)
+            or len(self.output_units) != len(self.output_ids)
+            or len(self.structural_dependencies) != len(self.output_ids)
+            or any(
+                any(param_id not in self.controlled_ids for param_id in row)
+                for row in self.structural_dependencies
+            )
+        ):
+            raise ValueError("Constraint Jacobian provenance or scope is inconsistent")
+        expected_claims = (
+            ClaimAssessment(
+                "CONSTRAINT_OUTPUT_LINEARIZATION_COMPLETE",
+                ClaimState.SATISFIED,
+            ),
+            ClaimAssessment(
+                "CONSTRAINT_OUTPUT_LINEARIZATION_RELIABLE",
+                ClaimState.SATISFIED,
+            ),
+        )
+        if self.claims != expected_claims:
+            raise ValueError("Constraint Jacobian claims are inconsistent")
+        rows, dependencies, diagnostics, failure = _constraint_rows(
+            self.accepted_anchor,
+            self.source_problem,
+            self.source_parameterization,
+            self.source_policy,
+            self.source_capabilities,
+            self.output_ids,
+            None,
+        )
+        if (
+            failure is not None
+            or rows != matrix
+            or dependencies != self.structural_dependencies
+            or diagnostics is None
+            or tuple(item.identity for item in diagnostics)
+            != tuple(item.identity for item in self.function_partial_diagnostics)
+            or self.problem_identity != self.source_problem.identity
+            or self.parameterization_identity != self.source_parameterization.identity
+            or self.constraint_program_identity
+            != self.source_parameterization.program.fingerprint
+            or self.capability_selection_identity != self.source_capabilities.identity
+        ):
+            raise ValueError(
+                "Constraint Jacobian does not match its compiled derivation"
+            )
         object.__setattr__(self, "matrix", matrix)
         object.__setattr__(
             self,
@@ -1139,6 +1985,7 @@ class ConstraintJacobianEvidence:
                 (
                     self.request_identity,
                     self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
                     self.accepted_evaluation_identity,
                     self.problem_identity,
                     self.parameterization_identity,
@@ -1167,6 +2014,7 @@ class ConstrainedPropagationEvidence:
     source_covariance_identity: str
     source_constraint_jacobian_identity: str
     accepted_result_identity: str
+    accepted_occurrence_identity: str
     controlled_ids: tuple[str, ...]
     output_ids: tuple[str, ...]
     output_units: tuple[ParameterUnit, ...]
@@ -1174,9 +2022,32 @@ class ConstrainedPropagationEvidence:
     factor: tuple[tuple[float, ...], ...]
     covariance: tuple[tuple[float, ...], ...]
     claims: tuple[ClaimAssessment, ...]
+    source_covariance: CovarianceEvidence = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    source_constraint_jacobian: ConstraintJacobianEvidence = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    accepted_anchor: AcceptedFitResult = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        _validate_accepted_anchor(
+            self.accepted_anchor,
+            self.accepted_result_identity,
+            self.accepted_occurrence_identity,
+        )
         rows = len(self.output_ids)
         columns = len(self.controlled_ids)
         if len(self.output_scales) != rows or any(
@@ -1195,6 +2066,89 @@ class ConstrainedPropagationEvidence:
             columns=rows,
             name="propagated covariance",
         )
+        source_covariance = self.source_covariance
+        source_jacobian = self.source_constraint_jacobian
+        if (
+            self.source_covariance_identity != source_covariance.identity
+            or self.source_constraint_jacobian_identity != source_jacobian.identity
+            or self.controlled_ids != source_covariance.controlled_ids
+            or self.controlled_ids != source_jacobian.controlled_ids
+            or self.output_ids != source_jacobian.output_ids
+            or self.output_units != source_jacobian.output_units
+            or self.output_scales != source_jacobian.output_scales
+        ):
+            raise ValueError("Constrained propagation lineage is inconsistent")
+        expected_factor = tuple(
+            tuple(
+                _finite(
+                    _pairwise_sum(
+                        tuple(
+                            source_jacobian.matrix[row][inner]
+                            * source_covariance.factor[inner][column]
+                            for inner in range(columns)
+                        )
+                    ),
+                    name="validated propagated factor",
+                )
+                for column in range(columns)
+            )
+            for row in range(rows)
+        )
+        if factor != expected_factor or covariance != _gram_matrix(expected_factor):
+            raise ValueError("Constrained covariance differs from G_S L")
+        inherited_claims = tuple(
+            ClaimAssessment(f"SOURCE_COVARIANCE::{item.name}", item.state, item.detail)
+            for item in source_covariance.claims
+        ) + tuple(
+            ClaimAssessment(
+                f"SOURCE_CONSTRAINT_LINEARIZATION::{item.name}",
+                item.state,
+                item.detail,
+            )
+            for item in source_jacobian.claims
+        )
+        if self.claims[: len(inherited_claims)] != inherited_claims:
+            raise ValueError(
+                "Constrained propagation inherited claims are inconsistent"
+            )
+        per_output_degeneracy = tuple(
+            all(value == 0.0 for value in source_jacobian.matrix[index])
+            and bool(source_jacobian.structural_dependencies[index])
+            for index in range(rows)
+        )
+        expected_states = {
+            "EXACT_LINEAGE": ClaimState.SATISFIED,
+            "CONSTRAINT_LINEARIZATION_REGULARITY": ClaimState.SATISFIED,
+            "GRAM_ARITHMETIC_INTEGRITY": ClaimState.SATISFIED,
+            "LOCAL_FIRST_ORDER_DEGENERACY": (
+                ClaimState.VIOLATED
+                if any(per_output_degeneracy)
+                else ClaimState.SATISFIED
+            ),
+            "RESIDUAL_VARIANCE_NONDEGENERACY": (
+                ClaimState.VIOLATED
+                if source_covariance.residual_variance_scale == 0.0
+                else ClaimState.SATISFIED
+            ),
+            "SOURCE_COVARIANCE_USABILITY": source_covariance.claim(
+                "USABLE_LOCAL_COVARIANCE"
+            ),
+        }
+        expected_states.update(
+            {
+                f"OUTPUT_FIRST_ORDER_NONDEGENERACY::{param_id}": (
+                    ClaimState.VIOLATED
+                    if per_output_degeneracy[index]
+                    else ClaimState.SATISFIED
+                )
+                for index, param_id in enumerate(self.output_ids)
+            }
+        )
+        for name, state in expected_states.items():
+            if _named_claim(self.claims, name).state is not state:
+                raise ValueError(
+                    f"Constrained propagation claim {name!r} is inconsistent"
+                )
         object.__setattr__(self, "factor", factor)
         object.__setattr__(self, "covariance", covariance)
         object.__setattr__(
@@ -1207,6 +2161,7 @@ class ConstrainedPropagationEvidence:
                     self.source_covariance_identity,
                     self.source_constraint_jacobian_identity,
                     self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
                     self.controlled_ids,
                     self.output_ids,
                     self.output_units,
@@ -1230,6 +2185,7 @@ class ConstrainedPropagationEvidence:
 @dataclass(frozen=True, slots=True)
 class UncertaintyEvidence:
     accepted_result_identity: str
+    accepted_occurrence_identity: str
     request_identity: str
     policy_identity: str
     resolved_environment_identity: str = field(compare=False)
@@ -1244,9 +2200,95 @@ class UncertaintyEvidence:
     constrained_propagation: ConstrainedPropagationEvidence | None = None
     constrained_marginal_errors: MarginalErrorEvidence | None = None
     constrained_correlations: CorrelationEvidence | None = None
+    accepted_anchor: AcceptedFitResult = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        _validate_accepted_anchor(
+            self.accepted_anchor,
+            self.accepted_result_identity,
+            self.accepted_occurrence_identity,
+        )
+        artifacts = tuple(
+            item
+            for item in (
+                self.residual_jacobian,
+                self.rank_diagnostic,
+                self.covariance,
+                self.marginal_errors,
+                self.correlations,
+                self.constraint_jacobian,
+                self.constrained_propagation,
+                self.constrained_marginal_errors,
+                self.constrained_correlations,
+            )
+            if item is not None
+        )
+        if any(
+            item.accepted_result_identity != self.accepted_result_identity
+            or item.accepted_occurrence_identity != self.accepted_occurrence_identity
+            for item in artifacts
+        ):
+            raise ValueError("Evidence bundle mixes accepted fit occurrences")
+        if self.residual_jacobian is not None and (
+            self.rank_diagnostic is not None
+            and self.rank_diagnostic.source_jacobian_identity
+            != self.residual_jacobian.identity
+            or self.covariance is not None
+            and self.covariance.source_jacobian_identity
+            != self.residual_jacobian.identity
+        ):
+            raise ValueError("Evidence bundle mixes residual Jacobian sources")
+        if self.covariance is not None and (
+            self.rank_diagnostic is None
+            or self.covariance.rank_diagnostic_identity != self.rank_diagnostic.identity
+            or self.marginal_errors is not None
+            and self.marginal_errors.source_identity != self.covariance.identity
+            or self.correlations is not None
+            and self.correlations.source_identity != self.covariance.identity
+        ):
+            raise ValueError("Evidence bundle has incompatible covariance descendants")
+        if self.constrained_propagation is not None and (
+            self.covariance is None
+            or self.constraint_jacobian is None
+            or self.constrained_propagation.source_covariance_identity
+            != self.covariance.identity
+            or self.constrained_propagation.source_constraint_jacobian_identity
+            != self.constraint_jacobian.identity
+            or self.constrained_marginal_errors is not None
+            and self.constrained_marginal_errors.source_identity
+            != self.constrained_propagation.identity
+            or self.constrained_correlations is not None
+            and self.constrained_correlations.source_identity
+            != self.constrained_propagation.identity
+        ):
+            raise ValueError("Evidence bundle has incompatible constrained descendants")
+        stage_artifacts = {
+            stage: artifact.identity
+            for stage, artifact in (
+                ("residual_linearization", self.residual_jacobian),
+                ("covariance", self.covariance),
+                ("marginal_errors", self.marginal_errors),
+                ("correlations", self.correlations),
+                ("constraint_linearization", self.constraint_jacobian),
+                ("constrained_propagation", self.constrained_propagation),
+                ("constrained_marginal_errors", self.constrained_marginal_errors),
+                ("constrained_correlations", self.constrained_correlations),
+            )
+            if artifact is not None
+        }
+        completed = {
+            item.stage: item.artifact_identity
+            for item in self.operations
+            if item.terminal is OperationTerminal.COMPLETED
+        }
+        if completed != stage_artifacts:
+            raise ValueError("Evidence operations do not bind the assembled artifacts")
         object.__setattr__(
             self,
             "identity",
@@ -1254,6 +2296,7 @@ class UncertaintyEvidence:
                 "native-uncertainty-evidence-bundle",
                 (
                     self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
                     self.request_identity,
                     self.policy_identity,
                     tuple(item.identity for item in self.operations),
@@ -1322,6 +2365,19 @@ def _pairwise_sum(values: Sequence[float]) -> float:
     return terms[0] if terms else 0.0
 
 
+def _pairwise_sum_feasibility(values: Sequence[float]) -> float:
+    """Use the canonical reduction order while retaining exceptional values."""
+    terms = list(values)
+    while len(terms) > 1:
+        reduced = [
+            terms[index] + terms[index + 1] for index in range(0, len(terms) - 1, 2)
+        ]
+        if len(terms) % 2:
+            reduced.append(terms[-1])
+        terms = reduced
+    return terms[0] if terms else 0.0
+
+
 def _gram_matrix(factor: Sequence[Sequence[float]]) -> tuple[tuple[float, ...], ...]:
     rows = len(factor)
     result = [[0.0] * rows for _index in range(rows)]
@@ -1337,6 +2393,44 @@ def _gram_matrix(factor: Sequence[Sequence[float]]) -> tuple[tuple[float, ...], 
             result[left][right] = value
             result[right][left] = value
     return tuple(tuple(row) for row in result)
+
+
+def _canonical_covariance_reduction(
+    jacobian: Sequence[Sequence[float]],
+    coordinate_scales: Sequence[float],
+    residual_variance_scale: float,
+) -> tuple[
+    tuple[tuple[float, ...], ...],
+    tuple[tuple[float, ...], ...],
+    tuple[tuple[float, ...], ...],
+]:
+    """Reduce the full-rank information matrix through one canonical factor."""
+    matrix = np.asarray(jacobian, dtype=np.float64)
+    scales = np.asarray(coordinate_scales, dtype=np.float64)
+    scaled = matrix * scales[np.newaxis, :]
+    information = scaled.T @ scaled
+    inverse_scaled = np.linalg.solve(
+        information,
+        np.eye(information.shape[0], dtype=np.float64),
+    )
+    scale_matrix = np.diag(scales)
+    unscaled_array = scale_matrix @ inverse_scaled @ scale_matrix
+    unscaled_array = 0.5 * (unscaled_array + unscaled_array.T)
+    unscaled = _canonical_matrix(
+        unscaled_array,
+        rows=len(scales),
+        columns=len(scales),
+        name="canonical unscaled covariance",
+    )
+    unscaled_factor = np.linalg.cholesky(unscaled_array)
+    factor_array = math.sqrt(residual_variance_scale) * unscaled_factor
+    factor = _canonical_matrix(
+        factor_array,
+        rows=len(scales),
+        columns=len(scales),
+        name="canonical covariance factor",
+    )
+    return unscaled, factor, _gram_matrix(factor)
 
 
 def _has_positive_scale_zero_variance(
@@ -1356,6 +2450,88 @@ def _canonical_right_singular_vectors(values: np.ndarray) -> np.ndarray:
         if canonical[pivot, column] < 0.0:
             canonical[:, column] *= -1.0
     return canonical
+
+
+def _invariant_singular_subspaces(
+    right: np.ndarray,
+    singular_values: tuple[float, ...],
+    *,
+    rank_threshold: float,
+    weak_threshold: float,
+    cluster_relative_tolerance: float,
+) -> tuple[SingularSubspaceEvidence, ...]:
+    """Retain projectors, never basis orientation, for clustered directions."""
+
+    def direction_class(index: int) -> Literal["identifiable", "weak", "null"]:
+        value = singular_values[index]
+        if value <= rank_threshold:
+            return "null"
+        if value <= weak_threshold:
+            return "weak"
+        return "identifiable"
+
+    groups = _singular_cluster_indices(
+        singular_values,
+        rank_threshold=rank_threshold,
+        weak_threshold=weak_threshold,
+        cluster_relative_tolerance=cluster_relative_tolerance,
+    )
+
+    def projector(indices: tuple[int, ...]) -> tuple[tuple[float, ...], ...]:
+        factor = tuple(
+            tuple(
+                _finite(right[row, column], name="right singular subspace")
+                for column in indices
+            )
+            for row in range(right.shape[0])
+        )
+        return _gram_matrix(factor)
+
+    return tuple(
+        SingularSubspaceEvidence(
+            indices,
+            tuple(singular_values[index] for index in indices),
+            ("isolated_" if len(indices) == 1 else "clustered_")
+            + direction_class(indices[0]),
+            projector(indices),
+        )
+        for indices in groups
+    )
+
+
+def _singular_cluster_indices(
+    singular_values: tuple[float, ...],
+    *,
+    rank_threshold: float,
+    weak_threshold: float,
+    cluster_relative_tolerance: float,
+) -> tuple[tuple[int, ...], ...]:
+    largest = singular_values[0] if singular_values else 0.0
+
+    def direction_class(index: int) -> Literal["identifiable", "weak", "null"]:
+        value = singular_values[index]
+        if value <= rank_threshold:
+            return "null"
+        if value <= weak_threshold:
+            return "weak"
+        return "identifiable"
+
+    groups: list[tuple[int, ...]] = []
+    current: list[int] = []
+    for index, value in enumerate(singular_values):
+        if current:
+            previous = singular_values[current[-1]]
+            if not (
+                direction_class(index) == direction_class(current[-1])
+                and abs(previous - value)
+                <= cluster_relative_tolerance * max(largest, previous, value)
+            ):
+                groups.append(tuple(current))
+                current = []
+        current.append(index)
+    if current:
+        groups.append(tuple(current))
+    return tuple(groups)
 
 
 def _singular_spectrum_error(
@@ -1445,6 +2621,8 @@ def _lineage_failure(
     engine: EvaluationEngine,
     policy: UncertaintyPolicy,
 ) -> str | None:
+    if not accepted_occurrence_is_authoritative(accepted):
+        return "accepted_occurrence_identity_mismatch"
     scales = tuple(param_id for param_id, _value in policy.coordinate_scales)
     if scales != problem.controlled_ids:
         return "coordinate_scale_scope_mismatch"
@@ -1835,14 +3013,14 @@ def _linearize_residuals(
             "Fresh uncertainty baseline differs from accepted materialization",
             accepted.identity,
         )
+    _raise_if_terminated(cancellation_probe)
     base_residuals = tuple(float(value) for value in base.residuals)
     scales = tuple(value for _param_id, value in policy.coordinate_scales)
     column_values: list[tuple[float, ...]] = []
     column_evidence: list[LinearizationColumn] = []
-    aggregate_trajectory: list[object] = []
     for column, (param_id, scale) in enumerate(policy.coordinate_scales):
         _raise_if_terminated(cancellation_probe)
-        accepted_column, trajectory, failure = _linearize_residual_column(
+        accepted_column, _trajectory, failure = _linearize_residual_column(
             accepted,
             problem=problem,
             parameterization=parameterization,
@@ -1854,7 +3032,6 @@ def _linearize_residuals(
             scale=scale,
             cancellation_probe=cancellation_probe,
         )
-        aggregate_trajectory.append((param_id, tuple(trajectory)))
         if failure is not None:
             return None, failure
         if accepted_column is None:
@@ -1872,12 +3049,13 @@ def _linearize_residuals(
     )
     trajectory_fingerprint = _identity(
         "residual-linearization-trajectory",
-        aggregate_trajectory,
+        tuple((item.param_id, item.trajectory_fingerprint) for item in column_evidence),
     )
     return (
         ResidualJacobianEvidence(
             request_identity,
             accepted.identity,
+            accepted.occurrence_identity,
             accepted.evaluation_result.identity,
             problem.identity,
             problem.source_snapshot.occurrence_identity,
@@ -1895,6 +3073,7 @@ def _linearize_residuals(
             matrix,
             tuple(column_evidence),
             trajectory_fingerprint,
+            accepted_anchor=accepted,
         ),
         None,
     )
@@ -1931,13 +3110,12 @@ def _profiled_normalization_regular(
     return True
 
 
-def _boundary_claims(
+def _box_boundary_claims(
     accepted: AcceptedFitResult,
     problem: OptimizationProblem,
     covariance: tuple[tuple[float, ...], ...],
     residual_variance_scale: float,
-    affine_feasibility_policy: str,
-) -> tuple[ClaimAssessment, ClaimAssessment, ClaimAssessment]:
+) -> tuple[ClaimAssessment, ClaimAssessment]:
     strict_interior = True
     separation = ClaimState.SATISFIED
     details: list[str] = []
@@ -1953,11 +3131,6 @@ def _boundary_claims(
             return (
                 ClaimAssessment("INTERIOR_POINT", ClaimState.VIOLATED),
                 ClaimAssessment("BOUNDARY_SEPARATION", ClaimState.VIOLATED),
-                ClaimAssessment(
-                    "AFFINE_FEASIBILITY",
-                    ClaimState.VIOLATED,
-                    "Accepted point is outside its box",
-                ),
             )
         if value in (lower, upper):
             strict_interior = False
@@ -1988,12 +3161,175 @@ def _boundary_claims(
             ClaimState.SATISFIED if strict_interior else ClaimState.VIOLATED,
         ),
         ClaimAssessment("BOUNDARY_SEPARATION", separation, "; ".join(details)),
-        ClaimAssessment(
+    )
+
+
+def _classify_affine_restriction(
+    label: str,
+    coefficient_array: np.ndarray,
+    upper_bound: float,
+    full_values: np.ndarray,
+    controlled_frame_indices: tuple[int, ...],
+    covariance: tuple[tuple[float, ...], ...],
+    residual_variance_scale: float,
+) -> tuple[ClaimState, str]:
+    linear_value = _pairwise_sum_feasibility(
+        tuple(
+            float(coefficient) * float(value)
+            for coefficient, value in zip(
+                coefficient_array,
+                full_values,
+                strict=True,
+            )
+        )
+    )
+    slack = float(upper_bound - linear_value)
+    if not math.isfinite(slack):
+        return ClaimState.INDETERMINATE, f"{label}: non-finite slack"
+    controlled = tuple(
+        float(coefficient_array[index]) for index in controlled_frame_indices
+    )
+    if all(value == 0.0 for value in controlled):
+        state = ClaimState.SATISFIED if slack >= 0.0 else ClaimState.VIOLATED
+        return state, f"{label}: held-only slack={slack.hex()}"
+    if slack < 0.0:
+        return ClaimState.VIOLATED, f"{label}: negative slack={slack.hex()}"
+    if residual_variance_scale == 0.0:
+        return ClaimState.INDETERMINATE, f"{label}: phi=0 covariance degeneracy"
+    variance = _pairwise_sum_feasibility(
+        tuple(
+            left_value * covariance[left][right] * right_value
+            for left, left_value in enumerate(controlled)
+            for right, right_value in enumerate(controlled)
+        )
+    )
+    if not math.isfinite(variance) or variance < 0.0:
+        return ClaimState.INDETERMINATE, f"{label}: invalid directional variance"
+    if variance == 0.0:
+        return ClaimState.INDETERMINATE, f"{label}: zero directional variance"
+    with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+        zeta = float(slack / math.sqrt(variance))
+    if not math.isfinite(zeta):
+        return ClaimState.INDETERMINATE, f"{label}: non-finite zeta"
+    state = ClaimState.SATISFIED if zeta > _BOUNDARY_THRESHOLD else ClaimState.VIOLATED
+    return state, f"{label}: zeta={zeta.hex()}"
+
+
+def _affine_feasibility_claim(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    covariance: tuple[tuple[float, ...], ...],
+    residual_variance_scale: float,
+    affine_feasibility_policy: str,
+) -> ClaimAssessment:
+    if not problem.affine_half_spaces and not problem.affine_equalities:
+        return ClaimAssessment(
             "AFFINE_FEASIBILITY",
             ClaimState.NOT_APPLICABLE,
             affine_feasibility_policy,
-        ),
+        )
+    controlled_ids = set(problem.controlled_ids)
+    accepted_controlled = dict(
+        zip(problem.controlled_ids, accepted.vector, strict=True)
     )
+    full_values = np.asarray(
+        tuple(
+            accepted_controlled.get(param_id, value)
+            for param_id, value in problem.independent_items
+        ),
+        dtype=np.float64,
+    )
+    controlled_frame_indices = tuple(
+        index
+        for index, (param_id, _value) in enumerate(problem.independent_items)
+        if param_id in controlled_ids
+    )
+    restrictions = [
+        (
+            item.restriction_id,
+            np.asarray(item.coefficients, dtype=np.float64),
+            item.upper_bound,
+        )
+        for item in problem.affine_half_spaces
+    ]
+    restrictions.extend(
+        (
+            f"{item.restriction_id}:positive",
+            np.asarray(item.coefficients, dtype=np.float64),
+            item.value,
+        )
+        for item in problem.affine_equalities
+    )
+    restrictions.extend(
+        (
+            f"{item.restriction_id}:negative",
+            -np.asarray(item.coefficients, dtype=np.float64),
+            -item.value,
+        )
+        for item in problem.affine_equalities
+    )
+    assessments = tuple(
+        _classify_affine_restriction(
+            label,
+            coefficients,
+            upper_bound,
+            full_values,
+            controlled_frame_indices,
+            covariance,
+            residual_variance_scale,
+        )
+        for label, coefficients, upper_bound in restrictions
+    )
+    states = tuple(state for state, _detail in assessments)
+    if ClaimState.VIOLATED in states:
+        affine_state = ClaimState.VIOLATED
+    elif ClaimState.INDETERMINATE in states:
+        affine_state = ClaimState.INDETERMINATE
+    else:
+        affine_state = ClaimState.SATISFIED
+    return ClaimAssessment(
+        "AFFINE_FEASIBILITY",
+        affine_state,
+        "; ".join(detail for _state, detail in assessments),
+    )
+
+
+def _boundary_claims(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    covariance: tuple[tuple[float, ...], ...],
+    residual_variance_scale: float,
+    affine_feasibility_policy: str,
+) -> tuple[ClaimAssessment, ClaimAssessment, ClaimAssessment]:
+    box = _box_boundary_claims(
+        accepted,
+        problem,
+        covariance,
+        residual_variance_scale,
+    )
+    if box[0].state is ClaimState.VIOLATED and any(
+        not lower <= value <= upper
+        for value, lower, upper in zip(
+            accepted.vector,
+            problem.lower_bounds,
+            problem.upper_bounds,
+            strict=True,
+        )
+    ):
+        affine = ClaimAssessment(
+            "AFFINE_FEASIBILITY",
+            ClaimState.VIOLATED,
+            "Accepted point is outside its box",
+        )
+    else:
+        affine = _affine_feasibility_claim(
+            accepted,
+            problem,
+            covariance,
+            residual_variance_scale,
+            affine_feasibility_policy,
+        )
+    return (*box, affine)
 
 
 def _residual_variance_scale(
@@ -2032,7 +3368,57 @@ def _residual_variance_scale(
     return float(scale), None
 
 
-def _covariance_from_jacobian(
+def _full_dimensional_feasible_interior_claim(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    box_interior: ClaimAssessment,
+) -> ClaimAssessment:
+    if problem.affine_equalities:
+        return ClaimAssessment(
+            "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
+            ClaimState.VIOLATED,
+            "Affine equality restrictions remove a full-dimensional local interior",
+        )
+    accepted_controlled = dict(
+        zip(problem.controlled_ids, accepted.vector, strict=True)
+    )
+    values = np.asarray(
+        tuple(
+            accepted_controlled.get(param_id, value)
+            for param_id, value in problem.independent_items
+        )
+    )
+    slacks = tuple(
+        float(
+            restriction.upper_bound
+            - _pairwise_sum_feasibility(
+                tuple(
+                    coefficient * float(value)
+                    for coefficient, value in zip(
+                        restriction.coefficients,
+                        values,
+                        strict=True,
+                    )
+                )
+            )
+        )
+        for restriction in problem.affine_half_spaces
+    )
+    state = (
+        ClaimState.SATISFIED
+        if box_interior.state is ClaimState.SATISFIED
+        and all(math.isfinite(slack) and slack > 0.0 for slack in slacks)
+        else ClaimState.VIOLATED
+    )
+    detail = (
+        "Accepted point is in the strict box and affine-half-space interior"
+        if problem.affine_half_spaces
+        else "Accepted point is in the strict box interior"
+    )
+    return ClaimAssessment("FULL_DIMENSIONAL_FEASIBLE_INTERIOR", state, detail)
+
+
+def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gates
     accepted: AcceptedFitResult,
     jacobian: ResidualJacobianEvidence,
     *,
@@ -2134,7 +3520,9 @@ def _covariance_from_jacobian(
         )
         for index in range(coordinate_count)
     )
-    right = _canonical_right_singular_vectors(right_transpose.T)
+    # Individual vectors inside a repeated/clustered singular subspace are not
+    # authoritative.  Only projectors are retained below.
+    right = np.asarray(right_transpose.T, dtype=np.float64)
     weak_threshold = _finite(
         max(threshold, policy.weak_relative_tolerance * largest),
         name="weak-subspace threshold",
@@ -2159,7 +3547,17 @@ def _covariance_from_jacobian(
             if threshold < value <= weak_threshold
         )
     )
+    subspaces = _invariant_singular_subspaces(
+        right,
+        singular_values,
+        rank_threshold=threshold,
+        weak_threshold=weak_threshold,
+        cluster_relative_tolerance=(policy.singular_value_cluster_relative_tolerance),
+    )
     rank_diagnostic = RankDiagnostic(
+        request_identity,
+        accepted.identity,
+        accepted.occurrence_identity,
         jacobian.identity,
         jacobian.controlled_ids,
         singular_values,
@@ -2171,7 +3569,13 @@ def _covariance_from_jacobian(
         identifiable_projector,
         null_projector,
         weak_projector,
+        subspaces,
+        source_jacobian=jacobian,
+        source_policy=policy,
     )
+    terminal = _cancellation_terminal(cancellation_probe)
+    if terminal is not None:
+        raise DerivationTermination(terminal, rank_diagnostic)
     if rank != coordinate_count:
         return (
             None,
@@ -2204,27 +3608,13 @@ def _covariance_from_jacobian(
     )
     if variance_failure is not None or residual_variance_scale is None:
         return None, rank_diagnostic, variance_failure
+    _raise_if_terminated(cancellation_probe)
     chi_square = _finite(accepted.chi_square, name="accepted chi-square")
-    unscaled_factor = tuple(
-        tuple(
-            _finite(
-                scales[row] * right[row, column] / singular_values[column],
-                name=f"unscaled covariance factor[{row},{column}]",
-            )
-            for column in range(coordinate_count)
-        )
-        for row in range(coordinate_count)
+    unscaled_covariance, factor, covariance = _canonical_covariance_reduction(
+        jacobian.matrix,
+        jacobian.coordinate_scales,
+        residual_variance_scale,
     )
-    unscaled_covariance = _gram_matrix(unscaled_factor)
-    scale_root = math.sqrt(residual_variance_scale)
-    factor = tuple(
-        tuple(
-            _finite(scale_root * value, name="scaled covariance factor")
-            for value in row
-        )
-        for row in unscaled_factor
-    )
-    covariance = _gram_matrix(factor)
     if _has_positive_scale_zero_variance(covariance, residual_variance_scale):
         return (
             None,
@@ -2242,6 +3632,11 @@ def _covariance_from_jacobian(
         covariance,
         residual_variance_scale,
         policy.affine_feasibility_policy,
+    )
+    full_dimensional_interior = _full_dimensional_feasible_interior_claim(
+        accepted,
+        problem,
+        interior,
     )
     conditioning = ClaimAssessment(
         "CONDITIONING_ADEQUACY",
@@ -2270,8 +3665,12 @@ def _covariance_from_jacobian(
     required = (
         conditioning.state,
         ClaimState.SATISFIED,
+        full_dimensional_interior.state,
         interior.state,
         boundary.state,
+        affine.state
+        if affine.state is not ClaimState.NOT_APPLICABLE
+        else ClaimState.SATISFIED,
         normalization.state,
         variance_nondegeneracy.state
         if variance_nondegeneracy.state is not ClaimState.NOT_APPLICABLE
@@ -2283,11 +3682,7 @@ def _covariance_from_jacobian(
         ClaimAssessment("EFFECTIVE_OBSERVATION_SUFFICIENCY", ClaimState.SATISFIED),
         ClaimAssessment("FULL_COLUMN_RANK", ClaimState.SATISFIED),
         conditioning,
-        ClaimAssessment(
-            "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
-            ClaimState.SATISFIED,
-            "OptimizationProblem v1 represents a box domain with a nonempty interior",
-        ),
+        full_dimensional_interior,
         interior,
         boundary,
         affine,
@@ -2309,6 +3704,7 @@ def _covariance_from_jacobian(
         request_identity,
         jacobian.identity,
         accepted.identity,
+        accepted.occurrence_identity,
         problem.identity,
         accepted.parameterization_identity,
         accepted.evaluation_result.plan_identity,
@@ -2335,6 +3731,13 @@ def _covariance_from_jacobian(
         factor,
         covariance,
         claims,
+        rank_diagnostic.identity,
+        source_jacobian=jacobian,
+        source_rank_diagnostic=rank_diagnostic,
+        accepted_anchor=accepted,
+        source_problem=problem,
+        source_policy=policy,
+        source_engine=engine,
     )
     return covariance_evidence, rank_diagnostic, None
 
@@ -2342,6 +3745,8 @@ def _covariance_from_jacobian(
 def _marginal_errors(
     *,
     source_identity: str,
+    accepted_result_identity: str,
+    accepted_occurrence_identity: str,
     source_family: str,
     output_ids: tuple[str, ...],
     units: tuple[ParameterUnit, ...],
@@ -2349,6 +3754,7 @@ def _marginal_errors(
     residual_variance_degenerate: bool,
     source_reportable: bool,
     inherited_claims: tuple[ClaimAssessment, ...],
+    source_artifact: CovarianceEvidence | ConstrainedPropagationEvidence,
 ) -> MarginalErrorEvidence:
     entries: list[ScalarEvidenceEntry] = []
     for index, param_id in enumerate(output_ids):
@@ -2390,18 +3796,23 @@ def _marginal_errors(
     )
     return MarginalErrorEvidence(
         source_identity,
+        accepted_result_identity,
+        accepted_occurrence_identity,
         source_family,
         output_ids,
         units,
         tuple(entries),
         claims,
         reportable,
+        source_artifact=source_artifact,
     )
 
 
 def _correlations(
     *,
     source_identity: str,
+    accepted_result_identity: str,
+    accepted_occurrence_identity: str,
     source_family: str,
     output_ids: tuple[str, ...],
     units: tuple[ParameterUnit, ...],
@@ -2410,63 +3821,13 @@ def _correlations(
     source_reportable: bool,
     policy: UncertaintyPolicy,
     inherited_claims: tuple[ClaimAssessment, ...],
+    source_artifact: CovarianceEvidence | ConstrainedPropagationEvidence,
 ) -> CorrelationEvidence:
-    dimension = len(output_ids)
-    entries: list[list[CorrelationEntry]] = [
-        [CorrelationEntry(None, "UNAVAILABLE") for _right in range(dimension)]
-        for _left in range(dimension)
-    ]
-    standard_errors = tuple(
-        math.sqrt(covariance[index][index]) if covariance[index][index] > 0.0 else None
-        for index in range(dimension)
+    entries = _expected_correlation_entries(
+        covariance,
+        residual_variance_degenerate=residual_variance_degenerate,
+        policy=policy,
     )
-    tolerance = policy.correlation_roundoff_multiplier * _EPSILON
-    for left in range(dimension):
-        if standard_errors[left] is not None and not residual_variance_degenerate:
-            entries[left][left] = CorrelationEntry(1.0, "AVAILABLE", 1.0)
-        else:
-            entries[left][left] = CorrelationEntry(
-                None,
-                "RESIDUAL_VARIANCE_DEGENERACY"
-                if residual_variance_degenerate
-                else "INVALID_VARIANCE",
-            )
-        for right in range(left + 1, dimension):
-            left_error = standard_errors[left]
-            right_error = standard_errors[right]
-            if residual_variance_degenerate:
-                entry = CorrelationEntry(None, "RESIDUAL_VARIANCE_DEGENERACY")
-            elif left_error is None or right_error is None:
-                entry = CorrelationEntry(None, "INVALID_VARIANCE")
-            else:
-                raw = (covariance[left][right] / left_error) / right_error
-                if not math.isfinite(raw):
-                    entry = CorrelationEntry(None, "NON_FINITE_CORRELATION")
-                else:
-                    excess = max(0.0, abs(raw) - 1.0)
-                    if abs(raw) <= 1.0:
-                        entry = CorrelationEntry(
-                            raw, "AVAILABLE", raw, excess, tolerance
-                        )
-                    elif excess <= tolerance:
-                        canonical = math.copysign(1.0, raw)
-                        entry = CorrelationEntry(
-                            canonical,
-                            "ENDPOINT_CANONICALIZED",
-                            raw,
-                            excess,
-                            tolerance,
-                        )
-                    else:
-                        entry = CorrelationEntry(
-                            None,
-                            "CORRELATION_RANGE_VIOLATION",
-                            raw,
-                            excess,
-                            tolerance,
-                        )
-            entries[left][right] = entry
-            entries[right][left] = entry
     complete = all(item.value is not None for row in entries for item in row)
     reportable = source_reportable and complete
     claims = (
@@ -2482,12 +3843,16 @@ def _correlations(
     )
     return CorrelationEvidence(
         source_identity,
+        accepted_result_identity,
+        accepted_occurrence_identity,
         source_family,
         output_ids,
         units,
-        tuple(tuple(row) for row in entries),
+        entries,
         claims,
         reportable,
+        source_artifact=source_artifact,
+        source_policy=policy,
     )
 
 
@@ -2659,6 +4024,7 @@ def _analytic_function_partials(
     arguments: tuple[float, ...],
     capability: FunctionAnalyticPartialCapability,
 ) -> tuple[tuple[float, ...], tuple[FunctionPartialDiagnostic, ...]]:
+    capability.validate_implementations()
     if len(capability.partials) != len(arguments):
         raise UncertaintyConstructionError(
             f"Scientific function {expression.function_id!r} capability has the "
@@ -2676,7 +4042,7 @@ def _analytic_function_partials(
             raise FunctionPartialFailure(
                 "analytic_function_partial_domain_failure",
                 str(error),
-                capability.implementation_identity,
+                capability.identity,
                 ("versioned_analytic_partial_failed",),
             ) from error
         estimates.append(estimate)
@@ -2694,12 +4060,12 @@ def _analytic_function_partials(
                 abs(estimate),
                 0.0,
                 1,
-                capability.implementation_identity,
+                capability.identity,
                 (
                     ClaimAssessment(
                         "FUNCTION_PARTIAL_RELIABILITY",
                         ClaimState.SATISFIED,
-                        capability.implementation_identity,
+                        capability.identity,
                     ),
                 ),
             )
@@ -2976,6 +4342,7 @@ def _constraint_rows(
     policy: UncertaintyPolicy,
     compiled_capabilities: CompiledConstraintLinearizationCapabilities,
     output_scope: tuple[str, ...],
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
 ) -> tuple[
     tuple[tuple[float, ...], ...] | None,
     tuple[tuple[str, ...], ...] | None,
@@ -2993,6 +4360,7 @@ def _constraint_rows(
     diagnostics: dict[str, FunctionPartialDiagnostic] = {}
     try:
         for param_id in output_scope:
+            _raise_if_terminated(cancellation_probe)
             role = parameterization.role(param_id)
             if (
                 param_id in parameterization.independent_ids
@@ -3019,6 +4387,7 @@ def _constraint_rows(
                 policy=policy,
                 compiled_capabilities=compiled_capabilities,
             )
+            _raise_if_terminated(cancellation_probe)
             if role is ParameterRole.DERIVED and not value.structural_dependencies:
                 return (
                     None,
@@ -3082,6 +4451,7 @@ def _linearize_constraints(
     output_units: tuple[ParameterUnit, ...],
     output_scales: tuple[float, ...],
     request_identity: str,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
 ) -> tuple[ConstraintJacobianEvidence | None, EvidenceFailure | None]:
     if not output_scope:
         return None, None
@@ -3099,6 +4469,7 @@ def _linearize_constraints(
         policy,
         compiled_capabilities,
         output_scope,
+        cancellation_probe,
     )
     if (
         row_failure is not None
@@ -3111,6 +4482,7 @@ def _linearize_constraints(
         ConstraintJacobianEvidence(
             request_identity,
             accepted.identity,
+            accepted.occurrence_identity,
             accepted.evaluation_result.identity,
             problem.identity,
             parameterization.identity,
@@ -3133,6 +4505,11 @@ def _linearize_constraints(
                     ClaimState.SATISFIED,
                 ),
             ),
+            accepted_anchor=accepted,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_policy=policy,
+            source_capabilities=compiled_capabilities,
         ),
         None,
     )
@@ -3279,6 +4656,7 @@ def _propagate_constraints(
         covariance.identity,
         constraint_jacobian.identity,
         accepted.identity,
+        accepted.occurrence_identity,
         covariance.controlled_ids,
         constraint_jacobian.output_ids,
         constraint_jacobian.output_units,
@@ -3286,6 +4664,9 @@ def _propagate_constraints(
         factor,
         propagated,
         claims,
+        source_covariance=covariance,
+        source_constraint_jacobian=constraint_jacobian,
+        accepted_anchor=accepted,
     )
 
 
@@ -3388,7 +4769,7 @@ class _CovarianceBranch:
     correlations: CorrelationEvidence | None
 
 
-def _derive_covariance_branch(
+def _derive_covariance_branch(  # noqa: C901 - ordered cancellation phase ledger
     accepted: AcceptedFitResult,
     *,
     problem: OptimizationProblem,
@@ -3403,7 +4784,13 @@ def _derive_covariance_branch(
     failures: list[EvidenceFailure] = []
     residual_request = _identity(
         "native-residual-linearization-request",
-        (request_identity, accepted.identity, engine.plan.identity, policy.identity),
+        (
+            request_identity,
+            accepted.identity,
+            accepted.occurrence_identity,
+            engine.plan.identity,
+            policy.identity,
+        ),
     )
     residual_jacobian: ResidualJacobianEvidence | None = None
     residual_failure: EvidenceFailure | None = None
@@ -3474,6 +4861,8 @@ def _derive_covariance_branch(
             )
         except DerivationTermination as termination:
             covariance_terminal = termination.terminal
+            if isinstance(termination.partial_artifact, RankDiagnostic):
+                rank_diagnostic = termination.partial_artifact
         except (ArithmeticError, TypeError, ValueError) as error:
             covariance_failure = EvidenceFailure(
                 "covariance",
@@ -3498,7 +4887,7 @@ def _derive_covariance_branch(
             tuple(operations),
             tuple(failures),
             residual_jacobian,
-            None,
+            rank_diagnostic,
             None,
             None,
             None,
@@ -3506,9 +4895,31 @@ def _derive_covariance_branch(
     marginal_errors: MarginalErrorEvidence | None = None
     correlations: CorrelationEvidence | None = None
     if covariance is not None:
+        terminal = _cancellation_terminal(cancellation_probe)
+        if terminal is not None:
+            operation = _operation(
+                "marginal_errors",
+                covariance.identity,
+                None,
+                None,
+                resolved_environment_identity=resolved_environment_identity,
+                terminal_override=terminal,
+            )
+            _record_operation(operations, failures, operation)
+            return _CovarianceBranch(
+                tuple(operations),
+                tuple(failures),
+                residual_jacobian,
+                rank_diagnostic,
+                covariance,
+                None,
+                None,
+            )
         variance_degenerate = covariance.residual_variance_scale == 0.0
         marginal_errors = _marginal_errors(
             source_identity=covariance.identity,
+            accepted_result_identity=accepted.identity,
+            accepted_occurrence_identity=accepted.occurrence_identity,
             source_family="local_covariance",
             output_ids=covariance.controlled_ids,
             units=covariance.units,
@@ -3516,25 +4927,11 @@ def _derive_covariance_branch(
             residual_variance_degenerate=variance_degenerate,
             source_reportable=covariance.usable,
             inherited_claims=covariance.claims,
-        )
-        correlations = _correlations(
-            source_identity=covariance.identity,
-            source_family="local_covariance",
-            output_ids=covariance.controlled_ids,
-            units=covariance.units,
-            covariance=covariance.covariance,
-            residual_variance_degenerate=variance_degenerate,
-            source_reportable=covariance.usable,
-            policy=policy,
-            inherited_claims=covariance.claims,
+            source_artifact=covariance,
         )
         marginal_request = _identity(
             "native-marginal-error-request",
             (covariance.identity, _MARGINAL_VERSION),
-        )
-        correlation_request = _identity(
-            "native-correlation-request",
-            (covariance.identity, policy.identity, _CORRELATION_VERSION),
         )
         _record_operation(
             operations,
@@ -3546,6 +4943,47 @@ def _derive_covariance_branch(
                 None,
                 resolved_environment_identity=resolved_environment_identity,
             ),
+        )
+        correlation_request = _identity(
+            "native-correlation-request",
+            (covariance.identity, policy.identity, _CORRELATION_VERSION),
+        )
+        terminal = _cancellation_terminal(cancellation_probe)
+        if terminal is not None:
+            _record_operation(
+                operations,
+                failures,
+                _operation(
+                    "correlations",
+                    correlation_request,
+                    None,
+                    None,
+                    resolved_environment_identity=resolved_environment_identity,
+                    terminal_override=terminal,
+                ),
+            )
+            return _CovarianceBranch(
+                tuple(operations),
+                tuple(failures),
+                residual_jacobian,
+                rank_diagnostic,
+                covariance,
+                marginal_errors,
+                None,
+            )
+        correlations = _correlations(
+            source_identity=covariance.identity,
+            accepted_result_identity=accepted.identity,
+            accepted_occurrence_identity=accepted.occurrence_identity,
+            source_family="local_covariance",
+            output_ids=covariance.controlled_ids,
+            units=covariance.units,
+            covariance=covariance.covariance,
+            residual_variance_degenerate=variance_degenerate,
+            source_reportable=covariance.usable,
+            policy=policy,
+            inherited_claims=covariance.claims,
+            source_artifact=covariance,
         )
         _record_operation(
             operations,
@@ -3592,6 +5030,7 @@ def _derive_constraint_branch(
     output_scales: tuple[float, ...],
     covariance: CovarianceEvidence | None,
     resolved_environment_identity: str,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
 ) -> _ConstraintBranch:
     if not output_scope:
         return _ConstraintBranch((), (), None, None, None, None)
@@ -3602,23 +5041,32 @@ def _derive_constraint_branch(
         (
             request_identity,
             accepted.identity,
+            accepted.occurrence_identity,
             output_scope,
             output_units,
             _vector_tokens(output_scales),
             policy.identity,
         ),
     )
-    jacobian, constraint_failure = _linearize_constraints(
-        accepted,
-        problem=problem,
-        parameterization=parameterization,
-        policy=policy,
-        compiled_capabilities=compiled_capabilities,
-        output_scope=output_scope,
-        output_units=output_units,
-        output_scales=output_scales,
-        request_identity=constraint_request,
-    )
+    jacobian: ConstraintJacobianEvidence | None = None
+    constraint_failure: EvidenceFailure | None = None
+    constraint_terminal: OperationTerminal | None = None
+    try:
+        _raise_if_terminated(cancellation_probe)
+        jacobian, constraint_failure = _linearize_constraints(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            policy=policy,
+            compiled_capabilities=compiled_capabilities,
+            output_scope=output_scope,
+            output_units=output_units,
+            output_scales=output_scales,
+            request_identity=constraint_request,
+            cancellation_probe=cancellation_probe,
+        )
+    except DerivationTermination as termination:
+        constraint_terminal = termination.terminal
     _record_operation(
         operations,
         failures,
@@ -3628,8 +5076,13 @@ def _derive_constraint_branch(
             jacobian,
             constraint_failure,
             resolved_environment_identity=resolved_environment_identity,
+            terminal_override=constraint_terminal,
         ),
     )
+    if constraint_terminal is not None:
+        return _ConstraintBranch(
+            tuple(operations), tuple(failures), None, None, None, None
+        )
     propagation_request = _identity(
         "native-constrained-propagation-request",
         (
@@ -3642,8 +5095,10 @@ def _derive_constraint_branch(
     )
     propagation: ConstrainedPropagationEvidence | None = None
     propagation_failure: EvidenceFailure | None = None
+    propagation_terminal: OperationTerminal | None = None
     if covariance is not None and jacobian is not None:
         try:
+            _raise_if_terminated(cancellation_probe)
             propagation = _propagate_constraints(
                 accepted,
                 covariance,
@@ -3651,6 +5106,9 @@ def _derive_constraint_branch(
                 request_identity=propagation_request,
                 policy=policy,
             )
+            _raise_if_terminated(cancellation_probe)
+        except DerivationTermination as termination:
+            propagation_terminal = termination.terminal
         except (ArithmeticError, TypeError, ValueError) as error:
             propagation_failure = EvidenceFailure(
                 "constrained_propagation",
@@ -3667,8 +5125,13 @@ def _derive_constraint_branch(
             propagation,
             propagation_failure,
             resolved_environment_identity=resolved_environment_identity,
+            terminal_override=propagation_terminal,
         ),
     )
+    if propagation_terminal is not None:
+        return _ConstraintBranch(
+            tuple(operations), tuple(failures), jacobian, None, None, None
+        )
     marginal: MarginalErrorEvidence | None = None
     correlations: CorrelationEvidence | None = None
     if propagation is not None and covariance is not None:
@@ -3680,6 +5143,8 @@ def _derive_constraint_branch(
         )
         marginal = _marginal_errors(
             source_identity=propagation.identity,
+            accepted_result_identity=accepted.identity,
+            accepted_occurrence_identity=accepted.occurrence_identity,
             source_family="constrained_propagation",
             output_ids=propagation.output_ids,
             units=propagation.output_units,
@@ -3687,9 +5152,12 @@ def _derive_constraint_branch(
             residual_variance_degenerate=variance_degenerate,
             source_reportable=source_reportable,
             inherited_claims=propagation.claims,
+            source_artifact=propagation,
         )
         correlations = _correlations(
             source_identity=propagation.identity,
+            accepted_result_identity=accepted.identity,
+            accepted_occurrence_identity=accepted.occurrence_identity,
             source_family="constrained_propagation",
             output_ids=propagation.output_ids,
             units=propagation.output_units,
@@ -3698,6 +5166,7 @@ def _derive_constraint_branch(
             source_reportable=source_reportable,
             policy=policy,
             inherited_claims=propagation.claims,
+            source_artifact=propagation,
         )
         marginal_request = _identity(
             "native-constrained-marginal-error-request",
@@ -3739,7 +5208,7 @@ def _derive_constraint_branch(
     )
 
 
-def derive_uncertainty_evidence(
+def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
     accepted: AcceptedFitResult,
     *,
     problem: OptimizationProblem,
@@ -3802,6 +5271,7 @@ def derive_uncertainty_evidence(
         "native-uncertainty-request",
         (
             accepted.identity,
+            accepted.occurrence_identity,
             problem.identity,
             parameterization.identity,
             engine.plan.identity,
@@ -3825,11 +5295,13 @@ def derive_uncertainty_evidence(
         terminal_failure = cast("EvidenceFailure", operation.failure)
         return UncertaintyEvidence(
             accepted.identity,
+            accepted.occurrence_identity,
             request_identity,
             policy.identity,
             resolved_environment_identity,
             (operation,),
             (terminal_failure,),
+            accepted_anchor=accepted,
         )
     lineage_category = _lineage_failure(
         accepted,
@@ -3854,11 +5326,13 @@ def derive_uncertainty_evidence(
         )
         return UncertaintyEvidence(
             accepted.identity,
+            accepted.occurrence_identity,
             request_identity,
             policy.identity,
             resolved_environment_identity,
             (operation,),
             (failure,),
+            accepted_anchor=accepted,
         )
 
     covariance_branch = _derive_covariance_branch(
@@ -3877,6 +5351,7 @@ def derive_uncertainty_evidence(
     }:
         return UncertaintyEvidence(
             accepted.identity,
+            accepted.occurrence_identity,
             request_identity,
             policy.identity,
             resolved_environment_identity,
@@ -3887,6 +5362,7 @@ def derive_uncertainty_evidence(
             covariance_branch.covariance,
             covariance_branch.marginal_errors,
             covariance_branch.correlations,
+            accepted_anchor=accepted,
         )
     branch_terminal = (
         _cancellation_terminal(cancellation_probe) if output_scope else None
@@ -3903,6 +5379,7 @@ def derive_uncertainty_evidence(
         terminal_failure = cast("EvidenceFailure", operation.failure)
         return UncertaintyEvidence(
             accepted.identity,
+            accepted.occurrence_identity,
             request_identity,
             policy.identity,
             resolved_environment_identity,
@@ -3913,6 +5390,7 @@ def derive_uncertainty_evidence(
             covariance_branch.covariance,
             covariance_branch.marginal_errors,
             covariance_branch.correlations,
+            accepted_anchor=accepted,
         )
     constraint_branch = _derive_constraint_branch(
         accepted,
@@ -3926,15 +5404,37 @@ def derive_uncertainty_evidence(
         output_scales=output_scales,
         covariance=covariance_branch.covariance,
         resolved_environment_identity=resolved_environment_identity,
+        cancellation_probe=cancellation_probe,
     )
+
+    combined_operations = covariance_branch.operations + constraint_branch.operations
+    combined_failures = covariance_branch.failures + constraint_branch.failures
+    constraint_terminated = bool(constraint_branch.operations) and (
+        constraint_branch.operations[-1].terminal
+        in {OperationTerminal.CANCELLED, OperationTerminal.INTERRUPTED}
+    )
+    if not constraint_terminated:
+        final_terminal = _cancellation_terminal(cancellation_probe)
+        if final_terminal is not None:
+            final_operation = _operation(
+                "final_bundle_assembly",
+                request_identity,
+                None,
+                None,
+                resolved_environment_identity=resolved_environment_identity,
+                terminal_override=final_terminal,
+            )
+            combined_operations += (final_operation,)
+            combined_failures += (cast("EvidenceFailure", final_operation.failure),)
 
     return UncertaintyEvidence(
         accepted.identity,
+        accepted.occurrence_identity,
         request_identity,
         policy.identity,
         resolved_environment_identity,
-        covariance_branch.operations + constraint_branch.operations,
-        covariance_branch.failures + constraint_branch.failures,
+        combined_operations,
+        combined_failures,
         covariance_branch.residual_jacobian,
         covariance_branch.rank_diagnostic,
         covariance_branch.covariance,
@@ -3944,4 +5444,5 @@ def derive_uncertainty_evidence(
         constraint_branch.propagation,
         constraint_branch.marginal_errors,
         constraint_branch.correlations,
+        accepted_anchor=accepted,
     )

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -852,7 +852,8 @@ def _validate_accepted_anchor(
     occurrence_identity: str,
 ) -> None:
     if (
-        semantic_identity != accepted.identity
+        not accepted_occurrence_is_authoritative(accepted)
+        or semantic_identity != accepted.identity
         or occurrence_identity != accepted.occurrence_identity
     ):
         raise ValueError(
@@ -1307,6 +1308,39 @@ class RankDiagnostic:
             atol=tolerance,
         ):
             raise ValueError("Weak-subspace projector is inconsistent")
+        expected_identifiable = sum(
+            (
+                np.asarray(item.projector)
+                for item in self.subspaces
+                if not item.classification.endswith("_null")
+            ),
+            start=np.zeros((dimension, dimension), dtype=np.float64),
+        )
+        expected_null = sum(
+            (
+                np.asarray(item.projector)
+                for item in self.subspaces
+                if item.classification.endswith("_null")
+            ),
+            start=np.zeros((dimension, dimension), dtype=np.float64),
+        )
+        if not (
+            np.allclose(
+                identifiable,
+                expected_identifiable,
+                rtol=0.0,
+                atol=tolerance,
+            )
+            and np.allclose(
+                null,
+                expected_null,
+                rtol=0.0,
+                atol=tolerance,
+            )
+        ):
+            raise ValueError(
+                "Identifiable/null projectors do not match classified subspaces"
+            )
         object.__setattr__(self, "identifiable_projector", identifiable)
         object.__setattr__(self, "null_projector", null)
         object.__setattr__(self, "weak_projector", weak)
@@ -1505,79 +1539,17 @@ class CovarianceEvidence:
             != expected_jacobian_condition * expected_jacobian_condition
         ):
             raise ValueError("Covariance conditioning claims do not match the spectrum")
-        (
-            expected_interior,
-            expected_boundary,
-            expected_affine,
-            expected_controlled_affine,
-        ) = _boundary_claims(
+        expected_claims = _canonical_covariance_claims(
             accepted,
             problem,
             covariance,
             expected_scale,
-            policy.affine_feasibility_policy,
+            expected_jacobian_condition,
+            policy,
+            engine,
         )
-        expected_full_dimensional = _full_dimensional_feasible_interior_claim(
-            accepted,
-            problem,
-            expected_interior,
-        )
-        expected_claim_states = {
-            "AUTHORITATIVE_LINEAGE": ClaimState.SATISFIED,
-            "LOCAL_LINEARIZATION_REGULARITY": ClaimState.SATISFIED,
-            "EFFECTIVE_OBSERVATION_SUFFICIENCY": ClaimState.SATISFIED,
-            "FULL_COLUMN_RANK": ClaimState.SATISFIED,
-            "COVARIANCE_ARITHMETIC_INTEGRITY": ClaimState.SATISFIED,
-            "FULL_DIMENSIONAL_FEASIBLE_INTERIOR": expected_full_dimensional.state,
-            "INTERIOR_POINT": expected_interior.state,
-            "BOUNDARY_SEPARATION": expected_boundary.state,
-            "AFFINE_FEASIBILITY": expected_affine.state,
-            "CONTROLLED_AFFINE_SEPARATION": expected_controlled_affine.state,
-            "CONDITIONING_ADEQUACY": (
-                ClaimState.SATISFIED
-                if expected_jacobian_condition <= policy.conditioning_limit
-                else ClaimState.VIOLATED
-            ),
-            "PROFILED_NORMALIZATION_REGULARITY": (
-                ClaimState.SATISFIED
-                if _profiled_normalization_regular(accepted, engine)
-                else ClaimState.VIOLATED
-            ),
-        }
-        for name, state in expected_claim_states.items():
-            if _named_claim(self.claims, name).state is not state:
-                raise ValueError(f"Covariance claim {name!r} is inconsistent")
-        usable_inputs = (
-            expected_claim_states["CONDITIONING_ADEQUACY"],
-            expected_full_dimensional.state,
-            expected_interior.state,
-            expected_boundary.state,
-            expected_controlled_affine.state
-            if expected_controlled_affine.state is not ClaimState.NOT_APPLICABLE
-            else ClaimState.SATISFIED,
-            expected_claim_states["PROFILED_NORMALIZATION_REGULARITY"],
-            (
-                ClaimState.SATISFIED
-                if policy.residual_variance_scaling
-                is ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
-                or expected_scale > 0.0
-                else ClaimState.VIOLATED
-            ),
-        )
-        expected_usable = (
-            ClaimState.SATISFIED
-            if all(state is ClaimState.SATISFIED for state in usable_inputs)
-            else (
-                ClaimState.INDETERMINATE
-                if ClaimState.INDETERMINATE in usable_inputs
-                else ClaimState.VIOLATED
-            )
-        )
-        if (
-            _named_claim(self.claims, "USABLE_LOCAL_COVARIANCE").state
-            is not expected_usable
-        ):
-            raise ValueError("Covariance usability claim is inconsistent")
+        if self.claims != expected_claims:
+            raise ValueError("Covariance claims are inconsistent")
         object.__setattr__(self, "unscaled_covariance", unscaled)
         object.__setattr__(self, "factor", factor)
         object.__setattr__(self, "covariance", covariance)
@@ -2209,59 +2181,13 @@ class ConstrainedPropagationEvidence:
         )
         if factor != expected_factor or covariance != _gram_matrix(expected_factor):
             raise ValueError("Constrained covariance differs from G_S L")
-        inherited_claims = tuple(
-            ClaimAssessment(f"SOURCE_COVARIANCE::{item.name}", item.state, item.detail)
-            for item in source_covariance.claims
-        ) + tuple(
-            ClaimAssessment(
-                f"SOURCE_CONSTRAINT_LINEARIZATION::{item.name}",
-                item.state,
-                item.detail,
-            )
-            for item in source_jacobian.claims
+        expected_claims = _canonical_constrained_propagation_claims(
+            source_covariance,
+            source_jacobian,
+            source_covariance.source_policy,
         )
-        if self.claims[: len(inherited_claims)] != inherited_claims:
-            raise ValueError(
-                "Constrained propagation inherited claims are inconsistent"
-            )
-        per_output_degeneracy = tuple(
-            all(value == 0.0 for value in source_jacobian.matrix[index])
-            and bool(source_jacobian.structural_dependencies[index])
-            for index in range(rows)
-        )
-        expected_states = {
-            "EXACT_LINEAGE": ClaimState.SATISFIED,
-            "CONSTRAINT_LINEARIZATION_REGULARITY": ClaimState.SATISFIED,
-            "GRAM_ARITHMETIC_INTEGRITY": ClaimState.SATISFIED,
-            "LOCAL_FIRST_ORDER_DEGENERACY": (
-                ClaimState.VIOLATED
-                if any(per_output_degeneracy)
-                else ClaimState.SATISFIED
-            ),
-            "RESIDUAL_VARIANCE_NONDEGENERACY": (
-                ClaimState.VIOLATED
-                if source_covariance.residual_variance_scale == 0.0
-                else ClaimState.SATISFIED
-            ),
-            "SOURCE_COVARIANCE_USABILITY": source_covariance.claim(
-                "USABLE_LOCAL_COVARIANCE"
-            ),
-        }
-        expected_states.update(
-            {
-                f"OUTPUT_FIRST_ORDER_NONDEGENERACY::{param_id}": (
-                    ClaimState.VIOLATED
-                    if per_output_degeneracy[index]
-                    else ClaimState.SATISFIED
-                )
-                for index, param_id in enumerate(self.output_ids)
-            }
-        )
-        for name, state in expected_states.items():
-            if _named_claim(self.claims, name).state is not state:
-                raise ValueError(
-                    f"Constrained propagation claim {name!r} is inconsistent"
-                )
+        if self.claims != expected_claims:
+            raise ValueError("Constrained propagation claims are inconsistent")
         object.__setattr__(self, "factor", factor)
         object.__setattr__(self, "covariance", covariance)
         object.__setattr__(
@@ -3697,6 +3623,92 @@ def _full_dimensional_feasible_interior_claim(
     return ClaimAssessment("FULL_DIMENSIONAL_FEASIBLE_INTERIOR", state, detail)
 
 
+def _canonical_covariance_claims(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    covariance: tuple[tuple[float, ...], ...],
+    residual_variance_scale: float,
+    jacobian_condition: float,
+    policy: UncertaintyPolicy,
+    engine: EvaluationEngine,
+) -> tuple[ClaimAssessment, ...]:
+    interior, boundary, affine, controlled_affine = _boundary_claims(
+        accepted,
+        problem,
+        covariance,
+        residual_variance_scale,
+        policy.affine_feasibility_policy,
+    )
+    full_dimensional_interior = _full_dimensional_feasible_interior_claim(
+        accepted,
+        problem,
+        interior,
+    )
+    conditioning = ClaimAssessment(
+        "CONDITIONING_ADEQUACY",
+        ClaimState.SATISFIED
+        if jacobian_condition <= policy.conditioning_limit
+        else ClaimState.VIOLATED,
+        f"kappa_J={float(jacobian_condition).hex()}",
+    )
+    normalization = ClaimAssessment(
+        "PROFILED_NORMALIZATION_REGULARITY",
+        ClaimState.SATISFIED
+        if _profiled_normalization_regular(accepted, engine)
+        else ClaimState.VIOLATED,
+    )
+    variance_nondegeneracy = ClaimAssessment(
+        "RESIDUAL_VARIANCE_NONDEGENERACY",
+        ClaimState.NOT_APPLICABLE
+        if policy.residual_variance_scaling
+        is ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+        else (
+            ClaimState.SATISFIED
+            if residual_variance_scale > 0.0
+            else ClaimState.VIOLATED
+        ),
+    )
+    required = (
+        conditioning.state,
+        ClaimState.SATISFIED,
+        full_dimensional_interior.state,
+        interior.state,
+        boundary.state,
+        controlled_affine.state
+        if controlled_affine.state is not ClaimState.NOT_APPLICABLE
+        else ClaimState.SATISFIED,
+        normalization.state,
+        variance_nondegeneracy.state
+        if variance_nondegeneracy.state is not ClaimState.NOT_APPLICABLE
+        else ClaimState.SATISFIED,
+    )
+    return (
+        ClaimAssessment("AUTHORITATIVE_LINEAGE", ClaimState.SATISFIED),
+        ClaimAssessment("LOCAL_LINEARIZATION_REGULARITY", ClaimState.SATISFIED),
+        ClaimAssessment("EFFECTIVE_OBSERVATION_SUFFICIENCY", ClaimState.SATISFIED),
+        ClaimAssessment("FULL_COLUMN_RANK", ClaimState.SATISFIED),
+        conditioning,
+        full_dimensional_interior,
+        interior,
+        boundary,
+        affine,
+        controlled_affine,
+        variance_nondegeneracy,
+        normalization,
+        ClaimAssessment("COVARIANCE_ARITHMETIC_INTEGRITY", ClaimState.SATISFIED),
+        ClaimAssessment(
+            "USABLE_LOCAL_COVARIANCE",
+            ClaimState.SATISFIED
+            if all(state is ClaimState.SATISFIED for state in required)
+            else (
+                ClaimState.INDETERMINATE
+                if ClaimState.INDETERMINATE in required
+                else ClaimState.VIOLATED
+            ),
+        ),
+    )
+
+
 def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gates
     accepted: AcceptedFitResult,
     jacobian: ResidualJacobianEvidence,
@@ -3905,80 +3917,14 @@ def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gat
                 jacobian.identity,
             ),
         )
-    interior, boundary, affine, controlled_affine = _boundary_claims(
+    claims = _canonical_covariance_claims(
         accepted,
         problem,
         covariance,
         residual_variance_scale,
-        policy.affine_feasibility_policy,
-    )
-    full_dimensional_interior = _full_dimensional_feasible_interior_claim(
-        accepted,
-        problem,
-        interior,
-    )
-    conditioning = ClaimAssessment(
-        "CONDITIONING_ADEQUACY",
-        ClaimState.SATISFIED
-        if jacobian_condition <= policy.conditioning_limit
-        else ClaimState.VIOLATED,
-        f"kappa_J={float(jacobian_condition).hex()}",
-    )
-    normalization = ClaimAssessment(
-        "PROFILED_NORMALIZATION_REGULARITY",
-        ClaimState.SATISFIED
-        if _profiled_normalization_regular(accepted, engine)
-        else ClaimState.VIOLATED,
-    )
-    variance_nondegeneracy = ClaimAssessment(
-        "RESIDUAL_VARIANCE_NONDEGENERACY",
-        ClaimState.NOT_APPLICABLE
-        if policy.residual_variance_scaling
-        is ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
-        else (
-            ClaimState.SATISFIED
-            if residual_variance_scale > 0.0
-            else ClaimState.VIOLATED
-        ),
-    )
-    required = (
-        conditioning.state,
-        ClaimState.SATISFIED,
-        full_dimensional_interior.state,
-        interior.state,
-        boundary.state,
-        controlled_affine.state
-        if controlled_affine.state is not ClaimState.NOT_APPLICABLE
-        else ClaimState.SATISFIED,
-        normalization.state,
-        variance_nondegeneracy.state
-        if variance_nondegeneracy.state is not ClaimState.NOT_APPLICABLE
-        else ClaimState.SATISFIED,
-    )
-    claims = (
-        ClaimAssessment("AUTHORITATIVE_LINEAGE", ClaimState.SATISFIED),
-        ClaimAssessment("LOCAL_LINEARIZATION_REGULARITY", ClaimState.SATISFIED),
-        ClaimAssessment("EFFECTIVE_OBSERVATION_SUFFICIENCY", ClaimState.SATISFIED),
-        ClaimAssessment("FULL_COLUMN_RANK", ClaimState.SATISFIED),
-        conditioning,
-        full_dimensional_interior,
-        interior,
-        boundary,
-        affine,
-        controlled_affine,
-        variance_nondegeneracy,
-        normalization,
-        ClaimAssessment("COVARIANCE_ARITHMETIC_INTEGRITY", ClaimState.SATISFIED),
-        ClaimAssessment(
-            "USABLE_LOCAL_COVARIANCE",
-            ClaimState.SATISFIED
-            if all(state is ClaimState.SATISFIED for state in required)
-            else (
-                ClaimState.INDETERMINATE
-                if ClaimState.INDETERMINATE in required
-                else ClaimState.VIOLATED
-            ),
-        ),
+        jacobian_condition,
+        policy,
+        engine,
     )
     covariance_evidence = CovarianceEvidence(
         request_identity,
@@ -4795,6 +4741,104 @@ def _linearize_constraints(
     )
 
 
+def _canonical_constrained_propagation_claims(
+    covariance: CovarianceEvidence,
+    constraint_jacobian: ConstraintJacobianEvidence,
+    policy: UncertaintyPolicy,
+) -> tuple[ClaimAssessment, ...]:
+    per_output_degeneracy = tuple(
+        all(value == 0.0 for value in constraint_jacobian.matrix[index])
+        and bool(constraint_jacobian.structural_dependencies[index])
+        for index in range(len(constraint_jacobian.output_ids))
+    )
+    scaled_gradient = (
+        np.asarray(constraint_jacobian.matrix, dtype=np.float64)
+        * np.asarray(covariance.coordinate_scales, dtype=np.float64)[np.newaxis, :]
+        / np.asarray(constraint_jacobian.output_scales, dtype=np.float64)[:, np.newaxis]
+    )
+    try:
+        gradient_singular = tuple(
+            _finite(value, name="constraint-output singular value")
+            for value in svd(
+                scaled_gradient,
+                full_matrices=False,
+                compute_uv=False,
+                overwrite_a=False,
+                check_finite=True,
+                lapack_driver=policy.svd_driver,
+            )
+        )
+        if any(value < 0.0 for value in gradient_singular) or any(
+            left < right for left, right in pairwise(gradient_singular)
+        ):
+            raise ValueError("invalid scaled constraint-output singular spectrum")
+        largest = gradient_singular[0] if gradient_singular else 0.0
+        rank_threshold = _finite(
+            policy.rank_absolute_tolerance + policy.rank_relative_tolerance * largest,
+            name="constraint-output rank threshold",
+        )
+        output_rank = sum(value > rank_threshold for value in gradient_singular)
+        output_rank_claim = ClaimAssessment(
+            "OUTPUT_RANK_DEFICIENCY_EXPECTED",
+            ClaimState.SATISFIED
+            if output_rank < len(constraint_jacobian.output_ids)
+            else ClaimState.NOT_APPLICABLE,
+            f"scaled-rank={output_rank}; rows={len(constraint_jacobian.output_ids)}; "
+            f"threshold={float(rank_threshold).hex()}",
+        )
+    except Exception as error:  # noqa: BLE001 - diagnostic kernel fence
+        output_rank_claim = ClaimAssessment(
+            "OUTPUT_RANK_DEFICIENCY_EXPECTED",
+            ClaimState.INDETERMINATE,
+            f"diagnostic scaled-SVD unavailable: {error}",
+        )
+    inherited_claims = tuple(
+        ClaimAssessment(f"SOURCE_COVARIANCE::{item.name}", item.state, item.detail)
+        for item in covariance.claims
+    ) + tuple(
+        ClaimAssessment(
+            f"SOURCE_CONSTRAINT_LINEARIZATION::{item.name}",
+            item.state,
+            item.detail,
+        )
+        for item in constraint_jacobian.claims
+    )
+    output_claims = tuple(
+        ClaimAssessment(
+            f"OUTPUT_FIRST_ORDER_NONDEGENERACY::{param_id}",
+            ClaimState.VIOLATED
+            if per_output_degeneracy[index]
+            else ClaimState.SATISFIED,
+        )
+        for index, param_id in enumerate(constraint_jacobian.output_ids)
+    )
+    return (
+        *inherited_claims,
+        ClaimAssessment("EXACT_LINEAGE", ClaimState.SATISFIED),
+        ClaimAssessment(
+            "CONSTRAINT_LINEARIZATION_REGULARITY",
+            ClaimState.SATISFIED,
+        ),
+        ClaimAssessment("GRAM_ARITHMETIC_INTEGRITY", ClaimState.SATISFIED),
+        output_rank_claim,
+        ClaimAssessment(
+            "LOCAL_FIRST_ORDER_DEGENERACY",
+            ClaimState.VIOLATED if any(per_output_degeneracy) else ClaimState.SATISFIED,
+        ),
+        ClaimAssessment(
+            "RESIDUAL_VARIANCE_NONDEGENERACY",
+            ClaimState.VIOLATED
+            if covariance.residual_variance_scale == 0.0
+            else ClaimState.SATISFIED,
+        ),
+        ClaimAssessment(
+            "SOURCE_COVARIANCE_USABILITY",
+            covariance.claim("USABLE_LOCAL_COVARIANCE"),
+        ),
+        *output_claims,
+    )
+
+
 def _propagate_constraints(
     accepted: AcceptedFitResult,
     covariance: CovarianceEvidence,
@@ -4820,12 +4864,6 @@ def _propagate_constraints(
         for row in range(len(constraint_jacobian.output_ids))
     )
     propagated = _gram_matrix(factor)
-    per_output_degeneracy = tuple(
-        all(value == 0.0 for value in constraint_jacobian.matrix[index])
-        and bool(constraint_jacobian.structural_dependencies[index])
-        for index in range(len(factor))
-    )
-    local_degeneracy = any(per_output_degeneracy)
     residual_variance_degenerate = covariance.residual_variance_scale == 0.0
     if not residual_variance_degenerate:
         for index, row in enumerate(factor):
@@ -4839,97 +4877,10 @@ def _propagate_constraints(
                 raise ArithmeticError(
                     "Nonzero propagated factor row underflowed to zero variance"
                 )
-    scaled_gradient = (
-        np.asarray(gradient, dtype=np.float64)
-        * np.asarray(covariance.coordinate_scales, dtype=np.float64)[np.newaxis, :]
-        / np.asarray(constraint_jacobian.output_scales, dtype=np.float64)[:, np.newaxis]
-    )
-    output_rank_claim: ClaimAssessment
-    try:
-        gradient_singular = tuple(
-            _finite(value, name="constraint-output singular value")
-            for value in svd(
-                scaled_gradient,
-                full_matrices=False,
-                compute_uv=False,
-                overwrite_a=False,
-                check_finite=True,
-                lapack_driver=policy.svd_driver,
-            )
-        )
-        if any(value < 0.0 for value in gradient_singular) or any(
-            left < right for left, right in pairwise(gradient_singular)
-        ):
-            raise ValueError("invalid scaled constraint-output singular spectrum")
-        largest = gradient_singular[0] if gradient_singular else 0.0
-        rank_threshold = _finite(
-            policy.rank_absolute_tolerance + policy.rank_relative_tolerance * largest,
-            name="constraint-output rank threshold",
-        )
-        output_rank = sum(value > rank_threshold for value in gradient_singular)
-        output_rank_deficient = output_rank < len(constraint_jacobian.output_ids)
-        output_rank_claim = ClaimAssessment(
-            "OUTPUT_RANK_DEFICIENCY_EXPECTED",
-            ClaimState.SATISFIED
-            if output_rank_deficient
-            else ClaimState.NOT_APPLICABLE,
-            f"scaled-rank={output_rank}; rows={len(constraint_jacobian.output_ids)}; "
-            f"threshold={float(rank_threshold).hex()}",
-        )
-    except Exception as error:  # noqa: BLE001 - diagnostic kernel fence
-        output_rank_claim = ClaimAssessment(
-            "OUTPUT_RANK_DEFICIENCY_EXPECTED",
-            ClaimState.INDETERMINATE,
-            f"diagnostic scaled-SVD unavailable: {error}",
-        )
-    inherited_claims = tuple(
-        ClaimAssessment(
-            f"SOURCE_COVARIANCE::{item.name}",
-            item.state,
-            item.detail,
-        )
-        for item in covariance.claims
-    ) + tuple(
-        ClaimAssessment(
-            f"SOURCE_CONSTRAINT_LINEARIZATION::{item.name}",
-            item.state,
-            item.detail,
-        )
-        for item in constraint_jacobian.claims
-    )
-    output_claims = tuple(
-        ClaimAssessment(
-            f"OUTPUT_FIRST_ORDER_NONDEGENERACY::{param_id}",
-            ClaimState.VIOLATED
-            if per_output_degeneracy[index]
-            else ClaimState.SATISFIED,
-        )
-        for index, param_id in enumerate(constraint_jacobian.output_ids)
-    )
-    claims = (
-        *inherited_claims,
-        ClaimAssessment("EXACT_LINEAGE", ClaimState.SATISFIED),
-        ClaimAssessment(
-            "CONSTRAINT_LINEARIZATION_REGULARITY",
-            ClaimState.SATISFIED,
-        ),
-        ClaimAssessment("GRAM_ARITHMETIC_INTEGRITY", ClaimState.SATISFIED),
-        output_rank_claim,
-        ClaimAssessment(
-            "LOCAL_FIRST_ORDER_DEGENERACY",
-            ClaimState.VIOLATED if local_degeneracy else ClaimState.SATISFIED,
-        ),
-        ClaimAssessment(
-            "RESIDUAL_VARIANCE_NONDEGENERACY",
-            ClaimState.VIOLATED
-            if residual_variance_degenerate
-            else ClaimState.SATISFIED,
-        ),
-        ClaimAssessment(
-            "SOURCE_COVARIANCE_USABILITY",
-            covariance.claim("USABLE_LOCAL_COVARIANCE"),
-        ),
-        *output_claims,
+    claims = _canonical_constrained_propagation_claims(
+        covariance,
+        constraint_jacobian,
+        policy,
     )
     return ConstrainedPropagationEvidence(
         request_identity,
@@ -5509,6 +5460,11 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
         raise UncertaintyConstructionError(
             "Uncertainty evidence requires a resolved environment identity"
         )
+    if not accepted_occurrence_is_authoritative(accepted):
+        raise UncertaintyConstructionError(
+            "Uncertainty construction requires an exact authoritative accepted "
+            "occurrence"
+        )
     output_scope = tuple(constrained_scope)
     compiled_capabilities = (
         compile_constraint_linearization_capabilities(
@@ -5562,6 +5518,49 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             compiled_capabilities.identity,
         ),
     )
+
+    def assemble_evidence(
+        operations: tuple[DerivationOperation, ...],
+        failures: tuple[EvidenceFailure, ...],
+        *,
+        residual_jacobian: ResidualJacobianEvidence | None = None,
+        rank_diagnostic: RankDiagnostic | None = None,
+        covariance: CovarianceEvidence | None = None,
+        marginal_errors: MarginalErrorEvidence | None = None,
+        correlations: CorrelationEvidence | None = None,
+        constraint_jacobian: ConstraintJacobianEvidence | None = None,
+        constrained_propagation: ConstrainedPropagationEvidence | None = None,
+        constrained_marginal_errors: MarginalErrorEvidence | None = None,
+        constrained_correlations: CorrelationEvidence | None = None,
+    ) -> UncertaintyEvidence:
+        return UncertaintyEvidence(
+            accepted.identity,
+            accepted.occurrence_identity,
+            request_identity,
+            policy.identity,
+            resolved_environment_identity,
+            operations,
+            failures,
+            residual_jacobian,
+            rank_diagnostic,
+            covariance,
+            marginal_errors,
+            correlations,
+            constraint_jacobian,
+            constrained_propagation,
+            constrained_marginal_errors,
+            constrained_correlations,
+            accepted_anchor=accepted,
+            requested_output_scope=output_scope,
+            requested_output_units=output_units,
+            requested_output_scales=output_scales,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_engine=engine,
+            source_policy=policy,
+            source_capabilities=compiled_capabilities,
+        )
+
     initial_terminal = _cancellation_terminal(cancellation_probe)
     if initial_terminal is not None:
         operation = _operation(
@@ -5573,23 +5572,9 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             terminal_override=initial_terminal,
         )
         terminal_failure = cast("EvidenceFailure", operation.failure)
-        return UncertaintyEvidence(
-            accepted.identity,
-            accepted.occurrence_identity,
-            request_identity,
-            policy.identity,
-            resolved_environment_identity,
+        return assemble_evidence(
             (operation,),
             (terminal_failure,),
-            accepted_anchor=accepted,
-            requested_output_scope=output_scope,
-            requested_output_units=output_units,
-            requested_output_scales=output_scales,
-            source_problem=problem,
-            source_parameterization=parameterization,
-            source_engine=engine,
-            source_policy=policy,
-            source_capabilities=compiled_capabilities,
         )
     lineage_category = _lineage_failure(
         accepted,
@@ -5612,23 +5597,9 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             failure,
             resolved_environment_identity=resolved_environment_identity,
         )
-        return UncertaintyEvidence(
-            accepted.identity,
-            accepted.occurrence_identity,
-            request_identity,
-            policy.identity,
-            resolved_environment_identity,
+        return assemble_evidence(
             (operation,),
             (failure,),
-            accepted_anchor=accepted,
-            requested_output_scope=output_scope,
-            requested_output_units=output_units,
-            requested_output_scales=output_scales,
-            source_problem=problem,
-            source_parameterization=parameterization,
-            source_engine=engine,
-            source_policy=policy,
-            source_capabilities=compiled_capabilities,
         )
 
     covariance_branch = _derive_covariance_branch(
@@ -5645,28 +5616,14 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
         OperationTerminal.CANCELLED,
         OperationTerminal.INTERRUPTED,
     }:
-        return UncertaintyEvidence(
-            accepted.identity,
-            accepted.occurrence_identity,
-            request_identity,
-            policy.identity,
-            resolved_environment_identity,
+        return assemble_evidence(
             covariance_branch.operations,
             covariance_branch.failures,
-            covariance_branch.residual_jacobian,
-            covariance_branch.rank_diagnostic,
-            covariance_branch.covariance,
-            covariance_branch.marginal_errors,
-            covariance_branch.correlations,
-            accepted_anchor=accepted,
-            requested_output_scope=output_scope,
-            requested_output_units=output_units,
-            requested_output_scales=output_scales,
-            source_problem=problem,
-            source_parameterization=parameterization,
-            source_engine=engine,
-            source_policy=policy,
-            source_capabilities=compiled_capabilities,
+            residual_jacobian=covariance_branch.residual_jacobian,
+            rank_diagnostic=covariance_branch.rank_diagnostic,
+            covariance=covariance_branch.covariance,
+            marginal_errors=covariance_branch.marginal_errors,
+            correlations=covariance_branch.correlations,
         )
     branch_terminal = (
         _cancellation_terminal(cancellation_probe) if output_scope else None
@@ -5681,28 +5638,14 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             terminal_override=branch_terminal,
         )
         terminal_failure = cast("EvidenceFailure", operation.failure)
-        return UncertaintyEvidence(
-            accepted.identity,
-            accepted.occurrence_identity,
-            request_identity,
-            policy.identity,
-            resolved_environment_identity,
+        return assemble_evidence(
             covariance_branch.operations + (operation,),
             covariance_branch.failures + (terminal_failure,),
-            covariance_branch.residual_jacobian,
-            covariance_branch.rank_diagnostic,
-            covariance_branch.covariance,
-            covariance_branch.marginal_errors,
-            covariance_branch.correlations,
-            accepted_anchor=accepted,
-            requested_output_scope=output_scope,
-            requested_output_units=output_units,
-            requested_output_scales=output_scales,
-            source_problem=problem,
-            source_parameterization=parameterization,
-            source_engine=engine,
-            source_policy=policy,
-            source_capabilities=compiled_capabilities,
+            residual_jacobian=covariance_branch.residual_jacobian,
+            rank_diagnostic=covariance_branch.rank_diagnostic,
+            covariance=covariance_branch.covariance,
+            marginal_errors=covariance_branch.marginal_errors,
+            correlations=covariance_branch.correlations,
         )
     constraint_branch = _derive_constraint_branch(
         accepted,
@@ -5739,30 +5682,16 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             combined_operations += (final_operation,)
             combined_failures += (cast("EvidenceFailure", final_operation.failure),)
 
-    return UncertaintyEvidence(
-        accepted.identity,
-        accepted.occurrence_identity,
-        request_identity,
-        policy.identity,
-        resolved_environment_identity,
+    return assemble_evidence(
         combined_operations,
         combined_failures,
-        covariance_branch.residual_jacobian,
-        covariance_branch.rank_diagnostic,
-        covariance_branch.covariance,
-        covariance_branch.marginal_errors,
-        covariance_branch.correlations,
-        constraint_branch.jacobian,
-        constraint_branch.propagation,
-        constraint_branch.marginal_errors,
-        constraint_branch.correlations,
-        accepted_anchor=accepted,
-        requested_output_scope=output_scope,
-        requested_output_units=output_units,
-        requested_output_scales=output_scales,
-        source_problem=problem,
-        source_parameterization=parameterization,
-        source_engine=engine,
-        source_policy=policy,
-        source_capabilities=compiled_capabilities,
+        residual_jacobian=covariance_branch.residual_jacobian,
+        rank_diagnostic=covariance_branch.rank_diagnostic,
+        covariance=covariance_branch.covariance,
+        marginal_errors=covariance_branch.marginal_errors,
+        correlations=covariance_branch.correlations,
+        constraint_jacobian=constraint_branch.jacobian,
+        constrained_propagation=constraint_branch.propagation,
+        constrained_marginal_errors=constraint_branch.marginal_errors,
+        constrained_correlations=constraint_branch.correlations,
     )

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -35,6 +35,7 @@ from chemex.evaluation.native import (
 )
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
+    DirectTrfConstructionError,
     OptimizationProblem,
     accepted_occurrence_is_authoritative,
 )
@@ -55,8 +56,8 @@ from chemex.typing import Array
 _SCHEMA_VERSION = 1
 _RESIDUAL_LINEARIZATION_VERSION = "external-real-finite-difference-v1"
 _CONSTRAINT_LINEARIZATION_VERSION = "constraint-forward-chain-v1"
-_COVARIANCE_VERSION = "full-rank-scaled-svd-cholesky-v2"
-_FACTOR_VERSION = "canonical-information-cholesky-gram-v2"
+_COVARIANCE_VERSION = "full-rank-direct-scaled-svd-factor-gram-v3"
+_FACTOR_VERSION = "direct-scaled-svd-factor-gram-v3"
 _REDUCTION_VERSION = "fixed-pairwise-binary64-v1"
 _MARGINAL_VERSION = "covariance-diagonal-square-root-v1"
 _CORRELATION_VERSION = "ordered-double-division-v1"
@@ -760,6 +761,9 @@ class LinearizationColumn:
     param_id: str
     orientation: str
     nominal_step: float
+    feasible_displacement_interval: tuple[float, float]
+    lower_feasibility_limiters: tuple[str, ...]
+    upper_feasibility_limiters: tuple[str, ...]
     represented_displacements: tuple[float, ...]
     fine_estimate: tuple[float, ...]
     companion_estimate: tuple[float, ...]
@@ -781,6 +785,9 @@ class LinearizationColumn:
                     self.param_id,
                     self.orientation,
                     _float_token(self.nominal_step),
+                    _vector_tokens(self.feasible_displacement_interval),
+                    self.lower_feasibility_limiters,
+                    self.upper_feasibility_limiters,
                     _vector_tokens(self.represented_displacements),
                     _vector_tokens(self.fine_estimate),
                     _vector_tokens(self.companion_estimate),
@@ -1105,6 +1112,37 @@ class SingularSubspaceEvidence:
         )
 
 
+def _recomputed_scaled_svd(
+    source: ResidualJacobianEvidence,
+    policy: UncertaintyPolicy,
+) -> tuple[tuple[float, ...], tuple[tuple[float, ...], ...]]:
+    scaled = (
+        np.asarray(source.matrix, dtype=np.float64)
+        * np.asarray(source.coordinate_scales, dtype=np.float64)[np.newaxis, :]
+    )
+    _left, singular_values, right_transpose = svd(
+        scaled,
+        full_matrices=False,
+        compute_uv=True,
+        overwrite_a=False,
+        check_finite=True,
+        lapack_driver=policy.svd_driver,
+    )
+    dimension = len(source.controlled_ids)
+    return (
+        tuple(
+            _finite(value, name=f"recomputed singular value[{index}]")
+            for index, value in enumerate(singular_values)
+        ),
+        _canonical_matrix(
+            right_transpose,
+            rows=dimension,
+            columns=dimension,
+            name="recomputed right singular vectors",
+        ),
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class RankDiagnostic:
     request_identity: str
@@ -1200,9 +1238,10 @@ class RankDiagnostic:
         expected_norms = tuple(
             float(np.linalg.norm(scaled[:, index])) for index in range(dimension)
         )
-        information_eigenvalues = np.linalg.eigvalsh(scaled.T @ scaled)[::-1]
-        with np.errstate(over="ignore", invalid="ignore"):
-            expected_squared = np.square(np.asarray(self.singular_values))
+        recomputed_singular, recomputed_right_t = _recomputed_scaled_svd(
+            source,
+            self.source_policy,
+        )
         tolerance = 512.0 * _EPSILON * max(1, dimension)
         if (
             self.normalized_singular_values != expected_normalized
@@ -1212,10 +1251,10 @@ class RankDiagnostic:
                 self.scaled_column_norms, expected_norms, rtol=tolerance, atol=0.0
             )
             or not np.allclose(
-                expected_squared,
-                information_eigenvalues,
+                self.singular_values,
+                recomputed_singular,
                 rtol=tolerance,
-                atol=tolerance,
+                atol=0.0,
             )
         ):
             raise ValueError("SVD/rank numerical evidence does not derive from J_z")
@@ -1254,8 +1293,20 @@ class RankDiagnostic:
                 "Singular subspaces violate the declared clustering policy"
             )
         subspace_sum = np.zeros((dimension, dimension), dtype=np.float64)
-        information = scaled.T @ scaled
-        for item in self.subspaces:
+        recomputed_subspaces = _invariant_singular_subspaces(
+            np.asarray(recomputed_right_t, dtype=np.float64).T,
+            recomputed_singular,
+            rank_threshold=self.threshold,
+            weak_threshold=self.weak_threshold,
+            cluster_relative_tolerance=(
+                self.source_policy.singular_value_cluster_relative_tolerance
+            ),
+        )
+        for item, expected_subspace in zip(
+            self.subspaces,
+            recomputed_subspaces,
+            strict=True,
+        ):
             if item.singular_values != tuple(
                 self.singular_values[index] for index in item.indices
             ):
@@ -1271,16 +1322,16 @@ class RankDiagnostic:
             if item.classification != expected_classification:
                 raise ValueError("Singular subspace classification is inconsistent")
             item_projector = np.asarray(item.projector)
-            if not np.allclose(
-                item_projector @ information,
-                information @ item_projector,
-                rtol=tolerance,
-                atol=tolerance,
-            ) or not np.allclose(
-                np.trace(item_projector @ information),
-                sum(value * value for value in item.singular_values),
-                rtol=tolerance,
-                atol=tolerance,
+            if (
+                item.indices != expected_subspace.indices
+                or item.singular_values != expected_subspace.singular_values
+                or item.classification != expected_subspace.classification
+                or not np.allclose(
+                    item_projector,
+                    expected_subspace.projector,
+                    rtol=0.0,
+                    atol=tolerance,
+                )
             ):
                 raise ValueError(
                     "Singular projector does not match its invariant spectrum"
@@ -1519,9 +1570,16 @@ class CovarianceEvidence:
             or self.factorization != _FACTOR_VERSION
         ):
             raise ValueError("Covariance derivation lineage is internally inconsistent")
+        recomputed_singular, recomputed_right_t = _recomputed_scaled_svd(
+            source,
+            policy,
+        )
+        if recomputed_singular != rank_source.singular_values:
+            raise ValueError("Covariance SVD kernel differs from rank evidence")
         expected_unscaled, expected_factor, expected_covariance = (
             _canonical_covariance_reduction(
-                source.matrix,
+                rank_source.singular_values,
+                recomputed_right_t,
                 source.coordinate_scales,
                 expected_scale,
             )
@@ -2548,7 +2606,8 @@ def _gram_matrix(factor: Sequence[Sequence[float]]) -> tuple[tuple[float, ...], 
 
 
 def _canonical_covariance_reduction(
-    jacobian: Sequence[Sequence[float]],
+    singular_values: Sequence[float],
+    right_transpose: Sequence[Sequence[float]],
     coordinate_scales: Sequence[float],
     residual_variance_scale: float,
 ) -> tuple[
@@ -2556,32 +2615,60 @@ def _canonical_covariance_reduction(
     tuple[tuple[float, ...], ...],
     tuple[tuple[float, ...], ...],
 ]:
-    """Reduce the full-rank information matrix through one canonical factor."""
-    matrix = np.asarray(jacobian, dtype=np.float64)
-    scales = np.asarray(coordinate_scales, dtype=np.float64)
-    scaled = matrix * scales[np.newaxis, :]
-    information = scaled.T @ scaled
-    inverse_scaled = np.linalg.solve(
-        information,
-        np.eye(information.shape[0], dtype=np.float64),
+    """Construct ``C0`` and ``L`` directly from one declared full-rank SVD."""
+    scales = tuple(
+        _finite(value, name=f"coordinate scale[{index}]")
+        for index, value in enumerate(coordinate_scales)
     )
-    scale_matrix = np.diag(scales)
-    unscaled_array = scale_matrix @ inverse_scaled @ scale_matrix
-    unscaled_array = 0.5 * (unscaled_array + unscaled_array.T)
-    unscaled = _canonical_matrix(
-        unscaled_array,
-        rows=len(scales),
-        columns=len(scales),
-        name="canonical unscaled covariance",
+    if any(value <= 0.0 for value in scales):
+        raise ValueError("Coordinate scales must be strictly positive")
+    dimension = len(scales)
+    spectrum = tuple(
+        _finite(value, name=f"singular value[{index}]")
+        for index, value in enumerate(singular_values)
     )
-    unscaled_factor = np.linalg.cholesky(unscaled_array)
-    factor_array = math.sqrt(residual_variance_scale) * unscaled_factor
-    factor = _canonical_matrix(
-        factor_array,
-        rows=len(scales),
-        columns=len(scales),
-        name="canonical covariance factor",
+    if len(spectrum) != dimension or any(value <= 0.0 for value in spectrum):
+        raise ValueError("Direct SVD covariance requires a positive full-rank spectrum")
+    right_t = _canonical_matrix(
+        right_transpose,
+        rows=dimension,
+        columns=dimension,
+        name="right singular vectors",
     )
+    phi = _finite(residual_variance_scale, name="residual variance scale")
+    if phi < 0.0:
+        raise ValueError("Residual variance scale cannot be negative")
+    square_root_phi = _finite(math.sqrt(phi), name="sqrt residual variance scale")
+    inverse_singular = tuple(
+        _finite(1.0 / value, name=f"reciprocal singular value[{index}]")
+        for index, value in enumerate(spectrum)
+    )
+    right = tuple(zip(*right_t, strict=True))
+    unscaled_factor = tuple(
+        tuple(
+            _finite(
+                _finite(
+                    scales[row] * right[row][column],
+                    name=f"scaled right singular vector[{row},{column}]",
+                )
+                * inverse_singular[column],
+                name=f"unscaled SVD covariance factor[{row},{column}]",
+            )
+            for column in range(dimension)
+        )
+        for row in range(dimension)
+    )
+    factor = tuple(
+        tuple(
+            _finite(
+                square_root_phi * unscaled_factor[row][column],
+                name=f"scaled SVD covariance factor[{row},{column}]",
+            )
+            for column in range(dimension)
+        )
+        for row in range(dimension)
+    )
+    unscaled = _gram_matrix(unscaled_factor)
     return unscaled, factor, _gram_matrix(factor)
 
 
@@ -2896,12 +2983,15 @@ def _evaluate_stencil(
     results: list[tuple[float, ...]] = []
     displacements: list[float] = []
     for trial in vectors:
-        result = _evaluate_vector(
-            trial,
-            problem=problem,
-            parameterization=parameterization,
-            evaluator=evaluator,
-        )
+        try:
+            result = _evaluate_vector(
+                trial,
+                problem=problem,
+                parameterization=parameterization,
+                evaluator=evaluator,
+            )
+        except DirectTrfConstructionError:
+            return None, None, None
         if isinstance(result, EvaluationFailure):
             if result.validity == "INVALID_TRIAL":
                 return None, None, None
@@ -2999,13 +3089,26 @@ def _linearize_residual_column(
     cancellation_probe: Callable[[], OperationTerminal | None] | None,
 ) -> tuple[LinearizationColumn | None, tuple[object, ...], EvidenceFailure | None]:
     center = accepted.vector[column]
+    line_feasibility = problem.coordinate_line_feasibility(
+        accepted.vector,
+        column,
+    )
     orientations = _column_orientations(
         center,
-        problem.lower_bounds[column],
-        problem.upper_bounds[column],
+        center + line_feasibility.minimum_displacement,
+        center + line_feasibility.maximum_displacement,
     )
     nominal = _NOMINAL_STEP_FACTOR * scale
-    trajectory: list[object] = []
+    trajectory: list[object] = [
+        (
+            "exact-coordinate-line-feasibility",
+            line_feasibility.identity,
+            _float_token(line_feasibility.minimum_displacement),
+            _float_token(line_feasibility.maximum_displacement),
+            line_feasibility.lower_limiters,
+            line_feasibility.upper_limiters,
+        )
+    ]
     if not orientations:
         return (
             None,
@@ -3096,6 +3199,12 @@ def _linearize_residual_column(
                         param_id,
                         orientation,
                         nominal,
+                        (
+                            line_feasibility.minimum_displacement,
+                            line_feasibility.maximum_displacement,
+                        ),
+                        line_feasibility.lower_limiters,
+                        line_feasibility.upper_limiters,
                         tuple(displacements),
                         fine,
                         coarse,
@@ -3902,7 +4011,8 @@ def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gat
     _raise_if_terminated(cancellation_probe)
     chi_square = _finite(accepted.chi_square, name="accepted chi-square")
     unscaled_covariance, factor, covariance = _canonical_covariance_reduction(
-        jacobian.matrix,
+        singular_values,
+        right_transpose,
         jacobian.coordinate_scales,
         residual_variance_scale,
     )
@@ -5248,7 +5358,7 @@ class _ConstraintBranch:
     correlations: CorrelationEvidence | None
 
 
-def _derive_constraint_branch(
+def _derive_constraint_branch(  # noqa: C901 - ordered cancellation phase ledger
     accepted: AcceptedFitResult,
     *,
     problem: OptimizationProblem,
@@ -5366,6 +5476,36 @@ def _derive_constraint_branch(
     marginal: MarginalErrorEvidence | None = None
     correlations: CorrelationEvidence | None = None
     if propagation is not None and covariance is not None:
+        marginal_request = _identity(
+            "native-constrained-marginal-error-request",
+            (propagation.identity, _MARGINAL_VERSION),
+        )
+        correlation_request = _identity(
+            "native-constrained-correlation-request",
+            (propagation.identity, policy.identity, _CORRELATION_VERSION),
+        )
+        marginal_terminal = _cancellation_terminal(cancellation_probe)
+        if marginal_terminal is not None:
+            _record_operation(
+                operations,
+                failures,
+                _operation(
+                    "constrained_marginal_errors",
+                    marginal_request,
+                    None,
+                    None,
+                    resolved_environment_identity=resolved_environment_identity,
+                    terminal_override=marginal_terminal,
+                ),
+            )
+            return _ConstraintBranch(
+                tuple(operations),
+                tuple(failures),
+                jacobian,
+                propagation,
+                None,
+                None,
+            )
         variance_degenerate = covariance.residual_variance_scale == 0.0
         source_reportable = (
             covariance.usable
@@ -5385,6 +5525,39 @@ def _derive_constraint_branch(
             inherited_claims=propagation.claims,
             source_artifact=propagation,
         )
+        _record_operation(
+            operations,
+            failures,
+            _operation(
+                "constrained_marginal_errors",
+                marginal_request,
+                marginal,
+                None,
+                resolved_environment_identity=resolved_environment_identity,
+            ),
+        )
+        correlation_terminal = _cancellation_terminal(cancellation_probe)
+        if correlation_terminal is not None:
+            _record_operation(
+                operations,
+                failures,
+                _operation(
+                    "constrained_correlations",
+                    correlation_request,
+                    None,
+                    None,
+                    resolved_environment_identity=resolved_environment_identity,
+                    terminal_override=correlation_terminal,
+                ),
+            )
+            return _ConstraintBranch(
+                tuple(operations),
+                tuple(failures),
+                jacobian,
+                propagation,
+                marginal,
+                None,
+            )
         correlations = _correlations(
             source_identity=propagation.identity,
             accepted_result_identity=accepted.identity,
@@ -5398,25 +5571,6 @@ def _derive_constraint_branch(
             policy=policy,
             inherited_claims=propagation.claims,
             source_artifact=propagation,
-        )
-        marginal_request = _identity(
-            "native-constrained-marginal-error-request",
-            (propagation.identity, _MARGINAL_VERSION),
-        )
-        correlation_request = _identity(
-            "native-constrained-correlation-request",
-            (propagation.identity, policy.identity, _CORRELATION_VERSION),
-        )
-        _record_operation(
-            operations,
-            failures,
-            _operation(
-                "constrained_marginal_errors",
-                marginal_request,
-                marginal,
-                None,
-                resolved_environment_identity=resolved_environment_identity,
-            ),
         )
         _record_operation(
             operations,

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -50,6 +50,7 @@ from chemex.parameters.parameterization import (
     UnaryExpression,
     scientific_callable_fingerprint,
 )
+from chemex.typing import Array
 
 _SCHEMA_VERSION = 1
 _RESIDUAL_LINEARIZATION_VERSION = "external-real-finite-difference-v1"
@@ -895,6 +896,18 @@ class ResidualJacobianEvidence:
         metadata={"record": False},
         kw_only=True,
     )
+    source_problem: OptimizationProblem = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_parameterization: ActiveParameterization = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_engine: EvaluationEngine = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_policy: UncertaintyPolicy = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -955,6 +968,43 @@ class ResidualJacobianEvidence:
             or self.trajectory_fingerprint != expected_trajectory
         ):
             raise ValueError("Residual Jacobian differs from its accepted columns")
+        evaluator = self.source_engine.new_evaluator()
+        base = _evaluate_vector(
+            self.accepted_anchor.vector,
+            problem=self.source_problem,
+            parameterization=self.source_parameterization,
+            evaluator=evaluator,
+        )
+        if (
+            isinstance(base, EvaluationFailure)
+            or base.identity != self.accepted_evaluation_identity
+        ):
+            raise ValueError("Residual Jacobian baseline cannot be replayed")
+        base_residuals = tuple(float(value) for value in base.residuals)
+        for column, (param_id, scale, declared) in enumerate(
+            zip(
+                self.controlled_ids,
+                self.coordinate_scales,
+                self.columns,
+                strict=True,
+            )
+        ):
+            replayed, _trajectory, failure = _linearize_residual_column(
+                self.accepted_anchor,
+                problem=self.source_problem,
+                parameterization=self.source_parameterization,
+                evaluator=evaluator,
+                policy=self.source_policy,
+                base_residuals=base_residuals,
+                column=column,
+                param_id=param_id,
+                scale=scale,
+                cancellation_probe=None,
+            )
+            if failure is not None or replayed != declared:
+                raise ValueError(
+                    "Residual Jacobian stencil evidence cannot be replayed"
+                )
         object.__setattr__(self, "matrix", matrix)
         object.__setattr__(
             self,
@@ -1189,6 +1239,16 @@ class RankDiagnostic:
                 self.singular_values[index] for index in item.indices
             ):
                 raise ValueError("Singular subspace spectrum is inconsistent")
+            expected_classification = (
+                "isolated_" if len(item.indices) == 1 else "clustered_"
+            ) + _singular_direction_class(
+                self.singular_values,
+                item.indices[0],
+                rank_threshold=self.threshold,
+                weak_threshold=self.weak_threshold,
+            )
+            if item.classification != expected_classification:
+                raise ValueError("Singular subspace classification is inconsistent")
             item_projector = np.asarray(item.projector)
             if not np.allclose(
                 item_projector @ information,
@@ -1410,7 +1470,12 @@ class CovarianceEvidence:
             != expected_jacobian_condition * expected_jacobian_condition
         ):
             raise ValueError("Covariance conditioning claims do not match the spectrum")
-        expected_interior, expected_boundary, expected_affine = _boundary_claims(
+        (
+            expected_interior,
+            expected_boundary,
+            expected_affine,
+            expected_controlled_affine,
+        ) = _boundary_claims(
             accepted,
             problem,
             covariance,
@@ -1432,6 +1497,7 @@ class CovarianceEvidence:
             "INTERIOR_POINT": expected_interior.state,
             "BOUNDARY_SEPARATION": expected_boundary.state,
             "AFFINE_FEASIBILITY": expected_affine.state,
+            "CONTROLLED_AFFINE_SEPARATION": expected_controlled_affine.state,
             "CONDITIONING_ADEQUACY": (
                 ClaimState.SATISFIED
                 if expected_jacobian_condition <= policy.conditioning_limit
@@ -1451,8 +1517,8 @@ class CovarianceEvidence:
             expected_full_dimensional.state,
             expected_interior.state,
             expected_boundary.state,
-            expected_affine.state
-            if expected_affine.state is not ClaimState.NOT_APPLICABLE
+            expected_controlled_affine.state
+            if expected_controlled_affine.state is not ClaimState.NOT_APPLICABLE
             else ClaimState.SATISFIED,
             expected_claim_states["PROFILED_NORMALIZATION_REGULARITY"],
             (
@@ -1629,13 +1695,19 @@ class MarginalErrorEvidence:
         ):
             raise ValueError("Marginal validity claim is inconsistent")
         report_claim = _named_claim(self.claims, "MARGINAL_SCOPE_REPORTABILITY")
+        source_reportable = (
+            source.source_covariance.usable
+            and source.claim("LOCAL_FIRST_ORDER_DEGENERACY") is ClaimState.SATISFIED
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else source.usable
+        )
+        expected_reportable = source_reportable and complete
         if (
             report_claim.state
             is not (
-                ClaimState.SATISFIED if self.scope_reportable else ClaimState.VIOLATED
+                ClaimState.SATISFIED if expected_reportable else ClaimState.VIOLATED
             )
-            or self.scope_reportable
-            and not complete
+            or self.scope_reportable is not expected_reportable
         ):
             raise ValueError("Marginal reportability claim is inconsistent")
         object.__setattr__(
@@ -1816,13 +1888,19 @@ class CorrelationEvidence:
             ClaimState.SATISFIED if complete else ClaimState.VIOLATED
         ):
             raise ValueError("Correlation validity claim is inconsistent")
+        source_reportable = (
+            source.source_covariance.usable
+            and source.claim("LOCAL_FIRST_ORDER_DEGENERACY") is ClaimState.SATISFIED
+            if isinstance(source, ConstrainedPropagationEvidence)
+            else source.usable
+        )
+        expected_reportable = source_reportable and complete
         if (
             _named_claim(self.claims, "CORRELATION_SCOPE_REPORTABILITY").state
             is not (
-                ClaimState.SATISFIED if self.scope_reportable else ClaimState.VIOLATED
+                ClaimState.SATISFIED if expected_reportable else ClaimState.VIOLATED
             )
-            or self.scope_reportable
-            and not complete
+            or self.scope_reportable is not expected_reportable
         ):
             raise ValueError("Correlation reportability claim is inconsistent")
         object.__setattr__(
@@ -2206,14 +2284,57 @@ class UncertaintyEvidence:
         metadata={"record": False},
         kw_only=True,
     )
+    requested_output_scope: tuple[str, ...] = field(kw_only=True)
+    requested_output_units: tuple[ParameterUnit, ...] = field(kw_only=True)
+    requested_output_scales: tuple[float, ...] = field(kw_only=True)
+    source_problem: OptimizationProblem = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_parameterization: ActiveParameterization = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_engine: EvaluationEngine = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_policy: UncertaintyPolicy = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_capabilities: CompiledConstraintLinearizationCapabilities = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: C901 - complete bundle integrity chain
         _validate_accepted_anchor(
             self.accepted_anchor,
             self.accepted_result_identity,
             self.accepted_occurrence_identity,
         )
+        expected_request = _identity(
+            "native-uncertainty-request",
+            (
+                self.accepted_anchor.identity,
+                self.accepted_anchor.occurrence_identity,
+                self.source_problem.identity,
+                self.source_parameterization.identity,
+                self.source_engine.plan.identity,
+                self.source_policy.identity,
+                self.requested_output_scope,
+                self.requested_output_units,
+                _vector_tokens(self.requested_output_scales),
+                self.source_capabilities.identity,
+            ),
+        )
+        if (
+            self.request_identity != expected_request
+            or self.policy_identity != self.source_policy.identity
+            or self.source_capabilities.output_scope != self.requested_output_scope
+            or len(self.requested_output_units) != len(self.requested_output_scope)
+            or len(self.requested_output_scales) != len(self.requested_output_scope)
+        ):
+            raise ValueError(
+                "Uncertainty request does not match its exact source inputs"
+            )
         artifacts = tuple(
             item
             for item in (
@@ -2289,6 +2410,76 @@ class UncertaintyEvidence:
         }
         if completed != stage_artifacts:
             raise ValueError("Evidence operations do not bind the assembled artifacts")
+        if self.residual_jacobian is not None:
+            expected_residual_request = _identity(
+                "native-residual-linearization-request",
+                (
+                    self.request_identity,
+                    self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
+                    self.source_engine.plan.identity,
+                    self.source_policy.identity,
+                ),
+            )
+            if self.residual_jacobian.request_identity != expected_residual_request:
+                raise ValueError("Residual Jacobian request lineage is inconsistent")
+        if self.rank_diagnostic is not None:
+            expected_covariance_request = _identity(
+                "native-covariance-request",
+                (
+                    self.request_identity,
+                    None
+                    if self.residual_jacobian is None
+                    else self.residual_jacobian.identity,
+                    self.source_policy.identity,
+                ),
+            )
+            if self.rank_diagnostic.request_identity != expected_covariance_request or (
+                self.covariance is not None
+                and self.covariance.request_identity != expected_covariance_request
+            ):
+                raise ValueError("Covariance request lineage is inconsistent")
+        if self.constraint_jacobian is not None:
+            expected_constraint_request = _identity(
+                "native-constraint-linearization-request",
+                (
+                    self.request_identity,
+                    self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
+                    self.requested_output_scope,
+                    self.requested_output_units,
+                    _vector_tokens(self.requested_output_scales),
+                    self.source_policy.identity,
+                ),
+            )
+            if (
+                self.constraint_jacobian.request_identity != expected_constraint_request
+                or self.constraint_jacobian.output_ids != self.requested_output_scope
+                or self.constraint_jacobian.output_units != self.requested_output_units
+                or self.constraint_jacobian.output_scales
+                != self.requested_output_scales
+            ):
+                raise ValueError("Constraint Jacobian request lineage is inconsistent")
+        if self.constrained_propagation is not None:
+            expected_propagation_request = _identity(
+                "native-constrained-propagation-request",
+                (
+                    self.request_identity,
+                    None if self.covariance is None else self.covariance.identity,
+                    None
+                    if self.constraint_jacobian is None
+                    else self.constraint_jacobian.identity,
+                    self.requested_output_scope,
+                    self.source_policy.identity,
+                ),
+            )
+            if (
+                self.constrained_propagation.request_identity
+                != expected_propagation_request
+            ):
+                raise ValueError(
+                    "Constrained propagation request lineage is inconsistent"
+                )
         object.__setattr__(
             self,
             "identity",
@@ -2442,18 +2633,8 @@ def _has_positive_scale_zero_variance(
     )
 
 
-def _canonical_right_singular_vectors(values: np.ndarray) -> np.ndarray:
-    """Fix each isolated right-singular direction by its first max-magnitude entry."""
-    canonical = np.array(values, dtype=np.float64, copy=True)
-    for column in range(canonical.shape[1]):
-        pivot = int(np.argmax(np.abs(canonical[:, column])))
-        if canonical[pivot, column] < 0.0:
-            canonical[:, column] *= -1.0
-    return canonical
-
-
 def _invariant_singular_subspaces(
-    right: np.ndarray,
+    right: Array,
     singular_values: tuple[float, ...],
     *,
     rank_threshold: float,
@@ -2461,14 +2642,6 @@ def _invariant_singular_subspaces(
     cluster_relative_tolerance: float,
 ) -> tuple[SingularSubspaceEvidence, ...]:
     """Retain projectors, never basis orientation, for clustered directions."""
-
-    def direction_class(index: int) -> Literal["identifiable", "weak", "null"]:
-        value = singular_values[index]
-        if value <= rank_threshold:
-            return "null"
-        if value <= weak_threshold:
-            return "weak"
-        return "identifiable"
 
     groups = _singular_cluster_indices(
         singular_values,
@@ -2492,7 +2665,12 @@ def _invariant_singular_subspaces(
             indices,
             tuple(singular_values[index] for index in indices),
             ("isolated_" if len(indices) == 1 else "clustered_")
-            + direction_class(indices[0]),
+            + _singular_direction_class(
+                singular_values,
+                indices[0],
+                rank_threshold=rank_threshold,
+                weak_threshold=weak_threshold,
+            ),
             projector(indices),
         )
         for indices in groups
@@ -2508,21 +2686,24 @@ def _singular_cluster_indices(
 ) -> tuple[tuple[int, ...], ...]:
     largest = singular_values[0] if singular_values else 0.0
 
-    def direction_class(index: int) -> Literal["identifiable", "weak", "null"]:
-        value = singular_values[index]
-        if value <= rank_threshold:
-            return "null"
-        if value <= weak_threshold:
-            return "weak"
-        return "identifiable"
-
     groups: list[tuple[int, ...]] = []
     current: list[int] = []
     for index, value in enumerate(singular_values):
         if current:
             previous = singular_values[current[-1]]
             if not (
-                direction_class(index) == direction_class(current[-1])
+                _singular_direction_class(
+                    singular_values,
+                    index,
+                    rank_threshold=rank_threshold,
+                    weak_threshold=weak_threshold,
+                )
+                == _singular_direction_class(
+                    singular_values,
+                    current[-1],
+                    rank_threshold=rank_threshold,
+                    weak_threshold=weak_threshold,
+                )
                 and abs(previous - value)
                 <= cluster_relative_tolerance * max(largest, previous, value)
             ):
@@ -2532,6 +2713,21 @@ def _singular_cluster_indices(
     if current:
         groups.append(tuple(current))
     return tuple(groups)
+
+
+def _singular_direction_class(
+    singular_values: tuple[float, ...],
+    index: int,
+    *,
+    rank_threshold: float,
+    weak_threshold: float,
+) -> Literal["identifiable", "weak", "null"]:
+    value = singular_values[index]
+    if value <= rank_threshold:
+        return "null"
+    if value <= weak_threshold:
+        return "weak"
+    return "identifiable"
 
 
 def _singular_spectrum_error(
@@ -3074,6 +3270,10 @@ def _linearize_residuals(
             tuple(column_evidence),
             trajectory_fingerprint,
             accepted_anchor=accepted,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_engine=engine,
+            source_policy=policy,
         ),
         None,
     )
@@ -3166,9 +3366,9 @@ def _box_boundary_claims(
 
 def _classify_affine_restriction(
     label: str,
-    coefficient_array: np.ndarray,
+    coefficient_array: Array,
     upper_bound: float,
-    full_values: np.ndarray,
+    full_values: Array,
     controlled_frame_indices: tuple[int, ...],
     covariance: tuple[tuple[float, ...], ...],
     residual_variance_scale: float,
@@ -3221,10 +3421,15 @@ def _affine_feasibility_claim(
     covariance: tuple[tuple[float, ...], ...],
     residual_variance_scale: float,
     affine_feasibility_policy: str,
+    *,
+    controlled_only: bool = False,
 ) -> ClaimAssessment:
+    claim_name = (
+        "CONTROLLED_AFFINE_SEPARATION" if controlled_only else "AFFINE_FEASIBILITY"
+    )
     if not problem.affine_half_spaces and not problem.affine_equalities:
         return ClaimAssessment(
-            "AFFINE_FEASIBILITY",
+            claim_name,
             ClaimState.NOT_APPLICABLE,
             affine_feasibility_policy,
         )
@@ -3260,6 +3465,18 @@ def _affine_feasibility_claim(
         )
         for item in problem.affine_equalities
     )
+    if controlled_only:
+        restrictions = [
+            item
+            for item in restrictions
+            if any(item[1][index] != 0.0 for index in controlled_frame_indices)
+        ]
+    if not restrictions:
+        return ClaimAssessment(
+            claim_name,
+            ClaimState.NOT_APPLICABLE,
+            "No affine restriction has a controlled-coordinate coefficient",
+        )
     restrictions.extend(
         (
             f"{item.restriction_id}:negative",
@@ -3288,7 +3505,7 @@ def _affine_feasibility_claim(
     else:
         affine_state = ClaimState.SATISFIED
     return ClaimAssessment(
-        "AFFINE_FEASIBILITY",
+        claim_name,
         affine_state,
         "; ".join(detail for _state, detail in assessments),
     )
@@ -3300,7 +3517,12 @@ def _boundary_claims(
     covariance: tuple[tuple[float, ...], ...],
     residual_variance_scale: float,
     affine_feasibility_policy: str,
-) -> tuple[ClaimAssessment, ClaimAssessment, ClaimAssessment]:
+) -> tuple[
+    ClaimAssessment,
+    ClaimAssessment,
+    ClaimAssessment,
+    ClaimAssessment,
+]:
     box = _box_boundary_claims(
         accepted,
         problem,
@@ -3329,7 +3551,15 @@ def _boundary_claims(
             residual_variance_scale,
             affine_feasibility_policy,
         )
-    return (*box, affine)
+    controlled_affine = _affine_feasibility_claim(
+        accepted,
+        problem,
+        covariance,
+        residual_variance_scale,
+        affine_feasibility_policy,
+        controlled_only=True,
+    )
+    return (*box, affine, controlled_affine)
 
 
 def _residual_variance_scale(
@@ -3373,7 +3603,18 @@ def _full_dimensional_feasible_interior_claim(
     problem: OptimizationProblem,
     box_interior: ClaimAssessment,
 ) -> ClaimAssessment:
-    if problem.affine_equalities:
+    controlled_ids = set(problem.controlled_ids)
+    controlled_frame_indices = tuple(
+        index
+        for index, (param_id, _value) in enumerate(problem.independent_items)
+        if param_id in controlled_ids
+    )
+    relevant_equalities = tuple(
+        item
+        for item in problem.affine_equalities
+        if any(item.coefficients[index] != 0.0 for index in controlled_frame_indices)
+    )
+    if relevant_equalities:
         return ClaimAssessment(
             "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
             ClaimState.VIOLATED,
@@ -3403,6 +3644,9 @@ def _full_dimensional_feasible_interior_claim(
             )
         )
         for restriction in problem.affine_half_spaces
+        if any(
+            restriction.coefficients[index] != 0.0 for index in controlled_frame_indices
+        )
     )
     state = (
         ClaimState.SATISFIED
@@ -3412,7 +3656,7 @@ def _full_dimensional_feasible_interior_claim(
     )
     detail = (
         "Accepted point is in the strict box and affine-half-space interior"
-        if problem.affine_half_spaces
+        if slacks
         else "Accepted point is in the strict box interior"
     )
     return ClaimAssessment("FULL_DIMENSIONAL_FEASIBLE_INTERIOR", state, detail)
@@ -3626,7 +3870,7 @@ def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gat
                 jacobian.identity,
             ),
         )
-    interior, boundary, affine = _boundary_claims(
+    interior, boundary, affine, controlled_affine = _boundary_claims(
         accepted,
         problem,
         covariance,
@@ -3668,8 +3912,8 @@ def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gat
         full_dimensional_interior.state,
         interior.state,
         boundary.state,
-        affine.state
-        if affine.state is not ClaimState.NOT_APPLICABLE
+        controlled_affine.state
+        if controlled_affine.state is not ClaimState.NOT_APPLICABLE
         else ClaimState.SATISFIED,
         normalization.state,
         variance_nondegeneracy.state
@@ -3686,6 +3930,7 @@ def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gat
         interior,
         boundary,
         affine,
+        controlled_affine,
         variance_nondegeneracy,
         normalization,
         ClaimAssessment("COVARIANCE_ARITHMETIC_INTEGRITY", ClaimState.SATISFIED),
@@ -5302,6 +5547,14 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             (operation,),
             (terminal_failure,),
             accepted_anchor=accepted,
+            requested_output_scope=output_scope,
+            requested_output_units=output_units,
+            requested_output_scales=output_scales,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_engine=engine,
+            source_policy=policy,
+            source_capabilities=compiled_capabilities,
         )
     lineage_category = _lineage_failure(
         accepted,
@@ -5333,6 +5586,14 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             (operation,),
             (failure,),
             accepted_anchor=accepted,
+            requested_output_scope=output_scope,
+            requested_output_units=output_units,
+            requested_output_scales=output_scales,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_engine=engine,
+            source_policy=policy,
+            source_capabilities=compiled_capabilities,
         )
 
     covariance_branch = _derive_covariance_branch(
@@ -5363,6 +5624,14 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             covariance_branch.marginal_errors,
             covariance_branch.correlations,
             accepted_anchor=accepted,
+            requested_output_scope=output_scope,
+            requested_output_units=output_units,
+            requested_output_scales=output_scales,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_engine=engine,
+            source_policy=policy,
+            source_capabilities=compiled_capabilities,
         )
     branch_terminal = (
         _cancellation_terminal(cancellation_probe) if output_scope else None
@@ -5391,6 +5660,14 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             covariance_branch.marginal_errors,
             covariance_branch.correlations,
             accepted_anchor=accepted,
+            requested_output_scope=output_scope,
+            requested_output_units=output_units,
+            requested_output_scales=output_scales,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_engine=engine,
+            source_policy=policy,
+            source_capabilities=compiled_capabilities,
         )
     constraint_branch = _derive_constraint_branch(
         accepted,
@@ -5445,4 +5722,12 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
         constraint_branch.marginal_errors,
         constraint_branch.correlations,
         accepted_anchor=accepted,
+        requested_output_scope=output_scope,
+        requested_output_units=output_units,
+        requested_output_scales=output_scales,
+        source_problem=problem,
+        source_parameterization=parameterization,
+        source_engine=engine,
+        source_policy=policy,
+        source_capabilities=compiled_capabilities,
     )

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -450,6 +450,14 @@ def _scientific_function_record(function: Callable[..., object]) -> object:
     )
 
 
+def scientific_callable_fingerprint(function: Callable[..., object]) -> str:
+    """Return ChemEx's canonical scientific implementation fingerprint."""
+    return _fingerprint(
+        "scientific-callable-implementation",
+        _scientific_function_record(function),
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ScientificFunctionBinder:
     """Immutable trusted binding of the existing model-owned scalar functions."""

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -45,6 +45,7 @@ from chemex.optimize.de_direct_trf import (
     execute_de_direct_trf,
 )
 from chemex.optimize.direct_trf import (
+    AffineHalfSpace,
     CancellationToken,
     DePolishProblemDerivation,
     DirectTrfCandidateOutcome,
@@ -582,6 +583,15 @@ def test_de_selects_canonical_restart_then_runs_one_full_trf_polish_and_commit()
     (param_id,) = problem.controlled_ids
     search_lower = max(problem.lower_bounds[0], problem.start[0] * 0.5)
     search_upper = min(problem.upper_bounds[0], problem.start[0] * 1.5)
+    restriction = AffineHalfSpace(
+        "de-root-upper",
+        tuple(
+            1.0 if independent_id == param_id else 0.0
+            for independent_id, _value in problem.independent_items
+        ),
+        search_upper,
+    )
+    problem = dataclasses.replace(problem, affine_half_spaces=(restriction,))
     invocation = DeDirectTrfInvocation.for_problem(
         problem,
         search_coordinates=((param_id, search_lower, search_upper, "linear"),),
@@ -591,6 +601,9 @@ def test_de_selects_canonical_restart_then_runs_one_full_trf_polish_and_commit()
         population_multiplier=4,
         maximum_generations=1,
     )
+    assert invocation.search_problem.affine_half_spaces == (restriction,)
+    with pytest.raises(DirectTrfConstructionError, match="feasibility"):
+        dataclasses.replace(invocation.search_problem, affine_half_spaces=())
     de_calls = 0
     polish_starts: list[tuple[float, ...]] = []
 
@@ -670,6 +683,9 @@ def test_de_selects_canonical_restart_then_runs_one_full_trf_polish_and_commit()
     assert outcome.polish_problem is not None
     assert outcome.polish_problem.controlled_ids == problem.controlled_ids
     assert outcome.polish_problem.start == outcome.search.best_candidate.full_vector
+    assert outcome.polish_problem.affine_half_spaces == (restriction,)
+    with pytest.raises(DirectTrfConstructionError, match="feasibility"):
+        dataclasses.replace(outcome.polish_problem, affine_half_spaces=())
     assert not outcome.polish_problem.acceptance_authority
     assert outcome.polish is not None
     assert outcome.accepted_result is not None

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import math
 import pickle
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -27,6 +28,8 @@ from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import EvaluationEngine
 from chemex.experiments.builder import build_experiments
 from chemex.optimize.direct_trf import (
+    AffineEquality,
+    AffineHalfSpace,
     CancellationToken,
     CandidateSummary,
     DirectTrfConstructionError,
@@ -98,6 +101,58 @@ def _qualification_fit(
         objective_request_budget=budget,
     )
     return session, experiments, parameterization, engine, problem, invocation
+
+
+def _full_frame_coefficients(
+    problem: OptimizationProblem,
+    param_id: str,
+    coefficient: float = 1.0,
+) -> tuple[float, ...]:
+    return tuple(
+        coefficient if independent_id == param_id else 0.0
+        for independent_id, _value in problem.independent_items
+    )
+
+
+def test_lifecycle_frame_rejects_exact_box_and_affine_infeasibility() -> None:
+    _session, _experiments, parameterization, _engine, problem, _invocation = (
+        _qualification_fit()
+    )
+    param_id = problem.controlled_ids[0]
+    active_value = problem.start[0]
+    constrained = dataclasses.replace(
+        problem,
+        affine_half_spaces=(
+            AffineHalfSpace(
+                "active-upper",
+                _full_frame_coefficients(problem, param_id),
+                active_value,
+            ),
+        ),
+    )
+    constrained.lifecycle_frame(constrained.start, parameterization)
+    with pytest.raises(DirectTrfConstructionError, match="affine half-space"):
+        constrained.lifecycle_frame(
+            (float(np.nextafter(active_value, math.inf)),),
+            parameterization,
+        )
+    equality = dataclasses.replace(
+        problem,
+        affine_equalities=(
+            AffineEquality(
+                "fixed-coordinate",
+                _full_frame_coefficients(problem, param_id),
+                active_value,
+            ),
+        ),
+    )
+    with pytest.raises(DirectTrfConstructionError, match="affine equality"):
+        equality.lifecycle_frame(
+            (float(np.nextafter(active_value, -math.inf)),),
+            parameterization,
+        )
+    with pytest.raises(DirectTrfConstructionError, match="box bounds"):
+        problem.lifecycle_frame((problem.lower_bounds[0] - 1.0,), parameterization)
 
 
 def _legacy_values(

--- a/tests/test_native_grid_direct_trf.py
+++ b/tests/test_native_grid_direct_trf.py
@@ -478,6 +478,7 @@ def test_plain_base_evidence_cannot_recreate_grid_commit_authority() -> None:
         accepted.commit_scope,
         accepted.commit_items,
         accepted.origin_context_identity,
+        occurrence_witness=None,
     )
     assert plain_evidence.identity == accepted.identity
     replaced_evidence = dataclasses.replace(accepted)
@@ -525,6 +526,7 @@ def test_plain_base_evidence_cannot_recreate_grid_commit_authority() -> None:
             plain_evidence.commit_scope,
             plain_evidence.commit_items,
             plain_evidence.origin_context_identity,
+            occurrence_witness=None,
         ).identity
     )
     assert session.analysis_values.snapshot() == before

--- a/tests/test_native_grid_direct_trf.py
+++ b/tests/test_native_grid_direct_trf.py
@@ -23,6 +23,7 @@ from chemex.evaluation.native import EvaluationEngine
 from chemex.experiments.builder import build_experiments
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
+    AffineHalfSpace,
     CancellationToken,
     DirectTrfConstructionError,
     DirectTrfInvocation,
@@ -81,6 +82,35 @@ def _qualification_problem(
         session.analysis_values.snapshot(),
     )
     return session, experiments, parameterization, engine, problem
+
+
+def test_grid_seed_problems_preserve_root_affine_feasibility() -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    param_id = problem.controlled_ids[0]
+    restriction = AffineHalfSpace(
+        "grid-root-upper",
+        tuple(
+            1.0 if independent_id == param_id else 0.0
+            for independent_id, _value in problem.independent_items
+        ),
+        problem.start[0] + 1.0,
+    )
+    constrained = dataclasses.replace(
+        problem,
+        affine_half_spaces=(restriction,),
+    )
+    invocation = GridDirectTrfInvocation.for_problem(
+        constrained,
+        axes=((param_id, (constrained.start[0],)),),
+        objective_request_budget=5,
+    )
+    (seed,) = invocation.seeds
+    assert seed.problem is not None
+    assert seed.problem.affine_half_spaces == (restriction,)
+    with pytest.raises(DirectTrfConstructionError, match="feasibility"):
+        dataclasses.replace(seed.problem, affine_half_spaces=())
 
 
 def test_cartesian_seed_plan_is_canonical_physical_and_rooted_once() -> None:

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -18,6 +18,7 @@ from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import EvaluationEngine
 from chemex.experiments.builder import build_experiments
 from chemex.optimize.direct_trf import (
+    AffineHalfSpace,
     CancellationToken,
     DirectTrfConstructionError,
     DirectTrfInvocation,
@@ -197,6 +198,34 @@ def test_exact_decomposition_is_deterministic_and_distinguishes_shared_coordinat
         component.disposition is ComponentDisposition.NOT_STARTED
         for component in invalid_outcome.components
     )
+
+
+def test_grouped_components_preserve_root_affine_feasibility() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    controlled_id = problem.controlled_ids[0]
+    coefficients = tuple(
+        1.0 if param_id == controlled_id else 0.0
+        for param_id, _value in problem.independent_items
+    )
+    restriction = AffineHalfSpace(
+        "grouped-root-upper",
+        coefficients,
+        problem.start[0] + 1.0,
+    )
+    constrained = dataclasses.replace(
+        problem,
+        affine_half_spaces=(restriction,),
+    )
+    decomposition = FitDecomposition.from_root(
+        constrained,
+        parameterization,
+        engine,
+    )
+    assert decomposition.components
+    for component in decomposition.components:
+        assert component.problem.affine_half_spaces == (restriction,)
+        with pytest.raises(DirectTrfConstructionError, match="feasibility"):
+            dataclasses.replace(component.problem, affine_half_spaces=())
 
 
 def test_all_masked_unscaled_profile_cannot_supply_a_control_dependency() -> None:

--- a/tests/test_native_grouped_grid_direct_trf.py
+++ b/tests/test_native_grouped_grid_direct_trf.py
@@ -18,6 +18,7 @@ from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import EvaluationEngine
 from chemex.experiments.builder import build_experiments
 from chemex.optimize.direct_trf import (
+    AffineHalfSpace,
     CancellationToken,
     DirectTrfConstructionError,
     OptimizationProblem,
@@ -106,6 +107,64 @@ def _component_objective(
     candidate = attempt.components[component_ordinal].candidate
     assert candidate is not None
     return candidate.chi_square
+
+
+def test_grouped_grid_seed_and_components_preserve_root_affine_feasibility() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    controlled_id = problem.controlled_ids[0]
+    coefficients = tuple(
+        1.0 if param_id == controlled_id else 0.0
+        for param_id, _value in problem.independent_items
+    )
+    restriction = AffineHalfSpace(
+        "grouped-grid-affine",
+        coefficients,
+        problem.start[0] + 1.0,
+    )
+    affine_problem = dataclasses.replace(
+        problem,
+        affine_half_spaces=(restriction,),
+    )
+    decomposition = FitDecomposition.from_root(
+        affine_problem,
+        parameterization,
+        engine,
+    )
+    assert all(
+        component.problem.affine_half_spaces == (restriction,)
+        for component in decomposition.components
+    )
+    invocation = GridDirectTrfInvocation.for_problem(
+        affine_problem,
+        axes=((controlled_id, (affine_problem.start[0],)),),
+        objective_request_budget=1,
+    )
+    (seed,) = invocation.seeds
+    assert seed.problem is not None
+    assert seed.problem.affine_half_spaces == (restriction,)
+    seed_decomposition = FitDecomposition.from_root(
+        seed.problem,
+        parameterization,
+        engine,
+    )
+    assert all(
+        component.problem.affine_half_spaces == (restriction,)
+        for component in seed_decomposition.components
+    )
+
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="affine feasibility differs",
+    ):
+        dataclasses.replace(seed.problem, affine_half_spaces=())
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="affine feasibility differs",
+    ):
+        dataclasses.replace(
+            seed_decomposition.components[0].problem,
+            affine_half_spaces=(),
+        )
 
 
 def test_each_seed_uses_exact_components_and_only_selected_aggregate_commits() -> None:

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -203,7 +203,7 @@ def _accepted_reference_anchor(
     evaluation = engine.new_evaluator().evaluate(frame)
     assert isinstance(evaluation, EvaluationResult)
     chi_square = float(np.dot(evaluation.residuals, evaluation.residuals))
-    return AcceptedFitResult(
+    return AcceptedFitResult.for_qualification(
         "qualification-anchor-occurrence",
         problem.identity,
         "qualification-anchor-invocation",
@@ -220,6 +220,36 @@ def _accepted_reference_anchor(
         problem.controlled_ids,
         tuple(zip(problem.controlled_ids, anchor, strict=True)),
         "qualification-anchor-origin",
+    )
+
+
+def _qualified_accepted_copy(
+    accepted: AcceptedFitResult,
+    *,
+    occurrence_identity: str | None = None,
+    problem_identity: str | None = None,
+    chi_square: float | None = None,
+) -> AcceptedFitResult:
+    """Mint a distinct authoritative occurrence for isolated qualification."""
+    return AcceptedFitResult.for_qualification(
+        accepted.occurrence_identity
+        if occurrence_identity is None
+        else occurrence_identity,
+        accepted.problem_identity if problem_identity is None else problem_identity,
+        accepted.invocation_identity,
+        accepted.execution_identity,
+        accepted.materialization_identity,
+        accepted.parameterization_identity,
+        accepted.evaluator_parameterization_identity,
+        accepted.source_occurrence_identity,
+        accepted.source_revision,
+        accepted.controlled_ids,
+        accepted.vector,
+        accepted.chi_square if chi_square is None else chi_square,
+        accepted.evaluation_result,
+        accepted.commit_scope,
+        accepted.commit_items,
+        accepted.origin_context_identity,
     )
 
 
@@ -747,10 +777,9 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
         problem,
         lower_bounds=(accepted.vector[0],),
     )
-    boundary_accepted = dataclasses.replace(
+    boundary_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=boundary_problem.identity,
-        occurrence_witness=None,
     )
 
     evidence = derive_uncertainty_evidence(
@@ -832,10 +861,9 @@ def test_nonfinite_boundary_separation_is_indeterminate() -> None:
         problem,
         upper_bounds=(float(np.finfo(np.float64).max),),
     )
-    compatible_accepted = dataclasses.replace(
+    compatible_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=finite_extreme_problem.identity,
-        occurrence_witness=None,
     )
 
     evidence = derive_uncertainty_evidence(
@@ -853,10 +881,9 @@ def test_nonfinite_boundary_separation_is_indeterminate() -> None:
 
 def test_non_finite_accepted_objective_yields_only_typed_failed_covariance() -> None:
     _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
-    non_finite = dataclasses.replace(
+    non_finite = _qualified_accepted_copy(
         accepted,
         chi_square=float("inf"),
-        occurrence_witness=None,
     )
 
     evidence = derive_uncertainty_evidence(
@@ -1077,6 +1104,20 @@ def test_exact_accepted_occurrence_is_not_reconstructible_or_mixable() -> None:
     assert rejected.residual_jacobian is None
     assert rejected.covariance is None
     assert rejected.failures[0].category == "accepted_occurrence_identity_mismatch"
+    no_witness = dataclasses.replace(accepted, occurrence_witness=None)
+    rejected_no_witness = derive_uncertainty_evidence(
+        no_witness,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="missing-occurrence-witness",
+    )
+    assert rejected_no_witness.residual_jacobian is None
+    assert (
+        rejected_no_witness.failures[0].category
+        == "accepted_occurrence_identity_mismatch"
+    )
 
     evidence = derive_uncertainty_evidence(
         accepted,
@@ -1110,10 +1151,9 @@ def test_exact_accepted_occurrence_is_not_reconstructible_or_mixable() -> None:
     with pytest.raises(ValueError, match="request"):
         dataclasses.replace(evidence, policy_identity="foreign-policy")
 
-    equivalent_occurrence = dataclasses.replace(
+    equivalent_occurrence = _qualified_accepted_copy(
         accepted,
         occurrence_identity="equivalent-authoritative-occurrence",
-        occurrence_witness=None,
     )
     assert equivalent_occurrence.identity == accepted.identity
     other_evidence = derive_uncertainty_evidence(
@@ -1124,7 +1164,19 @@ def test_exact_accepted_occurrence_is_not_reconstructible_or_mixable() -> None:
         policy=_qualification_policy(problem.controlled_ids[0]),
         resolved_environment_identity="other-equivalent-occurrence",
     )
+    assert other_evidence.residual_jacobian is not None
+    assert other_evidence.rank_diagnostic is not None
     assert other_evidence.covariance is not None
+    with pytest.raises(ValueError, match="accepted fit occurrences"):
+        dataclasses.replace(
+            evidence,
+            residual_jacobian=other_evidence.residual_jacobian,
+        )
+    with pytest.raises(ValueError, match="accepted fit occurrences"):
+        dataclasses.replace(
+            evidence,
+            rank_diagnostic=other_evidence.rank_diagnostic,
+        )
     with pytest.raises(ValueError, match="accepted fit occurrences"):
         dataclasses.replace(evidence, covariance=other_evidence.covariance)
 
@@ -1161,10 +1213,20 @@ def test_authoritative_artifacts_reject_inconsistent_reconstruction() -> None:
 
     replacements = (
         (jacobian, {"matrix": ((42.0,),) * 7}),
+        (jacobian, {"constraint_program_identity": "foreign-program"}),
+        (jacobian, {"evaluation_plan_identity": "foreign-plan"}),
+        (jacobian, {"policy_identity": "foreign-policy"}),
+        (jacobian, {"calibration_identity": "foreign-calibration"}),
+        (
+            jacobian,
+            {"numerical_compatibility_requirement": "foreign-requirement"},
+        ),
         (rank, {"source_jacobian_identity": "foreign-jacobian"}),
         (rank, {"singular_values": (42.0,)}),
+        (rank, {"weak_threshold": 42.0}),
         (rank, {"rank": 0}),
         (rank, {"identifiable_projector": ((0.0,),)}),
+        (rank, {"weak_projector": ((1.0,),)}),
         (covariance, {"source_jacobian_identity": "foreign-jacobian"}),
         (covariance, {"rank_diagnostic_identity": "foreign-svd"}),
         (covariance, {"coordinate_scales": (42.0,)}),
@@ -1265,11 +1327,10 @@ def test_affine_directional_separation_uses_exact_full_frame_slack(
         accepted.vector[0] + zeta * standard_error,
     )
     affine_problem = dataclasses.replace(problem, affine_half_spaces=(restriction,))
-    affine_accepted = dataclasses.replace(
+    affine_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=affine_problem.identity,
         occurrence_identity=f"affine-{zeta.hex()}",
-        occurrence_witness=None,
     )
     evidence = derive_uncertainty_evidence(
         affine_accepted,
@@ -1298,11 +1359,10 @@ def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
         accepted.vector[0],
     )
     held_problem = dataclasses.replace(problem, affine_half_spaces=(held_only,))
-    held_accepted = dataclasses.replace(
+    held_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=held_problem.identity,
         occurrence_identity="held-only-occurrence",
-        occurrence_witness=None,
     )
     held_evidence = derive_uncertainty_evidence(
         held_accepted,
@@ -1324,11 +1384,10 @@ def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
     held_equality_problem = dataclasses.replace(
         problem, affine_equalities=(held_equality,)
     )
-    held_equality_accepted = dataclasses.replace(
+    held_equality_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=held_equality_problem.identity,
         occurrence_identity="held-equality-occurrence",
-        occurrence_witness=None,
     )
     held_equality_evidence = derive_uncertainty_evidence(
         held_equality_accepted,
@@ -1340,13 +1399,16 @@ def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
     )
     assert held_equality_evidence.covariance is not None
     assert held_equality_evidence.covariance.usable
+    assert (
+        held_equality_evidence.covariance.claim("CONTROLLED_AFFINE_SEPARATION")
+        is ClaimState.NOT_APPLICABLE
+    )
 
     equality_problem = dataclasses.replace(problem, affine_equalities=(equality,))
-    equality_accepted = dataclasses.replace(
+    equality_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=equality_problem.identity,
         occurrence_identity="equality-occurrence",
-        occurrence_witness=None,
     )
     equality_evidence = derive_uncertainty_evidence(
         equality_accepted,
@@ -1421,11 +1483,10 @@ def test_affine_coupled_negative_degenerate_and_nonfinite_cases() -> None:
         constrained_problem = dataclasses.replace(
             problem, affine_half_spaces=(restriction,)
         )
-        constrained_accepted = dataclasses.replace(
+        constrained_accepted = _qualified_accepted_copy(
             accepted,
             problem_identity=constrained_problem.identity,
             occurrence_identity=f"{label}-affine-occurrence",
-            occurrence_witness=None,
         )
         evidence = derive_uncertainty_evidence(
             constrained_accepted,
@@ -1444,12 +1505,11 @@ def test_affine_coupled_negative_degenerate_and_nonfinite_cases() -> None:
         accepted.vector[0] + 1.0,
     )
     degenerate_problem = dataclasses.replace(problem, affine_half_spaces=(positive,))
-    degenerate_accepted = dataclasses.replace(
+    degenerate_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=degenerate_problem.identity,
         occurrence_identity="degenerate-affine-occurrence",
         chi_square=0.0,
-        occurrence_witness=None,
     )
     degenerate = derive_uncertainty_evidence(
         degenerate_accepted,

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -44,6 +44,7 @@ from chemex.optimize.uncertainty import (
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.spin_system import SpinSystem
 from chemex.runtime import AnalysisSession
+from chemex.typing import Array
 
 ROOT = Path(__file__).parent.parent
 EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
@@ -230,10 +231,10 @@ def _independent_five_point_jacobian(
     steps: tuple[float, ...],
     *,
     forward_columns: frozenset[int] = frozenset(),
-) -> np.ndarray:
+) -> Array:
     """Auditable five-point reference independent of uncertainty.py."""
 
-    def residuals(candidate: tuple[float, ...]) -> np.ndarray:
+    def residuals(candidate: tuple[float, ...]) -> Array:
         frame = EvaluationFrame.from_lifecycle_frame(
             parameterization,
             problem.lifecycle_frame(candidate, parameterization),
@@ -243,9 +244,9 @@ def _independent_five_point_jacobian(
         return np.asarray(evaluated.residuals, dtype=np.float64)
 
     base = residuals(vector)
-    columns: list[np.ndarray] = []
+    columns: list[Array] = []
     for column, step in enumerate(steps):
-        values: list[np.ndarray] = []
+        values: list[Array] = []
         if column in forward_columns:
             for multiplier in (1.0, 2.0, 3.0, 4.0):
                 candidate = list(vector)
@@ -749,6 +750,7 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
     boundary_accepted = dataclasses.replace(
         accepted,
         problem_identity=boundary_problem.identity,
+        occurrence_witness=None,
     )
 
     evidence = derive_uncertainty_evidence(
@@ -786,6 +788,18 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
     assert evidence.correlations is not None
     assert evidence.correlations.entries[0][0].value == 1.0
     assert not evidence.correlations.scope_reportable
+    forged_reportability_claims = tuple(
+        dataclasses.replace(item, state=ClaimState.SATISFIED)
+        if item.name == "MARGINAL_SCOPE_REPORTABILITY"
+        else item
+        for item in evidence.marginal_errors.claims
+    )
+    with pytest.raises(ValueError, match="reportability"):
+        dataclasses.replace(
+            evidence.marginal_errors,
+            scope_reportable=True,
+            claims=forged_reportability_claims,
+        )
 
 
 def test_unrepresentable_centered_interval_falls_back_to_inward_stencil() -> None:
@@ -821,6 +835,7 @@ def test_nonfinite_boundary_separation_is_indeterminate() -> None:
     compatible_accepted = dataclasses.replace(
         accepted,
         problem_identity=finite_extreme_problem.identity,
+        occurrence_witness=None,
     )
 
     evidence = derive_uncertainty_evidence(
@@ -838,7 +853,11 @@ def test_nonfinite_boundary_separation_is_indeterminate() -> None:
 
 def test_non_finite_accepted_objective_yields_only_typed_failed_covariance() -> None:
     _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
-    non_finite = dataclasses.replace(accepted, chi_square=float("inf"))
+    non_finite = dataclasses.replace(
+        accepted,
+        chi_square=float("inf"),
+        occurrence_witness=None,
+    )
 
     evidence = derive_uncertainty_evidence(
         non_finite,
@@ -1086,6 +1105,28 @@ def test_exact_accepted_occurrence_is_not_reconstructible_or_mixable() -> None:
             accepted_occurrence_identity="foreign-occurrence",
             accepted_anchor=accepted,
         )
+    with pytest.raises(ValueError, match="request"):
+        dataclasses.replace(evidence, request_identity="foreign-request")
+    with pytest.raises(ValueError, match="request"):
+        dataclasses.replace(evidence, policy_identity="foreign-policy")
+
+    equivalent_occurrence = dataclasses.replace(
+        accepted,
+        occurrence_identity="equivalent-authoritative-occurrence",
+        occurrence_witness=None,
+    )
+    assert equivalent_occurrence.identity == accepted.identity
+    other_evidence = derive_uncertainty_evidence(
+        equivalent_occurrence,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="other-equivalent-occurrence",
+    )
+    assert other_evidence.covariance is not None
+    with pytest.raises(ValueError, match="accepted fit occurrences"):
+        dataclasses.replace(evidence, covariance=other_evidence.covariance)
 
 
 def test_authoritative_artifacts_reject_inconsistent_reconstruction() -> None:
@@ -1141,6 +1182,24 @@ def test_authoritative_artifacts_reject_inconsistent_reconstruction() -> None:
     for artifact, changes in replacements:
         with pytest.raises(ValueError):
             dataclasses.replace(artifact, **changes)
+
+    forged_column = dataclasses.replace(
+        jacobian.columns[0],
+        fine_estimate=tuple(value + 1.0 for value in jacobian.columns[0].fine_estimate),
+    )
+    forged_matrix = tuple((value,) for value in forged_column.fine_estimate)
+    with pytest.raises(ValueError, match="replayed"):
+        dataclasses.replace(
+            jacobian,
+            columns=(forged_column,),
+            matrix=forged_matrix,
+        )
+    forged_subspace = dataclasses.replace(
+        rank.subspaces[0],
+        classification="isolated_null",
+    )
+    with pytest.raises(ValueError, match="classification"):
+        dataclasses.replace(rank, subspaces=(forged_subspace,))
 
     altered_claims = tuple(
         dataclasses.replace(item, state=ClaimState.SATISFIED)
@@ -1210,6 +1269,7 @@ def test_affine_directional_separation_uses_exact_full_frame_slack(
         accepted,
         problem_identity=affine_problem.identity,
         occurrence_identity=f"affine-{zeta.hex()}",
+        occurrence_witness=None,
     )
     evidence = derive_uncertainty_evidence(
         affine_accepted,
@@ -1242,6 +1302,7 @@ def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
         accepted,
         problem_identity=held_problem.identity,
         occurrence_identity="held-only-occurrence",
+        occurrence_witness=None,
     )
     held_evidence = derive_uncertainty_evidence(
         held_accepted,
@@ -1253,12 +1314,39 @@ def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
     )
     assert held_evidence.covariance is not None
     assert held_evidence.covariance.claim("AFFINE_FEASIBILITY") is ClaimState.SATISFIED
+    assert held_evidence.covariance.usable
+
+    held_equality = AffineEquality(
+        "held-equality",
+        _full_frame_coefficients(problem, {held_id: 1.0}),
+        held_value,
+    )
+    held_equality_problem = dataclasses.replace(
+        problem, affine_equalities=(held_equality,)
+    )
+    held_equality_accepted = dataclasses.replace(
+        accepted,
+        problem_identity=held_equality_problem.identity,
+        occurrence_identity="held-equality-occurrence",
+        occurrence_witness=None,
+    )
+    held_equality_evidence = derive_uncertainty_evidence(
+        held_equality_accepted,
+        problem=held_equality_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="held-equality-affine",
+    )
+    assert held_equality_evidence.covariance is not None
+    assert held_equality_evidence.covariance.usable
 
     equality_problem = dataclasses.replace(problem, affine_equalities=(equality,))
     equality_accepted = dataclasses.replace(
         accepted,
         problem_identity=equality_problem.identity,
         occurrence_identity="equality-occurrence",
+        occurrence_witness=None,
     )
     equality_evidence = derive_uncertainty_evidence(
         equality_accepted,
@@ -1337,6 +1425,7 @@ def test_affine_coupled_negative_degenerate_and_nonfinite_cases() -> None:
             accepted,
             problem_identity=constrained_problem.identity,
             occurrence_identity=f"{label}-affine-occurrence",
+            occurrence_witness=None,
         )
         evidence = derive_uncertainty_evidence(
             constrained_accepted,
@@ -1360,6 +1449,7 @@ def test_affine_coupled_negative_degenerate_and_nonfinite_cases() -> None:
         problem_identity=degenerate_problem.identity,
         occurrence_identity="degenerate-affine-occurrence",
         chi_square=0.0,
+        occurrence_witness=None,
     )
     degenerate = derive_uncertainty_evidence(
         degenerate_accepted,

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -204,22 +204,22 @@ def _accepted_reference_anchor(
     assert isinstance(evaluation, EvaluationResult)
     chi_square = float(np.dot(evaluation.residuals, evaluation.residuals))
     return AcceptedFitResult.for_qualification(
-        "qualification-anchor-occurrence",
-        problem.identity,
-        "qualification-anchor-invocation",
-        "qualification-anchor-execution",
-        "qualification-anchor-materialization",
-        problem.parameterization_identity,
-        problem.evaluator_parameterization_identity,
-        problem.source_snapshot.occurrence_identity,
-        problem.source_snapshot.revision,
-        problem.controlled_ids,
-        anchor,
-        chi_square,
-        evaluation,
-        problem.controlled_ids,
-        tuple(zip(problem.controlled_ids, anchor, strict=True)),
-        "qualification-anchor-origin",
+        occurrence_identity="qualification-anchor-occurrence",
+        problem_identity=problem.identity,
+        invocation_identity="qualification-anchor-invocation",
+        execution_identity="qualification-anchor-execution",
+        materialization_identity="qualification-anchor-materialization",
+        parameterization_identity=problem.parameterization_identity,
+        evaluator_parameterization_identity=problem.evaluator_parameterization_identity,
+        source_occurrence_identity=problem.source_snapshot.occurrence_identity,
+        source_revision=problem.source_snapshot.revision,
+        controlled_ids=problem.controlled_ids,
+        vector=anchor,
+        chi_square=chi_square,
+        evaluation_result=evaluation,
+        commit_scope=problem.controlled_ids,
+        commit_items=tuple(zip(problem.controlled_ids, anchor, strict=True)),
+        origin_context_identity="qualification-anchor-origin",
     )
 
 
@@ -232,24 +232,28 @@ def _qualified_accepted_copy(
 ) -> AcceptedFitResult:
     """Mint a distinct authoritative occurrence for isolated qualification."""
     return AcceptedFitResult.for_qualification(
-        accepted.occurrence_identity
-        if occurrence_identity is None
-        else occurrence_identity,
-        accepted.problem_identity if problem_identity is None else problem_identity,
-        accepted.invocation_identity,
-        accepted.execution_identity,
-        accepted.materialization_identity,
-        accepted.parameterization_identity,
-        accepted.evaluator_parameterization_identity,
-        accepted.source_occurrence_identity,
-        accepted.source_revision,
-        accepted.controlled_ids,
-        accepted.vector,
-        accepted.chi_square if chi_square is None else chi_square,
-        accepted.evaluation_result,
-        accepted.commit_scope,
-        accepted.commit_items,
-        accepted.origin_context_identity,
+        occurrence_identity=(
+            accepted.occurrence_identity
+            if occurrence_identity is None
+            else occurrence_identity
+        ),
+        problem_identity=(
+            accepted.problem_identity if problem_identity is None else problem_identity
+        ),
+        invocation_identity=accepted.invocation_identity,
+        execution_identity=accepted.execution_identity,
+        materialization_identity=accepted.materialization_identity,
+        parameterization_identity=accepted.parameterization_identity,
+        evaluator_parameterization_identity=accepted.evaluator_parameterization_identity,
+        source_occurrence_identity=accepted.source_occurrence_identity,
+        source_revision=accepted.source_revision,
+        controlled_ids=accepted.controlled_ids,
+        vector=accepted.vector,
+        chi_square=accepted.chi_square if chi_square is None else chi_square,
+        evaluation_result=accepted.evaluation_result,
+        commit_scope=accepted.commit_scope,
+        commit_items=accepted.commit_items,
+        origin_context_identity=accepted.origin_context_identity,
     )
 
 
@@ -662,6 +666,12 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
         rtol=0.0,
         atol=3.0e-16,
     )
+    with pytest.raises(ValueError, match="classified subspaces"):
+        dataclasses.replace(
+            evidence.rank_diagnostic,
+            identifiable_projector=((1.0, 0.0), (0.0, 0.0)),
+            null_projector=((0.0, 0.0), (0.0, 1.0)),
+        )
     assert evidence.covariance is not None
     expected_covariance = np.linalg.solve(
         reference_jacobian.T @ reference_jacobian,
@@ -1093,31 +1103,25 @@ def test_exact_accepted_occurrence_is_not_reconstructible_or_mixable() -> None:
         accepted, occurrence_identity="replacement-occurrence"
     )
     assert reconstructed.identity == accepted.identity
-    rejected = derive_uncertainty_evidence(
-        reconstructed,
-        problem=problem,
-        parameterization=parameterization,
-        engine=engine,
-        policy=_qualification_policy(problem.controlled_ids[0]),
-        resolved_environment_identity="reconstructed-occurrence",
-    )
-    assert rejected.residual_jacobian is None
-    assert rejected.covariance is None
-    assert rejected.failures[0].category == "accepted_occurrence_identity_mismatch"
+    with pytest.raises(ValueError, match="authoritative accepted occurrence"):
+        derive_uncertainty_evidence(
+            reconstructed,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            resolved_environment_identity="reconstructed-occurrence",
+        )
     no_witness = dataclasses.replace(accepted, occurrence_witness=None)
-    rejected_no_witness = derive_uncertainty_evidence(
-        no_witness,
-        problem=problem,
-        parameterization=parameterization,
-        engine=engine,
-        policy=_qualification_policy(problem.controlled_ids[0]),
-        resolved_environment_identity="missing-occurrence-witness",
-    )
-    assert rejected_no_witness.residual_jacobian is None
-    assert (
-        rejected_no_witness.failures[0].category
-        == "accepted_occurrence_identity_mismatch"
-    )
+    with pytest.raises(ValueError, match="authoritative accepted occurrence"):
+        derive_uncertainty_evidence(
+            no_witness,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            resolved_environment_identity="missing-occurrence-witness",
+        )
 
     evidence = derive_uncertainty_evidence(
         accepted,
@@ -1130,6 +1134,17 @@ def test_exact_accepted_occurrence_is_not_reconstructible_or_mixable() -> None:
     assert evidence.residual_jacobian is not None
     assert evidence.rank_diagnostic is not None
     assert evidence.covariance is not None
+    reconstructed_anchor = dataclasses.replace(
+        accepted,
+        occurrence_identity="direct-artifact-reconstruction",
+        occurrence_witness=None,
+    )
+    with pytest.raises(ValueError, match="exact accepted occurrence"):
+        dataclasses.replace(
+            evidence.residual_jacobian,
+            accepted_anchor=reconstructed_anchor,
+            accepted_occurrence_identity=reconstructed_anchor.occurrence_identity,
+        )
     with pytest.raises(ValueError, match="exact accepted occurrence"):
         dataclasses.replace(
             evidence.residual_jacobian,
@@ -1276,8 +1291,24 @@ def test_authoritative_artifacts_reject_inconsistent_reconstruction() -> None:
             else item
             for item in covariance.claims
         )
-    with pytest.raises(ValueError, match="usability"):
+    with pytest.raises(ValueError, match="Covariance claims"):
         dataclasses.replace(covariance, claims=altered_claims)
+    forged_variance_claims = tuple(
+        dataclasses.replace(item, detail="forged residual variance claim")
+        if item.name == "RESIDUAL_VARIANCE_NONDEGENERACY"
+        else item
+        for item in covariance.claims
+    )
+    with pytest.raises(ValueError, match="Covariance claims"):
+        dataclasses.replace(covariance, claims=forged_variance_claims)
+    forged_rank_claims = tuple(
+        dataclasses.replace(item, detail="forged propagated rank claim")
+        if item.name == "OUTPUT_RANK_DEFICIENCY_EXPECTED"
+        else item
+        for item in propagation.claims
+    )
+    with pytest.raises(ValueError, match="propagation claims"):
+        dataclasses.replace(propagation, claims=forged_rank_claims)
     with pytest.raises(ValueError):
         dataclasses.replace(
             evidence.marginal_errors,

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import math
 from pathlib import Path
 from typing import cast
 from unittest.mock import patch
@@ -20,8 +21,11 @@ from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
 from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
 from chemex.experiments.builder import build_experiments
+from chemex.optimize import uncertainty as uncertainty_module
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
+    AffineEquality,
+    AffineHalfSpace,
     DirectTrfInvocation,
     OptimizationProblem,
     execute_direct_trf,
@@ -49,6 +53,18 @@ DCEST_EXPERIMENT = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Experiments/3h
 DCEST_PARAMETERS = (
     ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Parameters/parameters.toml"
 )
+
+
+def _analytic_pa_kab(kab: float, kba: float) -> float:
+    return -kba / (kab + kba) ** 2
+
+
+def _analytic_pa_kab_alternative(kab: float, kba: float) -> float:
+    return -(kba + 1.0) / (kab + kba + 1.0) ** 2
+
+
+def _analytic_pa_kba(kab: float, kba: float) -> float:
+    return kab / (kab + kba) ** 2
 
 
 def _accepted_relaxation_fit() -> tuple[
@@ -117,9 +133,10 @@ def _qualification_policy(controlled_id: str) -> UncertaintyPolicy:
         rank_absolute_tolerance=0.0,
         rank_relative_tolerance=1.0e-12,
         weak_relative_tolerance=1.0e-6,
+        singular_value_cluster_relative_tolerance=1.0e-10,
         conditioning_limit=1.0e12,
         correlation_roundoff_multiplier=64.0,
-        affine_feasibility_policy="box-domain-no-affine-restrictions-v1",
+        affine_feasibility_policy="canonical-root-affine-halfspace-zeta-gt-3-v1",
     )
 
 
@@ -205,6 +222,54 @@ def _accepted_reference_anchor(
     )
 
 
+def _independent_five_point_jacobian(
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    problem: OptimizationProblem,
+    vector: tuple[float, ...],
+    steps: tuple[float, ...],
+    *,
+    forward_columns: frozenset[int] = frozenset(),
+) -> np.ndarray:
+    """Auditable five-point reference independent of uncertainty.py."""
+
+    def residuals(candidate: tuple[float, ...]) -> np.ndarray:
+        frame = EvaluationFrame.from_lifecycle_frame(
+            parameterization,
+            problem.lifecycle_frame(candidate, parameterization),
+        )
+        evaluated = engine.new_evaluator().evaluate(frame)
+        assert isinstance(evaluated, EvaluationResult)
+        return np.asarray(evaluated.residuals, dtype=np.float64)
+
+    base = residuals(vector)
+    columns: list[np.ndarray] = []
+    for column, step in enumerate(steps):
+        values: list[np.ndarray] = []
+        if column in forward_columns:
+            for multiplier in (1.0, 2.0, 3.0, 4.0):
+                candidate = list(vector)
+                candidate[column] += multiplier * step
+                values.append(residuals(tuple(candidate)))
+            derivative = (
+                -25.0 * base
+                + 48.0 * values[0]
+                - 36.0 * values[1]
+                + 16.0 * values[2]
+                - 3.0 * values[3]
+            ) / (12.0 * step)
+        else:
+            for multiplier in (-2.0, -1.0, 1.0, 2.0):
+                candidate = list(vector)
+                candidate[column] += multiplier * step
+                values.append(residuals(tuple(candidate)))
+            derivative = (values[0] - 8.0 * values[1] + 8.0 * values[2] - values[3]) / (
+                12.0 * step
+            )
+        columns.append(derivative)
+    return np.column_stack(columns)
+
+
 def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation() -> (
     None
 ):
@@ -240,23 +305,18 @@ def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation()
     assert evidence.residual_jacobian.residual_count == 7
     assert evidence.residual_jacobian.coordinate_count == 1
     assert evidence.residual_jacobian.complete_reliable
-    # Frozen from an independently evaluated five-point stencil (h=1e-4).  The
-    # tolerance covers its O(h^4) truncation plus the production two-scale
-    # stencil's binary64 roundoff without masking a scientifically material shift.
-    expected_jacobian = np.asarray(
-        (
-            6.877571026489022,
-            3.791023675708857,
-            1.0915054108627373,
-            -1.2596720503206598,
-            -3.297643939993577,
-            -5.054307903075824,
-            -6.558611676446162,
-        )
+    # Independent five-point O(h^4) derivative, followed below by the scalar
+    # closed form C = (chi²/nu) / (J^T J).  Neither calls uncertainty.py.
+    expected_jacobian = _independent_five_point_jacobian(
+        parameterization,
+        engine,
+        problem,
+        accepted.vector,
+        (1.0e-4,),
     )
     np.testing.assert_allclose(
         np.asarray(evidence.residual_jacobian.matrix)[:, 0],
-        expected_jacobian,
+        expected_jacobian[:, 0],
         rtol=2.0e-7,
         atol=2.0e-9,
     )
@@ -271,10 +331,15 @@ def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation()
     assert evidence.covariance.profiled_normalization_count == 1
     assert evidence.covariance.nominal_residual_degrees_of_freedom == 5
     assert evidence.covariance.rank == 1
-    assert evidence.covariance.factorization == "scaled-svd-gram-v1"
+    assert evidence.covariance.factorization == (
+        "canonical-information-cholesky-gram-v2"
+    )
+    expected_variance = (accepted.chi_square / 5.0) / float(
+        expected_jacobian[:, 0] @ expected_jacobian[:, 0]
+    )
     np.testing.assert_allclose(
         evidence.covariance.covariance[0][0],
-        0.018371558813164147,
+        expected_variance,
         rtol=4.0e-7,
         atol=2.0e-12,
     )
@@ -536,20 +601,27 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
 
     assert evidence.failures == ()
     assert evidence.residual_jacobian is not None
+    reference_jacobian = _independent_five_point_jacobian(
+        parameterization,
+        engine,
+        problem,
+        accepted.vector,
+        (1.0e-4, 1.0e-2),
+    )
     np.testing.assert_allclose(
-        np.asarray(evidence.residual_jacobian.matrix)[:3],
-        (
-            (666.6712446920574, 1.910664913855726),
-            (0.27370067627634853, -0.01357184843345749),
-            (-5.879327716305852, -0.3296351577155292),
-        ),
-        rtol=2.0e-7,
+        np.asarray(evidence.residual_jacobian.matrix),
+        reference_jacobian,
+        # Small near-cancellation entries show a 2.54e-6 relative difference;
+        # the absolute maximum is 6.51e-6 over the complete 42x2 Jacobian.
+        rtol=3.0e-6,
         atol=2.0e-9,
     )
     assert evidence.rank_diagnostic is not None
+    scaled_reference = reference_jacobian * np.asarray((0.1, 10.0))[np.newaxis, :]
+    expected_singular_values = np.linalg.svd(scaled_reference, compute_uv=False)
     np.testing.assert_allclose(
         evidence.rank_diagnostic.singular_values,
-        (154.19754083595208, 24.21131174143699),
+        expected_singular_values,
         rtol=2.0e-7,
         atol=2.0e-9,
     )
@@ -560,11 +632,9 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
         atol=3.0e-16,
     )
     assert evidence.covariance is not None
-    expected_covariance = np.asarray(
-        (
-            (4.078404361040173e-06, -0.0006890732177197917),
-            (-0.0006890732177197917, 0.13401556849617918),
-        )
+    expected_covariance = np.linalg.solve(
+        reference_jacobian.T @ reference_jacobian,
+        np.eye(2),
     )
     np.testing.assert_allclose(
         evidence.covariance.covariance,
@@ -573,6 +643,9 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
         atol=2.0e-12,
     )
     assert evidence.correlations is not None
+    expected_correlation = expected_covariance[0, 1] / math.sqrt(
+        expected_covariance[0, 0] * expected_covariance[1, 1]
+    )
     np.testing.assert_allclose(
         np.asarray(
             [
@@ -580,7 +653,7 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
                 for row in evidence.correlations.entries
             ]
         ),
-        ((1.0, -0.9320572795396814), (-0.9320572795396814, 1.0)),
+        ((1.0, expected_correlation), (expected_correlation, 1.0)),
         rtol=2.0e-7,
         atol=2.0e-9,
     )
@@ -598,8 +671,8 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
     np.testing.assert_allclose(
         evidence.constrained_propagation.covariance,
         expected_gradient @ expected_covariance @ expected_gradient.T,
-        rtol=4.0e-15,
-        atol=2.0e-17,
+        rtol=4.0e-7,
+        atol=2.0e-12,
     )
 
 
@@ -689,6 +762,20 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
 
     assert evidence.residual_jacobian is not None
     assert evidence.residual_jacobian.columns[0].orientation == "one_sided_positive"
+    independent_forward = _independent_five_point_jacobian(
+        parameterization,
+        engine,
+        boundary_problem,
+        boundary_accepted.vector,
+        (1.0e-4,),
+        forward_columns=frozenset({0}),
+    )
+    np.testing.assert_allclose(
+        np.asarray(evidence.residual_jacobian.matrix),
+        independent_forward,
+        rtol=2.0e-7,
+        atol=2.0e-9,
+    )
     assert evidence.covariance is not None
     assert evidence.covariance.claim("INTERIOR_POINT") is ClaimState.VIOLATED
     assert evidence.covariance.claim("BOUNDARY_SEPARATION") is ClaimState.VIOLATED
@@ -848,7 +935,12 @@ def test_absolute_observation_uncertainties_do_not_apply_residual_scaling() -> N
 
     assert evidence.covariance is not None
     assert evidence.covariance.residual_variance_scale == 1.0
-    assert evidence.covariance.covariance == (evidence.covariance.unscaled_covariance)
+    np.testing.assert_allclose(
+        evidence.covariance.covariance,
+        evidence.covariance.unscaled_covariance,
+        rtol=3.0e-16,
+        atol=0.0,
+    )
     assert (
         evidence.covariance.claim("RESIDUAL_VARIANCE_NONDEGENERACY")
         is ClaimState.NOT_APPLICABLE
@@ -920,7 +1012,7 @@ def test_positive_scale_covariance_factor_underflow_is_typed_failure() -> None:
         )
 
     assert evidence.covariance is None
-    assert evidence.failures[-1].category == "covariance_factor_underflow"
+    assert evidence.failures[-1].category == "invalid_covariance_arithmetic"
 
 
 def test_cancellation_freezes_terminal_operation_without_artifact() -> None:
@@ -947,3 +1039,649 @@ def test_cancellation_freezes_terminal_operation_without_artifact() -> None:
     assert evidence.operations[0].artifact_identity is None
     assert evidence.failures[0].category == "cancelled"
     assert len(evidence.operations) == 1
+
+
+def test_exact_accepted_occurrence_is_not_reconstructible_or_mixable() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    reconstructed = dataclasses.replace(
+        accepted, occurrence_identity="replacement-occurrence"
+    )
+    assert reconstructed.identity == accepted.identity
+    rejected = derive_uncertainty_evidence(
+        reconstructed,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="reconstructed-occurrence",
+    )
+    assert rejected.residual_jacobian is None
+    assert rejected.covariance is None
+    assert rejected.failures[0].category == "accepted_occurrence_identity_mismatch"
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="occurrence-integrity",
+    )
+    assert evidence.residual_jacobian is not None
+    assert evidence.rank_diagnostic is not None
+    assert evidence.covariance is not None
+    with pytest.raises(ValueError, match="exact accepted occurrence"):
+        dataclasses.replace(
+            evidence.residual_jacobian,
+            accepted_occurrence_identity="foreign-occurrence",
+        )
+    with pytest.raises(ValueError, match="exact accepted occurrence"):
+        dataclasses.replace(
+            evidence.covariance,
+            accepted_occurrence_identity="foreign-occurrence",
+        )
+    with pytest.raises(ValueError, match="exact accepted occurrence"):
+        dataclasses.replace(
+            evidence,
+            accepted_occurrence_identity="foreign-occurrence",
+            accepted_anchor=accepted,
+        )
+
+
+def test_authoritative_artifacts_reject_inconsistent_reconstruction() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    derived_id = "__R1A_B_G2N_H_800_0MHZ"
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        constrained_scope=(derived_id,),
+        constrained_units=((derived_id, ParameterUnit.RATE_PER_SECOND),),
+        constrained_scales=((derived_id, 1.0),),
+        compiled_constraint_linearization=compile_constraint_linearization_capabilities(
+            parameterization, (derived_id,), ()
+        ),
+        resolved_environment_identity="artifact-integrity",
+    )
+    jacobian = evidence.residual_jacobian
+    rank = evidence.rank_diagnostic
+    covariance = evidence.covariance
+    constraint = evidence.constraint_jacobian
+    propagation = evidence.constrained_propagation
+    assert jacobian is not None
+    assert rank is not None
+    assert covariance is not None
+    assert constraint is not None
+    assert propagation is not None
+    assert evidence.marginal_errors is not None
+
+    replacements = (
+        (jacobian, {"matrix": ((42.0,),) * 7}),
+        (rank, {"source_jacobian_identity": "foreign-jacobian"}),
+        (rank, {"singular_values": (42.0,)}),
+        (rank, {"rank": 0}),
+        (rank, {"identifiable_projector": ((0.0,),)}),
+        (covariance, {"source_jacobian_identity": "foreign-jacobian"}),
+        (covariance, {"rank_diagnostic_identity": "foreign-svd"}),
+        (covariance, {"coordinate_scales": (42.0,)}),
+        (covariance, {"residual_variance_scale": 42.0}),
+        (covariance, {"factor": ((0.0,),)}),
+        (covariance, {"unscaled_covariance": ((42.0,),)}),
+        (covariance, {"covariance": ((42.0,),)}),
+        (constraint, {"accepted_evaluation_identity": "foreign-evaluation"}),
+        (constraint, {"matrix": ((42.0,),)}),
+        (constraint, {"output_ids": ("__FOREIGN",)}),
+        (propagation, {"source_constraint_jacobian_identity": "foreign-G"}),
+        (propagation, {"output_ids": ("__FOREIGN",)}),
+        (propagation, {"covariance": ((42.0,),)}),
+    )
+    for artifact, changes in replacements:
+        with pytest.raises(ValueError):
+            dataclasses.replace(artifact, **changes)
+
+    altered_claims = tuple(
+        dataclasses.replace(item, state=ClaimState.SATISFIED)
+        if item.name == "USABLE_LOCAL_COVARIANCE"
+        else item
+        for item in covariance.claims
+    )
+    if altered_claims == covariance.claims:
+        altered_claims = tuple(
+            dataclasses.replace(item, state=ClaimState.VIOLATED)
+            if item.name == "USABLE_LOCAL_COVARIANCE"
+            else item
+            for item in covariance.claims
+        )
+    with pytest.raises(ValueError, match="usability"):
+        dataclasses.replace(covariance, claims=altered_claims)
+    with pytest.raises(ValueError):
+        dataclasses.replace(
+            evidence.marginal_errors,
+            entries=(
+                dataclasses.replace(evidence.marginal_errors.entries[0], value=42.0),
+            ),
+        )
+
+
+def _full_frame_coefficients(
+    problem: OptimizationProblem,
+    coefficients: dict[str, float],
+) -> tuple[float, ...]:
+    return tuple(
+        coefficients.get(param_id, 0.0)
+        for param_id, _value in problem.independent_items
+    )
+
+
+@pytest.mark.parametrize(
+    ("zeta", "expected"),
+    (
+        (4.0, ClaimState.SATISFIED),
+        (2.0, ClaimState.VIOLATED),
+        (0.0, ClaimState.VIOLATED),
+    ),
+)
+def test_affine_directional_separation_uses_exact_full_frame_slack(
+    zeta: float,
+    expected: ClaimState,
+) -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    policy = _qualification_policy(problem.controlled_ids[0])
+    baseline = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="affine-baseline",
+    )
+    assert baseline.covariance is not None
+    standard_error = math.sqrt(baseline.covariance.covariance[0][0])
+    restriction = AffineHalfSpace(
+        "controlled-upper",
+        _full_frame_coefficients(problem, {problem.controlled_ids[0]: 1.0}),
+        accepted.vector[0] + zeta * standard_error,
+    )
+    affine_problem = dataclasses.replace(problem, affine_half_spaces=(restriction,))
+    affine_accepted = dataclasses.replace(
+        accepted,
+        problem_identity=affine_problem.identity,
+        occurrence_identity=f"affine-{zeta.hex()}",
+    )
+    evidence = derive_uncertainty_evidence(
+        affine_accepted,
+        problem=affine_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="affine-case",
+    )
+    assert evidence.covariance is not None
+    assert evidence.covariance.claim("AFFINE_FEASIBILITY") is expected
+    assert evidence.covariance.usable is (expected is ClaimState.SATISFIED)
+
+
+def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    held_id, held_value = problem.held_items[0]
+    held_only = AffineHalfSpace(
+        "held-only",
+        _full_frame_coefficients(problem, {held_id: 1.0}),
+        held_value,
+    )
+    equality = AffineEquality(
+        "controlled-equality",
+        _full_frame_coefficients(problem, {problem.controlled_ids[0]: 1.0}),
+        accepted.vector[0],
+    )
+    held_problem = dataclasses.replace(problem, affine_half_spaces=(held_only,))
+    held_accepted = dataclasses.replace(
+        accepted,
+        problem_identity=held_problem.identity,
+        occurrence_identity="held-only-occurrence",
+    )
+    held_evidence = derive_uncertainty_evidence(
+        held_accepted,
+        problem=held_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="held-affine",
+    )
+    assert held_evidence.covariance is not None
+    assert held_evidence.covariance.claim("AFFINE_FEASIBILITY") is ClaimState.SATISFIED
+
+    equality_problem = dataclasses.replace(problem, affine_equalities=(equality,))
+    equality_accepted = dataclasses.replace(
+        accepted,
+        problem_identity=equality_problem.identity,
+        occurrence_identity="equality-occurrence",
+    )
+    equality_evidence = derive_uncertainty_evidence(
+        equality_accepted,
+        problem=equality_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="equality-affine",
+    )
+    assert equality_evidence.covariance is not None
+    assert (
+        equality_evidence.covariance.claim("AFFINE_FEASIBILITY") is ClaimState.VIOLATED
+    )
+    assert (
+        equality_evidence.covariance.claim("FULL_DIMENSIONAL_FEASIBLE_INTERIOR")
+        is ClaimState.VIOLATED
+    )
+
+
+def test_affine_coupled_negative_degenerate_and_nonfinite_cases() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    held_id, held_value = problem.held_items[0]
+    policy = _qualification_policy(controlled_id)
+    baseline = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="affine-exception-baseline",
+    )
+    assert baseline.covariance is not None
+    standard_error = math.sqrt(baseline.covariance.covariance[0][0])
+
+    restrictions = (
+        (
+            "coupled",
+            AffineHalfSpace(
+                "coupled",
+                _full_frame_coefficients(problem, {controlled_id: 1.0, held_id: 1.0}),
+                accepted.vector[0] + held_value + 4.0 * standard_error,
+            ),
+            ClaimState.SATISFIED,
+        ),
+        (
+            "negative",
+            AffineHalfSpace(
+                "negative",
+                _full_frame_coefficients(problem, {controlled_id: 1.0}),
+                accepted.vector[0] - 1.0,
+            ),
+            ClaimState.VIOLATED,
+        ),
+        (
+            "nonfinite",
+            AffineHalfSpace(
+                "nonfinite",
+                _full_frame_coefficients(
+                    problem,
+                    {
+                        controlled_id: float(np.finfo(np.float64).max),
+                        held_id: float(np.finfo(np.float64).max),
+                    },
+                ),
+                float(np.finfo(np.float64).max),
+            ),
+            ClaimState.INDETERMINATE,
+        ),
+    )
+    for label, restriction, expected in restrictions:
+        constrained_problem = dataclasses.replace(
+            problem, affine_half_spaces=(restriction,)
+        )
+        constrained_accepted = dataclasses.replace(
+            accepted,
+            problem_identity=constrained_problem.identity,
+            occurrence_identity=f"{label}-affine-occurrence",
+        )
+        evidence = derive_uncertainty_evidence(
+            constrained_accepted,
+            problem=constrained_problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=policy,
+            resolved_environment_identity=f"affine-{label}",
+        )
+        assert evidence.covariance is not None, evidence.failures
+        assert evidence.covariance.claim("AFFINE_FEASIBILITY") is expected
+
+    positive = AffineHalfSpace(
+        "positive-with-zero-variance",
+        _full_frame_coefficients(problem, {controlled_id: 1.0}),
+        accepted.vector[0] + 1.0,
+    )
+    degenerate_problem = dataclasses.replace(problem, affine_half_spaces=(positive,))
+    degenerate_accepted = dataclasses.replace(
+        accepted,
+        problem_identity=degenerate_problem.identity,
+        occurrence_identity="degenerate-affine-occurrence",
+        chi_square=0.0,
+    )
+    degenerate = derive_uncertainty_evidence(
+        degenerate_accepted,
+        problem=degenerate_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="affine-degenerate",
+    )
+    assert degenerate.covariance is not None
+    assert degenerate.covariance.claim("AFFINE_FEASIBILITY") is ClaimState.INDETERMINATE
+
+
+def test_analytic_capability_identity_binds_actual_callable_semantics() -> None:
+    first = FunctionAnalyticPartialCapability(
+        "pop_2st",
+        "pa",
+        "same-user-facing-label",
+        (_analytic_pa_kab, _analytic_pa_kba),
+    )
+    different = FunctionAnalyticPartialCapability(
+        "pop_2st",
+        "pa",
+        "same-user-facing-label",
+        (_analytic_pa_kab_alternative, _analytic_pa_kba),
+    )
+    rebound = dataclasses.replace(
+        first,
+        partials=(_analytic_pa_kab_alternative, _analytic_pa_kba),
+    )
+    assert first.identity != different.identity
+    assert first.identity != rebound.identity
+    assert first.implementation_fingerprints != different.implementation_fingerprints
+
+    parameterization, _engine, _problem, _accepted = _accepted_hd_fit()
+    output_id = "__PA_1_0_1000"
+
+    def wrong_domain(_single: float) -> float:
+        return 1.0
+
+    incompatible = FunctionAnalyticPartialCapability(
+        "pop_2st",
+        "pa",
+        "incompatible-domain",
+        (wrong_domain, _analytic_pa_kba),
+    )
+    with pytest.raises(ValueError, match="domain arity"):
+        compile_constraint_linearization_capabilities(
+            parameterization,
+            (output_id,),
+            (incompatible,),
+        )
+
+
+def test_clustered_singular_evidence_retains_only_invariant_projectors() -> None:
+    identity = np.eye(3)
+    angle = 0.731
+    rotated = np.asarray(
+        (
+            (math.cos(angle), -math.sin(angle), 0.0),
+            (math.sin(angle), math.cos(angle), 0.0),
+            (0.0, 0.0, 1.0),
+        )
+    )
+    exact = uncertainty_module._invariant_singular_subspaces(
+        identity,
+        (2.0, 2.0, 1.0),
+        rank_threshold=1.0e-12,
+        weak_threshold=1.0e-6,
+        cluster_relative_tolerance=1.0e-10,
+    )
+    rotated_exact = uncertainty_module._invariant_singular_subspaces(
+        rotated,
+        (2.0, 2.0, 1.0),
+        rank_threshold=1.0e-12,
+        weak_threshold=1.0e-6,
+        cluster_relative_tolerance=1.0e-10,
+    )
+    assert exact[0].classification == "clustered_identifiable"
+    assert exact[1].classification == "isolated_identifiable"
+    np.testing.assert_allclose(
+        exact[0].projector, rotated_exact[0].projector, atol=2e-16
+    )
+
+    near = uncertainty_module._invariant_singular_subspaces(
+        identity,
+        (2.0, 2.0 * (1.0 - 5.0e-11), 1.0),
+        rank_threshold=1.0e-12,
+        weak_threshold=1.0e-6,
+        cluster_relative_tolerance=1.0e-10,
+    )
+    assert near[0].classification == "clustered_identifiable"
+    classified = uncertainty_module._invariant_singular_subspaces(
+        identity,
+        (2.0, 1.0e-7, 0.0),
+        rank_threshold=1.0e-9,
+        weak_threshold=1.0e-6,
+        cluster_relative_tolerance=1.0e-10,
+    )
+    assert tuple(item.classification for item in classified) == (
+        "isolated_identifiable",
+        "isolated_weak",
+        "isolated_null",
+    )
+
+
+def test_cancellation_after_svd_prevents_covariance_assembly() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    observed_svd = False
+    original_svd = uncertainty_module.svd
+
+    def traced_svd(*args: object, **kwargs: object) -> object:
+        nonlocal observed_svd
+        result = original_svd(*args, **kwargs)
+        observed_svd = True
+        return result
+
+    with (
+        patch("chemex.optimize.uncertainty.svd", side_effect=traced_svd),
+        patch(
+            "chemex.optimize.uncertainty._canonical_covariance_reduction",
+            wraps=uncertainty_module._canonical_covariance_reduction,
+        ) as covariance_reduction,
+    ):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            cancellation_probe=lambda: (
+                OperationTerminal.CANCELLED if observed_svd else None
+            ),
+            resolved_environment_identity="cancel-after-svd",
+        )
+    covariance_reduction.assert_not_called()
+    assert evidence.rank_diagnostic is None
+    assert evidence.covariance is None
+    assert evidence.operations[-1].terminal is OperationTerminal.CANCELLED
+
+
+def test_cancellation_after_rank_retains_diagnostic_but_not_covariance() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    rank_subspaces_complete = False
+    original_subspaces = uncertainty_module._invariant_singular_subspaces
+
+    def traced_subspaces(*args: object, **kwargs: object) -> object:
+        nonlocal rank_subspaces_complete
+        result = original_subspaces(*args, **kwargs)
+        rank_subspaces_complete = True
+        return result
+
+    with (
+        patch(
+            "chemex.optimize.uncertainty._invariant_singular_subspaces",
+            side_effect=traced_subspaces,
+        ),
+        patch(
+            "chemex.optimize.uncertainty._canonical_covariance_reduction"
+        ) as covariance_reduction,
+    ):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            cancellation_probe=lambda: (
+                OperationTerminal.CANCELLED if rank_subspaces_complete else None
+            ),
+            resolved_environment_identity="cancel-after-rank",
+        )
+    covariance_reduction.assert_not_called()
+    assert evidence.rank_diagnostic is not None
+    assert evidence.covariance is None
+    assert evidence.operations[-1].terminal is OperationTerminal.CANCELLED
+
+
+def test_cancellation_before_marginals_and_constraint_phases_is_ordered() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    derived_id = "__R1A_B_G2N_H_800_0MHZ"
+    original_reduction = uncertainty_module._canonical_covariance_reduction
+    covariance_complete = False
+
+    def traced_reduction(*args: object, **kwargs: object) -> object:
+        nonlocal covariance_complete
+        result = original_reduction(*args, **kwargs)
+        covariance_complete = True
+        return result
+
+    with (
+        patch(
+            "chemex.optimize.uncertainty._canonical_covariance_reduction",
+            side_effect=traced_reduction,
+        ),
+        patch("chemex.optimize.uncertainty._marginal_errors") as marginal,
+    ):
+        before_marginal = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(controlled_id),
+            cancellation_probe=lambda: (
+                OperationTerminal.CANCELLED if covariance_complete else None
+            ),
+            resolved_environment_identity="cancel-before-marginal",
+        )
+    marginal.assert_not_called()
+    assert before_marginal.covariance is not None
+    assert before_marginal.marginal_errors is None
+
+    original_correlations = uncertainty_module._correlations
+    correlations_complete = False
+
+    def traced_correlations(*args: object, **kwargs: object) -> object:
+        nonlocal correlations_complete
+        result = original_correlations(*args, **kwargs)
+        correlations_complete = True
+        return result
+
+    with (
+        patch(
+            "chemex.optimize.uncertainty._correlations",
+            side_effect=traced_correlations,
+        ),
+        patch("chemex.optimize.uncertainty._linearize_constraints") as linearize_g,
+    ):
+        before_g = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(controlled_id),
+            constrained_scope=(derived_id,),
+            constrained_units=((derived_id, ParameterUnit.RATE_PER_SECOND),),
+            constrained_scales=((derived_id, 1.0),),
+            compiled_constraint_linearization=compile_constraint_linearization_capabilities(
+                parameterization, (derived_id,), ()
+            ),
+            cancellation_probe=lambda: (
+                OperationTerminal.CANCELLED if correlations_complete else None
+            ),
+            resolved_environment_identity="cancel-before-g",
+        )
+    linearize_g.assert_not_called()
+    assert before_g.constraint_jacobian is None
+
+
+def test_cancellation_during_g_and_before_propagation_emits_no_downstream() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    derived_id = "__R1A_B_G2N_H_800_0MHZ"
+    compiled = compile_constraint_linearization_capabilities(
+        parameterization, (controlled_id, derived_id), ()
+    )
+    original_target = uncertainty_module._differentiate_target
+    target_started = False
+
+    def traced_target(*args: object, **kwargs: object) -> object:
+        nonlocal target_started
+        result = original_target(*args, **kwargs)
+        target_started = True
+        return result
+
+    common = {
+        "problem": problem,
+        "parameterization": parameterization,
+        "engine": engine,
+        "policy": _qualification_policy(controlled_id),
+        "constrained_scope": (controlled_id, derived_id),
+        "constrained_units": (
+            (controlled_id, ParameterUnit.RATE_PER_SECOND),
+            (derived_id, ParameterUnit.RATE_PER_SECOND),
+        ),
+        "constrained_scales": ((controlled_id, 1.0), (derived_id, 1.0)),
+        "compiled_constraint_linearization": compiled,
+    }
+    with (
+        patch(
+            "chemex.optimize.uncertainty._differentiate_target",
+            side_effect=traced_target,
+        ),
+        patch("chemex.optimize.uncertainty._propagate_constraints") as propagate,
+    ):
+        during_g = derive_uncertainty_evidence(
+            accepted,
+            **common,
+            cancellation_probe=lambda: (
+                OperationTerminal.CANCELLED if target_started else None
+            ),
+            resolved_environment_identity="cancel-during-g",
+        )
+    propagate.assert_not_called()
+    assert during_g.constraint_jacobian is None
+    assert during_g.constrained_propagation is None
+
+    original_linearize = uncertainty_module._linearize_constraints
+    g_complete = False
+
+    def traced_linearize(*args: object, **kwargs: object) -> object:
+        nonlocal g_complete
+        result = original_linearize(*args, **kwargs)
+        g_complete = True
+        return result
+
+    with (
+        patch(
+            "chemex.optimize.uncertainty._linearize_constraints",
+            side_effect=traced_linearize,
+        ),
+        patch("chemex.optimize.uncertainty._propagate_constraints") as propagate,
+    ):
+        before_propagation = derive_uncertainty_evidence(
+            accepted,
+            **common,
+            cancellation_probe=lambda: (
+                OperationTerminal.CANCELLED if g_complete else None
+            ),
+            resolved_environment_identity="cancel-before-propagation",
+        )
+    propagate.assert_not_called()
+    assert before_propagation.constraint_jacobian is not None
+    assert before_propagation.constrained_propagation is None

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -677,9 +677,10 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
     np.testing.assert_allclose(
         np.asarray(evidence.residual_jacobian.matrix),
         reference_jacobian,
-        # Small near-cancellation entries show a 2.54e-6 relative difference;
-        # the absolute maximum is 6.51e-6 over the complete 42x2 Jacobian.
-        rtol=3.0e-6,
+        # The independent five-point and production adaptive finite-difference
+        # calculations differ by up to 4.674e-6 across the qualified local,
+        # GitHub Actions Python 3.13, and Python 3.14 platform envelope.
+        rtol=6.0e-6,
         atol=2.0e-9,
     )
     assert evidence.rank_diagnostic is not None

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -1,0 +1,949 @@
+"""Behavioral qualification tests for native uncertainty evidence (#598).
+
+The public seam is one immutable accepted fit plus its exact native problem,
+parameterization, and evaluator lineage.  Evidence derivation must not mutate
+the fit, its commit authority, or session-owned Analysis Values.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.parameters import read_defaults
+from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
+from chemex.experiments.builder import build_experiments
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    DirectTrfInvocation,
+    OptimizationProblem,
+    execute_direct_trf,
+)
+from chemex.optimize.uncertainty import (
+    ClaimState,
+    FunctionAnalyticPartialCapability,
+    FunctionFiniteDifferenceCapability,
+    OperationTerminal,
+    ParameterUnit,
+    ResidualVarianceScaling,
+    UncertaintyPolicy,
+    compile_constraint_linearization_capabilities,
+    derive_uncertainty_evidence,
+)
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parent.parent
+EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
+METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+DCEST_EXPERIMENT = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Experiments/3hz.toml"
+DCEST_PARAMETERS = (
+    ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Parameters/parameters.toml"
+)
+
+
+def _accepted_relaxation_fit() -> tuple[
+    AnalysisSession,
+    ActiveParameterization,
+    EvaluationEngine,
+    OptimizationProblem,
+    AcceptedFitResult,
+]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(
+            include=[SpinSystem.from_name("G2N-HN")],
+            exclude=None,
+        ),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    method = read_methods([METHOD])["DEFAULT"]
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    invocation = DirectTrfInvocation.for_problem(
+        problem,
+        objective_request_budget=80,
+    )
+    outcome = execute_direct_trf(
+        problem,
+        invocation,
+        parameterization,
+        engine,
+    )
+    assert outcome.accepted_result is not None
+    return session, parameterization, engine, problem, outcome.accepted_result
+
+
+def _qualification_policy(controlled_id: str) -> UncertaintyPolicy:
+    # These are explicit qualification inputs, not inferred production defaults.
+    return UncertaintyPolicy(
+        calibration_identity="issue-598-relaxation-qualification-v1",
+        numerical_compatibility_requirement=(
+            "binary64-scipy-economical-svd-fixed-pairwise-v1"
+        ),
+        coordinate_scales=((controlled_id, 1.0),),
+        coordinate_units=((controlled_id, ParameterUnit.RATE_PER_SECOND),),
+        residual_variance_scaling=(
+            ResidualVarianceScaling.ESTIMATED_COMMON_RESIDUAL_VARIANCE
+        ),
+        relative_step_tolerance=1.0e-4,
+        roundoff_multiplier=64.0,
+        smaller_step_extent=8,
+        larger_step_extent=8,
+        svd_driver="gesdd",
+        rank_absolute_tolerance=0.0,
+        rank_relative_tolerance=1.0e-12,
+        weak_relative_tolerance=1.0e-6,
+        conditioning_limit=1.0e12,
+        correlation_roundoff_multiplier=64.0,
+        affine_feasibility_policy="box-domain-no-affine-restrictions-v1",
+    )
+
+
+def _hd_problem(
+    method: Method,
+) -> tuple[ActiveParameterization, EvaluationEngine, OptimizationProblem]:
+    session = AnalysisSession.create()
+    session.set_model("2st_hd")
+    experiments = build_experiments(
+        [DCEST_EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("1N")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([DCEST_PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    return parameterization, engine, problem
+
+
+def _accepted_hd_fit() -> tuple[
+    ActiveParameterization,
+    EvaluationEngine,
+    OptimizationProblem,
+    AcceptedFitResult,
+]:
+    method = Method(
+        fit=("D2O",),
+        fix=("CS_A", "DW_AB", "KDH", "PHI", "R1_A", "R2_A", "R2_B"),
+    )
+    parameterization, engine, problem = _hd_problem(method)
+    outcome = execute_direct_trf(
+        problem,
+        DirectTrfInvocation.for_problem(problem, objective_request_budget=80),
+        parameterization,
+        engine,
+    )
+    assert outcome.accepted_result is not None
+    return parameterization, engine, problem, outcome.accepted_result
+
+
+def _accepted_reference_anchor(
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    problem: OptimizationProblem,
+    vector: tuple[float, ...] | None = None,
+) -> AcceptedFitResult:
+    anchor = problem.start if vector is None else vector
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        problem.lifecycle_frame(anchor, parameterization),
+    )
+    evaluation = engine.new_evaluator().evaluate(frame)
+    assert isinstance(evaluation, EvaluationResult)
+    chi_square = float(np.dot(evaluation.residuals, evaluation.residuals))
+    return AcceptedFitResult(
+        "qualification-anchor-occurrence",
+        problem.identity,
+        "qualification-anchor-invocation",
+        "qualification-anchor-execution",
+        "qualification-anchor-materialization",
+        problem.parameterization_identity,
+        problem.evaluator_parameterization_identity,
+        problem.source_snapshot.occurrence_identity,
+        problem.source_snapshot.revision,
+        problem.controlled_ids,
+        anchor,
+        chi_square,
+        evaluation,
+        problem.controlled_ids,
+        tuple(zip(problem.controlled_ids, anchor, strict=True)),
+        "qualification-anchor-origin",
+    )
+
+
+def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation() -> (
+    None
+):
+    session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    before = session.analysis_values.snapshot()
+    controlled_id = problem.controlled_ids[0]
+    derived_id = "__R1A_B_G2N_H_800_0MHZ"
+    compiled = compile_constraint_linearization_capabilities(
+        parameterization,
+        (controlled_id, derived_id),
+        (),
+    )
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        constrained_scope=(controlled_id, derived_id),
+        constrained_units=(
+            (controlled_id, ParameterUnit.RATE_PER_SECOND),
+            (derived_id, ParameterUnit.RATE_PER_SECOND),
+        ),
+        constrained_scales=((controlled_id, 1.0), (derived_id, 1.0)),
+        compiled_constraint_linearization=compiled,
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.accepted_result_identity == accepted.identity
+    assert evidence.residual_jacobian is not None
+    assert evidence.residual_jacobian.controlled_ids == (controlled_id,)
+    assert evidence.residual_jacobian.residual_count == 7
+    assert evidence.residual_jacobian.coordinate_count == 1
+    assert evidence.residual_jacobian.complete_reliable
+    # Frozen from an independently evaluated five-point stencil (h=1e-4).  The
+    # tolerance covers its O(h^4) truncation plus the production two-scale
+    # stencil's binary64 roundoff without masking a scientifically material shift.
+    expected_jacobian = np.asarray(
+        (
+            6.877571026489022,
+            3.791023675708857,
+            1.0915054108627373,
+            -1.2596720503206598,
+            -3.297643939993577,
+            -5.054307903075824,
+            -6.558611676446162,
+        )
+    )
+    np.testing.assert_allclose(
+        np.asarray(evidence.residual_jacobian.matrix)[:, 0],
+        expected_jacobian,
+        rtol=2.0e-7,
+        atol=2.0e-9,
+    )
+    assert evidence.covariance is not None
+    factor = np.asarray(evidence.covariance.factor)
+    for column in range(factor.shape[1]):
+        pivot = int(np.argmax(np.abs(factor[:, column])))
+        assert factor[pivot, column] >= 0.0
+    assert evidence.covariance.controlled_ids == (controlled_id,)
+    assert evidence.covariance.retained_residual_count == 7
+    assert evidence.covariance.controlled_coordinate_count == 1
+    assert evidence.covariance.profiled_normalization_count == 1
+    assert evidence.covariance.nominal_residual_degrees_of_freedom == 5
+    assert evidence.covariance.rank == 1
+    assert evidence.covariance.factorization == "scaled-svd-gram-v1"
+    np.testing.assert_allclose(
+        evidence.covariance.covariance[0][0],
+        0.018371558813164147,
+        rtol=4.0e-7,
+        atol=2.0e-12,
+    )
+    assert evidence.marginal_errors is not None
+    assert evidence.marginal_errors.entries[0].value is not None
+    assert evidence.correlations is not None
+    assert evidence.correlations.entries[0][0].value == 1.0
+    assert evidence.correlations.units == (ParameterUnit.RATE_PER_SECOND,)
+    assert any(
+        item.name == "CORRELATION_SCOPE_REPORTABILITY"
+        for item in evidence.correlations.claims
+    )
+
+    assert evidence.constraint_jacobian is not None
+    assert evidence.constraint_jacobian.output_ids == (controlled_id, derived_id)
+    assert evidence.constraint_jacobian.matrix == ((1.0,), (1.0,))
+    assert (
+        evidence.constraint_jacobian.claims[0].name
+        == "CONSTRAINT_OUTPUT_LINEARIZATION_COMPLETE"
+    )
+    assert evidence.constrained_propagation is not None
+    propagated = evidence.constrained_propagation.covariance
+    source_variance = evidence.covariance.covariance[0][0]
+    np.testing.assert_allclose(
+        propagated,
+        ((source_variance, source_variance),) * 2,
+        rtol=0.0,
+        atol=0.0,
+    )
+    assert (
+        evidence.constrained_propagation.claim("OUTPUT_RANK_DEFICIENCY_EXPECTED")
+        is ClaimState.SATISFIED
+    )
+    assert any(
+        item.name.startswith("SOURCE_COVARIANCE::")
+        for item in evidence.constrained_propagation.claims
+    )
+    assert evidence.residual_jacobian.evaluation_plan_identity == engine.plan.identity
+    assert evidence.covariance.source_jacobian_identity == (
+        evidence.residual_jacobian.identity
+    )
+    assert evidence.constrained_propagation.source_covariance_identity == (
+        evidence.covariance.identity
+    )
+    assert evidence.resolved_environment_identity == ("local-qualification-environment")
+    assert all(
+        item.resolved_environment_identity == "local-qualification-environment"
+        for item in evidence.operations
+    )
+    assert evidence.rank_diagnostic is not None
+    assert evidence.rank_diagnostic.identifiable_projector == ((1.0,),)
+    assert evidence.rank_diagnostic.null_projector == ((0.0,),)
+    assert evidence.rank_diagnostic.weak_projector == ((0.0,),)
+    record = evidence.to_record()
+    json.dumps(record, allow_nan=False, sort_keys=True)
+    payload = record["payload"]
+    assert isinstance(payload, dict)
+    typed_payload = cast("dict[str, object]", payload)
+    assert typed_payload["resolved_environment_identity"] == (
+        "local-qualification-environment"
+    )
+    other_environment = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        constrained_scope=(controlled_id, derived_id),
+        constrained_units=(
+            (controlled_id, ParameterUnit.RATE_PER_SECOND),
+            (derived_id, ParameterUnit.RATE_PER_SECOND),
+        ),
+        constrained_scales=((controlled_id, 1.0), (derived_id, 1.0)),
+        compiled_constraint_linearization=compiled,
+        resolved_environment_identity="different-local-environment",
+    )
+    assert other_environment.identity == evidence.identity
+    assert tuple(item.identity for item in other_environment.operations) == tuple(
+        item.identity for item in evidence.operations
+    )
+    assert tuple(
+        item.occurrence_identity for item in other_environment.operations
+    ) != tuple(item.occurrence_identity for item in evidence.operations)
+    assert session.analysis_values.snapshot() == before
+
+
+def test_scientific_constraint_requires_and_uses_declared_numerical_capability() -> (
+    None
+):
+    parameterization, engine, problem, accepted = _accepted_hd_fit()
+    controlled_id = problem.controlled_ids[0]
+    output_id = "__PA_1_0_1000"
+    base_policy = dataclasses.replace(
+        _qualification_policy(controlled_id),
+        coordinate_units=((controlled_id, ParameterUnit.FRACTION),),
+    )
+
+    with pytest.raises(ValueError, match="lacks capabilities"):
+        compile_constraint_linearization_capabilities(
+            parameterization,
+            (output_id,),
+            (),
+        )
+
+    capability = FunctionFiniteDifferenceCapability(
+        function_id="pop_2st",
+        component="pa",
+        argument_scales=(10.0, 10.0),
+        output_scale=1.0,
+    )
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=base_policy,
+        constrained_scope=(output_id,),
+        constrained_units=((output_id, ParameterUnit.FRACTION),),
+        constrained_scales=((output_id, 1.0),),
+        compiled_constraint_linearization=(
+            compile_constraint_linearization_capabilities(
+                parameterization,
+                (output_id,),
+                (capability,),
+            )
+        ),
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.constraint_jacobian is not None
+    d2o = accepted.evaluation_result.resolved_values[controlled_id]
+    phi = accepted.evaluation_result.resolved_values["__PHI_1"]
+    expected = -phi / (1.0 + d2o * (phi - 1.0)) ** 2
+    np.testing.assert_allclose(
+        evidence.constraint_jacobian.matrix[0][0],
+        expected,
+        rtol=2.0e-6,
+        atol=2.0e-8,
+    )
+    assert len(evidence.constraint_jacobian.function_partial_diagnostics) == 2
+    assert all(
+        item.method == "centered_two_scale_numerical"
+        for item in evidence.constraint_jacobian.function_partial_diagnostics
+    )
+
+    unreliable = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=dataclasses.replace(
+            base_policy,
+            relative_step_tolerance=0.0,
+            roundoff_multiplier=0.0,
+            smaller_step_extent=0,
+            larger_step_extent=0,
+        ),
+        constrained_scope=(output_id,),
+        constrained_units=((output_id, ParameterUnit.FRACTION),),
+        constrained_scales=((output_id, 1.0),),
+        compiled_constraint_linearization=(
+            compile_constraint_linearization_capabilities(
+                parameterization,
+                (output_id,),
+                (capability,),
+            )
+        ),
+        resolved_environment_identity="local-qualification-environment",
+    )
+    assert any(
+        item.category == "unreliable_or_nondifferentiable_function_partial"
+        and item.trajectory_fingerprint is not None
+        for item in unreliable.failures
+    )
+
+    analytic = FunctionAnalyticPartialCapability(
+        function_id="pop_2st",
+        component="pa",
+        implementation_identity="pop-2st-pa-analytic-partials-v1",
+        partials=(
+            lambda kab, kba: -kba / (kab + kba) ** 2,
+            lambda kab, kba: kab / (kab + kba) ** 2,
+        ),
+    )
+    analytic_evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=base_policy,
+        constrained_scope=(output_id,),
+        constrained_units=((output_id, ParameterUnit.FRACTION),),
+        constrained_scales=((output_id, 1.0),),
+        compiled_constraint_linearization=(
+            compile_constraint_linearization_capabilities(
+                parameterization,
+                (output_id,),
+                (analytic,),
+            )
+        ),
+        resolved_environment_identity="local-qualification-environment",
+    )
+    assert analytic_evidence.constraint_jacobian is not None
+    np.testing.assert_allclose(
+        analytic_evidence.constraint_jacobian.matrix[0][0],
+        expected,
+        rtol=5.0e-15,
+        atol=5.0e-15,
+    )
+    assert all(
+        item.method == "versioned_analytic_partial"
+        for item in analytic_evidence.constraint_jacobian.function_partial_diagnostics
+    )
+
+
+def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -> None:
+    method = Method(
+        fit=("D2O", "KDH"),
+        fix=("CS_A", "DW_AB", "PHI", "R1_A", "R2_A", "R2_B"),
+    )
+    parameterization, engine, problem = _hd_problem(method)
+    accepted = _accepted_reference_anchor(parameterization, engine, problem)
+    d2o_id, kdh_id = problem.controlled_ids
+    kab_id = "__KAB_1_0_1000"
+    policy = dataclasses.replace(
+        _qualification_policy(d2o_id),
+        coordinate_scales=((d2o_id, 0.1), (kdh_id, 10.0)),
+        coordinate_units=(
+            (d2o_id, ParameterUnit.FRACTION),
+            (kdh_id, ParameterUnit.RATE_PER_SECOND),
+        ),
+        residual_variance_scaling=(
+            ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+        ),
+    )
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        constrained_scope=(d2o_id, kdh_id, kab_id),
+        constrained_units=(
+            (d2o_id, ParameterUnit.FRACTION),
+            (kdh_id, ParameterUnit.RATE_PER_SECOND),
+            (kab_id, ParameterUnit.RATE_PER_SECOND),
+        ),
+        constrained_scales=((d2o_id, 0.1), (kdh_id, 10.0), (kab_id, 10.0)),
+        compiled_constraint_linearization=(
+            compile_constraint_linearization_capabilities(
+                parameterization,
+                (d2o_id, kdh_id, kab_id),
+                (),
+            )
+        ),
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.failures == ()
+    assert evidence.residual_jacobian is not None
+    np.testing.assert_allclose(
+        np.asarray(evidence.residual_jacobian.matrix)[:3],
+        (
+            (666.6712446920574, 1.910664913855726),
+            (0.27370067627634853, -0.01357184843345749),
+            (-5.879327716305852, -0.3296351577155292),
+        ),
+        rtol=2.0e-7,
+        atol=2.0e-9,
+    )
+    assert evidence.rank_diagnostic is not None
+    np.testing.assert_allclose(
+        evidence.rank_diagnostic.singular_values,
+        (154.19754083595208, 24.21131174143699),
+        rtol=2.0e-7,
+        atol=2.0e-9,
+    )
+    np.testing.assert_allclose(
+        evidence.rank_diagnostic.identifiable_projector,
+        np.eye(2),
+        rtol=0.0,
+        atol=3.0e-16,
+    )
+    assert evidence.covariance is not None
+    expected_covariance = np.asarray(
+        (
+            (4.078404361040173e-06, -0.0006890732177197917),
+            (-0.0006890732177197917, 0.13401556849617918),
+        )
+    )
+    np.testing.assert_allclose(
+        evidence.covariance.covariance,
+        expected_covariance,
+        rtol=4.0e-7,
+        atol=2.0e-12,
+    )
+    assert evidence.correlations is not None
+    np.testing.assert_allclose(
+        np.asarray(
+            [
+                [cast("float", entry.value) for entry in row]
+                for row in evidence.correlations.entries
+            ]
+        ),
+        ((1.0, -0.9320572795396814), (-0.9320572795396814, 1.0)),
+        rtol=2.0e-7,
+        atol=2.0e-9,
+    )
+    assert evidence.constraint_jacobian is not None
+    d2o, kdh = accepted.vector
+    phi = accepted.evaluation_result.resolved_values["__PHI_1"]
+    expected_gradient = np.asarray(((1.0, 0.0), (0.0, 1.0), (kdh * phi, d2o * phi)))
+    np.testing.assert_allclose(
+        evidence.constraint_jacobian.matrix,
+        expected_gradient,
+        rtol=0.0,
+        atol=0.0,
+    )
+    assert evidence.constrained_propagation is not None
+    np.testing.assert_allclose(
+        evidence.constrained_propagation.covariance,
+        expected_gradient @ expected_covariance @ expected_gradient.T,
+        rtol=4.0e-15,
+        atol=2.0e-17,
+    )
+
+
+def test_rank_deficiency_is_diagnostic_and_never_manufactures_uncertainty() -> None:
+    session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    policy = _qualification_policy(controlled_id)
+    rank_rejecting_policy = dataclasses.replace(
+        policy,
+        rank_absolute_tolerance=1.0e100,
+    )
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=rank_rejecting_policy,
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.residual_jacobian is not None
+    assert evidence.rank_diagnostic is not None
+    assert evidence.rank_diagnostic.rank == 0
+    assert evidence.covariance is None
+    assert evidence.marginal_errors is None
+    assert evidence.correlations is None
+    assert [(item.stage, item.category) for item in evidence.failures] == [
+        ("covariance", "rank_deficient")
+    ]
+    assert all(
+        operation.artifact_identity is None
+        for operation in evidence.operations
+        if operation.stage == "covariance"
+    )
+    assert session.analysis_values.snapshot().revision == 0
+
+
+def test_stencil_exhaustion_retains_trajectory_and_each_search_extent() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    policy = dataclasses.replace(
+        _qualification_policy(problem.controlled_ids[0]),
+        relative_step_tolerance=0.0,
+        roundoff_multiplier=0.0,
+        smaller_step_extent=0,
+        larger_step_extent=0,
+    )
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    failure = evidence.failures[0]
+    assert failure.category == "exhausted_declared_step_search_extent"
+    assert failure.trajectory_fingerprint is not None
+    assert failure.termination_details == (
+        "exhausted_declared_smaller_step_extent",
+        "exhausted_declared_larger_step_extent",
+    )
+
+
+def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    boundary_problem = dataclasses.replace(
+        problem,
+        lower_bounds=(accepted.vector[0],),
+    )
+    boundary_accepted = dataclasses.replace(
+        accepted,
+        problem_identity=boundary_problem.identity,
+    )
+
+    evidence = derive_uncertainty_evidence(
+        boundary_accepted,
+        problem=boundary_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.residual_jacobian is not None
+    assert evidence.residual_jacobian.columns[0].orientation == "one_sided_positive"
+    assert evidence.covariance is not None
+    assert evidence.covariance.claim("INTERIOR_POINT") is ClaimState.VIOLATED
+    assert evidence.covariance.claim("BOUNDARY_SEPARATION") is ClaimState.VIOLATED
+    assert evidence.covariance.claim("USABLE_LOCAL_COVARIANCE") is ClaimState.VIOLATED
+    assert evidence.marginal_errors is not None
+    assert evidence.marginal_errors.entries[0].value is not None
+    assert not evidence.marginal_errors.scope_reportable
+    assert evidence.correlations is not None
+    assert evidence.correlations.entries[0][0].value == 1.0
+    assert not evidence.correlations.scope_reportable
+
+
+def test_unrepresentable_centered_interval_falls_back_to_inward_stencil() -> None:
+    _session, parameterization, engine, problem, _accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    interior = (float(np.nextafter(0.0, 1.0)),)
+    anchor = _accepted_reference_anchor(
+        parameterization,
+        engine,
+        problem,
+        vector=interior,
+    )
+
+    evidence = derive_uncertainty_evidence(
+        anchor,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.residual_jacobian is not None
+    assert evidence.residual_jacobian.columns[0].orientation == "one_sided_positive"
+
+
+def test_nonfinite_boundary_separation_is_indeterminate() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    finite_extreme_problem = dataclasses.replace(
+        problem,
+        upper_bounds=(float(np.finfo(np.float64).max),),
+    )
+    compatible_accepted = dataclasses.replace(
+        accepted,
+        problem_identity=finite_extreme_problem.identity,
+    )
+
+    evidence = derive_uncertainty_evidence(
+        compatible_accepted,
+        problem=finite_extreme_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.covariance is not None
+    assert evidence.covariance.claim("BOUNDARY_SEPARATION") is ClaimState.INDETERMINATE
+
+
+def test_non_finite_accepted_objective_yields_only_typed_failed_covariance() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    non_finite = dataclasses.replace(accepted, chi_square=float("inf"))
+
+    evidence = derive_uncertainty_evidence(
+        non_finite,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.residual_jacobian is not None
+    assert evidence.covariance is None
+    assert evidence.rank_diagnostic is not None
+    assert [(item.stage, item.category) for item in evidence.failures] == [
+        ("covariance", "non_finite_chi_square")
+    ]
+    assert evidence.marginal_errors is None
+    assert evidence.correlations is None
+
+
+def test_foreign_coordinate_scope_fails_before_any_numerical_evidence() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    policy = dataclasses.replace(
+        _qualification_policy(problem.controlled_ids[0]),
+        coordinate_scales=(("__FOREIGN", 1.0),),
+        coordinate_units=(("__FOREIGN", ParameterUnit.RATE_PER_SECOND),),
+    )
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.residual_jacobian is None
+    assert evidence.rank_diagnostic is None
+    assert evidence.covariance is None
+    assert evidence.constraint_jacobian is None
+    assert evidence.failures[0].category == "coordinate_scale_scope_mismatch"
+    assert len(evidence.operations) == 1
+
+
+def test_held_constraint_output_is_explicitly_outside_uncertainty_basis() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        constrained_scope=("__PB",),
+        constrained_units=(("__PB", ParameterUnit.FRACTION),),
+        constrained_scales=(("__PB", 1.0),),
+        compiled_constraint_linearization=(
+            compile_constraint_linearization_capabilities(
+                parameterization,
+                ("__PB",),
+                (),
+            )
+        ),
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.covariance is not None
+    assert evidence.constraint_jacobian is None
+    assert evidence.constrained_propagation is None
+    assert [item.category for item in evidence.failures[-2:]] == [
+        "held_independent_outside_uncertainty_basis",
+        "source_artifact_unavailable",
+    ]
+
+
+def test_absolute_observation_uncertainties_do_not_apply_residual_scaling() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    policy = dataclasses.replace(
+        _qualification_policy(problem.controlled_ids[0]),
+        residual_variance_scaling=(
+            ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+        ),
+    )
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.covariance is not None
+    assert evidence.covariance.residual_variance_scale == 1.0
+    assert evidence.covariance.covariance == (evidence.covariance.unscaled_covariance)
+    assert (
+        evidence.covariance.claim("RESIDUAL_VARIANCE_NONDEGENERACY")
+        is ClaimState.NOT_APPLICABLE
+    )
+
+
+def test_malformed_non_finite_svd_output_is_a_typed_covariance_failure() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    malformed_svd = (
+        np.ones((7, 1), dtype=np.float64),
+        np.array([np.nan], dtype=np.float64),
+        np.ones((1, 1), dtype=np.float64),
+    )
+
+    with patch("chemex.optimize.uncertainty.svd", return_value=malformed_svd):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            resolved_environment_identity="local-qualification-environment",
+        )
+
+    assert evidence.residual_jacobian is not None
+    assert evidence.covariance is None
+    assert evidence.rank_diagnostic is None
+    assert evidence.failures[-1].category == "invalid_covariance_arithmetic"
+
+
+def test_negative_svd_spectrum_is_typed_invalid_evidence() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    malformed_svd = (
+        np.ones((7, 1), dtype=np.float64),
+        np.array([-1.0], dtype=np.float64),
+        np.ones((1, 1), dtype=np.float64),
+    )
+
+    with patch("chemex.optimize.uncertainty.svd", return_value=malformed_svd):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            resolved_environment_identity="local-qualification-environment",
+        )
+
+    assert evidence.covariance is None
+    assert evidence.failures[-1].category == "invalid_singular_spectrum"
+
+
+def test_positive_scale_covariance_factor_underflow_is_typed_failure() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    underflowing_svd = (
+        np.ones((7, 1), dtype=np.float64),
+        np.array([1.0e200], dtype=np.float64),
+        np.ones((1, 1), dtype=np.float64),
+    )
+
+    with patch("chemex.optimize.uncertainty.svd", return_value=underflowing_svd):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            resolved_environment_identity="local-qualification-environment",
+        )
+
+    assert evidence.covariance is None
+    assert evidence.failures[-1].category == "covariance_factor_underflow"
+
+
+def test_cancellation_freezes_terminal_operation_without_artifact() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    probe_count = 0
+
+    def cancel_inside_residual_operation() -> OperationTerminal | None:
+        nonlocal probe_count
+        probe_count += 1
+        return None if probe_count == 1 else OperationTerminal.CANCELLED
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        cancellation_probe=cancel_inside_residual_operation,
+        resolved_environment_identity="local-qualification-environment",
+    )
+
+    assert evidence.residual_jacobian is None
+    assert evidence.operations[0].terminal is OperationTerminal.CANCELLED
+    assert evidence.operations[0].artifact_identity is None
+    assert evidence.failures[0].category == "cancelled"
+    assert len(evidence.operations) == 1

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -19,13 +19,19 @@ import pytest
 
 from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
-from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
+from chemex.evaluation.native import (
+    BoundEvaluator,
+    EvaluationEngine,
+    EvaluationFrame,
+    EvaluationResult,
+)
 from chemex.experiments.builder import build_experiments
 from chemex.optimize import uncertainty as uncertainty_module
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     AffineEquality,
     AffineHalfSpace,
+    DirectTrfConstructionError,
     DirectTrfInvocation,
     OptimizationProblem,
     execute_direct_trf,
@@ -305,6 +311,25 @@ def _independent_five_point_jacobian(
     return np.column_stack(columns)
 
 
+def _independent_svd_covariance(
+    jacobian: Array,
+    coordinate_scales: tuple[float, ...],
+    residual_variance_scale: float,
+) -> tuple[Array, Array, Array]:
+    """Direct closed-form SVD reference independent of uncertainty.py."""
+    scales = np.asarray(coordinate_scales, dtype=np.float64)
+    scaled = np.asarray(jacobian, dtype=np.float64) * scales[np.newaxis, :]
+    _left, singular_values, right_transpose = np.linalg.svd(
+        scaled,
+        full_matrices=False,
+    )
+    right = right_transpose.T
+    inverse_singular = 1.0 / singular_values
+    unscaled_factor = scales[:, np.newaxis] * right * inverse_singular[np.newaxis, :]
+    factor = math.sqrt(residual_variance_scale) * unscaled_factor
+    return unscaled_factor @ unscaled_factor.T, factor, factor @ factor.T
+
+
 def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation() -> (
     None
 ):
@@ -342,6 +367,11 @@ def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation()
     assert evidence.residual_jacobian.complete_reliable
     # Independent five-point O(h^4) derivative, followed below by the scalar
     # closed form C = (chi²/nu) / (J^T J).  Neither calls uncertainty.py.
+    # The reference J is [6.8775710242, 3.7910236726, 1.0915054084,
+    # -1.2596720492, -3.2976439424, -5.0543079057, -6.5586116745]; the
+    # observed production/reference maxima are 3.16e-9 absolute and 2.23e-9
+    # relative.  Its independently derived variance is 0.01837155881904635;
+    # production differs by 5.89e-12, supporting the declared tolerances.
     expected_jacobian = _independent_five_point_jacobian(
         parameterization,
         engine,
@@ -357,18 +387,19 @@ def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation()
     )
     assert evidence.covariance is not None
     factor = np.asarray(evidence.covariance.factor)
-    for column in range(factor.shape[1]):
-        pivot = int(np.argmax(np.abs(factor[:, column])))
-        assert factor[pivot, column] >= 0.0
+    np.testing.assert_allclose(
+        factor @ factor.T,
+        evidence.covariance.covariance,
+        rtol=0.0,
+        atol=0.0,
+    )
     assert evidence.covariance.controlled_ids == (controlled_id,)
     assert evidence.covariance.retained_residual_count == 7
     assert evidence.covariance.controlled_coordinate_count == 1
     assert evidence.covariance.profiled_normalization_count == 1
     assert evidence.covariance.nominal_residual_degrees_of_freedom == 5
     assert evidence.covariance.rank == 1
-    assert evidence.covariance.factorization == (
-        "canonical-information-cholesky-gram-v2"
-    )
+    assert evidence.covariance.factorization == ("direct-scaled-svd-factor-gram-v3")
     expected_variance = (accepted.chi_square / 5.0) / float(
         expected_jacobian[:, 0] @ expected_jacobian[:, 0]
     )
@@ -654,6 +685,9 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
     assert evidence.rank_diagnostic is not None
     scaled_reference = reference_jacobian * np.asarray((0.1, 10.0))[np.newaxis, :]
     expected_singular_values = np.linalg.svd(scaled_reference, compute_uv=False)
+    # Independent expected singular values are [154.1975407925,
+    # 24.2113113641].  The SVD comparison therefore measures the production
+    # derivative error, not a copied production decomposition.
     np.testing.assert_allclose(
         evidence.rank_diagnostic.singular_values,
         expected_singular_values,
@@ -673,13 +707,26 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
             null_projector=((0.0, 0.0), (0.0, 1.0)),
         )
     assert evidence.covariance is not None
-    expected_covariance = np.linalg.solve(
-        reference_jacobian.T @ reference_jacobian,
-        np.eye(2),
+    expected_unscaled, _expected_factor, expected_covariance = (
+        _independent_svd_covariance(
+            reference_jacobian,
+            (0.1, 10.0),
+            1.0,
+        )
     )
+    # Direct SVD reference C = [[4.0784044539e-6, -6.8907323809e-4],
+    # [-6.8907323809e-4, 1.3401557289e-1]].  Observed production/reference
+    # covariance differences are 4.40e-9 absolute and 3.28e-8 relative, well
+    # inside the 4e-7 tolerance inherited from the finite-difference error.
     np.testing.assert_allclose(
         evidence.covariance.covariance,
         expected_covariance,
+        rtol=4.0e-7,
+        atol=2.0e-12,
+    )
+    np.testing.assert_allclose(
+        evidence.covariance.unscaled_covariance,
+        expected_unscaled,
         rtol=4.0e-7,
         atol=2.0e-12,
     )
@@ -715,6 +762,62 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
         rtol=4.0e-7,
         atol=2.0e-12,
     )
+
+
+def test_covariance_uses_direct_svd_not_normal_equations() -> None:
+    jacobian = np.asarray(
+        (
+            (1.0, 1.0),
+            (1.0, 1.0 + 1.0e-6),
+            (1.0, 1.0 - 1.0e-6),
+            (2.0, 2.0 + 0.5e-6),
+        ),
+        dtype=np.float64,
+    )
+    scales = (1.0e-3, 1.0e3)
+    expected_unscaled, expected_factor, expected_covariance = (
+        _independent_svd_covariance(jacobian, scales, 0.75)
+    )
+    scaled = jacobian * np.asarray(scales)[np.newaxis, :]
+    _left, singular_values, right_transpose = np.linalg.svd(
+        scaled,
+        full_matrices=False,
+    )
+    actual_unscaled, actual_factor, actual_covariance = (
+        uncertainty_module._canonical_covariance_reduction(
+            singular_values,
+            right_transpose,
+            scales,
+            0.75,
+        )
+    )
+    np.testing.assert_allclose(
+        actual_unscaled,
+        expected_unscaled,
+        rtol=2.0e-15,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        np.abs(actual_factor),
+        np.abs(expected_factor),
+        rtol=2.0e-15,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        actual_covariance,
+        expected_covariance,
+        rtol=2.0e-15,
+        atol=0.0,
+    )
+
+    scale_matrix = np.diag(scales)
+    normal_equation_covariance = 0.75 * (
+        scale_matrix @ np.linalg.solve(scaled.T @ scaled, np.eye(2)) @ scale_matrix
+    )
+    relative_difference = np.max(
+        np.abs((normal_equation_covariance - expected_covariance) / expected_covariance)
+    )
+    assert relative_difference > 1.0e-5
 
 
 def test_rank_deficiency_is_diagnostic_and_never_manufactures_uncertainty() -> None:
@@ -811,6 +914,10 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
         (1.0e-4,),
         forward_columns=frozenset({0}),
     )
+    # The independent one-sided O(h^4) reference J is [6.8775710282,
+    # 3.7910236723, 1.0915054092, -1.2596720491, -3.2976439423,
+    # -5.0543079056, -6.5586116752].  Observed maxima are 2.02e-8 absolute
+    # and 9.41e-9 relative, supporting the same 2e-7 / 2e-9 policy.
     np.testing.assert_allclose(
         np.asarray(evidence.residual_jacobian.matrix),
         independent_forward,
@@ -1068,7 +1175,7 @@ def test_positive_scale_covariance_factor_underflow_is_typed_failure() -> None:
         )
 
     assert evidence.covariance is None
-    assert evidence.failures[-1].category == "invalid_covariance_arithmetic"
+    assert evidence.failures[-1].category == "covariance_factor_underflow"
 
 
 def test_cancellation_freezes_terminal_operation_without_artifact() -> None:
@@ -1357,7 +1464,11 @@ def test_affine_directional_separation_uses_exact_full_frame_slack(
         _full_frame_coefficients(problem, {problem.controlled_ids[0]: 1.0}),
         accepted.vector[0] + zeta * standard_error,
     )
-    affine_problem = dataclasses.replace(problem, affine_half_spaces=(restriction,))
+    affine_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_half_spaces=(restriction,),
+    )
     affine_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=affine_problem.identity,
@@ -1374,6 +1485,187 @@ def test_affine_directional_separation_uses_exact_full_frame_slack(
     assert evidence.covariance is not None
     assert evidence.covariance.claim("AFFINE_FEASIBILITY") is expected
     assert evidence.covariance.usable is (expected is ClaimState.SATISFIED)
+
+
+def test_active_affine_upper_uses_inward_stencil_without_off_feasible_calls() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    restriction = AffineHalfSpace(
+        "active-stencil-upper",
+        _full_frame_coefficients(problem, {controlled_id: 1.0}),
+        accepted.vector[0],
+    )
+    constrained_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_half_spaces=(restriction,),
+    )
+    constrained_accepted = _qualified_accepted_copy(
+        accepted,
+        problem_identity=constrained_problem.identity,
+        occurrence_identity="active-stencil-upper-occurrence",
+    )
+    original_evaluate = BoundEvaluator.evaluate
+    evaluated_values: list[float] = []
+
+    def guarded_evaluate(
+        bound: BoundEvaluator,
+        frame: EvaluationFrame,
+    ) -> object:
+        items = cast("list[list[object]]", frame.to_record()["items"])
+        encoded = cast(
+            "str",
+            next(item[1] for item in items if item[0] == controlled_id),
+        )
+        value = float.fromhex(encoded)
+        assert value <= accepted.vector[0]
+        evaluated_values.append(value)
+        return original_evaluate(bound, frame)
+
+    with patch.object(BoundEvaluator, "evaluate", guarded_evaluate):
+        evidence = derive_uncertainty_evidence(
+            constrained_accepted,
+            problem=constrained_problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(controlled_id),
+            resolved_environment_identity="active-affine-stencil",
+        )
+
+    assert evidence.residual_jacobian is not None
+    column = evidence.residual_jacobian.columns[0]
+    assert column.orientation == "one_sided_negative"
+    assert column.feasible_displacement_interval[1] == 0.0
+    assert column.upper_feasibility_limiters == ("affine:active-stencil-upper",)
+    assert evaluated_values
+
+
+def test_affine_lower_inactive_box_intersection_and_coupled_held_stencils() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    lower_restriction = AffineHalfSpace(
+        "active-stencil-lower",
+        _full_frame_coefficients(problem, {controlled_id: -1.0}),
+        -accepted.vector[0],
+    )
+    lower_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_half_spaces=(lower_restriction,),
+    )
+    lower_accepted = _qualified_accepted_copy(
+        accepted,
+        problem_identity=lower_problem.identity,
+        occurrence_identity="active-stencil-lower-occurrence",
+    )
+    lower_evidence = derive_uncertainty_evidence(
+        lower_accepted,
+        problem=lower_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        resolved_environment_identity="active-affine-lower-stencil",
+    )
+    assert lower_evidence.residual_jacobian is not None
+    lower_column = lower_evidence.residual_jacobian.columns[0]
+    assert lower_column.orientation == "one_sided_positive"
+    assert lower_column.feasible_displacement_interval[0] == 0.0
+    assert lower_column.lower_feasibility_limiters == ("affine:active-stencil-lower",)
+
+    inactive = AffineHalfSpace(
+        "inactive-stencil-upper",
+        _full_frame_coefficients(problem, {controlled_id: 1.0}),
+        accepted.vector[0] + 0.5,
+    )
+    inactive_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_half_spaces=(inactive,),
+    )
+    interval = inactive_problem.coordinate_line_feasibility(accepted.vector, 0)
+    assert interval.minimum_displacement == problem.lower_bounds[0] - accepted.vector[0]
+    assert interval.maximum_displacement == 0.5
+    assert interval.upper_limiters == ("affine:inactive-stencil-upper",)
+    inactive_accepted = _qualified_accepted_copy(
+        accepted,
+        problem_identity=inactive_problem.identity,
+        occurrence_identity="inactive-stencil-occurrence",
+    )
+    inactive_evidence = derive_uncertainty_evidence(
+        inactive_accepted,
+        problem=inactive_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        resolved_environment_identity="inactive-affine-stencil",
+    )
+    assert inactive_evidence.residual_jacobian is not None
+    assert inactive_evidence.residual_jacobian.columns[0].orientation == "centered"
+
+    held_id, held_value = problem.held_items[0]
+    coupled = AffineHalfSpace(
+        "coupled-held-stencil-upper",
+        _full_frame_coefficients(
+            problem,
+            {controlled_id: 1.0, held_id: 1.0},
+        ),
+        accepted.vector[0] + held_value,
+    )
+    coupled_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_half_spaces=(coupled,),
+    )
+    coupled_accepted = _qualified_accepted_copy(
+        accepted,
+        problem_identity=coupled_problem.identity,
+        occurrence_identity="coupled-held-stencil-occurrence",
+    )
+    coupled_evidence = derive_uncertainty_evidence(
+        coupled_accepted,
+        problem=coupled_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        resolved_environment_identity="coupled-held-affine-stencil",
+    )
+    assert coupled_evidence.residual_jacobian is not None
+    coupled_column = coupled_evidence.residual_jacobian.columns[0]
+    assert coupled_column.orientation == "one_sided_negative"
+    assert coupled_column.upper_feasibility_limiters == (
+        "affine:coupled-held-stencil-upper",
+    )
+
+
+def test_affine_equality_has_no_single_coordinate_stencil() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    equality = AffineEquality(
+        "fixed-stencil-coordinate",
+        _full_frame_coefficients(problem, {controlled_id: 1.0}),
+        accepted.vector[0],
+    )
+    equality_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_equalities=(equality,),
+    )
+    equality_accepted = _qualified_accepted_copy(
+        accepted,
+        problem_identity=equality_problem.identity,
+        occurrence_identity="fixed-stencil-coordinate-occurrence",
+    )
+    evidence = derive_uncertainty_evidence(
+        equality_accepted,
+        problem=equality_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        resolved_environment_identity="fixed-affine-stencil",
+    )
+    assert evidence.residual_jacobian is None
+    assert evidence.covariance is None
+    assert evidence.failures[0].category == "exhausted_exact_feasible_distance"
 
 
 def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
@@ -1435,7 +1727,11 @@ def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
         is ClaimState.NOT_APPLICABLE
     )
 
-    equality_problem = dataclasses.replace(problem, affine_equalities=(equality,))
+    equality_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_equalities=(equality,),
+    )
     equality_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=equality_problem.identity,
@@ -1449,14 +1745,9 @@ def test_affine_held_only_and_equality_semantics_fail_closed() -> None:
         policy=_qualification_policy(problem.controlled_ids[0]),
         resolved_environment_identity="equality-affine",
     )
-    assert equality_evidence.covariance is not None
-    assert (
-        equality_evidence.covariance.claim("AFFINE_FEASIBILITY") is ClaimState.VIOLATED
-    )
-    assert (
-        equality_evidence.covariance.claim("FULL_DIMENSIONAL_FEASIBLE_INTERIOR")
-        is ClaimState.VIOLATED
-    )
+    assert equality_evidence.residual_jacobian is None
+    assert equality_evidence.covariance is None
+    assert equality_evidence.failures[0].category == "exhausted_exact_feasible_distance"
 
 
 def test_affine_coupled_negative_degenerate_and_nonfinite_cases() -> None:
@@ -1475,67 +1766,70 @@ def test_affine_coupled_negative_degenerate_and_nonfinite_cases() -> None:
     assert baseline.covariance is not None
     standard_error = math.sqrt(baseline.covariance.covariance[0][0])
 
-    restrictions = (
-        (
-            "coupled",
-            AffineHalfSpace(
-                "coupled",
-                _full_frame_coefficients(problem, {controlled_id: 1.0, held_id: 1.0}),
-                accepted.vector[0] + held_value + 4.0 * standard_error,
-            ),
-            ClaimState.SATISFIED,
-        ),
-        (
+    coupled = AffineHalfSpace(
+        "coupled",
+        _full_frame_coefficients(problem, {controlled_id: 1.0, held_id: 1.0}),
+        accepted.vector[0] + held_value + 4.0 * standard_error,
+    )
+    coupled_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_half_spaces=(coupled,),
+    )
+    coupled_accepted = _qualified_accepted_copy(
+        accepted,
+        problem_identity=coupled_problem.identity,
+        occurrence_identity="coupled-affine-occurrence",
+    )
+    coupled_evidence = derive_uncertainty_evidence(
+        coupled_accepted,
+        problem=coupled_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="affine-coupled",
+    )
+    assert coupled_evidence.covariance is not None, coupled_evidence.failures
+    assert (
+        coupled_evidence.covariance.claim("AFFINE_FEASIBILITY") is ClaimState.SATISFIED
+    )
+
+    invalid_restrictions = (
+        AffineHalfSpace(
             "negative",
-            AffineHalfSpace(
-                "negative",
-                _full_frame_coefficients(problem, {controlled_id: 1.0}),
-                accepted.vector[0] - 1.0,
-            ),
-            ClaimState.VIOLATED,
+            _full_frame_coefficients(problem, {controlled_id: 1.0}),
+            accepted.vector[0] - 1.0,
         ),
-        (
+        AffineHalfSpace(
             "nonfinite",
-            AffineHalfSpace(
-                "nonfinite",
-                _full_frame_coefficients(
-                    problem,
-                    {
-                        controlled_id: float(np.finfo(np.float64).max),
-                        held_id: float(np.finfo(np.float64).max),
-                    },
-                ),
-                float(np.finfo(np.float64).max),
+            _full_frame_coefficients(
+                problem,
+                {
+                    controlled_id: float(np.finfo(np.float64).max),
+                    held_id: float(np.finfo(np.float64).max),
+                },
             ),
-            ClaimState.INDETERMINATE,
+            float(np.finfo(np.float64).max),
         ),
     )
-    for label, restriction, expected in restrictions:
-        constrained_problem = dataclasses.replace(
-            problem, affine_half_spaces=(restriction,)
-        )
-        constrained_accepted = _qualified_accepted_copy(
-            accepted,
-            problem_identity=constrained_problem.identity,
-            occurrence_identity=f"{label}-affine-occurrence",
-        )
-        evidence = derive_uncertainty_evidence(
-            constrained_accepted,
-            problem=constrained_problem,
-            parameterization=parameterization,
-            engine=engine,
-            policy=policy,
-            resolved_environment_identity=f"affine-{label}",
-        )
-        assert evidence.covariance is not None, evidence.failures
-        assert evidence.covariance.claim("AFFINE_FEASIBILITY") is expected
+    for restriction in invalid_restrictions:
+        with pytest.raises(DirectTrfConstructionError, match="affine half-space"):
+            dataclasses.replace(
+                problem,
+                start=accepted.vector,
+                affine_half_spaces=(restriction,),
+            )
 
     positive = AffineHalfSpace(
         "positive-with-zero-variance",
         _full_frame_coefficients(problem, {controlled_id: 1.0}),
         accepted.vector[0] + 1.0,
     )
-    degenerate_problem = dataclasses.replace(problem, affine_half_spaces=(positive,))
+    degenerate_problem = dataclasses.replace(
+        problem,
+        start=accepted.vector,
+        affine_half_spaces=(positive,),
+    )
     degenerate_accepted = _qualified_accepted_copy(
         accepted,
         problem_identity=degenerate_problem.identity,
@@ -1866,3 +2160,66 @@ def test_cancellation_during_g_and_before_propagation_emits_no_downstream() -> N
     propagate.assert_not_called()
     assert before_propagation.constraint_jacobian is not None
     assert before_propagation.constrained_propagation is None
+
+
+def test_cancellation_between_constrained_marginals_and_correlations() -> None:
+    session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    derived_id = "__R1A_B_G2N_H_800_0MHZ"
+    before = session.analysis_values.snapshot()
+    original_marginals = uncertainty_module._marginal_errors
+    original_correlations = uncertainty_module._correlations
+    constrained_marginals_complete = False
+    constrained_correlations_started = False
+
+    def traced_marginals(*args: object, **kwargs: object) -> object:
+        nonlocal constrained_marginals_complete
+        result = original_marginals(*args, **kwargs)
+        if kwargs.get("source_family") == "constrained_propagation":
+            constrained_marginals_complete = True
+        return result
+
+    def traced_correlations(*args: object, **kwargs: object) -> object:
+        nonlocal constrained_correlations_started
+        if kwargs.get("source_family") == "constrained_propagation":
+            constrained_correlations_started = True
+        return original_correlations(*args, **kwargs)
+
+    with (
+        patch(
+            "chemex.optimize.uncertainty._marginal_errors",
+            side_effect=traced_marginals,
+        ),
+        patch(
+            "chemex.optimize.uncertainty._correlations",
+            side_effect=traced_correlations,
+        ),
+    ):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(controlled_id),
+            constrained_scope=(derived_id,),
+            constrained_units=((derived_id, ParameterUnit.RATE_PER_SECOND),),
+            constrained_scales=((derived_id, 1.0),),
+            compiled_constraint_linearization=compile_constraint_linearization_capabilities(
+                parameterization, (derived_id,), ()
+            ),
+            cancellation_probe=lambda: (
+                OperationTerminal.CANCELLED if constrained_marginals_complete else None
+            ),
+            resolved_environment_identity="cancel-before-constrained-correlations",
+        )
+
+    assert not constrained_correlations_started
+    assert evidence.constrained_propagation is not None
+    assert evidence.constrained_marginal_errors is not None
+    assert evidence.constrained_correlations is None
+    assert evidence.operations[-1].stage == "constrained_correlations"
+    assert evidence.operations[-1].terminal is OperationTerminal.CANCELLED
+    assert all(
+        operation.stage != "final_bundle_assembly" for operation in evidence.operations
+    )
+    assert session.analysis_values.snapshot() == before


### PR DESCRIPTION
Closes #598.

## Summary

Adds isolated native covariance and constrained-uncertainty qualification.

Accepted native fits can now produce typed, immutable evidence for:

* fresh accepted-point residual Jacobians;
* scaled-SVD rank and conditioning diagnostics;
* covariance and covariance factors;
* marginal uncertainties and correlations;
* constraint-output Jacobians;
* propagated constrained-parameter uncertainty;
* boundary, affine-feasibility, and scientific-usability claims.

Uncertainty evidence is separate from central parameter estimates and never mutates committed `AnalysisValues`.

## Numerical contract

Residual linearization is performed in canonical external physical coordinates using fresh ChemEx-owned finite differences of the complete retained-residual map.

Covariance is constructed directly from the declared scaled SVD:

`J_z = U diag(s) V^T`

with external covariance derived through `Q V diag(1/s)` and deterministic fixed-pairwise reductions.

The implementation does not use normal equations, matrix inversion/solve, Cholesky reconstruction, singular-value clipping, hidden regularization, or post-hoc covariance symmetrization.

Covariance is available only for full-rank evidence. Rank deficiency, unreliable derivatives, non-finite arithmetic, insufficient effective observations, and incompatible evidence remain explicit typed failures rather than producing pseudoinverse covariance, NaNs, zero placeholders, or generic `stderr`.

## Feasibility and constrained uncertainty

`OptimizationProblem` now owns canonical box, affine, and equality feasibility.

That feasibility context is preserved through:

* grouped Direct TRF;
* GRID;
* grouped GRID;
* DE search;
* DE polish.

Candidate lifecycle validation rejects infeasible frames before evaluation.

Finite-difference planning intersects exact box and affine line feasibility, so active restrictions select valid inward one-sided stencils or report an unavailable derivative instead of evaluating outside the feasible region.

Constrained uncertainty is represented as separate joint evidence derived from a compatible constraint-output Jacobian and covariance artifact.

## Evidence integrity

Uncertainty evidence is bound to the exact accepted fit occurrence while preserving the existing semantic `AcceptedFitResult.identity`.

Typed artifacts validate their complete numerical and provenance derivation chains. Reconstructed or mixed evidence with incompatible accepted occurrences, Jacobians, SVDs, scaling policies, factors, covariance matrices, claims, or constraint-propagation lineage is rejected fail-closed.

Analytic scientific-function derivative capabilities use deterministic callable-semantic fingerprints, and repeated or clustered singular directions retain invariant-subspace projectors rather than claiming arbitrary canonical basis vectors.

## Cancellation

Cancellation checkpoints cover all scientific phases, including:

* accepted-anchor validation;
* residual linearization;
* SVD/rank analysis;
* covariance construction;
* marginal errors and correlations;
* constraint linearization;
* constrained propagation;
* final evidence assembly.

Once cancellation is observed, later scientific phases do not start and completed partial evidence is retained only according to its typed validity contract.

## Numerical qualification

Independent references validate the implementation:

* one-coordinate reference variance: `0.01837155881904635`

  * observed difference: `5.89e-12`;
* two-coordinate singular values:

  * `[154.1975407925, 24.2113113641]`;
* two-coordinate covariance:

  * `[[4.0784044539e-6, -6.8907323809e-4],`
  * ` [-6.8907323809e-4, 1.3401557289e-1]]`;
* maximum observed covariance relative difference: `3.28e-8`;
* one-sided boundary derivative maximum relative difference: `9.41e-9`.

An adversarial scaled case also distinguishes the required direct-SVD construction from a normal-equation implementation, which diverges by approximately `1.82e-4`.

## Scope

This remains an isolated qualification API.

No changes to:

* production optimizer dispatch;
* CLI or TOML;
* parameter `stderr` handling;
* output/reporting;
* documentation;
* examples;
* committed central parameter values.

User-facing uncertainty migration remains for later tickets.

## Validation

Implementation validation:

* uncertainty qualification: 34 passed;
* derived optimizer suites: 125 passed;
* evaluation/constraint/parameterization: 117 passed;
* native optimizer slice: 224 passed;
* full suite: 723 passed;
* `uv run ty check`: passed;
* Ruff lint and format checks: passed;
* `git diff --check`: passed;
* Graphify refreshed.

One existing non-failing `emcee` autocorrelation warning remains.

Independent adversarial review: **MERGE**

* Standards: CLEAN
* Spec: CLEAN
* No Blocking or Important findings.
