### PR TITLE
Add relaxation-compensated 15N CPMG experiment (cpmg_15n_rc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO).
 
 ## [Unreleased]
-
+- Added `cpmg_15n_rc`, a relaxation-compensated 15N CPMG experiment corresponding
+to the Bruker `hsqcrexetf3gpsitc3d` pulse program (Long, Liu & Yang, JACS 2008),
+including the R1 compensation delay of Yuwen & Kay, J. Biomol. NMR 2019.
 ### Infrastructure
 - Removed the unused `B1FieldConfig` model and its `default_distribution_config`
   helper from `b1_config.py`; the flat-table `b1_frq` schema it implemented was

--- a/src/chemex/experiments/catalog/cpmg_15n_rc.py
+++ b/src/chemex/experiments/catalog/cpmg_15n_rc.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+from numpy.linalg import matrix_power
+from pydantic import Field, computed_field
+
+from chemex.configuration.base import ExperimentConfiguration, ToBeFitted
+from chemex.configuration.conditions import ConditionsWithValidations
+from chemex.configuration.data import RelaxationDataSettings
+from chemex.configuration.experiment import CpmgSettingsEvenNcycs
+from chemex.configuration.types import Delay, Frequency, PulseWidth
+from chemex.containers.data import Data
+from chemex.experiments.experiment_types import (
+    ProfileCalculation,
+    cpmg_type,
+    register_experiment_type,
+)
+from chemex.nmr.basis import Basis
+from chemex.nmr.spectrometer import Spectrometer
+from chemex.parameters.spin_system import SpinSystem
+from chemex.typing import Array
+
+EXPERIMENT_NAME = "cpmg_15n_rc"
+
+# Phases of the refocusing pulses within one repetition of the CPMG loops, in
+# the order they are applied. 0/1/2/3 denote x/y/-x/-y. The anti-phase block
+# uses the 1102 cycle and the in-phase block the same cycle rotated by 90
+# degrees, so that in both blocks half of the pulses are perpendicular to the
+# magnetization.
+_ANTIPHASE_CYCLE = (1, 1, 0, 2)
+_ANTIPHASE_REMAINDER = (1, 1)
+_INPHASE_CYCLE = (0, 0, 1, 3)
+_INPHASE_REMAINDER = (0, 0)
+
+
+class Cpmg15NRcSettings(CpmgSettingsEvenNcycs):
+    """Settings for the relaxation-compensated 15N CPMG experiment.
+
+    Two CPMG blocks of equal duration are separated by a P-element that
+    interconverts anti-phase and in-phase 15N magnetization. The magnetization
+    is anti-phase during the first block and in-phase during the second one, so
+    the measured rate is the average of the two irrespective of the CPMG
+    frequency.
+
+    The compensation delay equalizes the time spent along z during the
+    refocusing pulses across the whole series, which is why the largest ncyc is
+    needed.
+
+    References:
+        D. Long, M. Liu and D. Yang. J. Am. Chem. Soc. 130, 2432-2433 (2008).
+        T. Yuwen and L. E. Kay. J. Biomol. NMR 73, 641-650 (2019).
+
+    """
+
+    name: Literal["cpmg_15n_rc"]
+    time_t2: Delay = Field(description="Total CPMG relaxation delay in seconds")
+    carrier: Frequency = Field(description="15N carrier position in Hz")
+    pw90: PulseWidth = Field(
+        description="15N 90-degree pulse width in seconds, at the CPMG power level",
+    )
+    ncyc_max: int = Field(
+        gt=0,
+        description="Largest ncyc of the series, used for the R1 compensation delay",
+    )
+    taub: float = 2.68e-3
+
+    @property
+    def pw180(self) -> float:
+        """Width of the CPMG refocusing pulse."""
+        return 2.0 * self.pw90
+
+    @computed_field
+    @property
+    def start_terms(self) -> list[str]:
+        """Starting magnetization terms (anti-phase, from the refocused INEPT)."""
+        return self.get_start_terms("2izsz")
+
+    @computed_field
+    @property
+    def detection(self) -> str:
+        """The last 15N 90-degree pulse stores in-phase magnetization along z."""
+        return self.get_detection_expression("[iz]")
+
+
+class Cpmg15NRcConfig(
+    ExperimentConfiguration[
+        Cpmg15NRcSettings,
+        ConditionsWithValidations,
+        RelaxationDataSettings,
+    ],
+):
+    @property
+    def to_be_fitted(self) -> ToBeFitted:
+        state = self.experiment.primary_state
+
+        return ToBeFitted(rates=[f"r2_i_{state}"], model_free=[f"tauc_{state}"])
+
+
+def build_spectrometer(
+    config: Cpmg15NRcConfig,
+    spin_system: SpinSystem,
+) -> Spectrometer:
+    settings = config.experiment
+    conditions = config.conditions
+
+    # The anti-phase block and the J evolution during the CPMG trains require
+    # the two-spin longitudinal basis.
+    basis = Basis(type="ixyzsz", spin_system="nh", model=config.model)
+    spectrometer = Spectrometer.from_spin_system(spin_system, basis, conditions)
+
+    spectrometer.carrier_i = settings.carrier
+    spectrometer.b1_i = 1 / (4.0 * settings.pw90)
+    spectrometer.detection = settings.detection
+
+    return spectrometer
+
+
+def _echo_train(echoes: list[Array], phases: tuple[int, ...]) -> Array:
+    """Chain spin echoes applied in the given order of refocusing phases."""
+    propagator = echoes[phases[0]]
+    for phase in phases[1:]:
+        propagator = echoes[phase] @ propagator
+    return propagator
+
+
+class Cpmg15NRcSequence:
+    """Sequence for the relaxation-compensated 15N CPMG experiment."""
+
+    def __init__(self, settings: Cpmg15NRcSettings) -> None:
+        self.settings = settings
+
+    @staticmethod
+    def even_ncyc(ncyc: float) -> int:
+        """Round ncyc down to the even value used by the pulse sequence.
+
+        The number of refocusing pulses per block is set by an integer loop
+        counter equal to ncyc / 2, and the CPMG frequency is recomputed from it
+        before the inter-pulse delay is derived. Valid CPMG frequencies are
+        multiples of 2 / time_t2, for which this rounding is a no-op.
+        """
+        return 2 * (int(ncyc) // 2)
+
+    def _get_delays(
+        self,
+        ncycs: Array,
+    ) -> tuple[dict[float, float], dict[float, float], list[float]]:
+        settings = self.settings
+
+        tau_cps = {
+            ncyc: settings.time_t2 / (4.0 * self.even_ncyc(ncyc))
+            - 0.375 * settings.pw180
+            for ncyc in ncycs
+            if self.even_ncyc(ncyc) > 0
+        }
+        deltas = {
+            ncyc: 0.25 * (settings.ncyc_max - self.even_ncyc(ncyc)) * settings.pw180
+            for ncyc in ncycs
+        }
+        delays = [settings.taub, *tau_cps.values(), *deltas.values()]
+
+        return tau_cps, deltas, delays
+
+    def calculate(self, spectrometer: Spectrometer, data: Data) -> Array:
+        ncycs = data.metadata
+        settings = self.settings
+
+        # Calculation of the propagators corresponding to all the delays
+        tau_cps, deltas, all_delays = self._get_delays(ncycs)
+        delays = dict(zip(all_delays, spectrometer.delays(all_delays), strict=True))
+        d_taub = delays[settings.taub]
+        d_cp = {ncyc: delays[delay] for ncyc, delay in tau_cps.items()}
+        d_comp = {ncyc: delays[delay] for ncyc, delay in deltas.items()}
+
+        # Calculation of the propagators corresponding to all the pulses
+        p90 = spectrometer.p90_i
+        p180 = spectrometer.p180_i
+        p180_ix = spectrometer.perfect180_i[0]
+        p180_sx = spectrometer.perfect180_s[0]
+
+        # Calculating the P-element, which lets J evolve for 1 / (2 J) and
+        # converts the anti-phase magnetization of the first block into the
+        # in-phase magnetization of the second one
+        p_element = d_taub @ p180_sx @ p180_ix @ d_taub
+
+        # Getting the starting magnetization
+        start = spectrometer.get_start_magnetization(settings.start_terms)
+
+        # Calculating the intensities as a function of ncyc
+        intst: dict[float, float] = {}
+
+        for ncyc in set(ncycs):
+            d_r1 = d_comp[ncyc]
+            magnetization = p90[0] @ d_r1 @ start
+
+            if self.even_ncyc(ncyc) > 0:
+                echoes = [d_cp[ncyc] @ p180[phase] @ d_cp[ncyc] for phase in range(4)]
+                counter1, counter2 = divmod(self.even_ncyc(ncyc) // 2, 2)
+                cpmg1 = matrix_power(
+                    _echo_train(echoes, _ANTIPHASE_REMAINDER),
+                    counter2,
+                ) @ matrix_power(_echo_train(echoes, _ANTIPHASE_CYCLE), counter1)
+                cpmg2 = matrix_power(
+                    _echo_train(echoes, _INPHASE_REMAINDER),
+                    counter2,
+                ) @ matrix_power(_echo_train(echoes, _INPHASE_CYCLE), counter1)
+                magnetization = cpmg2 @ p_element @ cpmg1 @ magnetization
+            else:
+                magnetization = p_element @ magnetization
+
+            intst[ncyc] = spectrometer.detect(d_r1 @ p90[1] @ magnetization)
+
+        # Return profile
+        return np.array([intst[ncyc] for ncyc in ncycs])
+
+    @staticmethod
+    def is_reference(metadata: Array) -> Array:
+        return metadata == 0
+
+
+def create_profile_calculation(
+    config: Cpmg15NRcConfig,
+    spin_system: SpinSystem,
+) -> ProfileCalculation:
+    return ProfileCalculation(
+        spectrometer=build_spectrometer(config, spin_system),
+        pulse_sequence=Cpmg15NRcSequence(config.experiment),
+    )
+
+
+EXPERIMENT_TYPE = cpmg_type(
+    name=EXPERIMENT_NAME,
+    config_type=Cpmg15NRcConfig,
+)(create_profile_calculation)
+
+
+def register() -> None:
+    register_experiment_type(EXPERIMENT_TYPE)

--- a/tests/experiments/test_cpmg_15n_rc.py
+++ b/tests/experiments/test_cpmg_15n_rc.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from chemex.configuration.methods import Selection
+from chemex.configuration.parameters import read_defaults
+from chemex.experiments.builder import build_experiments
+from chemex.experiments.catalog.cpmg_15n_rc import (
+    EXPERIMENT_NAME,
+    Cpmg15NRcConfig,
+    Cpmg15NRcSequence,
+)
+from chemex.models.model import ModelSpec
+from chemex.runtime import AnalysisSession
+
+TIME_T2 = 0.040
+NCYC_MAX = 40
+
+
+def _build_config(model: str = "2st", **overrides: object) -> Cpmg15NRcConfig:
+    experiment = {
+        "name": EXPERIMENT_NAME,
+        "time_t2": TIME_T2,
+        "carrier": 118.0,
+        "pw90": 40.0e-6,
+        "ncyc_max": NCYC_MAX,
+    } | overrides
+    return Cpmg15NRcConfig.model_validate(
+        {
+            "experiment": experiment,
+            "conditions": {"h_larmor_frq": 600.0, "temperature": 25.0},
+            "data": {"path": ".", "profiles": {}},
+            "model": ModelSpec(name=model, states="ab"[: 1 if model == "1st" else 2]),
+        },
+    )
+
+
+NCYCS = (0, 2, 4, 8, 12, 18, 24, 32, 40)
+
+
+def _write_input(tmp_path: Path) -> Path:
+    (tmp_path / "93N-HN.out").write_text(
+        "\n".join(f"{ncyc:6d} 1.0e6 1.0e4" for ncyc in NCYCS) + "\n",
+    )
+    filename = tmp_path / "experiment.toml"
+    filename.write_text(
+        f"""[experiment]
+name = "{EXPERIMENT_NAME}"
+time_t2 = {TIME_T2}
+carrier = 118.0
+pw90 = 40.0e-6
+ncyc_max = {NCYC_MAX}
+
+[conditions]
+h_larmor_frq = 600.0
+temperature = 25.0
+
+[data]
+path = "."
+
+[data.profiles]
+93N = "93N-HN.out"
+""",
+    )
+    return filename
+
+
+def _calculated_profile(tmp_path: Path, model: str) -> np.ndarray:
+    filename = _write_input(tmp_path)
+    parameters = tmp_path / "parameters.toml"
+    parameters.write_text(
+        """[GLOBAL]
+R2_I_A = 20.0
+TAUC_A = 9.0
+PB = 0.03
+KEX_AB = 800.0
+DW_AB = 3.0
+
+[CS_A]
+93N = 118.0
+""",
+    )
+
+    session = AnalysisSession()
+    session.set_model(model)
+    experiments = build_experiments(
+        [filename],
+        Selection(include=None, exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([parameters]))
+    params = session.parameters.build_lmfit_params(experiments.param_ids)
+    (experiment,) = list(experiments)
+    (profile,) = list(experiment)
+    return profile.calculate(params)
+
+
+def test_settings_expose_the_expected_coherences() -> None:
+    settings = _build_config().experiment
+
+    assert settings.start_terms == ["2izsz"]
+    assert settings.detection == "[iz_a]"
+    assert settings.even_ncycs is True
+    assert settings.pw180 == pytest.approx(2.0 * settings.pw90)
+
+
+def test_reference_plane_is_flagged() -> None:
+    metadata = np.array([0.0, 2.0, 40.0])
+
+    assert Cpmg15NRcSequence.is_reference(metadata).tolist() == [True, False, False]
+
+
+@pytest.mark.parametrize(
+    ("ncyc", "expected"),
+    [(0.0, 0), (1.0, 0), (2.0, 2), (3.0, 2), (40.0, 40)],
+)
+def test_odd_ncyc_is_rounded_down_like_the_pulse_sequence(
+    ncyc: float,
+    expected: int,
+) -> None:
+    assert Cpmg15NRcSequence.even_ncyc(ncyc) == expected
+
+
+def test_inter_pulse_delay_matches_the_rounded_cpmg_frequency() -> None:
+    settings = _build_config().experiment
+    sequence = Cpmg15NRcSequence(settings)
+
+    tau_cps, _, _ = sequence._get_delays(np.array([0.0, 2.0, 40.0]))
+
+    nu_cpmg = 2.0 / TIME_T2
+    expected = 1.0 / (4.0 * nu_cpmg) - 0.375 * settings.pw180
+    assert tau_cps[2.0] == pytest.approx(expected)
+    assert 0.0 not in tau_cps
+
+
+def test_compensation_delay_vanishes_at_the_largest_ncyc() -> None:
+    settings = _build_config().experiment
+    sequence = Cpmg15NRcSequence(settings)
+
+    _, deltas, _ = sequence._get_delays(np.array([0.0, NCYC_MAX]))
+
+    assert deltas[float(NCYC_MAX)] == pytest.approx(0.0)
+    assert deltas[0.0] == pytest.approx(0.25 * NCYC_MAX * settings.pw180)
+
+
+def test_baseline_is_flat_without_exchange(tmp_path: Path) -> None:
+    """The equal anti-phase / in-phase periods and the R1 compensation delay
+    should leave no residual dependence on the CPMG frequency."""
+    intensities = _calculated_profile(tmp_path, "1st")
+    rates = -np.log(intensities[1:] / intensities[0]) / TIME_T2
+
+    assert float(np.ptp(rates)) < 0.1
+
+
+def test_dispersion_is_monotonic_with_exchange(tmp_path: Path) -> None:
+    intensities = _calculated_profile(tmp_path, "2st")
+    rates = -np.log(intensities[1:] / intensities[0]) / TIME_T2
+
+    assert np.all(np.diff(rates) <= 1.0e-6)

--- a/tests/experiments/test_experiment_types.py
+++ b/tests/experiments/test_experiment_types.py
@@ -82,7 +82,7 @@ def test_all_discovered_experiment_types_register_through_public_surface() -> No
     register_experiments()
     registered = experiment_types.registered_experiment_types()
 
-    assert len(expected_names) == 37
+    assert len(expected_names) == 38
     assert set(registered) == expected_names
     assert all(name == adapter.name for name, adapter in registered.items())
 


### PR DESCRIPTION
## Behaviour changed
Adds `cpmg_15n_rc`, a relaxation-compensated ¹⁵N CPMG experiment corresponding
to the Bruker `hsqcrexetf3gpsitc3d` pulse program (Long, Liu & Yang, JACS 2008),
including the R₁ compensation delay of Yuwen & Kay, J. Biomol. NMR 2019.

Two CPMG blocks of equal duration are separated by a P-element that converts
anti-phase to in-phase ¹⁵N magnetization, so the measured rate is the average of
the two irrespective of ν_CPMG. Uses the `ixyzsz` basis, starts from `2izsz`,
detects `[iz]`. New required setting `ncyc_max` supplies the largest ncyc of the
series, which the compensation delay depends on and which cannot be derived
safely from filtered or resampled data.

## Compatibility
Additive only. No existing experiment, parameter, or output format is touched.
`tests/experiments/test_experiment_types.py` asserts a hardcoded catalog count;
updated 37 → 38.

## Checks run
- `uv run pytest -q` — 696 passed
- `uv run ty check` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed

