### PR TITLE
Add native numerical and optimizer qualification probes

### DIFF
--- a/src/chemex/baselines.py
+++ b/src/chemex/baselines.py
@@ -26,7 +26,11 @@ from typing import Literal, cast
 
 from chemex.chemex import run
 from chemex.cli import build_parser
-from chemex.numerical_lanes import LiveLaneAuthority
+from chemex.numerical_lanes import (
+    LiveLaneAuthority,
+    _LiveLaneAuthorityMismatch,
+    _validate_live_lane_authority,
+)
 
 _SCHEMA_VERSION = 1
 _SEMANTIC_VERSION = "chemex-baseline-v1"
@@ -783,22 +787,32 @@ class Occurrence:
                 raise TypeError(
                     "Qualified occurrence requires live current-process lane authority"
                 )
-            evidence = attestation.evidence
-            if evidence.lane_identity != specification.lane_reference:
-                raise ValueError("Occurrence attestation does not match its lane")
             execution_settings = specification.execution_settings.to_record_value()
             if not isinstance(execution_settings, Mapping):
                 raise TypeError("Qualified execution settings must be a record")
-            if (
-                type(execution_settings.get("workers")) is not int
-                or execution_settings.get("workers") != evidence.workers
-                or type(execution_settings.get("native_threads")) is not int
-                or execution_settings.get("native_threads") != evidence.native_threads
-            ):
+            workers = execution_settings.get("workers")
+            native_threads = execution_settings.get("native_threads")
+            if type(workers) is not int or type(native_threads) is not int:
                 raise ValueError(
                     "Qualified occurrence execution settings do not match "
                     "attested lane concurrency"
                 )
+            try:
+                evidence = _validate_live_lane_authority(
+                    attestation,
+                    required_lane_identity=specification.lane_reference,
+                    required_workers=workers,
+                    required_native_threads=native_threads,
+                )
+            except _LiveLaneAuthorityMismatch as error:
+                if error.fact == "lane_identity":
+                    raise ValueError(
+                        "Occurrence attestation does not match its lane"
+                    ) from error
+                raise ValueError(
+                    "Qualified occurrence execution settings do not match "
+                    "attested lane concurrency"
+                ) from error
         elif attestation is not None:
             raise ValueError("Unqualified occurrence cannot carry lane authority")
         return cls(

--- a/src/chemex/numerical_lanes/__init__.py
+++ b/src/chemex/numerical_lanes/__init__.py
@@ -24,7 +24,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, fields
 from importlib.resources import files
 from pathlib import Path, PurePosixPath
-from typing import Any, Literal, SupportsIndex, cast
+from typing import Any, Literal, NamedTuple, SupportsIndex, cast
 
 from chemex.runtime.execution import NATIVE_THREAD_ENV_VARS
 
@@ -1008,15 +1008,31 @@ class LaneAttestation:
         return attestation
 
 
-@dataclass(frozen=True, slots=True)
-class _LiveLaneBinding:
+class _LiveLaneBinding(NamedTuple):
     """Immutable process-owned facts bound to one opaque live capability."""
 
     lane_identity: str
     lane_role: LaneRole
     attestation_identity: str
     environment_identity: str
-    evidence: LaneAttestation
+    workers: int
+    native_threads: int
+
+
+type _LiveLaneAuthorityFact = Literal[
+    "lane_identity",
+    "lane_role",
+    "attestation_identity",
+    "environment_identity",
+    "workers",
+    "native_threads",
+]
+
+
+class _LiveLaneAuthorityMismatch(LaneAuthorityError):
+    def __init__(self, fact: _LiveLaneAuthorityFact) -> None:
+        self.fact = fact
+        super().__init__(f"Live lane authority does not match required {fact}")
 
 
 class LiveLaneAuthority:
@@ -1027,47 +1043,10 @@ class LiveLaneAuthority:
     def __new__(cls) -> LiveLaneAuthority:
         raise TypeError("Live lane authority is minted only by current-process probing")
 
-    @property
-    def _binding(self) -> _LiveLaneBinding:
-        try:
-            return _LIVE_LANE_BINDINGS[self]
-        except KeyError as error:
-            raise LaneAuthorityError(
-                "Live lane authority is not process-owned"
-            ) from error
-
-    @property
-    def evidence(self) -> LaneAttestation:
-        return self._binding.evidence
-
-    @property
-    def lane_identity(self) -> str:
-        return self._binding.lane_identity
-
-    @property
-    def environment_identity(self) -> str:
-        return self._binding.environment_identity
-
-    @property
-    def lane_role(self) -> LaneRole:
-        return self._binding.lane_role
-
-    @property
-    def workers(self) -> int:
-        return self.evidence.workers
-
-    @property
-    def native_threads(self) -> int:
-        return self.evidence.native_threads
-
-    @property
-    def identity(self) -> str:
-        return self._binding.attestation_identity
-
     def to_record(self) -> dict[str, object]:
         """Serialize evidence only; deserialization cannot recreate this capability."""
 
-        return self.evidence.to_record()
+        return _validate_live_lane_authority(self).to_record()
 
     def __copy__(self) -> LiveLaneAuthority:
         raise TypeError("Live lane authority cannot be copied")
@@ -1084,6 +1063,57 @@ class LiveLaneAuthority:
 _LIVE_LANE_BINDINGS: weakref.WeakKeyDictionary[LiveLaneAuthority, _LiveLaneBinding] = (
     weakref.WeakKeyDictionary()
 )
+
+
+def _validate_live_lane_authority(
+    authority: LiveLaneAuthority,
+    *,
+    required_lane_identity: str | None = None,
+    required_lane_role: LaneRole | None = None,
+    required_attestation_identity: str | None = None,
+    required_environment_identity: str | None = None,
+    required_workers: int | None = None,
+    required_native_threads: int | None = None,
+) -> LaneAttestation:
+    """Validate one exact live token without exposing its registry binding."""
+
+    if not isinstance(authority, LiveLaneAuthority):
+        raise TypeError("Live lane validation requires current-process authority")
+    try:
+        binding = _LIVE_LANE_BINDINGS[authority]
+    except KeyError as error:
+        raise LaneAuthorityError("Live lane authority is not process-owned") from error
+    required_facts = (
+        ("lane_role", required_lane_role, binding.lane_role),
+        ("lane_identity", required_lane_identity, binding.lane_identity),
+        (
+            "attestation_identity",
+            required_attestation_identity,
+            binding.attestation_identity,
+        ),
+        (
+            "environment_identity",
+            required_environment_identity,
+            binding.environment_identity,
+        ),
+        ("workers", required_workers, binding.workers),
+        ("native_threads", required_native_threads, binding.native_threads),
+    )
+    for fact, required, observed in required_facts:
+        if required is not None and required != observed:
+            raise _LiveLaneAuthorityMismatch(fact)
+    evidence = LaneAttestation(
+        binding.lane_identity,
+        binding.environment_identity,
+        binding.workers,
+        binding.native_threads,
+        "POST_IMPORT_CURRENT_PROCESS",
+    )
+    if evidence.identity != binding.attestation_identity:
+        raise LaneAuthorityError(
+            "Live lane authority binding is internally inconsistent"
+        )
+    return evidence
 
 
 @dataclass(frozen=True, slots=True)
@@ -1214,7 +1244,8 @@ class NumericalLane:
             lane_role=self.role,
             attestation_identity=evidence.identity,
             environment_identity=environment.identity,
-            evidence=evidence,
+            workers=evidence.workers,
+            native_threads=evidence.native_threads,
         )
         return authority
 
@@ -1563,8 +1594,8 @@ def comparison_scope(
         right, LiveLaneAuthority
     ):
         raise TypeError("Comparison scope requires live current-process lane authority")
-    left_evidence = left.evidence
-    right_evidence = right.evidence
+    left_evidence = _validate_live_lane_authority(left)
+    right_evidence = _validate_live_lane_authority(right)
     kind: ComparisonScopeKind = (
         "WITHIN_LANE_BITWISE"
         if left_evidence.lane_identity == right_evidence.lane_identity

--- a/src/chemex/numerical_lanes/__init__.py
+++ b/src/chemex/numerical_lanes/__init__.py
@@ -24,7 +24,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, fields
 from importlib.resources import files
 from pathlib import Path, PurePosixPath
-from typing import Any, Literal, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 from chemex.runtime.execution import NATIVE_THREAD_ENV_VARS
 
@@ -1011,8 +1011,9 @@ class LaneAttestation:
 class LiveLaneAuthority:
     """Non-serializable capability owned by one successfully probed process."""
 
-    __slots__ = ("_evidence", "__weakref__")
+    __slots__ = ("_evidence", "_lane_role", "__weakref__")
     _evidence: LaneAttestation
+    _lane_role: LaneRole
 
     def __new__(cls) -> LiveLaneAuthority:
         raise TypeError("Live lane authority is minted only by current-process probing")
@@ -1032,6 +1033,11 @@ class LiveLaneAuthority:
         return self.evidence.environment_identity
 
     @property
+    def lane_role(self) -> LaneRole:
+        _ = self.evidence
+        return self._lane_role
+
+    @property
     def workers(self) -> int:
         return self.evidence.workers
 
@@ -1047,6 +1053,17 @@ class LiveLaneAuthority:
         """Serialize evidence only; deserialization cannot recreate this capability."""
 
         return self.evidence.to_record()
+
+    def __copy__(self) -> LiveLaneAuthority:
+        raise TypeError("Live lane authority cannot be copied")
+
+    def __deepcopy__(self, memo: object) -> LiveLaneAuthority:
+        _ = memo
+        raise TypeError("Live lane authority cannot be copied")
+
+    def __reduce_ex__(self, protocol: SupportsIndex) -> str | tuple[object, ...]:
+        _ = protocol
+        raise TypeError("Live lane authority cannot be pickled")
 
 
 _LIVE_LANE_AUTHORITIES: weakref.WeakSet[LiveLaneAuthority] = weakref.WeakSet()
@@ -1176,6 +1193,7 @@ class NumericalLane:
         )
         authority = object.__new__(LiveLaneAuthority)
         object.__setattr__(authority, "_evidence", evidence)
+        object.__setattr__(authority, "_lane_role", self.role)
         _LIVE_LANE_AUTHORITIES.add(authority)
         return authority
 

--- a/src/chemex/numerical_lanes/__init__.py
+++ b/src/chemex/numerical_lanes/__init__.py
@@ -1008,34 +1008,49 @@ class LaneAttestation:
         return attestation
 
 
+@dataclass(frozen=True, slots=True)
+class _LiveLaneBinding:
+    """Immutable process-owned facts bound to one opaque live capability."""
+
+    lane_identity: str
+    lane_role: LaneRole
+    attestation_identity: str
+    environment_identity: str
+    evidence: LaneAttestation
+
+
 class LiveLaneAuthority:
     """Non-serializable capability owned by one successfully probed process."""
 
-    __slots__ = ("_evidence", "_lane_role", "__weakref__")
-    _evidence: LaneAttestation
-    _lane_role: LaneRole
+    __slots__ = ("__weakref__",)
 
     def __new__(cls) -> LiveLaneAuthority:
         raise TypeError("Live lane authority is minted only by current-process probing")
 
     @property
+    def _binding(self) -> _LiveLaneBinding:
+        try:
+            return _LIVE_LANE_BINDINGS[self]
+        except KeyError as error:
+            raise LaneAuthorityError(
+                "Live lane authority is not process-owned"
+            ) from error
+
+    @property
     def evidence(self) -> LaneAttestation:
-        if self not in _LIVE_LANE_AUTHORITIES:
-            raise LaneAuthorityError("Live lane authority is not process-owned")
-        return self._evidence
+        return self._binding.evidence
 
     @property
     def lane_identity(self) -> str:
-        return self.evidence.lane_identity
+        return self._binding.lane_identity
 
     @property
     def environment_identity(self) -> str:
-        return self.evidence.environment_identity
+        return self._binding.environment_identity
 
     @property
     def lane_role(self) -> LaneRole:
-        _ = self.evidence
-        return self._lane_role
+        return self._binding.lane_role
 
     @property
     def workers(self) -> int:
@@ -1047,7 +1062,7 @@ class LiveLaneAuthority:
 
     @property
     def identity(self) -> str:
-        return self.evidence.identity
+        return self._binding.attestation_identity
 
     def to_record(self) -> dict[str, object]:
         """Serialize evidence only; deserialization cannot recreate this capability."""
@@ -1066,7 +1081,9 @@ class LiveLaneAuthority:
         raise TypeError("Live lane authority cannot be pickled")
 
 
-_LIVE_LANE_AUTHORITIES: weakref.WeakSet[LiveLaneAuthority] = weakref.WeakSet()
+_LIVE_LANE_BINDINGS: weakref.WeakKeyDictionary[LiveLaneAuthority, _LiveLaneBinding] = (
+    weakref.WeakKeyDictionary()
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1192,9 +1209,13 @@ class NumericalLane:
             "POST_IMPORT_CURRENT_PROCESS",
         )
         authority = object.__new__(LiveLaneAuthority)
-        object.__setattr__(authority, "_evidence", evidence)
-        object.__setattr__(authority, "_lane_role", self.role)
-        _LIVE_LANE_AUTHORITIES.add(authority)
+        _LIVE_LANE_BINDINGS[authority] = _LiveLaneBinding(
+            lane_identity=self.identity,
+            lane_role=self.role,
+            attestation_identity=evidence.identity,
+            environment_identity=environment.identity,
+            evidence=evidence,
+        )
         return authority
 
     def compatibility_delta(self, other: NumericalLane) -> dict[str, tuple[str, str]]:

--- a/src/chemex/numerical_probes.py
+++ b/src/chemex/numerical_probes.py
@@ -1,0 +1,2325 @@
+"""Truth-backed reduced numerical probes for migration baseline qualification.
+
+The probes in this module are calibration evidence, not product fit entry points.
+They freeze independently derived truth, closed eligibility claims, numerical
+policy, work budgets, seeds, and failure expectations before any probe runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from itertools import product
+from typing import Literal, cast
+
+import numpy as np
+from scipy.optimize import Bounds, differential_evolution, least_squares
+
+from chemex.baselines import CanonicalBaselineValue
+from chemex.typing import Array
+
+_SCHEMA_VERSION = 1
+_SEMANTIC_VERSION = "chemex-numerical-probes-v1"
+_SOURCE_REVISION = "700cb71df950fc54c268c0bca199403e5621269d"
+
+type ProbeCategory = Literal[
+    "TRF_ROUTINE",
+    "TRF_DIFFICULT",
+    "GRID",
+    "DE_SEARCH",
+    "FINITE_DIFFERENCE",
+    "BOUNDS",
+    "RANK",
+    "CONDITIONING",
+]
+type TruthAuthorityKind = Literal["ANALYTIC_DERIVATION", "EXACT_LINEAR_ALGEBRA"]
+
+
+def _identity(kind: str, record: object) -> str:
+    content = json.dumps(
+        {
+            "kind": kind,
+            "schema_version": _SCHEMA_VERSION,
+            "semantic_version": _SEMANTIC_VERSION,
+            "record": record,
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(content).hexdigest()
+
+
+def _float_token(value: float) -> str:
+    scalar = float(value)
+    if not math.isfinite(scalar):
+        raise ValueError("Probe values must be finite binary64 values")
+    return (0.0 if scalar == 0.0 else scalar).hex()
+
+
+def _float_from_record(value: object, field_name: str) -> float:
+    if not isinstance(value, str):
+        raise TypeError(f"Probe {field_name} must be a binary64 token")
+    try:
+        scalar = float.fromhex(value)
+    except ValueError as error:
+        raise ValueError(f"Probe {field_name} is not binary64") from error
+    if _float_token(scalar) != value:
+        raise ValueError(f"Probe {field_name} is not canonical binary64")
+    return scalar
+
+
+def _vector_tokens(values: Sequence[float]) -> tuple[str, ...]:
+    return tuple(_float_token(value) for value in values)
+
+
+def _vector_from_record(value: object, field_name: str) -> tuple[float, ...]:
+    if not isinstance(value, list) or not value:
+        raise TypeError(f"Probe {field_name} must be a non-empty list")
+    return tuple(
+        _float_from_record(item, f"{field_name}[{index}]")
+        for index, item in enumerate(value)
+    )
+
+
+def _record_nonnegative_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"Probe {field_name} must be a non-negative integer")
+    return value
+
+
+def _nonempty_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Probe {field_name} must be a non-empty string")
+    return value
+
+
+def _canonical_strings(values: Sequence[str], field_name: str) -> tuple[str, ...]:
+    result = tuple(values)
+    if (
+        not result
+        or any(not isinstance(value, str) or not value for value in result)
+        or tuple(sorted(result)) != result
+        or len(set(result)) != len(result)
+    ):
+        raise ValueError(
+            f"Probe {field_name} must be non-empty, unique, and canonically ordered"
+        )
+    return result
+
+
+def _exact_keys(record: Mapping[str, object], expected: set[str], name: str) -> None:
+    if set(record) != expected:
+        raise ValueError(f"{name} record has unknown or missing fields")
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeDerivation:
+    """Exact source and reduction provenance for one synthetic probe."""
+
+    source_issue: int
+    source_revision: str
+    parent_case: str
+    reduction: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.source_issue, bool) or self.source_issue < 1:
+            raise ValueError("Probe source issue must be a positive integer")
+        for value, name in (
+            (self.source_revision, "source revision"),
+            (self.parent_case, "parent case"),
+            (self.reduction, "reduction"),
+        ):
+            _nonempty_string(value, name)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "probe-derivation",
+                (
+                    self.source_issue,
+                    self.source_revision,
+                    self.parent_case,
+                    self.reduction,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "source_issue": self.source_issue,
+            "source_revision": self.source_revision,
+            "parent_case": self.parent_case,
+            "reduction": self.reduction,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> ProbeDerivation:
+        _exact_keys(
+            record,
+            {
+                "source_issue",
+                "source_revision",
+                "parent_case",
+                "reduction",
+                "identity",
+            },
+            "Probe derivation",
+        )
+        source_issue = record.get("source_issue")
+        if not isinstance(source_issue, int) or isinstance(source_issue, bool):
+            raise TypeError("Probe source issue must be an integer")
+        derivation = cls(
+            source_issue,
+            _nonempty_string(record.get("source_revision"), "source revision"),
+            _nonempty_string(record.get("parent_case"), "parent case"),
+            _nonempty_string(record.get("reduction"), "reduction"),
+        )
+        if record.get("identity") != derivation.identity:
+            raise ValueError("Probe derivation identity does not match its payload")
+        return derivation
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeTruthAuthority:
+    """Non-observational authority that makes a reduced-case claim eligible."""
+
+    kind: TruthAuthorityKind
+    reference: str
+    derivation_digest: str = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"ANALYTIC_DERIVATION", "EXACT_LINEAR_ALGEBRA"}:
+            raise ValueError("Unknown probe truth authority")
+        _nonempty_string(self.reference, "truth reference")
+        digest = hashlib.sha256(self.reference.encode("utf-8")).hexdigest()
+        object.__setattr__(self, "derivation_digest", digest)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity("probe-truth-authority", (self.kind, digest)),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "reference": self.reference,
+            "derivation_digest": self.derivation_digest,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> ProbeTruthAuthority:
+        _exact_keys(
+            record,
+            {"kind", "reference", "derivation_digest", "identity"},
+            "Probe truth authority",
+        )
+        authority = cls(
+            cast("TruthAuthorityKind", record.get("kind")),
+            _nonempty_string(record.get("reference"), "truth reference"),
+        )
+        if (
+            record.get("derivation_digest") != authority.derivation_digest
+            or record.get("identity") != authority.identity
+        ):
+            raise ValueError(
+                "Probe truth authority identity does not match its payload"
+            )
+        return authority
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class ProbeFailureExpectation:
+    """Required terminal and risk truth for one probe run."""
+
+    terminal: str
+    required_risks: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.terminal, "expected terminal")
+        risks = tuple(self.required_risks)
+        if risks and (
+            tuple(sorted(risks)) != risks
+            or len(set(risks)) != len(risks)
+            or any(not risk for risk in risks)
+        ):
+            raise ValueError("Probe expected risks must be unique and ordered")
+
+    def to_record(self) -> dict[str, object]:
+        return {"terminal": self.terminal, "required_risks": list(self.required_risks)}
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> ProbeFailureExpectation:
+        _exact_keys(record, {"terminal", "required_risks"}, "Probe expectation")
+        risks = record.get("required_risks")
+        if not isinstance(risks, list) or any(
+            not isinstance(value, str) for value in risks
+        ):
+            raise TypeError("Probe expected risks must be strings")
+        return cls(
+            _nonempty_string(record.get("terminal"), "expected terminal"),
+            tuple(cast("list[str]", risks)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NumericalProbeDefinition:
+    """Immutable predeclared contract for one truth-backed reduced case."""
+
+    probe_id: str
+    category: ProbeCategory
+    derivation: ProbeDerivation
+    truth: ProbeTruthAuthority
+    eligible_claims: tuple[str, ...]
+    policy: CanonicalBaselineValue
+    budget: CanonicalBaselineValue
+    seed: CanonicalBaselineValue
+    failure_expectations: tuple[ProbeFailureExpectation, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.probe_id, "identifier")
+        if self.category not in {
+            "TRF_ROUTINE",
+            "TRF_DIFFICULT",
+            "GRID",
+            "DE_SEARCH",
+            "FINITE_DIFFERENCE",
+            "BOUNDS",
+            "RANK",
+            "CONDITIONING",
+        }:
+            raise ValueError("Unknown numerical probe category")
+        claims = _canonical_strings(self.eligible_claims, "eligible claims")
+        if (
+            not isinstance(self.policy, CanonicalBaselineValue)
+            or not isinstance(self.budget, CanonicalBaselineValue)
+            or not isinstance(self.seed, CanonicalBaselineValue)
+        ):
+            raise TypeError("Probe policy, budget, and seed must be canonical values")
+        expectations = tuple(self.failure_expectations)
+        if not expectations or tuple(sorted(expectations)) != expectations:
+            raise ValueError("Probe failure expectations must be non-empty and ordered")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "numerical-probe-definition",
+                (
+                    self.probe_id,
+                    self.category,
+                    self.derivation.identity,
+                    self.truth.identity,
+                    claims,
+                    self.policy.encoded,
+                    self.budget.encoded,
+                    self.seed.encoded,
+                    tuple(
+                        (expectation.terminal, expectation.required_risks)
+                        for expectation in expectations
+                    ),
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "semantic_version": _SEMANTIC_VERSION,
+            "probe_id": self.probe_id,
+            "category": self.category,
+            "derivation": self.derivation.to_record(),
+            "truth": self.truth.to_record(),
+            "eligible_claims": list(self.eligible_claims),
+            "policy": self.policy.to_record_value(),
+            "budget": self.budget.to_record_value(),
+            "seed": self.seed.to_record_value(),
+            "failure_expectations": [
+                expectation.to_record() for expectation in self.failure_expectations
+            ],
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> NumericalProbeDefinition:
+        _exact_keys(
+            record,
+            {
+                "schema_version",
+                "semantic_version",
+                "probe_id",
+                "category",
+                "derivation",
+                "truth",
+                "eligible_claims",
+                "policy",
+                "budget",
+                "seed",
+                "failure_expectations",
+                "identity",
+            },
+            "Numerical probe definition",
+        )
+        if (
+            record.get("schema_version") != _SCHEMA_VERSION
+            or record.get("semantic_version") != _SEMANTIC_VERSION
+        ):
+            raise ValueError("Unsupported numerical probe semantics")
+        raw_derivation = record.get("derivation")
+        raw_truth = record.get("truth")
+        raw_claims = record.get("eligible_claims")
+        raw_expectations = record.get("failure_expectations")
+        if (
+            not isinstance(raw_derivation, Mapping)
+            or not isinstance(raw_truth, Mapping)
+            or not isinstance(raw_claims, list)
+            or not isinstance(raw_expectations, list)
+            or any(not isinstance(value, str) for value in raw_claims)
+            or any(not isinstance(value, Mapping) for value in raw_expectations)
+        ):
+            raise TypeError("Malformed numerical probe definition")
+        definition = cls(
+            _nonempty_string(record.get("probe_id"), "identifier"),
+            cast("ProbeCategory", record.get("category")),
+            ProbeDerivation.from_record(cast("Mapping[str, object]", raw_derivation)),
+            ProbeTruthAuthority.from_record(cast("Mapping[str, object]", raw_truth)),
+            _canonical_strings(cast("Sequence[str]", raw_claims), "eligible claims"),
+            CanonicalBaselineValue.from_record(record.get("policy"), "probe policy"),
+            CanonicalBaselineValue.from_record(record.get("budget"), "probe budget"),
+            CanonicalBaselineValue.from_record(record.get("seed"), "probe seed"),
+            tuple(
+                ProbeFailureExpectation.from_record(
+                    cast("Mapping[str, object]", expectation)
+                )
+                for expectation in raw_expectations
+            ),
+        )
+        if record.get("identity") != definition.identity:
+            raise ValueError("Numerical probe identity does not match its payload")
+        return definition
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectiveRequestAccounting:
+    """Authoritative evaluator requests, distinct from backend diagnostics."""
+
+    workflow_requests: int
+    materialization_requests: int
+    requests_completed: int
+    requests_refused: int
+    cache_hits: int
+    cache_misses: int
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        values = (
+            self.workflow_requests,
+            self.materialization_requests,
+            self.requests_completed,
+            self.requests_refused,
+            self.cache_hits,
+            self.cache_misses,
+        )
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in values
+        ):
+            raise ValueError("Objective-request counters must be non-negative integers")
+        if self.requests_completed + self.requests_refused != self.requests_received:
+            raise ValueError("Objective requests do not reconcile with terminal counts")
+        if self.cache_hits + self.cache_misses != self.requests_completed:
+            raise ValueError("Objective cache accounting does not reconcile")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity("probe-objective-accounting", values),
+        )
+
+    @property
+    def requests_received(self) -> int:
+        return self.workflow_requests + self.materialization_requests
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "workflow_requests": self.workflow_requests,
+            "materialization_requests": self.materialization_requests,
+            "requests_received": self.requests_received,
+            "requests_completed": self.requests_completed,
+            "requests_refused": self.requests_refused,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> ObjectiveRequestAccounting:
+        _exact_keys(
+            record,
+            {
+                "workflow_requests",
+                "materialization_requests",
+                "requests_received",
+                "requests_completed",
+                "requests_refused",
+                "cache_hits",
+                "cache_misses",
+                "identity",
+            },
+            "Objective request accounting",
+        )
+        accounting = cls(
+            _record_nonnegative_int(
+                record.get("workflow_requests"), "workflow requests"
+            ),
+            _record_nonnegative_int(
+                record.get("materialization_requests"),
+                "materialization requests",
+            ),
+            _record_nonnegative_int(
+                record.get("requests_completed"), "completed requests"
+            ),
+            _record_nonnegative_int(record.get("requests_refused"), "refused requests"),
+            _record_nonnegative_int(record.get("cache_hits"), "cache hits"),
+            _record_nonnegative_int(record.get("cache_misses"), "cache misses"),
+        )
+        if (
+            record.get("requests_received") != accounting.requests_received
+            or record.get("identity") != accounting.identity
+        ):
+            raise ValueError("Objective request accounting does not match its payload")
+        return accounting
+
+
+@dataclass(frozen=True, slots=True)
+class BackendDiagnosticCounters:
+    """Non-authoritative backend/callback counters retained for diagnosis."""
+
+    nfev: int
+    njev: int | None
+    callback_calls: int
+    diagnostic_evaluations: int
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        values = (self.nfev, self.callback_calls, self.diagnostic_evaluations)
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in values
+        ) or (
+            self.njev is not None
+            and (
+                isinstance(self.njev, bool)
+                or not isinstance(self.njev, int)
+                or self.njev < 0
+            )
+        ):
+            raise ValueError("Backend diagnostic counters must be non-negative")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "probe-backend-diagnostics",
+                (
+                    self.nfev,
+                    self.njev,
+                    self.callback_calls,
+                    self.diagnostic_evaluations,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "nfev": self.nfev,
+            "njev": self.njev,
+            "callback_calls": self.callback_calls,
+            "diagnostic_evaluations": self.diagnostic_evaluations,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> BackendDiagnosticCounters:
+        _exact_keys(
+            record,
+            {
+                "nfev",
+                "njev",
+                "callback_calls",
+                "diagnostic_evaluations",
+                "identity",
+            },
+            "Backend diagnostics",
+        )
+        raw_njev = record.get("njev")
+        if raw_njev is not None:
+            raw_njev = _record_nonnegative_int(raw_njev, "backend njev")
+        diagnostics = cls(
+            _record_nonnegative_int(record.get("nfev"), "backend nfev"),
+            raw_njev,
+            _record_nonnegative_int(record.get("callback_calls"), "callback calls"),
+            _record_nonnegative_int(
+                record.get("diagnostic_evaluations"), "diagnostic evaluations"
+            ),
+        )
+        if record.get("identity") != diagnostics.identity:
+            raise ValueError("Backend diagnostics identity does not match its payload")
+        return diagnostics
+
+
+@dataclass(frozen=True, slots=True)
+class SolverProbeEvidence:
+    """Typed bounded least-squares result with detached accounting evidence."""
+
+    start: tuple[float, ...]
+    accepted: tuple[float, ...]
+    lower_bounds: tuple[float, ...]
+    upper_bounds: tuple[float, ...]
+    residuals: tuple[float, ...]
+    chi_square: float
+    active_mask: tuple[int, ...]
+    objective_accounting: ObjectiveRequestAccounting
+    backend_diagnostics: BackendDiagnosticCounters
+    trajectory_fingerprint: str
+    candidate_fingerprint: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        dimension = len(self.start)
+        if (
+            dimension < 1
+            or any(
+                len(values) != dimension
+                for values in (self.accepted, self.lower_bounds, self.upper_bounds)
+            )
+            or len(self.active_mask) != dimension
+        ):
+            raise ValueError("Solver probe vectors have inconsistent dimensions")
+        for values in (
+            self.start,
+            self.accepted,
+            self.lower_bounds,
+            self.upper_bounds,
+            self.residuals,
+        ):
+            _vector_tokens(values)
+        chi_square = float(self.chi_square)
+        if not math.isfinite(chi_square) or chi_square < 0.0:
+            raise ValueError("Solver probe chi square must be finite and non-negative")
+        if chi_square != math.fsum(value * value for value in self.residuals):
+            raise ValueError("Solver probe chi square does not match residuals")
+        if any(mask not in {-1, 0, 1} for mask in self.active_mask):
+            raise ValueError("Solver active-mask entries must be -1, 0, or 1")
+        for fingerprint in (
+            self.trajectory_fingerprint,
+            self.candidate_fingerprint,
+        ):
+            if len(fingerprint) != 64:
+                raise ValueError("Solver probe fingerprints must be SHA-256 digests")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "solver-probe-evidence",
+                (
+                    _vector_tokens(self.start),
+                    _vector_tokens(self.accepted),
+                    _vector_tokens(self.lower_bounds),
+                    _vector_tokens(self.upper_bounds),
+                    _vector_tokens(self.residuals),
+                    _float_token(chi_square),
+                    self.active_mask,
+                    self.objective_accounting.identity,
+                    self.backend_diagnostics.identity,
+                    self.trajectory_fingerprint,
+                    self.candidate_fingerprint,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "kind": "SOLVER",
+            "start": list(_vector_tokens(self.start)),
+            "accepted": list(_vector_tokens(self.accepted)),
+            "lower_bounds": list(_vector_tokens(self.lower_bounds)),
+            "upper_bounds": list(_vector_tokens(self.upper_bounds)),
+            "residuals": list(_vector_tokens(self.residuals)),
+            "chi_square": _float_token(self.chi_square),
+            "active_mask": list(self.active_mask),
+            "objective_accounting": self.objective_accounting.to_record(),
+            "backend_diagnostics": self.backend_diagnostics.to_record(),
+            "trajectory_fingerprint": self.trajectory_fingerprint,
+            "candidate_fingerprint": self.candidate_fingerprint,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> SolverProbeEvidence:
+        _exact_keys(
+            record,
+            {
+                "kind",
+                "start",
+                "accepted",
+                "lower_bounds",
+                "upper_bounds",
+                "residuals",
+                "chi_square",
+                "active_mask",
+                "objective_accounting",
+                "backend_diagnostics",
+                "trajectory_fingerprint",
+                "candidate_fingerprint",
+                "identity",
+            },
+            "Solver probe evidence",
+        )
+        if record.get("kind") != "SOLVER":
+            raise ValueError("Unknown solver probe evidence kind")
+        raw_mask = record.get("active_mask")
+        raw_accounting = record.get("objective_accounting")
+        raw_diagnostics = record.get("backend_diagnostics")
+        if (
+            not isinstance(raw_mask, list)
+            or any(not isinstance(value, int) for value in raw_mask)
+            or not isinstance(raw_accounting, Mapping)
+            or not isinstance(raw_diagnostics, Mapping)
+        ):
+            raise TypeError("Malformed solver probe evidence")
+        evidence = cls(
+            _vector_from_record(record.get("start"), "start"),
+            _vector_from_record(record.get("accepted"), "accepted"),
+            _vector_from_record(record.get("lower_bounds"), "lower bounds"),
+            _vector_from_record(record.get("upper_bounds"), "upper bounds"),
+            _vector_from_record(record.get("residuals"), "residuals"),
+            _float_from_record(record.get("chi_square"), "chi square"),
+            tuple(cast("list[int]", raw_mask)),
+            ObjectiveRequestAccounting.from_record(
+                cast("Mapping[str, object]", raw_accounting)
+            ),
+            BackendDiagnosticCounters.from_record(
+                cast("Mapping[str, object]", raw_diagnostics)
+            ),
+            _nonempty_string(
+                record.get("trajectory_fingerprint"), "trajectory fingerprint"
+            ),
+            _nonempty_string(
+                record.get("candidate_fingerprint"), "candidate fingerprint"
+            ),
+        )
+        if record.get("identity") != evidence.identity:
+            raise ValueError("Solver probe evidence identity does not match payload")
+        return evidence
+
+
+@dataclass(frozen=True, slots=True)
+class GridSeedEvidence:
+    """One physical-coordinate seed and its bounded local-solver evidence."""
+
+    ordinal: int
+    seed: tuple[float, ...]
+    solver: SolverProbeEvidence
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        _record_nonnegative_int(self.ordinal, "GRID seed ordinal")
+        if len(self.seed) != len(self.solver.start) or self.seed != self.solver.start:
+            raise ValueError("GRID seed does not match its solver start")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "grid-seed-probe-evidence",
+                (self.ordinal, _vector_tokens(self.seed), self.solver.identity),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "ordinal": self.ordinal,
+            "seed": list(_vector_tokens(self.seed)),
+            "solver": self.solver.to_record(),
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> GridSeedEvidence:
+        _exact_keys(record, {"ordinal", "seed", "solver", "identity"}, "GRID seed")
+        raw_solver = record.get("solver")
+        if not isinstance(raw_solver, Mapping):
+            raise TypeError("GRID seed solver evidence must be a record")
+        evidence = cls(
+            _record_nonnegative_int(record.get("ordinal"), "GRID seed ordinal"),
+            _vector_from_record(record.get("seed"), "GRID seed"),
+            SolverProbeEvidence.from_record(cast("Mapping[str, object]", raw_solver)),
+        )
+        if record.get("identity") != evidence.identity:
+            raise ValueError("GRID seed identity does not match its payload")
+        return evidence
+
+
+@dataclass(frozen=True, slots=True)
+class GridProbeEvidence:
+    """Typed immutable 27-seed execution and candidate-ordering evidence."""
+
+    seeds: tuple[GridSeedEvidence, ...]
+    ordered_seed_ordinals: tuple[int, ...]
+    selected_seed_ordinal: int
+    objective_accounting: ObjectiveRequestAccounting
+    backend_diagnostics: BackendDiagnosticCounters
+    trajectory_fingerprint: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if tuple(seed.ordinal for seed in self.seeds) != tuple(range(len(self.seeds))):
+            raise ValueError("GRID probe seeds must be in canonical ordinal order")
+        expected_order = tuple(
+            seed.ordinal
+            for seed in sorted(
+                self.seeds,
+                key=lambda seed: (seed.solver.chi_square, seed.ordinal),
+            )
+        )
+        if self.ordered_seed_ordinals != expected_order:
+            raise ValueError("GRID candidate ordering does not match evidence")
+        if not expected_order or self.selected_seed_ordinal != expected_order[0]:
+            raise ValueError("GRID selected seed is not the first ordered candidate")
+        if len(self.trajectory_fingerprint) != 64:
+            raise ValueError("GRID trajectory fingerprint must be a SHA-256 digest")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "grid-probe-evidence",
+                (
+                    tuple(seed.identity for seed in self.seeds),
+                    self.ordered_seed_ordinals,
+                    self.selected_seed_ordinal,
+                    self.objective_accounting.identity,
+                    self.backend_diagnostics.identity,
+                    self.trajectory_fingerprint,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "kind": "GRID",
+            "seeds": [seed.to_record() for seed in self.seeds],
+            "ordered_seed_ordinals": list(self.ordered_seed_ordinals),
+            "selected_seed_ordinal": self.selected_seed_ordinal,
+            "objective_accounting": self.objective_accounting.to_record(),
+            "backend_diagnostics": self.backend_diagnostics.to_record(),
+            "trajectory_fingerprint": self.trajectory_fingerprint,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> GridProbeEvidence:
+        _exact_keys(
+            record,
+            {
+                "kind",
+                "seeds",
+                "ordered_seed_ordinals",
+                "selected_seed_ordinal",
+                "objective_accounting",
+                "backend_diagnostics",
+                "trajectory_fingerprint",
+                "identity",
+            },
+            "GRID probe evidence",
+        )
+        raw_seeds = record.get("seeds")
+        raw_order = record.get("ordered_seed_ordinals")
+        raw_accounting = record.get("objective_accounting")
+        raw_diagnostics = record.get("backend_diagnostics")
+        if (
+            record.get("kind") != "GRID"
+            or not isinstance(raw_seeds, list)
+            or not isinstance(raw_order, list)
+            or any(not isinstance(value, Mapping) for value in raw_seeds)
+            or any(not isinstance(value, int) for value in raw_order)
+            or not isinstance(raw_accounting, Mapping)
+            or not isinstance(raw_diagnostics, Mapping)
+        ):
+            raise TypeError("Malformed GRID probe evidence")
+        evidence = cls(
+            tuple(
+                GridSeedEvidence.from_record(cast("Mapping[str, object]", seed))
+                for seed in raw_seeds
+            ),
+            tuple(cast("list[int]", raw_order)),
+            _record_nonnegative_int(
+                record.get("selected_seed_ordinal"), "selected GRID seed"
+            ),
+            ObjectiveRequestAccounting.from_record(
+                cast("Mapping[str, object]", raw_accounting)
+            ),
+            BackendDiagnosticCounters.from_record(
+                cast("Mapping[str, object]", raw_diagnostics)
+            ),
+            _nonempty_string(
+                record.get("trajectory_fingerprint"), "GRID trajectory fingerprint"
+            ),
+        )
+        if record.get("identity") != evidence.identity:
+            raise ValueError("GRID evidence identity does not match its payload")
+        return evidence
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class DePopulationCandidate:
+    """One terminal DE population member in stable backend index order."""
+
+    population_index: int
+    vector: tuple[float, ...]
+    objective: float
+    fingerprint: str = field(init=False, compare=False)
+
+    def __post_init__(self) -> None:
+        _record_nonnegative_int(self.population_index, "DE population index")
+        _vector_tokens(self.vector)
+        objective = float(self.objective)
+        if not math.isfinite(objective) or objective < 0.0:
+            raise ValueError("DE population objective must be finite and non-negative")
+        object.__setattr__(
+            self,
+            "fingerprint",
+            _identity(
+                "de-population-candidate",
+                (
+                    self.population_index,
+                    _vector_tokens(self.vector),
+                    _float_token(objective),
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "population_index": self.population_index,
+            "vector": list(_vector_tokens(self.vector)),
+            "objective": _float_token(self.objective),
+            "fingerprint": self.fingerprint,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> DePopulationCandidate:
+        _exact_keys(
+            record,
+            {"population_index", "vector", "objective", "fingerprint"},
+            "DE population candidate",
+        )
+        candidate = cls(
+            _record_nonnegative_int(
+                record.get("population_index"), "DE population index"
+            ),
+            _vector_from_record(record.get("vector"), "DE candidate vector"),
+            _float_from_record(record.get("objective"), "DE candidate objective"),
+        )
+        if record.get("fingerprint") != candidate.fingerprint:
+            raise ValueError("DE candidate fingerprint does not match its payload")
+        return candidate
+
+
+@dataclass(frozen=True, slots=True)
+class DeProbeEvidence:
+    """Seeded DE population ordering plus independently accounted TRF polish."""
+
+    root_seed: int
+    final_population: tuple[DePopulationCandidate, ...]
+    ordered_population_indices: tuple[int, ...]
+    selected_population_index: int
+    search_accounting: ObjectiveRequestAccounting
+    search_diagnostics: BackendDiagnosticCounters
+    polish: SolverProbeEvidence
+    trajectory_fingerprint: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.root_seed, bool)
+            or not isinstance(self.root_seed, int)
+            or not 0 <= self.root_seed < 2**64
+        ):
+            raise ValueError("DE root seed must be an unsigned 64-bit integer")
+        if tuple(
+            candidate.population_index for candidate in self.final_population
+        ) != tuple(range(len(self.final_population))):
+            raise ValueError("DE population must retain backend index order")
+        expected_order = tuple(
+            candidate.population_index
+            for candidate in sorted(
+                self.final_population,
+                key=lambda candidate: (candidate.objective, candidate.population_index),
+            )
+        )
+        if self.ordered_population_indices != expected_order:
+            raise ValueError("DE population ordering does not match candidate evidence")
+        if not expected_order or self.selected_population_index != expected_order[0]:
+            raise ValueError("DE selection is not the first ordered population member")
+        if len(self.trajectory_fingerprint) != 64:
+            raise ValueError("DE trajectory fingerprint must be a SHA-256 digest")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "de-probe-evidence",
+                (
+                    self.root_seed,
+                    tuple(candidate.fingerprint for candidate in self.final_population),
+                    self.ordered_population_indices,
+                    self.selected_population_index,
+                    self.search_accounting.identity,
+                    self.search_diagnostics.identity,
+                    self.polish.identity,
+                    self.trajectory_fingerprint,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "kind": "DE_SEARCH",
+            "root_seed": self.root_seed,
+            "final_population": [
+                candidate.to_record() for candidate in self.final_population
+            ],
+            "ordered_population_indices": list(self.ordered_population_indices),
+            "selected_population_index": self.selected_population_index,
+            "search_accounting": self.search_accounting.to_record(),
+            "search_diagnostics": self.search_diagnostics.to_record(),
+            "polish": self.polish.to_record(),
+            "trajectory_fingerprint": self.trajectory_fingerprint,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> DeProbeEvidence:
+        _exact_keys(
+            record,
+            {
+                "kind",
+                "root_seed",
+                "final_population",
+                "ordered_population_indices",
+                "selected_population_index",
+                "search_accounting",
+                "search_diagnostics",
+                "polish",
+                "trajectory_fingerprint",
+                "identity",
+            },
+            "DE probe evidence",
+        )
+        raw_population = record.get("final_population")
+        raw_order = record.get("ordered_population_indices")
+        raw_accounting = record.get("search_accounting")
+        raw_diagnostics = record.get("search_diagnostics")
+        raw_polish = record.get("polish")
+        if (
+            record.get("kind") != "DE_SEARCH"
+            or not isinstance(raw_population, list)
+            or not isinstance(raw_order, list)
+            or any(not isinstance(value, Mapping) for value in raw_population)
+            or any(not isinstance(value, int) for value in raw_order)
+            or not isinstance(raw_accounting, Mapping)
+            or not isinstance(raw_diagnostics, Mapping)
+            or not isinstance(raw_polish, Mapping)
+        ):
+            raise TypeError("Malformed DE probe evidence")
+        evidence = cls(
+            _record_nonnegative_int(record.get("root_seed"), "DE root seed"),
+            tuple(
+                DePopulationCandidate.from_record(
+                    cast("Mapping[str, object]", candidate)
+                )
+                for candidate in raw_population
+            ),
+            tuple(cast("list[int]", raw_order)),
+            _record_nonnegative_int(
+                record.get("selected_population_index"), "selected DE candidate"
+            ),
+            ObjectiveRequestAccounting.from_record(
+                cast("Mapping[str, object]", raw_accounting)
+            ),
+            BackendDiagnosticCounters.from_record(
+                cast("Mapping[str, object]", raw_diagnostics)
+            ),
+            SolverProbeEvidence.from_record(cast("Mapping[str, object]", raw_polish)),
+            _nonempty_string(
+                record.get("trajectory_fingerprint"), "DE trajectory fingerprint"
+            ),
+        )
+        if record.get("identity") != evidence.identity:
+            raise ValueError("DE evidence identity does not match its payload")
+        return evidence
+
+
+@dataclass(frozen=True, slots=True)
+class FiniteDifferenceProbeEvidence:
+    """Chosen finite-difference estimate with exact steps and request evidence."""
+
+    point: float
+    actual_steps: tuple[float, ...]
+    sampled_values: tuple[float, ...]
+    truth: float
+    estimate: float
+    absolute_error: float
+    absolute_tolerance: float
+    objective_accounting: ObjectiveRequestAccounting
+    backend_diagnostics: BackendDiagnosticCounters
+    trajectory_fingerprint: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        _float_token(self.point)
+        if len(self.actual_steps) != 5 or len(self.sampled_values) != 5:
+            raise ValueError("Finite-difference evidence requires five stencil points")
+        _vector_tokens(self.actual_steps)
+        _vector_tokens(self.sampled_values)
+        for value in (
+            self.truth,
+            self.estimate,
+            self.absolute_error,
+            self.absolute_tolerance,
+        ):
+            _float_token(value)
+        if self.absolute_error != abs(self.estimate - self.truth):
+            raise ValueError(
+                "Finite-difference error does not match estimate and truth"
+            )
+        if self.absolute_tolerance <= 0.0:
+            raise ValueError("Finite-difference tolerance must be positive")
+        if len(self.trajectory_fingerprint) != 64:
+            raise ValueError("Stencil trajectory fingerprint must be a SHA-256 digest")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "finite-difference-probe-evidence",
+                (
+                    _float_token(self.point),
+                    _vector_tokens(self.actual_steps),
+                    _vector_tokens(self.sampled_values),
+                    _float_token(self.truth),
+                    _float_token(self.estimate),
+                    _float_token(self.absolute_error),
+                    _float_token(self.absolute_tolerance),
+                    self.objective_accounting.identity,
+                    self.backend_diagnostics.identity,
+                    self.trajectory_fingerprint,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "kind": "FINITE_DIFFERENCE",
+            "point": _float_token(self.point),
+            "actual_steps": list(_vector_tokens(self.actual_steps)),
+            "sampled_values": list(_vector_tokens(self.sampled_values)),
+            "truth": _float_token(self.truth),
+            "estimate": _float_token(self.estimate),
+            "absolute_error": _float_token(self.absolute_error),
+            "absolute_tolerance": _float_token(self.absolute_tolerance),
+            "objective_accounting": self.objective_accounting.to_record(),
+            "backend_diagnostics": self.backend_diagnostics.to_record(),
+            "trajectory_fingerprint": self.trajectory_fingerprint,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> FiniteDifferenceProbeEvidence:
+        _exact_keys(
+            record,
+            {
+                "kind",
+                "point",
+                "actual_steps",
+                "sampled_values",
+                "truth",
+                "estimate",
+                "absolute_error",
+                "absolute_tolerance",
+                "objective_accounting",
+                "backend_diagnostics",
+                "trajectory_fingerprint",
+                "identity",
+            },
+            "Finite-difference probe evidence",
+        )
+        raw_accounting = record.get("objective_accounting")
+        raw_diagnostics = record.get("backend_diagnostics")
+        if (
+            record.get("kind") != "FINITE_DIFFERENCE"
+            or not isinstance(raw_accounting, Mapping)
+            or not isinstance(raw_diagnostics, Mapping)
+        ):
+            raise TypeError("Malformed finite-difference probe evidence")
+        evidence = cls(
+            _float_from_record(record.get("point"), "finite-difference point"),
+            _vector_from_record(record.get("actual_steps"), "actual steps"),
+            _vector_from_record(record.get("sampled_values"), "sampled values"),
+            _float_from_record(record.get("truth"), "derivative truth"),
+            _float_from_record(record.get("estimate"), "derivative estimate"),
+            _float_from_record(record.get("absolute_error"), "absolute error"),
+            _float_from_record(record.get("absolute_tolerance"), "absolute tolerance"),
+            ObjectiveRequestAccounting.from_record(
+                cast("Mapping[str, object]", raw_accounting)
+            ),
+            BackendDiagnosticCounters.from_record(
+                cast("Mapping[str, object]", raw_diagnostics)
+            ),
+            _nonempty_string(
+                record.get("trajectory_fingerprint"), "stencil trajectory fingerprint"
+            ),
+        )
+        if record.get("identity") != evidence.identity:
+            raise ValueError(
+                "Finite-difference evidence identity does not match payload"
+            )
+        return evidence
+
+
+@dataclass(frozen=True, slots=True)
+class SpectralRiskProbeEvidence:
+    """Exact small-matrix rank and conditioning risk evidence."""
+
+    jacobian: tuple[tuple[float, ...], ...]
+    singular_values: tuple[float, ...]
+    rank: int
+    dimension: int
+    condition: float | None
+    condition_limit: float
+    risks: tuple[str, ...]
+    objective_accounting: ObjectiveRequestAccounting
+    backend_diagnostics: BackendDiagnosticCounters
+    trajectory_fingerprint: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.jacobian or any(
+            len(row) != self.dimension for row in self.jacobian
+        ):
+            raise ValueError("Spectral probe Jacobian has the wrong dimension")
+        for row in self.jacobian:
+            _vector_tokens(row)
+        if len(self.singular_values) != self.dimension:
+            raise ValueError(
+                "Spectral probe must retain the complete singular spectrum"
+            )
+        _vector_tokens(self.singular_values)
+        if not 0 <= self.rank <= self.dimension:
+            raise ValueError("Spectral rank is outside its matrix dimension")
+        if self.condition is not None:
+            _float_token(self.condition)
+            if self.condition < 1.0:
+                raise ValueError("Spectral condition must be at least one")
+        _float_token(self.condition_limit)
+        if self.condition_limit <= 0.0:
+            raise ValueError("Conditioning limit must be positive")
+        _canonical_strings(self.risks, "spectral risks")
+        if len(self.trajectory_fingerprint) != 64:
+            raise ValueError("Spectral trajectory fingerprint must be a SHA-256 digest")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "spectral-risk-probe-evidence",
+                (
+                    tuple(_vector_tokens(row) for row in self.jacobian),
+                    _vector_tokens(self.singular_values),
+                    self.rank,
+                    self.dimension,
+                    None if self.condition is None else _float_token(self.condition),
+                    _float_token(self.condition_limit),
+                    self.risks,
+                    self.objective_accounting.identity,
+                    self.backend_diagnostics.identity,
+                    self.trajectory_fingerprint,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "kind": "SPECTRAL_RISK",
+            "jacobian": [list(_vector_tokens(row)) for row in self.jacobian],
+            "singular_values": list(_vector_tokens(self.singular_values)),
+            "rank": self.rank,
+            "dimension": self.dimension,
+            "condition": (
+                None if self.condition is None else _float_token(self.condition)
+            ),
+            "condition_limit": _float_token(self.condition_limit),
+            "risks": list(self.risks),
+            "objective_accounting": self.objective_accounting.to_record(),
+            "backend_diagnostics": self.backend_diagnostics.to_record(),
+            "trajectory_fingerprint": self.trajectory_fingerprint,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> SpectralRiskProbeEvidence:
+        _exact_keys(
+            record,
+            {
+                "kind",
+                "jacobian",
+                "singular_values",
+                "rank",
+                "dimension",
+                "condition",
+                "condition_limit",
+                "risks",
+                "objective_accounting",
+                "backend_diagnostics",
+                "trajectory_fingerprint",
+                "identity",
+            },
+            "Spectral risk probe evidence",
+        )
+        raw_jacobian = record.get("jacobian")
+        raw_risks = record.get("risks")
+        raw_accounting = record.get("objective_accounting")
+        raw_diagnostics = record.get("backend_diagnostics")
+        if (
+            record.get("kind") != "SPECTRAL_RISK"
+            or not isinstance(raw_jacobian, list)
+            or any(not isinstance(row, list) for row in raw_jacobian)
+            or not isinstance(raw_risks, list)
+            or any(not isinstance(risk, str) for risk in raw_risks)
+            or not isinstance(raw_accounting, Mapping)
+            or not isinstance(raw_diagnostics, Mapping)
+        ):
+            raise TypeError("Malformed spectral risk probe evidence")
+        raw_condition = record.get("condition")
+        evidence = cls(
+            tuple(
+                _vector_from_record(row, f"Jacobian row {index}")
+                for index, row in enumerate(raw_jacobian)
+            ),
+            _vector_from_record(record.get("singular_values"), "singular values"),
+            _record_nonnegative_int(record.get("rank"), "rank"),
+            _record_nonnegative_int(record.get("dimension"), "dimension"),
+            (
+                None
+                if raw_condition is None
+                else _float_from_record(raw_condition, "condition")
+            ),
+            _float_from_record(record.get("condition_limit"), "condition limit"),
+            _canonical_strings(cast("Sequence[str]", raw_risks), "spectral risks"),
+            ObjectiveRequestAccounting.from_record(
+                cast("Mapping[str, object]", raw_accounting)
+            ),
+            BackendDiagnosticCounters.from_record(
+                cast("Mapping[str, object]", raw_diagnostics)
+            ),
+            _nonempty_string(
+                record.get("trajectory_fingerprint"), "spectral fingerprint"
+            ),
+        )
+        if record.get("identity") != evidence.identity:
+            raise ValueError("Spectral evidence identity does not match its payload")
+        return evidence
+
+
+type NumericalProbeEvidence = (
+    SolverProbeEvidence
+    | GridProbeEvidence
+    | DeProbeEvidence
+    | FiniteDifferenceProbeEvidence
+    | SpectralRiskProbeEvidence
+)
+
+
+@dataclass(frozen=True, slots=True)
+class NumericalProbeArtifact:
+    """Content-addressed result of one predeclared probe definition."""
+
+    definition_identity: str
+    probe_id: str
+    terminal: str
+    risks: tuple[str, ...]
+    satisfied_claims: tuple[str, ...]
+    evidence: NumericalProbeEvidence
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        for value, name in (
+            (self.definition_identity, "definition identity"),
+            (self.probe_id, "identifier"),
+            (self.terminal, "terminal"),
+        ):
+            _nonempty_string(value, name)
+        if len(self.definition_identity) != 64:
+            raise ValueError("Probe definition identity must be a SHA-256 digest")
+        if self.risks and (
+            tuple(sorted(self.risks)) != self.risks
+            or len(set(self.risks)) != len(self.risks)
+        ):
+            raise ValueError("Probe risks must be unique and ordered")
+        _canonical_strings(self.satisfied_claims, "satisfied claims")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "numerical-probe-artifact",
+                (
+                    self.definition_identity,
+                    self.probe_id,
+                    self.terminal,
+                    self.risks,
+                    self.satisfied_claims,
+                    self.evidence.identity,
+                ),
+            ),
+        )
+
+    def validate_definition(self, definition: NumericalProbeDefinition) -> None:
+        expectation = definition.failure_expectations[0]
+        if (
+            self.definition_identity != definition.identity
+            or self.probe_id != definition.probe_id
+            or self.terminal != expectation.terminal
+            or not set(expectation.required_risks).issubset(self.risks)
+            or self.satisfied_claims != definition.eligible_claims
+        ):
+            raise ValueError("Numerical probe artifact violates its definition")
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "semantic_version": _SEMANTIC_VERSION,
+            "definition_identity": self.definition_identity,
+            "probe_id": self.probe_id,
+            "terminal": self.terminal,
+            "risks": list(self.risks),
+            "satisfied_claims": list(self.satisfied_claims),
+            "evidence": self.evidence.to_record(),
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        definition: NumericalProbeDefinition,
+    ) -> NumericalProbeArtifact:
+        _exact_keys(
+            record,
+            {
+                "schema_version",
+                "semantic_version",
+                "definition_identity",
+                "probe_id",
+                "terminal",
+                "risks",
+                "satisfied_claims",
+                "evidence",
+                "identity",
+            },
+            "Numerical probe artifact",
+        )
+        if (
+            record.get("schema_version") != _SCHEMA_VERSION
+            or record.get("semantic_version") != _SEMANTIC_VERSION
+        ):
+            raise ValueError("Unsupported numerical probe artifact semantics")
+        raw_risks = record.get("risks")
+        raw_claims = record.get("satisfied_claims")
+        raw_evidence = record.get("evidence")
+        if (
+            not isinstance(raw_risks, list)
+            or not isinstance(raw_claims, list)
+            or any(not isinstance(value, str) for value in (*raw_risks, *raw_claims))
+            or not isinstance(raw_evidence, Mapping)
+        ):
+            raise TypeError("Malformed numerical probe artifact")
+        evidence_kind = raw_evidence.get("kind")
+        if evidence_kind == "SOLVER":
+            evidence: NumericalProbeEvidence = SolverProbeEvidence.from_record(
+                cast("Mapping[str, object]", raw_evidence)
+            )
+        elif evidence_kind == "GRID":
+            evidence = GridProbeEvidence.from_record(
+                cast("Mapping[str, object]", raw_evidence)
+            )
+        elif evidence_kind == "DE_SEARCH":
+            evidence = DeProbeEvidence.from_record(
+                cast("Mapping[str, object]", raw_evidence)
+            )
+        elif evidence_kind == "FINITE_DIFFERENCE":
+            evidence = FiniteDifferenceProbeEvidence.from_record(
+                cast("Mapping[str, object]", raw_evidence)
+            )
+        elif evidence_kind == "SPECTRAL_RISK":
+            evidence = SpectralRiskProbeEvidence.from_record(
+                cast("Mapping[str, object]", raw_evidence)
+            )
+        else:
+            raise ValueError("Unknown numerical probe evidence kind")
+        artifact = cls(
+            _nonempty_string(record.get("definition_identity"), "definition identity"),
+            _nonempty_string(record.get("probe_id"), "identifier"),
+            _nonempty_string(record.get("terminal"), "terminal"),
+            tuple(cast("list[str]", raw_risks)),
+            _canonical_strings(cast("Sequence[str]", raw_claims), "satisfied claims"),
+            evidence,
+        )
+        artifact.validate_definition(definition)
+        if record.get("identity") != artifact.identity:
+            raise ValueError("Numerical probe artifact identity does not match payload")
+        return artifact
+
+
+@dataclass(frozen=True, slots=True)
+class NumericalProbeBaseline:
+    """Closed content-addressed manifest for the complete v1 probe catalogue."""
+
+    definitions: tuple[NumericalProbeDefinition, ...]
+    artifacts: tuple[NumericalProbeArtifact, ...]
+    manifest_identity: str = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        definitions = tuple(self.definitions)
+        artifacts = tuple(self.artifacts)
+        if (
+            not definitions
+            or len(definitions) != len(artifacts)
+            or len({definition.probe_id for definition in definitions})
+            != len(definitions)
+        ):
+            raise ValueError(
+                "Probe baseline requires one artifact per unique definition"
+            )
+        for definition, artifact in zip(definitions, artifacts, strict=True):
+            artifact.validate_definition(definition)
+        manifest = _identity(
+            "numerical-probe-manifest",
+            tuple(
+                (definition.probe_id, definition.identity, artifact.identity)
+                for definition, artifact in zip(
+                    definitions,
+                    artifacts,
+                    strict=True,
+                )
+            ),
+        )
+        object.__setattr__(self, "manifest_identity", manifest)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "numerical-probe-baseline",
+                (
+                    manifest,
+                    tuple(definition.identity for definition in definitions),
+                    tuple(artifact.identity for artifact in artifacts),
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "semantic_version": _SEMANTIC_VERSION,
+            "definitions": [definition.to_record() for definition in self.definitions],
+            "artifacts": [artifact.to_record() for artifact in self.artifacts],
+            "manifest_identity": self.manifest_identity,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> NumericalProbeBaseline:
+        _exact_keys(
+            record,
+            {
+                "schema_version",
+                "semantic_version",
+                "definitions",
+                "artifacts",
+                "manifest_identity",
+                "identity",
+            },
+            "Numerical probe baseline",
+        )
+        if (
+            record.get("schema_version") != _SCHEMA_VERSION
+            or record.get("semantic_version") != _SEMANTIC_VERSION
+        ):
+            raise ValueError("Unsupported numerical probe baseline semantics")
+        raw_definitions = record.get("definitions")
+        raw_artifacts = record.get("artifacts")
+        if (
+            not isinstance(raw_definitions, list)
+            or not isinstance(raw_artifacts, list)
+            or any(not isinstance(value, Mapping) for value in raw_definitions)
+            or any(not isinstance(value, Mapping) for value in raw_artifacts)
+        ):
+            raise TypeError("Malformed numerical probe baseline")
+        definitions = tuple(
+            NumericalProbeDefinition.from_record(
+                cast("Mapping[str, object]", definition)
+            )
+            for definition in raw_definitions
+        )
+        if len(definitions) != len(raw_artifacts):
+            raise ValueError("Probe baseline definition and artifact counts differ")
+        artifacts = tuple(
+            NumericalProbeArtifact.from_record(
+                cast("Mapping[str, object]", artifact),
+                definition,
+            )
+            for definition, artifact in zip(
+                definitions,
+                raw_artifacts,
+                strict=True,
+            )
+        )
+        baseline = cls(definitions, artifacts)
+        if (
+            record.get("manifest_identity") != baseline.manifest_identity
+            or record.get("identity") != baseline.identity
+        ):
+            raise ValueError("Numerical probe baseline identity does not match payload")
+        return baseline
+
+
+class _ProbeBudgetExhausted(RuntimeError):
+    pass
+
+
+class _ObjectiveRecorder:
+    def __init__(
+        self,
+        residual: Callable[[tuple[float, ...]], tuple[float, ...]],
+        budget: int,
+    ) -> None:
+        self._residual = residual
+        self._budget = budget
+        self._cache: dict[tuple[str, ...], tuple[float, ...]] = {}
+        self._trace: list[object] = []
+        self.workflow_requests = 0
+        self.materialization_requests = 0
+        self.completed = 0
+        self.refused = 0
+        self.cache_hits = 0
+        self.cache_misses = 0
+
+    def evaluate(self, vector: Array | Sequence[float], source: str) -> Array:
+        if source == "solver":
+            self.workflow_requests += 1
+        elif source == "materialization":
+            self.materialization_requests += 1
+        else:
+            raise ValueError("Unknown probe objective request source")
+        if self.completed >= self._budget:
+            self.refused += 1
+            self._trace.append((source, "budget_refused"))
+            raise _ProbeBudgetExhausted("Probe objective-request budget exhausted")
+        candidate = tuple(float(value) for value in vector)
+        key = _vector_tokens(candidate)
+        cached = self._cache.get(key)
+        disposition = "cache_hit"
+        if cached is None:
+            cached = tuple(float(value) for value in self._residual(candidate))
+            _vector_tokens(cached)
+            self._cache[key] = cached
+            self.cache_misses += 1
+            disposition = "cache_miss"
+        else:
+            self.cache_hits += 1
+        self.completed += 1
+        self._trace.append((source, key, disposition, _vector_tokens(cached)))
+        return np.asarray(cached, dtype=np.float64)
+
+    @property
+    def accounting(self) -> ObjectiveRequestAccounting:
+        return ObjectiveRequestAccounting(
+            self.workflow_requests,
+            self.materialization_requests,
+            self.completed,
+            self.refused,
+            self.cache_hits,
+            self.cache_misses,
+        )
+
+    @property
+    def trajectory_fingerprint(self) -> str:
+        return _identity("probe-objective-trajectory", tuple(self._trace))
+
+
+def _budget_value(definition: NumericalProbeDefinition, field_name: str) -> int:
+    budget = definition.budget.to_record_value()
+    if not isinstance(budget, Mapping):
+        raise TypeError("Probe budget must be a record")
+    value = budget.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"Probe budget {field_name!r} must be positive")
+    return value
+
+
+def _least_squares_evidence(
+    *,
+    start: tuple[float, ...],
+    lower: tuple[float, ...],
+    upper: tuple[float, ...],
+    residual: Callable[[tuple[float, ...]], tuple[float, ...]],
+    budget: int,
+) -> tuple[SolverProbeEvidence, bool]:
+    recorder = _ObjectiveRecorder(residual, budget)
+    result = least_squares(
+        lambda vector: recorder.evaluate(vector, "solver"),
+        np.asarray(start, dtype=np.float64),
+        bounds=(
+            np.asarray(lower, dtype=np.float64),
+            np.asarray(upper, dtype=np.float64),
+        ),
+        method="trf",
+        ftol=1.0e-10,
+        xtol=1.0e-10,
+        gtol=1.0e-10,
+        x_scale=1.0,
+        max_nfev=budget,
+    )
+    accepted = tuple(float(value) for value in result.x)
+    residuals = tuple(
+        float(value) for value in recorder.evaluate(accepted, "materialization")
+    )
+    chi_square = math.fsum(value * value for value in residuals)
+    candidate_fingerprint = _identity(
+        "probe-candidate",
+        (_vector_tokens(accepted), _vector_tokens(residuals), _float_token(chi_square)),
+    )
+    return (
+        SolverProbeEvidence(
+            start,
+            accepted,
+            lower,
+            upper,
+            residuals,
+            chi_square,
+            tuple(int(value) for value in result.active_mask),
+            recorder.accounting,
+            BackendDiagnosticCounters(
+                int(result.nfev),
+                None if result.njev is None else int(result.njev),
+                0,
+                0,
+            ),
+            recorder.trajectory_fingerprint,
+            candidate_fingerprint,
+        ),
+        bool(result.success),
+    )
+
+
+def _sum_accounting(
+    accounting: Sequence[ObjectiveRequestAccounting],
+) -> ObjectiveRequestAccounting:
+    return ObjectiveRequestAccounting(
+        sum(item.workflow_requests for item in accounting),
+        sum(item.materialization_requests for item in accounting),
+        sum(item.requests_completed for item in accounting),
+        sum(item.requests_refused for item in accounting),
+        sum(item.cache_hits for item in accounting),
+        sum(item.cache_misses for item in accounting),
+    )
+
+
+def _sum_diagnostics(
+    diagnostics: Sequence[BackendDiagnosticCounters],
+) -> BackendDiagnosticCounters:
+    njev = (
+        None
+        if any(item.njev is None for item in diagnostics)
+        else sum(cast("int", item.njev) for item in diagnostics)
+    )
+    return BackendDiagnosticCounters(
+        sum(item.nfev for item in diagnostics),
+        njev,
+        sum(item.callback_calls for item in diagnostics),
+        sum(item.diagnostic_evaluations for item in diagnostics),
+    )
+
+
+def _run_solver_probe(
+    definition: NumericalProbeDefinition,
+) -> NumericalProbeArtifact:
+    if definition.category == "TRF_ROUTINE":
+        start = (0.0, 0.0)
+        lower = (-4.0, -4.0)
+        upper = (4.0, 4.0)
+
+        def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
+            x_value, y_value = vector
+            return (x_value - 1.5, y_value + 0.5)
+
+    elif definition.category == "TRF_DIFFICULT":
+        start = (-1.2, 1.0)
+        lower = (-3.0, -3.0)
+        upper = (3.0, 3.0)
+
+        def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
+            x_value, y_value = vector
+            return (10.0 * (y_value - x_value * x_value), 1.0 - x_value)
+
+    elif definition.category == "BOUNDS":
+        start = (0.5,)
+        lower = (0.0,)
+        upper = (1.0,)
+
+        def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
+            return (vector[0] - 2.0,)
+
+    else:
+        raise ValueError(f"Probe {definition.probe_id!r} is not a solver probe")
+    evidence, succeeded = _least_squares_evidence(
+        start=start,
+        lower=lower,
+        upper=upper,
+        residual=residual,
+        budget=_budget_value(definition, "objective_requests"),
+    )
+    terminal = "CONVERGED" if succeeded else "NON_CONVERGED"
+    risks = ("ACTIVE_BOUND",) if definition.category == "BOUNDS" else ()
+    artifact = NumericalProbeArtifact(
+        definition.identity,
+        definition.probe_id,
+        terminal,
+        risks,
+        definition.eligible_claims if succeeded else (),
+        evidence,
+    )
+    artifact.validate_definition(definition)
+    return artifact
+
+
+def _run_grid_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifact:
+    lower = (-3.0, -3.0, -3.0)
+    upper = (3.0, 3.0, 3.0)
+
+    def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
+        x_value, y_value, z_value = vector
+        return (x_value - 1.0, y_value + 1.0, z_value - 0.5)
+
+    starts = tuple(product((-2.0, 0.0, 2.0), repeat=3))
+    seeds: list[GridSeedEvidence] = []
+    for ordinal, start in enumerate(starts):
+        solver, _succeeded = _least_squares_evidence(
+            start=start,
+            lower=lower,
+            upper=upper,
+            residual=residual,
+            budget=_budget_value(definition, "objective_requests_per_seed"),
+        )
+        seeds.append(GridSeedEvidence(ordinal, start, solver))
+    seed_evidence = tuple(seeds)
+    order = tuple(
+        seed.ordinal
+        for seed in sorted(
+            seed_evidence,
+            key=lambda seed: (seed.solver.chi_square, seed.ordinal),
+        )
+    )
+    evidence = GridProbeEvidence(
+        seed_evidence,
+        order,
+        order[0],
+        _sum_accounting(
+            tuple(seed.solver.objective_accounting for seed in seed_evidence)
+        ),
+        _sum_diagnostics(
+            tuple(seed.solver.backend_diagnostics for seed in seed_evidence)
+        ),
+        _identity(
+            "grid-probe-trajectory",
+            tuple(seed.solver.trajectory_fingerprint for seed in seed_evidence),
+        ),
+    )
+    artifact = NumericalProbeArtifact(
+        definition.identity,
+        definition.probe_id,
+        "SELECTED",
+        (),
+        definition.eligible_claims,
+        evidence,
+    )
+    artifact.validate_definition(definition)
+    return artifact
+
+
+def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifact:
+    root_seed = definition.seed.to_record_value()
+    if isinstance(root_seed, bool) or not isinstance(root_seed, int):
+        raise TypeError("DE probe root seed must be an integer")
+
+    def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
+        return (vector[0] - 0.25,)
+
+    search_recorder = _ObjectiveRecorder(
+        residual,
+        _budget_value(definition, "de_objective_requests"),
+    )
+
+    def objective(vector: Array) -> float:
+        values = search_recorder.evaluate(vector, "solver")
+        return float(np.dot(values, values))
+
+    result = differential_evolution(
+        objective,
+        Bounds(np.asarray((-2.0,)), np.asarray((2.0,))),
+        strategy="best1bin",
+        maxiter=6,
+        popsize=5,
+        mutation=(0.5, 1.0),
+        recombination=0.7,
+        tol=0.0,
+        atol=0.0,
+        polish=False,
+        rng=np.random.default_rng(root_seed),
+        updating="immediate",
+        workers=1,
+    )
+    selected_vector = tuple(float(value) for value in result.x)
+    search_recorder.evaluate(selected_vector, "materialization")
+    population = tuple(
+        DePopulationCandidate(
+            index,
+            tuple(float(value) for value in vector),
+            float(result.population_energies[index]),
+        )
+        for index, vector in enumerate(result.population)
+    )
+    order = tuple(
+        candidate.population_index
+        for candidate in sorted(
+            population,
+            key=lambda candidate: (candidate.objective, candidate.population_index),
+        )
+    )
+    polish, polish_succeeded = _least_squares_evidence(
+        start=selected_vector,
+        lower=(-2.0,),
+        upper=(2.0,),
+        residual=residual,
+        budget=_budget_value(definition, "trf_objective_requests"),
+    )
+    evidence = DeProbeEvidence(
+        root_seed,
+        population,
+        order,
+        order[0],
+        search_recorder.accounting,
+        BackendDiagnosticCounters(int(result.nfev), None, 0, 0),
+        polish,
+        _identity(
+            "de-probe-trajectory",
+            (
+                search_recorder.trajectory_fingerprint,
+                tuple(candidate.fingerprint for candidate in population),
+                polish.trajectory_fingerprint,
+            ),
+        ),
+    )
+    terminal = "POLISHED" if polish_succeeded else "POLISH_FAILED"
+    artifact = NumericalProbeArtifact(
+        definition.identity,
+        definition.probe_id,
+        terminal,
+        (),
+        definition.eligible_claims if polish_succeeded else (),
+        evidence,
+    )
+    artifact.validate_definition(definition)
+    return artifact
+
+
+def _policy_float(definition: NumericalProbeDefinition, field_name: str) -> float:
+    policy = definition.policy.to_record_value()
+    if not isinstance(policy, Mapping):
+        raise TypeError("Probe policy must be a record")
+    raw_value = policy.get(field_name)
+    if not isinstance(raw_value, Mapping) or set(raw_value) != {"binary64"}:
+        raise TypeError(f"Probe policy {field_name!r} must be binary64")
+    return _float_from_record(raw_value.get("binary64"), field_name)
+
+
+def _run_finite_difference_probe(
+    definition: NumericalProbeDefinition,
+) -> NumericalProbeArtifact:
+    point = 0.5
+    step = _policy_float(definition, "step")
+    actual_steps = (-2.0 * step, -step, 0.0, step, 2.0 * step)
+
+    def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
+        return (math.exp(vector[0]),)
+
+    recorder = _ObjectiveRecorder(
+        residual,
+        _budget_value(definition, "objective_requests"),
+    )
+    sampled = tuple(
+        float(recorder.evaluate((point + displacement,), "solver")[0])
+        for displacement in actual_steps
+    )
+    minus_two, minus_one, _center, plus_one, plus_two = sampled
+    estimate = (minus_two - 8.0 * minus_one + 8.0 * plus_one - plus_two) / (12.0 * step)
+    truth = math.exp(point)
+    absolute_error = abs(estimate - truth)
+    absolute_tolerance = _policy_float(definition, "absolute_tolerance")
+    evidence = FiniteDifferenceProbeEvidence(
+        point,
+        actual_steps,
+        sampled,
+        truth,
+        estimate,
+        absolute_error,
+        absolute_tolerance,
+        recorder.accounting,
+        BackendDiagnosticCounters(0, None, 0, 0),
+        recorder.trajectory_fingerprint,
+    )
+    reliable = absolute_error <= absolute_tolerance
+    artifact = NumericalProbeArtifact(
+        definition.identity,
+        definition.probe_id,
+        "RELIABLE" if reliable else "UNRELIABLE",
+        (),
+        definition.eligible_claims if reliable else (),
+        evidence,
+    )
+    artifact.validate_definition(definition)
+    return artifact
+
+
+def _run_spectral_risk_probe(
+    definition: NumericalProbeDefinition,
+) -> NumericalProbeArtifact:
+    if definition.category == "RANK":
+        jacobian = ((1.0, 1.0), (2.0, 2.0))
+        relative_tolerance = _policy_float(definition, "rank_relative_tolerance")
+        condition_limit = _policy_float(definition, "conditioning_limit")
+    elif definition.category == "CONDITIONING":
+        jacobian = ((1.0, 0.0), (0.0, 1.0e-8))
+        relative_tolerance = 0.0
+        condition_limit = _policy_float(definition, "conditioning_limit")
+    else:
+        raise ValueError(f"Probe {definition.probe_id!r} is not spectral")
+    singular_values = tuple(
+        float(value)
+        for value in np.linalg.svd(
+            np.asarray(jacobian, dtype=np.float64),
+            compute_uv=False,
+        )
+    )
+    rank_threshold = singular_values[0] * relative_tolerance
+    rank = sum(value > rank_threshold for value in singular_values)
+    dimension = len(jacobian[0])
+    condition = None if rank < dimension else singular_values[0] / singular_values[-1]
+    risks = (
+        ("RANK_DEFICIENT",)
+        if rank < dimension
+        else (
+            ("ILL_CONDITIONED",) if cast("float", condition) > condition_limit else ()
+        )
+    )
+    evidence = SpectralRiskProbeEvidence(
+        jacobian,
+        singular_values,
+        rank,
+        dimension,
+        condition,
+        condition_limit,
+        risks,
+        ObjectiveRequestAccounting(0, 0, 0, 0, 0, 0),
+        BackendDiagnosticCounters(0, None, 0, 1),
+        _identity(
+            "spectral-probe-trajectory",
+            (
+                tuple(_vector_tokens(row) for row in jacobian),
+                _vector_tokens(singular_values),
+                _float_token(rank_threshold),
+                rank,
+                risks,
+            ),
+        ),
+    )
+    artifact = NumericalProbeArtifact(
+        definition.identity,
+        definition.probe_id,
+        "RISK_DETECTED" if risks else "NO_RISK",
+        risks,
+        definition.eligible_claims if risks else (),
+        evidence,
+    )
+    artifact.validate_definition(definition)
+    return artifact
+
+
+def run_numerical_probe(
+    definition: NumericalProbeDefinition,
+) -> NumericalProbeArtifact:
+    """Execute one predeclared reduced case and return typed baseline evidence."""
+    canonical = next(
+        (
+            candidate
+            for candidate in numerical_probe_definitions()
+            if candidate.probe_id == definition.probe_id
+        ),
+        None,
+    )
+    if canonical != definition:
+        raise ValueError("Only an exact predeclared numerical probe may run")
+    if definition.category in {"TRF_ROUTINE", "TRF_DIFFICULT", "BOUNDS"}:
+        return _run_solver_probe(definition)
+    if definition.category == "GRID":
+        return _run_grid_probe(definition)
+    if definition.category == "DE_SEARCH":
+        return _run_de_probe(definition)
+    if definition.category == "FINITE_DIFFERENCE":
+        return _run_finite_difference_probe(definition)
+    if definition.category in {"RANK", "CONDITIONING"}:
+        return _run_spectral_risk_probe(definition)
+    raise NotImplementedError(f"Probe category {definition.category!r} is not runnable")
+
+
+def run_numerical_probe_baseline() -> NumericalProbeBaseline:
+    """Execute the closed v1 catalogue into one immutable typed manifest."""
+    definitions = numerical_probe_definitions()
+    return NumericalProbeBaseline(
+        definitions,
+        tuple(run_numerical_probe(definition) for definition in definitions),
+    )
+
+
+def _definition(
+    probe_id: str,
+    category: ProbeCategory,
+    *,
+    parent_case: str,
+    reduction: str,
+    truth_kind: TruthAuthorityKind,
+    truth_reference: str,
+    eligible_claims: Sequence[str],
+    policy: Mapping[str, object],
+    budget: Mapping[str, object],
+    seed: object,
+    terminal: str,
+    required_risks: Sequence[str] = (),
+) -> NumericalProbeDefinition:
+    return NumericalProbeDefinition(
+        probe_id,
+        category,
+        ProbeDerivation(591, _SOURCE_REVISION, parent_case, reduction),
+        ProbeTruthAuthority(truth_kind, truth_reference),
+        tuple(sorted(eligible_claims)),
+        CanonicalBaselineValue.from_value(policy),
+        CanonicalBaselineValue.from_value(budget),
+        CanonicalBaselineValue.from_value(seed),
+        (
+            ProbeFailureExpectation(
+                terminal,
+                tuple(sorted(required_risks)),
+            ),
+        ),
+    )
+
+
+def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
+    """Return the closed v1 reduced-case catalogue in canonical run order."""
+    trf_policy = {
+        "backend": "scipy.optimize.least_squares",
+        "method": "trf",
+        "ftol": 1.0e-10,
+        "xtol": 1.0e-10,
+        "gtol": 1.0e-10,
+        "x_scale": 1.0,
+    }
+    return (
+        _definition(
+            "trf-routine-quadratic-v1",
+            "TRF_ROUTINE",
+            parent_case="analytic bounded linear residual",
+            reduction="Two independent coordinates retain routine TRF convergence.",
+            truth_kind="ANALYTIC_DERIVATION",
+            truth_reference="r(x,y)=(x-1.5,y+0.5); unique minimizer=(1.5,-0.5).",
+            eligible_claims=(
+                "deterministic-trajectory-fingerprint",
+                "routine-trf-convergence",
+                "solver-request-accounting",
+            ),
+            policy={
+                **trf_policy,
+                "start": [0.0, 0.0],
+                "bounds": [[-4.0, 4.0], [-4.0, 4.0]],
+            },
+            budget={"objective_requests": 64},
+            seed="not-applicable",
+            terminal="CONVERGED",
+        ),
+        _definition(
+            "trf-difficult-rosenbrock-v1",
+            "TRF_DIFFICULT",
+            parent_case="Rosenbrock least-squares valley",
+            reduction="Canonical poor start retains curved-valley TRF behavior.",
+            truth_kind="ANALYTIC_DERIVATION",
+            truth_reference="r(x,y)=(10*(y-x^2),1-x); unique zero=(1,1).",
+            eligible_claims=(
+                "deterministic-trajectory-fingerprint",
+                "difficult-trf-convergence",
+                "solver-request-accounting",
+            ),
+            policy={
+                **trf_policy,
+                "start": [-1.2, 1.0],
+                "bounds": [[-3.0, 3.0], [-3.0, 3.0]],
+            },
+            budget={"objective_requests": 256},
+            seed="not-applicable",
+            terminal="CONVERGED",
+        ),
+        _definition(
+            "grid-27-seed-ordering-v1",
+            "GRID",
+            parent_case="immutable 27-seed physical-coordinate grid",
+            reduction="Three three-point axes retain Cartesian order and tie policy.",
+            truth_kind="ANALYTIC_DERIVATION",
+            truth_reference="r(x,y,z)=(x-1,y+1,z-0.5); unique zero=(1,-1,0.5).",
+            eligible_claims=(
+                "canonical-grid-candidate-ordering",
+                "grid-seed-coverage",
+                "solver-request-accounting",
+            ),
+            policy={
+                **trf_policy,
+                "physical_axes": [
+                    [-2.0, 0.0, 2.0],
+                    [-2.0, 0.0, 2.0],
+                    [-2.0, 0.0, 2.0],
+                ],
+                "bounds": [[-3.0, 3.0], [-3.0, 3.0], [-3.0, 3.0]],
+                "candidate_tie_break": "chi-square-then-seed-ordinal",
+            },
+            budget={"objective_requests_per_seed": 48, "seed_count": 27},
+            seed="not-applicable",
+            terminal="SELECTED",
+        ),
+        _definition(
+            "de-bounded-search-v1",
+            "DE_SEARCH",
+            parent_case="bounded multimodal basin search",
+            reduction="One selected coordinate retains seeded DE then TRF polish.",
+            truth_kind="ANALYTIC_DERIVATION",
+            truth_reference="f(x)=(x-0.25)^2; unique bounded minimizer x=0.25.",
+            eligible_claims=(
+                "de-seeded-replay",
+                "de-to-trf-candidate-ordering",
+                "solver-request-accounting",
+            ),
+            policy={
+                "de_strategy": "best1bin",
+                "bounds": [[-2.0, 2.0]],
+                "population_multiplier": 5,
+                "maximum_generations": 6,
+                "mutation": [0.5, 1.0],
+                "recombination": 0.7,
+                "relative_tolerance": 0.0,
+                "absolute_tolerance": 0.0,
+                "updating": "immediate",
+                "workers": 1,
+                "backend_polish": False,
+                "workflow_polish": "trf",
+            },
+            budget={"de_objective_requests": 128, "trf_objective_requests": 48},
+            seed=591,
+            terminal="POLISHED",
+        ),
+        _definition(
+            "finite-difference-reliability-v1",
+            "FINITE_DIFFERENCE",
+            parent_case="analytic exponential derivative",
+            reduction="Five-point centered stencil retains actual-step reliability.",
+            truth_kind="ANALYTIC_DERIVATION",
+            truth_reference="d exp(x)/dx at x=0.5 equals exp(0.5).",
+            eligible_claims=(
+                "finite-difference-reliability",
+                "stencil-request-accounting",
+                "stencil-trajectory-fingerprint",
+            ),
+            policy={
+                "stencil": "centered-five-point",
+                "point": 0.5,
+                "step": 1.0e-4,
+                "absolute_tolerance": 1.0e-10,
+            },
+            budget={"objective_requests": 5},
+            seed="not-applicable",
+            terminal="RELIABLE",
+        ),
+        _definition(
+            "trf-active-bound-v1",
+            "BOUNDS",
+            parent_case="bounded scalar residual",
+            reduction="An infeasible unconstrained optimum retains active-bound truth.",
+            truth_kind="ANALYTIC_DERIVATION",
+            truth_reference="r(x)=x-2 on [0,1]; constrained minimizer x=1.",
+            eligible_claims=(
+                "active-bound-detection",
+                "bound-safe-trf-convergence",
+                "solver-request-accounting",
+            ),
+            policy={
+                **trf_policy,
+                "start": [0.5],
+                "bounds": [[0.0, 1.0]],
+            },
+            budget={"objective_requests": 64},
+            seed="not-applicable",
+            terminal="CONVERGED",
+            required_risks=("ACTIVE_BOUND",),
+        ),
+        _definition(
+            "rank-deficient-linearization-v1",
+            "RANK",
+            parent_case="exact rank-one Jacobian",
+            reduction="A duplicated column retains fail-closed rank diagnosis.",
+            truth_kind="EXACT_LINEAR_ALGEBRA",
+            truth_reference="J=((1,1),(2,2)); exact rank=1 < 2.",
+            eligible_claims=("rank-risk-detection",),
+            policy={
+                "rank_relative_tolerance": 1.0e-12,
+                "conditioning_limit": 1.0e12,
+                "svd_driver": "gesdd",
+            },
+            budget={"svd_decompositions": 1},
+            seed="not-applicable",
+            terminal="RISK_DETECTED",
+            required_risks=("RANK_DEFICIENT",),
+        ),
+        _definition(
+            "ill-conditioned-linearization-v1",
+            "CONDITIONING",
+            parent_case="exact diagonal Jacobian spectrum",
+            reduction="Two separated singular values retain conditioning diagnosis.",
+            truth_kind="EXACT_LINEAR_ALGEBRA",
+            truth_reference="J=diag(1,1e-8); exact kappa_2(J)=1e8.",
+            eligible_claims=("conditioning-risk-detection",),
+            policy={"conditioning_limit": 1.0e6, "svd_driver": "gesdd"},
+            budget={"svd_decompositions": 1},
+            seed="not-applicable",
+            terminal="RISK_DETECTED",
+            required_risks=("ILL_CONDITIONED",),
+        ),
+    )

--- a/src/chemex/optimize/numerical_probes.py
+++ b/src/chemex/optimize/numerical_probes.py
@@ -20,7 +20,7 @@ from scipy.linalg import svd
 from scipy.optimize import Bounds, OptimizeResult, differential_evolution, least_squares
 
 from chemex.baselines import CanonicalBaselineValue
-from chemex.numerical_lanes import LaneRole, LiveLaneAuthority
+from chemex.numerical_lanes import LaneRole, LiveLaneAuthority, canonical_lanes
 from chemex.typing import Array
 
 _SCHEMA_VERSION = 2
@@ -2078,6 +2078,11 @@ class NumericalProbeBaseline:
             raise NumericalProbeQualificationError("MANIFEST_MISMATCH")
         if authority.lane_role != required_lane_role:
             raise NumericalProbeQualificationError("LANE_ROLE_MISMATCH")
+        required_lane = next(
+            lane for lane in canonical_lanes() if lane.role == required_lane_role
+        )
+        if authority.lane_identity != required_lane.identity:
+            raise NumericalProbeQualificationError("LANE_MISMATCH")
         if self.historical_qualification == "REFERENCE_MATCHED" and (
             self.observed_lane_identity != evidence.lane_identity
             or self.observed_lane_role != authority.lane_role
@@ -2196,13 +2201,7 @@ class _ObjectiveRecorder:
         if cached is None:
             try:
                 raw_result = self._residual(candidate)
-            except (
-                ArithmeticError,
-                LookupError,
-                RuntimeError,
-                TypeError,
-                ValueError,
-            ) as error:
+            except Exception as error:  # noqa: BLE001 - evaluator boundary
                 try:
                     self._fail(source, "EVALUATION_FAILURE")
                 except _ProbeRequestFailed as failure:

--- a/src/chemex/optimize/numerical_probes.py
+++ b/src/chemex/optimize/numerical_probes.py
@@ -16,9 +16,11 @@ from itertools import product
 from typing import Literal, cast
 
 import numpy as np
-from scipy.optimize import Bounds, differential_evolution, least_squares
+from scipy.linalg import svd
+from scipy.optimize import Bounds, OptimizeResult, differential_evolution, least_squares
 
 from chemex.baselines import CanonicalBaselineValue
+from chemex.numerical_lanes import LiveLaneAuthority
 from chemex.typing import Array
 
 _SCHEMA_VERSION = 1
@@ -503,21 +505,33 @@ class BackendDiagnosticCounters:
 
     nfev: int
     njev: int | None
+    iterations: int | None
     callback_calls: int
     diagnostic_evaluations: int
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         values = (self.nfev, self.callback_calls, self.diagnostic_evaluations)
-        if any(
-            isinstance(value, bool) or not isinstance(value, int) or value < 0
-            for value in values
-        ) or (
-            self.njev is not None
-            and (
-                isinstance(self.njev, bool)
-                or not isinstance(self.njev, int)
-                or self.njev < 0
+        if (
+            any(
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+                for value in values
+            )
+            or (
+                self.njev is not None
+                and (
+                    isinstance(self.njev, bool)
+                    or not isinstance(self.njev, int)
+                    or self.njev < 0
+                )
+            )
+            or (
+                self.iterations is not None
+                and (
+                    isinstance(self.iterations, bool)
+                    or not isinstance(self.iterations, int)
+                    or self.iterations < 0
+                )
             )
         ):
             raise ValueError("Backend diagnostic counters must be non-negative")
@@ -529,6 +543,7 @@ class BackendDiagnosticCounters:
                 (
                     self.nfev,
                     self.njev,
+                    self.iterations,
                     self.callback_calls,
                     self.diagnostic_evaluations,
                 ),
@@ -539,6 +554,7 @@ class BackendDiagnosticCounters:
         return {
             "nfev": self.nfev,
             "njev": self.njev,
+            "iterations": self.iterations,
             "callback_calls": self.callback_calls,
             "diagnostic_evaluations": self.diagnostic_evaluations,
             "identity": self.identity,
@@ -551,6 +567,7 @@ class BackendDiagnosticCounters:
             {
                 "nfev",
                 "njev",
+                "iterations",
                 "callback_calls",
                 "diagnostic_evaluations",
                 "identity",
@@ -560,9 +577,16 @@ class BackendDiagnosticCounters:
         raw_njev = record.get("njev")
         if raw_njev is not None:
             raw_njev = _record_nonnegative_int(raw_njev, "backend njev")
+        raw_iterations = record.get("iterations")
+        if raw_iterations is not None:
+            raw_iterations = _record_nonnegative_int(
+                raw_iterations,
+                "backend iterations",
+            )
         diagnostics = cls(
             _record_nonnegative_int(record.get("nfev"), "backend nfev"),
             raw_njev,
+            raw_iterations,
             _record_nonnegative_int(record.get("callback_calls"), "callback calls"),
             _record_nonnegative_int(
                 record.get("diagnostic_evaluations"), "diagnostic evaluations"
@@ -725,11 +749,13 @@ class GridSeedEvidence:
 
     ordinal: int
     seed: tuple[float, ...]
+    terminal: str
     solver: SolverProbeEvidence
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         _record_nonnegative_int(self.ordinal, "GRID seed ordinal")
+        _nonempty_string(self.terminal, "GRID seed terminal")
         if len(self.seed) != len(self.solver.start) or self.seed != self.solver.start:
             raise ValueError("GRID seed does not match its solver start")
         object.__setattr__(
@@ -737,7 +763,12 @@ class GridSeedEvidence:
             "identity",
             _identity(
                 "grid-seed-probe-evidence",
-                (self.ordinal, _vector_tokens(self.seed), self.solver.identity),
+                (
+                    self.ordinal,
+                    _vector_tokens(self.seed),
+                    self.terminal,
+                    self.solver.identity,
+                ),
             ),
         )
 
@@ -745,19 +776,25 @@ class GridSeedEvidence:
         return {
             "ordinal": self.ordinal,
             "seed": list(_vector_tokens(self.seed)),
+            "terminal": self.terminal,
             "solver": self.solver.to_record(),
             "identity": self.identity,
         }
 
     @classmethod
     def from_record(cls, record: Mapping[str, object]) -> GridSeedEvidence:
-        _exact_keys(record, {"ordinal", "seed", "solver", "identity"}, "GRID seed")
+        _exact_keys(
+            record,
+            {"ordinal", "seed", "terminal", "solver", "identity"},
+            "GRID seed",
+        )
         raw_solver = record.get("solver")
         if not isinstance(raw_solver, Mapping):
             raise TypeError("GRID seed solver evidence must be a record")
         evidence = cls(
             _record_nonnegative_int(record.get("ordinal"), "GRID seed ordinal"),
             _vector_from_record(record.get("seed"), "GRID seed"),
+            _nonempty_string(record.get("terminal"), "GRID seed terminal"),
             SolverProbeEvidence.from_record(cast("Mapping[str, object]", raw_solver)),
         )
         if record.get("identity") != evidence.identity:
@@ -1368,7 +1405,12 @@ class NumericalProbeArtifact:
             or len(set(self.risks)) != len(self.risks)
         ):
             raise ValueError("Probe risks must be unique and ordered")
-        _canonical_strings(self.satisfied_claims, "satisfied claims")
+        if self.satisfied_claims and (
+            tuple(sorted(self.satisfied_claims)) != self.satisfied_claims
+            or len(set(self.satisfied_claims)) != len(self.satisfied_claims)
+            or any(not claim for claim in self.satisfied_claims)
+        ):
+            raise ValueError("Probe satisfied claims must be unique and ordered")
         object.__setattr__(
             self,
             "identity",
@@ -1386,15 +1428,22 @@ class NumericalProbeArtifact:
         )
 
     def validate_definition(self, definition: NumericalProbeDefinition) -> None:
-        expectation = definition.failure_expectations[0]
         if (
             self.definition_identity != definition.identity
             or self.probe_id != definition.probe_id
-            or self.terminal != expectation.terminal
+            or not set(self.satisfied_claims).issubset(definition.eligible_claims)
+        ):
+            raise ValueError("Numerical probe artifact violates its definition")
+
+    def require_qualification(self, definition: NumericalProbeDefinition) -> None:
+        self.validate_definition(definition)
+        expectation = definition.failure_expectations[0]
+        if (
+            self.terminal != expectation.terminal
             or not set(expectation.required_risks).issubset(self.risks)
             or self.satisfied_claims != definition.eligible_claims
         ):
-            raise ValueError("Numerical probe artifact violates its definition")
+            raise ValueError("Numerical probe artifact does not qualify its definition")
 
     def to_record(self) -> dict[str, object]:
         return {
@@ -1473,7 +1522,7 @@ class NumericalProbeArtifact:
             _nonempty_string(record.get("probe_id"), "identifier"),
             _nonempty_string(record.get("terminal"), "terminal"),
             tuple(cast("list[str]", raw_risks)),
-            _canonical_strings(cast("Sequence[str]", raw_claims), "satisfied claims"),
+            tuple(cast("list[str]", raw_claims)),
             evidence,
         )
         artifact.validate_definition(definition)
@@ -1488,12 +1537,37 @@ class NumericalProbeBaseline:
 
     definitions: tuple[NumericalProbeDefinition, ...]
     artifacts: tuple[NumericalProbeArtifact, ...]
+    lane_reference: str = "unqualified-local-diagnostic-v1"
+    lane_attestation_identity: str | None = None
+    environment_identity: str | None = None
+    authority_role: Literal["QUALIFIED_LANE", "UNQUALIFIED_DIAGNOSTIC"] = (
+        "UNQUALIFIED_DIAGNOSTIC"
+    )
     manifest_identity: str = field(init=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         definitions = tuple(self.definitions)
         artifacts = tuple(self.artifacts)
+        if self.authority_role == "QUALIFIED_LANE":
+            for value, name in (
+                (self.lane_reference, "lane reference"),
+                (self.lane_attestation_identity, "lane attestation identity"),
+                (self.environment_identity, "environment identity"),
+            ):
+                if not isinstance(value, str) or len(value) != 64:
+                    raise ValueError(f"Qualified probe baseline requires {name}")
+        elif self.authority_role == "UNQUALIFIED_DIAGNOSTIC":
+            if (
+                not self.lane_reference.startswith("unqualified-")
+                or self.lane_attestation_identity is not None
+                or self.environment_identity is not None
+            ):
+                raise ValueError(
+                    "Diagnostic probe baseline cannot carry qualified lane evidence"
+                )
+        else:
+            raise ValueError("Unknown numerical probe baseline authority role")
         if (
             not definitions
             or len(definitions) != len(artifacts)
@@ -1504,7 +1578,7 @@ class NumericalProbeBaseline:
                 "Probe baseline requires one artifact per unique definition"
             )
         for definition, artifact in zip(definitions, artifacts, strict=True):
-            artifact.validate_definition(definition)
+            artifact.require_qualification(definition)
         manifest = _identity(
             "numerical-probe-manifest",
             tuple(
@@ -1514,6 +1588,15 @@ class NumericalProbeBaseline:
                     artifacts,
                     strict=True,
                 )
+            )
+            + (
+                (
+                    "lane",
+                    self.lane_reference,
+                    self.lane_attestation_identity,
+                    self.environment_identity,
+                    self.authority_role,
+                ),
             ),
         )
         object.__setattr__(self, "manifest_identity", manifest)
@@ -1524,6 +1607,10 @@ class NumericalProbeBaseline:
                 "numerical-probe-baseline",
                 (
                     manifest,
+                    self.lane_reference,
+                    self.lane_attestation_identity,
+                    self.environment_identity,
+                    self.authority_role,
                     tuple(definition.identity for definition in definitions),
                     tuple(artifact.identity for artifact in artifacts),
                 ),
@@ -1536,6 +1623,10 @@ class NumericalProbeBaseline:
             "semantic_version": _SEMANTIC_VERSION,
             "definitions": [definition.to_record() for definition in self.definitions],
             "artifacts": [artifact.to_record() for artifact in self.artifacts],
+            "lane_reference": self.lane_reference,
+            "lane_attestation_identity": self.lane_attestation_identity,
+            "environment_identity": self.environment_identity,
+            "authority_role": self.authority_role,
             "manifest_identity": self.manifest_identity,
             "identity": self.identity,
         }
@@ -1549,6 +1640,10 @@ class NumericalProbeBaseline:
                 "semantic_version",
                 "definitions",
                 "artifacts",
+                "lane_reference",
+                "lane_attestation_identity",
+                "environment_identity",
+                "authority_role",
                 "manifest_identity",
                 "identity",
             },
@@ -1587,7 +1682,20 @@ class NumericalProbeBaseline:
                 strict=True,
             )
         )
-        baseline = cls(definitions, artifacts)
+        authority_role = record.get("authority_role")
+        if authority_role not in {"QUALIFIED_LANE", "UNQUALIFIED_DIAGNOSTIC"}:
+            raise ValueError("Unknown numerical probe baseline authority role")
+        baseline = cls(
+            definitions,
+            artifacts,
+            _nonempty_string(record.get("lane_reference"), "lane reference"),
+            cast("str | None", record.get("lane_attestation_identity")),
+            cast("str | None", record.get("environment_identity")),
+            cast(
+                "Literal['QUALIFIED_LANE', 'UNQUALIFIED_DIAGNOSTIC']",
+                authority_role,
+            ),
+        )
         if (
             record.get("manifest_identity") != baseline.manifest_identity
             or record.get("identity") != baseline.identity
@@ -1595,9 +1703,43 @@ class NumericalProbeBaseline:
             raise ValueError("Numerical probe baseline identity does not match payload")
         return baseline
 
+    def require_replay(self, expected_manifest_identity: str) -> None:
+        if len(expected_manifest_identity) != 64:
+            raise ValueError(
+                "Expected numerical probe manifest must be a SHA-256 digest"
+            )
+        if self.manifest_identity != expected_manifest_identity:
+            raise ValueError(
+                "Numerical probe replay differs from the selected manifest"
+            )
+
+
+class NumericalProbeExecutionError(RuntimeError):
+    """Typed fail-closed terminal before a complete probe artifact exists."""
+
+    def __init__(
+        self,
+        definition_identity: str,
+        terminal: str,
+        accounting: ObjectiveRequestAccounting,
+        trajectory_fingerprint: str,
+    ) -> None:
+        self.definition_identity = definition_identity
+        self.terminal = terminal
+        self.accounting = accounting
+        self.trajectory_fingerprint = trajectory_fingerprint
+        super().__init__(f"Numerical probe terminated: {terminal}")
+
 
 class _ProbeBudgetExhausted(RuntimeError):
-    pass
+    def __init__(
+        self,
+        accounting: ObjectiveRequestAccounting,
+        trajectory_fingerprint: str,
+    ) -> None:
+        self.accounting = accounting
+        self.trajectory_fingerprint = trajectory_fingerprint
+        super().__init__("Probe objective-request budget exhausted")
 
 
 class _ObjectiveRecorder:
@@ -1627,7 +1769,10 @@ class _ObjectiveRecorder:
         if self.completed >= self._budget:
             self.refused += 1
             self._trace.append((source, "budget_refused"))
-            raise _ProbeBudgetExhausted("Probe objective-request budget exhausted")
+            raise _ProbeBudgetExhausted(
+                self.accounting,
+                self.trajectory_fingerprint,
+            )
         candidate = tuple(float(value) for value in vector)
         key = _vector_tokens(candidate)
         cached = self._cache.get(key)
@@ -1670,6 +1815,32 @@ def _budget_value(definition: NumericalProbeDefinition, field_name: str) -> int:
     return value
 
 
+@dataclass(frozen=True, slots=True)
+class _TrfSettings:
+    ftol: float
+    xtol: float
+    gtol: float
+    x_scale: float
+
+    @classmethod
+    def from_definition(
+        cls,
+        definition: NumericalProbeDefinition,
+        prefix: str = "",
+    ) -> _TrfSettings:
+        if prefix == "" and (
+            _policy_string(definition, "backend") != "scipy.optimize.least_squares"
+            or _policy_string(definition, "method") != "trf"
+        ):
+            raise ValueError("TRF probe policy selects an unsupported backend")
+        return cls(
+            _policy_float(definition, f"{prefix}ftol"),
+            _policy_float(definition, f"{prefix}xtol"),
+            _policy_float(definition, f"{prefix}gtol"),
+            _policy_float(definition, f"{prefix}x_scale"),
+        )
+
+
 def _least_squares_evidence(
     *,
     start: tuple[float, ...],
@@ -1677,8 +1848,15 @@ def _least_squares_evidence(
     upper: tuple[float, ...],
     residual: Callable[[tuple[float, ...]], tuple[float, ...]],
     budget: int,
+    settings: _TrfSettings,
 ) -> tuple[SolverProbeEvidence, bool]:
     recorder = _ObjectiveRecorder(residual, budget)
+    callback_calls = 0
+
+    def count_callback(_intermediate_result: object) -> None:
+        nonlocal callback_calls
+        callback_calls += 1
+
     result = least_squares(
         lambda vector: recorder.evaluate(vector, "solver"),
         np.asarray(start, dtype=np.float64),
@@ -1687,11 +1865,12 @@ def _least_squares_evidence(
             np.asarray(upper, dtype=np.float64),
         ),
         method="trf",
-        ftol=1.0e-10,
-        xtol=1.0e-10,
-        gtol=1.0e-10,
-        x_scale=1.0,
+        ftol=settings.ftol,
+        xtol=settings.xtol,
+        gtol=settings.gtol,
+        x_scale=settings.x_scale,
         max_nfev=budget,
+        callback=count_callback,
     )
     accepted = tuple(float(value) for value in result.x)
     residuals = tuple(
@@ -1715,7 +1894,8 @@ def _least_squares_evidence(
             BackendDiagnosticCounters(
                 int(result.nfev),
                 None if result.njev is None else int(result.njev),
-                0,
+                None,
+                callback_calls,
                 0,
             ),
             recorder.trajectory_fingerprint,
@@ -1746,39 +1926,60 @@ def _sum_diagnostics(
         if any(item.njev is None for item in diagnostics)
         else sum(cast("int", item.njev) for item in diagnostics)
     )
+    iterations = (
+        None
+        if any(item.iterations is None for item in diagnostics)
+        else sum(cast("int", item.iterations) for item in diagnostics)
+    )
     return BackendDiagnosticCounters(
         sum(item.nfev for item in diagnostics),
         njev,
+        iterations,
         sum(item.callback_calls for item in diagnostics),
         sum(item.diagnostic_evaluations for item in diagnostics),
+    )
+
+
+def _solver_matches_truth(
+    definition: NumericalProbeDefinition,
+    evidence: SolverProbeEvidence,
+) -> bool:
+    expected = _policy_vector(definition, "truth")
+    tolerance = _policy_float(definition, "truth_absolute_tolerance")
+    if len(expected) != len(evidence.accepted) or any(
+        not math.isclose(actual, truth, rel_tol=0.0, abs_tol=tolerance)
+        for actual, truth in zip(evidence.accepted, expected, strict=True)
+    ):
+        return False
+    if definition.category == "BOUNDS":
+        return evidence.active_mask == _policy_int_vector(
+            definition,
+            "expected_active_mask",
+        )
+    return evidence.chi_square <= _policy_float(
+        definition,
+        "maximum_chi_square",
     )
 
 
 def _run_solver_probe(
     definition: NumericalProbeDefinition,
 ) -> NumericalProbeArtifact:
+    start = _policy_vector(definition, "start")
+    lower, upper = _policy_bounds(definition)
     if definition.category == "TRF_ROUTINE":
-        start = (0.0, 0.0)
-        lower = (-4.0, -4.0)
-        upper = (4.0, 4.0)
 
         def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
             x_value, y_value = vector
             return (x_value - 1.5, y_value + 0.5)
 
     elif definition.category == "TRF_DIFFICULT":
-        start = (-1.2, 1.0)
-        lower = (-3.0, -3.0)
-        upper = (3.0, 3.0)
 
         def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
             x_value, y_value = vector
             return (10.0 * (y_value - x_value * x_value), 1.0 - x_value)
 
     elif definition.category == "BOUNDS":
-        start = (0.5,)
-        lower = (0.0,)
-        upper = (1.0,)
 
         def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
             return (vector[0] - 2.0,)
@@ -1791,15 +1992,17 @@ def _run_solver_probe(
         upper=upper,
         residual=residual,
         budget=_budget_value(definition, "objective_requests"),
+        settings=_TrfSettings.from_definition(definition),
     )
-    terminal = "CONVERGED" if succeeded else "NON_CONVERGED"
-    risks = ("ACTIVE_BOUND",) if definition.category == "BOUNDS" else ()
+    qualified = succeeded and _solver_matches_truth(definition, evidence)
+    terminal = "CONVERGED" if qualified else "TRUTH_MISMATCH"
+    risks = ("ACTIVE_BOUND",) if qualified and definition.category == "BOUNDS" else ()
     artifact = NumericalProbeArtifact(
         definition.identity,
         definition.probe_id,
         terminal,
         risks,
-        definition.eligible_claims if succeeded else (),
+        definition.eligible_claims if qualified else (),
         evidence,
     )
     artifact.validate_definition(definition)
@@ -1807,24 +2010,35 @@ def _run_solver_probe(
 
 
 def _run_grid_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifact:
-    lower = (-3.0, -3.0, -3.0)
-    upper = (3.0, 3.0, 3.0)
+    lower, upper = _policy_bounds(definition)
 
     def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
         x_value, y_value, z_value = vector
         return (x_value - 1.0, y_value + 1.0, z_value - 0.5)
 
-    starts = tuple(product((-2.0, 0.0, 2.0), repeat=3))
+    axes = _policy_matrix(definition, "physical_axes")
+    starts = tuple(product(*axes))
+    expected_seed_count = _budget_value(definition, "seed_count")
+    if len(starts) != expected_seed_count:
+        raise ValueError("GRID policy axes do not match its declared seed budget")
     seeds: list[GridSeedEvidence] = []
     for ordinal, start in enumerate(starts):
-        solver, _succeeded = _least_squares_evidence(
+        solver, succeeded = _least_squares_evidence(
             start=start,
             lower=lower,
             upper=upper,
             residual=residual,
             budget=_budget_value(definition, "objective_requests_per_seed"),
+            settings=_TrfSettings.from_definition(definition),
         )
-        seeds.append(GridSeedEvidence(ordinal, start, solver))
+        seeds.append(
+            GridSeedEvidence(
+                ordinal,
+                start,
+                "CONVERGED" if succeeded else "NON_CONVERGED",
+                solver,
+            )
+        )
     seed_evidence = tuple(seeds)
     order = tuple(
         seed.ordinal
@@ -1848,12 +2062,19 @@ def _run_grid_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtif
             tuple(seed.solver.trajectory_fingerprint for seed in seed_evidence),
         ),
     )
+    selected = seed_evidence[order[0]].solver
+    qualified = (
+        all(seed.terminal == "CONVERGED" for seed in seed_evidence)
+        and _solver_matches_truth(definition, selected)
+        and _policy_string(definition, "candidate_tie_break")
+        == "chi-square-then-seed-ordinal"
+    )
     artifact = NumericalProbeArtifact(
         definition.identity,
         definition.probe_id,
-        "SELECTED",
+        "SELECTED" if qualified else "TRUTH_MISMATCH",
         (),
-        definition.eligible_claims,
+        definition.eligible_claims if qualified else (),
         evidence,
     )
     artifact.validate_definition(definition)
@@ -1877,20 +2098,38 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
         values = search_recorder.evaluate(vector, "solver")
         return float(np.dot(values, values))
 
+    callback_calls = 0
+
+    def count_callback(intermediate_result: OptimizeResult) -> None:
+        nonlocal callback_calls
+        _ = intermediate_result
+        callback_calls += 1
+
+    lower, upper = _policy_bounds(definition)
+    mutation = _policy_vector(definition, "mutation")
+    if len(mutation) != 2:
+        raise ValueError("DE mutation policy requires one declared range")
+
+    strategy = _policy_string(definition, "de_strategy")
+    if strategy != "best1bin":
+        raise ValueError("DE probe policy selects an unsupported strategy")
     result = differential_evolution(
         objective,
-        Bounds(np.asarray((-2.0,)), np.asarray((2.0,))),
+        Bounds(np.asarray(lower), np.asarray(upper)),
         strategy="best1bin",
-        maxiter=6,
-        popsize=5,
-        mutation=(0.5, 1.0),
-        recombination=0.7,
-        tol=0.0,
-        atol=0.0,
-        polish=False,
+        maxiter=_policy_int(definition, "maximum_generations"),
+        popsize=_policy_int(definition, "population_multiplier"),
+        mutation=mutation,
+        recombination=_policy_float(definition, "recombination"),
+        tol=_policy_float(definition, "relative_tolerance"),
+        atol=_policy_float(definition, "absolute_tolerance"),
+        polish=_policy_bool(definition, "backend_polish"),
         rng=np.random.default_rng(root_seed),
-        updating="immediate",
-        workers=1,
+        updating=cast(
+            "Literal['immediate', 'deferred']", _policy_string(definition, "updating")
+        ),
+        workers=_policy_int(definition, "workers"),
+        callback=count_callback,
     )
     selected_vector = tuple(float(value) for value in result.x)
     search_recorder.evaluate(selected_vector, "materialization")
@@ -1911,10 +2150,11 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
     )
     polish, polish_succeeded = _least_squares_evidence(
         start=selected_vector,
-        lower=(-2.0,),
-        upper=(2.0,),
+        lower=lower,
+        upper=upper,
         residual=residual,
         budget=_budget_value(definition, "trf_objective_requests"),
+        settings=_TrfSettings.from_definition(definition, "polish_"),
     )
     evidence = DeProbeEvidence(
         root_seed,
@@ -1922,7 +2162,13 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
         order,
         order[0],
         search_recorder.accounting,
-        BackendDiagnosticCounters(int(result.nfev), None, 0, 0),
+        BackendDiagnosticCounters(
+            int(result.nfev),
+            None,
+            callback_calls,
+            callback_calls,
+            0,
+        ),
         polish,
         _identity(
             "de-probe-trajectory",
@@ -1933,33 +2179,128 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
             ),
         ),
     )
-    terminal = "POLISHED" if polish_succeeded else "POLISH_FAILED"
+    selected_population_vector = population[order[0]].vector
+    qualified = (
+        polish_succeeded
+        and _solver_matches_truth(definition, polish)
+        and all(
+            math.isclose(actual, selected, rel_tol=0.0, abs_tol=0.0)
+            for actual, selected in zip(
+                selected_vector,
+                selected_population_vector,
+                strict=True,
+            )
+        )
+        and _policy_string(definition, "workflow_polish") == "trf"
+    )
+    terminal = "POLISHED" if qualified else "TRUTH_MISMATCH"
     artifact = NumericalProbeArtifact(
         definition.identity,
         definition.probe_id,
         terminal,
         (),
-        definition.eligible_claims if polish_succeeded else (),
+        definition.eligible_claims if qualified else (),
         evidence,
     )
     artifact.validate_definition(definition)
     return artifact
 
 
-def _policy_float(definition: NumericalProbeDefinition, field_name: str) -> float:
+def _policy_record(definition: NumericalProbeDefinition) -> Mapping[str, object]:
     policy = definition.policy.to_record_value()
     if not isinstance(policy, Mapping):
         raise TypeError("Probe policy must be a record")
-    raw_value = policy.get(field_name)
+    return cast("Mapping[str, object]", policy)
+
+
+def _semantic_float(value: object, field_name: str) -> float:
+    raw_value = value
     if not isinstance(raw_value, Mapping) or set(raw_value) != {"binary64"}:
         raise TypeError(f"Probe policy {field_name!r} must be binary64")
     return _float_from_record(raw_value.get("binary64"), field_name)
 
 
+def _policy_float(definition: NumericalProbeDefinition, field_name: str) -> float:
+    return _semantic_float(_policy_record(definition).get(field_name), field_name)
+
+
+def _policy_int(definition: NumericalProbeDefinition, field_name: str) -> int:
+    value = _policy_record(definition).get(field_name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"Probe policy {field_name!r} must be an integer")
+    return value
+
+
+def _policy_string(definition: NumericalProbeDefinition, field_name: str) -> str:
+    return _nonempty_string(
+        _policy_record(definition).get(field_name),
+        f"policy {field_name}",
+    )
+
+
+def _policy_bool(definition: NumericalProbeDefinition, field_name: str) -> bool:
+    value = _policy_record(definition).get(field_name)
+    if not isinstance(value, bool):
+        raise TypeError(f"Probe policy {field_name!r} must be boolean")
+    return value
+
+
+def _semantic_vector(value: object, field_name: str) -> tuple[float, ...]:
+    if not isinstance(value, list) or not value:
+        raise TypeError(f"Probe policy {field_name!r} must be a non-empty list")
+    return tuple(
+        _semantic_float(item, f"{field_name}[{index}]")
+        for index, item in enumerate(value)
+    )
+
+
+def _policy_vector(
+    definition: NumericalProbeDefinition,
+    field_name: str,
+) -> tuple[float, ...]:
+    return _semantic_vector(_policy_record(definition).get(field_name), field_name)
+
+
+def _policy_matrix(
+    definition: NumericalProbeDefinition,
+    field_name: str,
+) -> tuple[tuple[float, ...], ...]:
+    value = _policy_record(definition).get(field_name)
+    if not isinstance(value, list) or not value:
+        raise TypeError(f"Probe policy {field_name!r} must be a non-empty matrix")
+    return tuple(
+        _semantic_vector(row, f"{field_name}[{index}]")
+        for index, row in enumerate(value)
+    )
+
+
+def _policy_int_vector(
+    definition: NumericalProbeDefinition,
+    field_name: str,
+) -> tuple[int, ...]:
+    value = _policy_record(definition).get(field_name)
+    if not isinstance(value, list) or any(
+        isinstance(item, bool) or not isinstance(item, int) for item in value
+    ):
+        raise TypeError(f"Probe policy {field_name!r} must be an integer list")
+    return tuple(cast("list[int]", value))
+
+
+def _policy_bounds(
+    definition: NumericalProbeDefinition,
+) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    rows = _policy_matrix(definition, "bounds")
+    if any(len(row) != 2 or row[0] >= row[1] for row in rows):
+        raise ValueError("Probe bounds must be ordered lower/upper pairs")
+    return tuple(row[0] for row in rows), tuple(row[1] for row in rows)
+
+
 def _run_finite_difference_probe(
     definition: NumericalProbeDefinition,
 ) -> NumericalProbeArtifact:
-    point = 0.5
+    if _policy_string(definition, "stencil") != "centered-five-point":
+        raise ValueError("Finite-difference probe requires its declared stencil")
+    point = _policy_float(definition, "point")
     step = _policy_float(definition, "step")
     actual_steps = (-2.0 * step, -step, 0.0, step, 2.0 * step)
 
@@ -1988,7 +2329,7 @@ def _run_finite_difference_probe(
         absolute_error,
         absolute_tolerance,
         recorder.accounting,
-        BackendDiagnosticCounters(0, None, 0, 0),
+        BackendDiagnosticCounters(0, None, None, 0, 0),
         recorder.trajectory_fingerprint,
     )
     reliable = absolute_error <= absolute_tolerance
@@ -2019,9 +2360,13 @@ def _run_spectral_risk_probe(
         raise ValueError(f"Probe {definition.probe_id!r} is not spectral")
     singular_values = tuple(
         float(value)
-        for value in np.linalg.svd(
+        for value in svd(
             np.asarray(jacobian, dtype=np.float64),
             compute_uv=False,
+            lapack_driver=cast(
+                "Literal['gesdd', 'gesvd']",
+                _policy_string(definition, "svd_driver"),
+            ),
         )
     )
     rank_threshold = singular_values[0] * relative_tolerance
@@ -2044,7 +2389,7 @@ def _run_spectral_risk_probe(
         condition_limit,
         risks,
         ObjectiveRequestAccounting(0, 0, 0, 0, 0, 0),
-        BackendDiagnosticCounters(0, None, 0, 1),
+        BackendDiagnosticCounters(0, None, None, 0, 1),
         _identity(
             "spectral-probe-trajectory",
             (
@@ -2056,12 +2401,26 @@ def _run_spectral_risk_probe(
             ),
         ),
     )
+    expected_rank = _policy_int(definition, "expected_rank")
+    qualified = rank == expected_rank and bool(risks)
+    if definition.category == "CONDITIONING":
+        expected_condition = _policy_float(definition, "expected_condition")
+        qualified = (
+            qualified
+            and condition is not None
+            and math.isclose(
+                condition,
+                expected_condition,
+                rel_tol=_policy_float(definition, "condition_relative_tolerance"),
+                abs_tol=0.0,
+            )
+        )
     artifact = NumericalProbeArtifact(
         definition.identity,
         definition.probe_id,
-        "RISK_DETECTED" if risks else "NO_RISK",
-        risks,
-        definition.eligible_claims if risks else (),
+        "RISK_DETECTED" if qualified else "TRUTH_MISMATCH",
+        risks if qualified else (),
+        definition.eligible_claims if qualified else (),
         evidence,
     )
     artifact.validate_definition(definition)
@@ -2082,26 +2441,55 @@ def run_numerical_probe(
     )
     if canonical != definition:
         raise ValueError("Only an exact predeclared numerical probe may run")
-    if definition.category in {"TRF_ROUTINE", "TRF_DIFFICULT", "BOUNDS"}:
-        return _run_solver_probe(definition)
-    if definition.category == "GRID":
-        return _run_grid_probe(definition)
-    if definition.category == "DE_SEARCH":
-        return _run_de_probe(definition)
-    if definition.category == "FINITE_DIFFERENCE":
-        return _run_finite_difference_probe(definition)
-    if definition.category in {"RANK", "CONDITIONING"}:
-        return _run_spectral_risk_probe(definition)
-    raise NotImplementedError(f"Probe category {definition.category!r} is not runnable")
+    runners: Mapping[
+        ProbeCategory,
+        Callable[[NumericalProbeDefinition], NumericalProbeArtifact],
+    ] = {
+        "TRF_ROUTINE": _run_solver_probe,
+        "TRF_DIFFICULT": _run_solver_probe,
+        "GRID": _run_grid_probe,
+        "DE_SEARCH": _run_de_probe,
+        "FINITE_DIFFERENCE": _run_finite_difference_probe,
+        "BOUNDS": _run_solver_probe,
+        "RANK": _run_spectral_risk_probe,
+        "CONDITIONING": _run_spectral_risk_probe,
+    }
+    try:
+        return runners[definition.category](definition)
+    except _ProbeBudgetExhausted as error:
+        raise NumericalProbeExecutionError(
+            definition.identity,
+            "BUDGET_EXHAUSTED",
+            error.accounting,
+            error.trajectory_fingerprint,
+        ) from error
 
 
-def run_numerical_probe_baseline() -> NumericalProbeBaseline:
+def run_numerical_probe_baseline(
+    authority: LiveLaneAuthority | None = None,
+    *,
+    expected_manifest_identity: str | None = None,
+) -> NumericalProbeBaseline:
     """Execute the closed v1 catalogue into one immutable typed manifest."""
     definitions = numerical_probe_definitions()
-    return NumericalProbeBaseline(
-        definitions,
-        tuple(run_numerical_probe(definition) for definition in definitions),
-    )
+    artifacts = tuple(run_numerical_probe(definition) for definition in definitions)
+    if authority is None:
+        baseline = NumericalProbeBaseline(definitions, artifacts)
+    else:
+        if not isinstance(authority, LiveLaneAuthority):
+            raise TypeError("Qualified numerical probes require live lane authority")
+        evidence = authority.evidence
+        baseline = NumericalProbeBaseline(
+            definitions,
+            artifacts,
+            evidence.lane_identity,
+            evidence.identity,
+            evidence.environment_identity,
+            "QUALIFIED_LANE",
+        )
+    if expected_manifest_identity is not None:
+        baseline.require_replay(expected_manifest_identity)
+    return baseline
 
 
 def _definition(
@@ -2164,6 +2552,9 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 **trf_policy,
                 "start": [0.0, 0.0],
                 "bounds": [[-4.0, 4.0], [-4.0, 4.0]],
+                "truth": [1.5, -0.5],
+                "truth_absolute_tolerance": 1.0e-8,
+                "maximum_chi_square": 1.0e-16,
             },
             budget={"objective_requests": 64},
             seed="not-applicable",
@@ -2185,6 +2576,9 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 **trf_policy,
                 "start": [-1.2, 1.0],
                 "bounds": [[-3.0, 3.0], [-3.0, 3.0]],
+                "truth": [1.0, 1.0],
+                "truth_absolute_tolerance": 1.0e-8,
+                "maximum_chi_square": 1.0e-16,
             },
             budget={"objective_requests": 256},
             seed="not-applicable",
@@ -2211,6 +2605,9 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 ],
                 "bounds": [[-3.0, 3.0], [-3.0, 3.0], [-3.0, 3.0]],
                 "candidate_tie_break": "chi-square-then-seed-ordinal",
+                "truth": [1.0, -1.0, 0.5],
+                "truth_absolute_tolerance": 1.0e-8,
+                "maximum_chi_square": 1.0e-16,
             },
             budget={"objective_requests_per_seed": 48, "seed_count": 27},
             seed="not-applicable",
@@ -2241,6 +2638,13 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 "workers": 1,
                 "backend_polish": False,
                 "workflow_polish": "trf",
+                "polish_ftol": 1.0e-10,
+                "polish_xtol": 1.0e-10,
+                "polish_gtol": 1.0e-10,
+                "polish_x_scale": 1.0,
+                "truth": [0.25],
+                "truth_absolute_tolerance": 1.0e-8,
+                "maximum_chi_square": 1.0e-16,
             },
             budget={"de_objective_requests": 128, "trf_objective_requests": 48},
             seed=591,
@@ -2284,6 +2688,9 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 **trf_policy,
                 "start": [0.5],
                 "bounds": [[0.0, 1.0]],
+                "truth": [1.0],
+                "truth_absolute_tolerance": 1.0e-8,
+                "expected_active_mask": [1],
             },
             budget={"objective_requests": 64},
             seed="not-applicable",
@@ -2302,6 +2709,7 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 "rank_relative_tolerance": 1.0e-12,
                 "conditioning_limit": 1.0e12,
                 "svd_driver": "gesdd",
+                "expected_rank": 1,
             },
             budget={"svd_decompositions": 1},
             seed="not-applicable",
@@ -2316,7 +2724,13 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
             truth_kind="EXACT_LINEAR_ALGEBRA",
             truth_reference="J=diag(1,1e-8); exact kappa_2(J)=1e8.",
             eligible_claims=("conditioning-risk-detection",),
-            policy={"conditioning_limit": 1.0e6, "svd_driver": "gesdd"},
+            policy={
+                "conditioning_limit": 1.0e6,
+                "svd_driver": "gesdd",
+                "expected_rank": 2,
+                "expected_condition": 1.0e8,
+                "condition_relative_tolerance": 1.0e-12,
+            },
             budget={"svd_decompositions": 1},
             seed="not-applicable",
             terminal="RISK_DETECTED",

--- a/src/chemex/optimize/numerical_probes.py
+++ b/src/chemex/optimize/numerical_probes.py
@@ -919,6 +919,7 @@ class DePopulationCandidate:
     population_index: int
     vector: tuple[float, ...]
     objective: float
+    backend_objective: float
     fingerprint: str = field(init=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -927,6 +928,11 @@ class DePopulationCandidate:
         objective = float(self.objective)
         if not math.isfinite(objective) or objective < 0.0:
             raise ValueError("DE population objective must be finite and non-negative")
+        backend_objective = float(self.backend_objective)
+        if not math.isfinite(backend_objective) or backend_objective < 0.0:
+            raise ValueError(
+                "DE backend population objective must be finite and non-negative"
+            )
         object.__setattr__(
             self,
             "fingerprint",
@@ -936,6 +942,7 @@ class DePopulationCandidate:
                     self.population_index,
                     _vector_tokens(self.vector),
                     _float_token(objective),
+                    _float_token(backend_objective),
                 ),
             ),
         )
@@ -945,6 +952,7 @@ class DePopulationCandidate:
             "population_index": self.population_index,
             "vector": list(_vector_tokens(self.vector)),
             "objective": _float_token(self.objective),
+            "backend_objective": _float_token(self.backend_objective),
             "fingerprint": self.fingerprint,
         }
 
@@ -952,7 +960,13 @@ class DePopulationCandidate:
     def from_record(cls, record: Mapping[str, object]) -> DePopulationCandidate:
         _exact_keys(
             record,
-            {"population_index", "vector", "objective", "fingerprint"},
+            {
+                "population_index",
+                "vector",
+                "objective",
+                "backend_objective",
+                "fingerprint",
+            },
             "DE population candidate",
         )
         candidate = cls(
@@ -961,6 +975,10 @@ class DePopulationCandidate:
             ),
             _vector_from_record(record.get("vector"), "DE candidate vector"),
             _float_from_record(record.get("objective"), "DE candidate objective"),
+            _float_from_record(
+                record.get("backend_objective"),
+                "DE backend candidate objective",
+            ),
         )
         if record.get("fingerprint") != candidate.fingerprint:
             raise ValueError("DE candidate fingerprint does not match its payload")
@@ -1107,6 +1125,7 @@ class FiniteDifferenceProbeEvidence:
 
     point: float
     actual_steps: tuple[float, ...]
+    weights: tuple[float, ...]
     sampled_values: tuple[float, ...]
     truth: float
     estimate: float
@@ -1119,9 +1138,14 @@ class FiniteDifferenceProbeEvidence:
 
     def __post_init__(self) -> None:
         _float_token(self.point)
-        if len(self.actual_steps) != 5 or len(self.sampled_values) != 5:
+        if (
+            len(self.actual_steps) != 5
+            or len(self.weights) != 5
+            or len(self.sampled_values) != 5
+        ):
             raise ValueError("Finite-difference evidence requires five stencil points")
         _vector_tokens(self.actual_steps)
+        _vector_tokens(self.weights)
         _vector_tokens(self.sampled_values)
         for value in (
             self.truth,
@@ -1134,6 +1158,12 @@ class FiniteDifferenceProbeEvidence:
             raise ValueError(
                 "Finite-difference error does not match estimate and truth"
             )
+        reconstructed = math.fsum(
+            weight * value
+            for weight, value in zip(self.weights, self.sampled_values, strict=True)
+        )
+        if self.estimate != reconstructed:
+            raise ValueError("Finite-difference estimate does not match its weights")
         if self.absolute_tolerance <= 0.0:
             raise ValueError("Finite-difference tolerance must be positive")
         if len(self.trajectory_fingerprint) != 64:
@@ -1146,6 +1176,7 @@ class FiniteDifferenceProbeEvidence:
                 (
                     _float_token(self.point),
                     _vector_tokens(self.actual_steps),
+                    _vector_tokens(self.weights),
                     _vector_tokens(self.sampled_values),
                     _float_token(self.truth),
                     _float_token(self.estimate),
@@ -1163,6 +1194,7 @@ class FiniteDifferenceProbeEvidence:
             "kind": "FINITE_DIFFERENCE",
             "point": _float_token(self.point),
             "actual_steps": list(_vector_tokens(self.actual_steps)),
+            "weights": list(_vector_tokens(self.weights)),
             "sampled_values": list(_vector_tokens(self.sampled_values)),
             "truth": _float_token(self.truth),
             "estimate": _float_token(self.estimate),
@@ -1182,6 +1214,7 @@ class FiniteDifferenceProbeEvidence:
                 "kind",
                 "point",
                 "actual_steps",
+                "weights",
                 "sampled_values",
                 "truth",
                 "estimate",
@@ -1205,6 +1238,7 @@ class FiniteDifferenceProbeEvidence:
         evidence = cls(
             _float_from_record(record.get("point"), "finite-difference point"),
             _vector_from_record(record.get("actual_steps"), "actual steps"),
+            _vector_from_record(record.get("weights"), "stencil weights"),
             _vector_from_record(record.get("sampled_values"), "sampled values"),
             _float_from_record(record.get("truth"), "derivative truth"),
             _float_from_record(record.get("estimate"), "derivative estimate"),
@@ -1434,6 +1468,19 @@ class NumericalProbeArtifact:
             or not set(self.satisfied_claims).issubset(definition.eligible_claims)
         ):
             raise ValueError("Numerical probe artifact violates its definition")
+        expected_evidence: type[NumericalProbeEvidence]
+        if definition.category in {"TRF_ROUTINE", "TRF_DIFFICULT", "BOUNDS"}:
+            expected_evidence = SolverProbeEvidence
+        elif definition.category == "GRID":
+            expected_evidence = GridProbeEvidence
+        elif definition.category == "DE_SEARCH":
+            expected_evidence = DeProbeEvidence
+        elif definition.category == "FINITE_DIFFERENCE":
+            expected_evidence = FiniteDifferenceProbeEvidence
+        else:
+            expected_evidence = SpectralRiskProbeEvidence
+        if not isinstance(self.evidence, expected_evidence):
+            raise TypeError("Numerical probe evidence does not match its category")
 
     def require_qualification(self, definition: NumericalProbeDefinition) -> None:
         self.validate_definition(definition)
@@ -1766,15 +1813,15 @@ class _ObjectiveRecorder:
             self.materialization_requests += 1
         else:
             raise ValueError("Unknown probe objective request source")
+        candidate = tuple(float(value) for value in vector)
+        key = _vector_tokens(candidate)
         if self.completed >= self._budget:
             self.refused += 1
-            self._trace.append((source, "budget_refused"))
+            self._trace.append((source, key, "budget_refused"))
             raise _ProbeBudgetExhausted(
                 self.accounting,
                 self.trajectory_fingerprint,
             )
-        candidate = tuple(float(value) for value in vector)
-        key = _vector_tokens(candidate)
         cached = self._cache.get(key)
         disposition = "cache_hit"
         if cached is None:
@@ -1851,11 +1898,6 @@ def _least_squares_evidence(
     settings: _TrfSettings,
 ) -> tuple[SolverProbeEvidence, bool]:
     recorder = _ObjectiveRecorder(residual, budget)
-    callback_calls = 0
-
-    def count_callback(_intermediate_result: object) -> None:
-        nonlocal callback_calls
-        callback_calls += 1
 
     result = least_squares(
         lambda vector: recorder.evaluate(vector, "solver"),
@@ -1870,7 +1912,6 @@ def _least_squares_evidence(
         gtol=settings.gtol,
         x_scale=settings.x_scale,
         max_nfev=budget,
-        callback=count_callback,
     )
     accepted = tuple(float(value) for value in result.x)
     residuals = tuple(
@@ -1895,7 +1936,7 @@ def _least_squares_evidence(
                 int(result.nfev),
                 None if result.njev is None else int(result.njev),
                 None,
-                callback_calls,
+                0,
                 0,
             ),
             recorder.trajectory_fingerprint,
@@ -2085,9 +2126,15 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
     root_seed = definition.seed.to_record_value()
     if isinstance(root_seed, bool) or not isinstance(root_seed, int):
         raise TypeError("DE probe root seed must be an integer")
+    oscillation_amplitude = _policy_float(definition, "oscillation_amplitude")
+    oscillation_frequency = _policy_float(definition, "oscillation_frequency")
 
     def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
-        return (vector[0] - 0.25,)
+        displacement = vector[0] - 0.25
+        return (
+            displacement,
+            oscillation_amplitude * math.sin(oscillation_frequency * displacement),
+        )
 
     search_recorder = _ObjectiveRecorder(
         residual,
@@ -2131,12 +2178,16 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
         workers=_policy_int(definition, "workers"),
         callback=count_callback,
     )
-    selected_vector = tuple(float(value) for value in result.x)
-    search_recorder.evaluate(selected_vector, "materialization")
     population = tuple(
         DePopulationCandidate(
             index,
             tuple(float(value) for value in vector),
+            float(
+                np.dot(
+                    values := search_recorder.evaluate(vector, "materialization"),
+                    values,
+                )
+            ),
             float(result.population_energies[index]),
         )
         for index, vector in enumerate(result.population)
@@ -2148,6 +2199,7 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
             key=lambda candidate: (candidate.objective, candidate.population_index),
         )
     )
+    selected_vector = population[order[0]].vector
     polish, polish_succeeded = _least_squares_evidence(
         start=selected_vector,
         lower=lower,
@@ -2165,7 +2217,7 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
         BackendDiagnosticCounters(
             int(result.nfev),
             None,
-            callback_calls,
+            int(result.nit),
             callback_calls,
             0,
         ),
@@ -2179,15 +2231,15 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
             ),
         ),
     )
-    selected_population_vector = population[order[0]].vector
+    backend_selected_vector = tuple(float(value) for value in result.x)
     qualified = (
         polish_succeeded
         and _solver_matches_truth(definition, polish)
         and all(
             math.isclose(actual, selected, rel_tol=0.0, abs_tol=0.0)
             for actual, selected in zip(
+                backend_selected_vector,
                 selected_vector,
-                selected_population_vector,
                 strict=True,
             )
         )
@@ -2300,9 +2352,16 @@ def _run_finite_difference_probe(
 ) -> NumericalProbeArtifact:
     if _policy_string(definition, "stencil") != "centered-five-point":
         raise ValueError("Finite-difference probe requires its declared stencil")
+    if (
+        _policy_string(definition, "weight_derivation")
+        != "lagrange-first-derivative-at-zero"
+    ):
+        raise ValueError("Finite-difference probe requires Lagrange weights")
     point = _policy_float(definition, "point")
     step = _policy_float(definition, "step")
-    actual_steps = (-2.0 * step, -step, 0.0, step, 2.0 * step)
+    nominal_steps = (-2.0 * step, -step, 0.0, step, 2.0 * step)
+    sample_points = tuple(float(point + displacement) for displacement in nominal_steps)
+    actual_steps = tuple(sample - point for sample in sample_points)
 
     def residual(vector: tuple[float, ...]) -> tuple[float, ...]:
         return (math.exp(vector[0]),)
@@ -2312,17 +2371,35 @@ def _run_finite_difference_probe(
         _budget_value(definition, "objective_requests"),
     )
     sampled = tuple(
-        float(recorder.evaluate((point + displacement,), "solver")[0])
-        for displacement in actual_steps
+        float(recorder.evaluate((sample,), "solver")[0]) for sample in sample_points
     )
-    minus_two, minus_one, _center, plus_one, plus_two = sampled
-    estimate = (minus_two - 8.0 * minus_one + 8.0 * plus_one - plus_two) / (12.0 * step)
+    weights = tuple(
+        math.fsum(
+            math.prod(
+                -actual_steps[other]
+                for other in range(len(actual_steps))
+                if other not in (index, omitted)
+            )
+            / math.prod(
+                actual_steps[index] - actual_steps[other]
+                for other in range(len(actual_steps))
+                if other != index
+            )
+            for omitted in range(len(actual_steps))
+            if omitted != index
+        )
+        for index in range(len(actual_steps))
+    )
+    estimate = math.fsum(
+        weight * value for weight, value in zip(weights, sampled, strict=True)
+    )
     truth = math.exp(point)
     absolute_error = abs(estimate - truth)
     absolute_tolerance = _policy_float(definition, "absolute_tolerance")
     evidence = FiniteDifferenceProbeEvidence(
         point,
         actual_steps,
+        weights,
         sampled,
         truth,
         estimate,
@@ -2617,9 +2694,15 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
             "de-bounded-search-v1",
             "DE_SEARCH",
             parent_case="bounded multimodal basin search",
-            reduction="One selected coordinate retains seeded DE then TRF polish.",
+            reduction=(
+                "One selected coordinate retains oscillatory local basins, seeded DE, "
+                "and separate TRF polish."
+            ),
             truth_kind="ANALYTIC_DERIVATION",
-            truth_reference="f(x)=(x-0.25)^2; unique bounded minimizer x=0.25.",
+            truth_reference=(
+                "f(x)=(x-0.25)^2+0.25 sin^2(5(x-0.25)); its non-negative "
+                "first term makes x=0.25 the unique bounded global minimizer."
+            ),
             eligible_claims=(
                 "de-seeded-replay",
                 "de-to-trf-candidate-ordering",
@@ -2628,6 +2711,8 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
             policy={
                 "de_strategy": "best1bin",
                 "bounds": [[-2.0, 2.0]],
+                "oscillation_amplitude": 0.5,
+                "oscillation_frequency": 5.0,
                 "population_multiplier": 5,
                 "maximum_generations": 6,
                 "mutation": [0.5, 1.0],
@@ -2664,6 +2749,7 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
             ),
             policy={
                 "stencil": "centered-five-point",
+                "weight_derivation": "lagrange-first-derivative-at-zero",
                 "point": 0.5,
                 "step": 1.0e-4,
                 "absolute_tolerance": 1.0e-10,

--- a/src/chemex/optimize/numerical_probes.py
+++ b/src/chemex/optimize/numerical_probes.py
@@ -32,8 +32,10 @@ from chemex.typing import Array
 _SCHEMA_VERSION = 2
 _SEMANTIC_VERSION = "chemex-numerical-probes-v2"
 _SOURCE_REVISION = "700cb71df950fc54c268c0bca199403e5621269d"
+# Frozen from two clean captures in #588's canonical Python 3.13 x86-64 lane
+# (lane 4f1e7dab3384f88149fd33befb09ba3e96730dc336e9427b224a39a8a7167e4f).
 CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY = (
-    "c8052d59d8b648bd0ba55effdd91d86cc18bf68b948faa420450ede3d47b93bf"
+    "cbc5dbc9a0b432b6dbbd053f49769bb4dc84d322c409a84da26f8f892298b839"
 )
 
 type ProbeCategory = Literal[
@@ -2079,18 +2081,10 @@ class NumericalProbeBaseline:
             raise NumericalProbeQualificationError("EXPECTED_REFERENCE_UNAVAILABLE")
         if expected_manifest_identity != CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY:
             raise NumericalProbeQualificationError("EXPECTED_REFERENCE_MISMATCH")
-        if self.manifest_identity != expected_manifest_identity:
-            raise NumericalProbeQualificationError("MANIFEST_MISMATCH")
         required_lane = next(
             lane for lane in canonical_lanes() if lane.role == required_lane_role
         )
         historical = self.historical_qualification == "REFERENCE_MATCHED"
-        if historical and (
-            self.observed_lane_identity != required_lane.identity
-            or self.observed_lane_role != required_lane_role
-            or self.reference_manifest_identity != expected_manifest_identity
-        ):
-            raise NumericalProbeQualificationError("LANE_MISMATCH")
         try:
             _validate_live_lane_authority(
                 authority,
@@ -2108,6 +2102,14 @@ class NumericalProbeBaseline:
                 "LANE_ROLE_MISMATCH" if error.fact == "lane_role" else "LANE_MISMATCH"
             )
             raise NumericalProbeQualificationError(terminal) from error
+        if historical and (
+            self.observed_lane_identity != required_lane.identity
+            or self.observed_lane_role != required_lane_role
+            or self.reference_manifest_identity != expected_manifest_identity
+        ):
+            raise NumericalProbeQualificationError("LANE_MISMATCH")
+        if self.manifest_identity != expected_manifest_identity:
+            raise NumericalProbeQualificationError("MANIFEST_MISMATCH")
 
 
 class NumericalProbeExecutionError(RuntimeError):

--- a/src/chemex/optimize/numerical_probes.py
+++ b/src/chemex/optimize/numerical_probes.py
@@ -13,24 +13,28 @@ import math
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import product
-from typing import Literal, cast
+from typing import Literal, Never, cast
 
 import numpy as np
 from scipy.linalg import svd
 from scipy.optimize import Bounds, OptimizeResult, differential_evolution, least_squares
 
 from chemex.baselines import CanonicalBaselineValue
-from chemex.numerical_lanes import LiveLaneAuthority
+from chemex.numerical_lanes import LaneRole, LiveLaneAuthority
 from chemex.typing import Array
 
-_SCHEMA_VERSION = 1
-_SEMANTIC_VERSION = "chemex-numerical-probes-v1"
+_SCHEMA_VERSION = 2
+_SEMANTIC_VERSION = "chemex-numerical-probes-v2"
 _SOURCE_REVISION = "700cb71df950fc54c268c0bca199403e5621269d"
+CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY = (
+    "c8052d59d8b648bd0ba55effdd91d86cc18bf68b948faa420450ede3d47b93bf"
+)
 
 type ProbeCategory = Literal[
     "TRF_ROUTINE",
     "TRF_DIFFICULT",
     "GRID",
+    "GRID_ORDERING",
     "DE_SEARCH",
     "FINITE_DIFFERENCE",
     "BOUNDS",
@@ -38,6 +42,11 @@ type ProbeCategory = Literal[
     "CONDITIONING",
 ]
 type TruthAuthorityKind = Literal["ANALYTIC_DERIVATION", "EXACT_LINEAR_ALGEBRA"]
+type RequestFailureKind = Literal[
+    "INVALID_INPUT",
+    "EVALUATION_FAILURE",
+    "NON_FINITE_RESULT",
+]
 
 
 def _identity(kind: str, record: object) -> str:
@@ -292,6 +301,7 @@ class NumericalProbeDefinition:
             "TRF_ROUTINE",
             "TRF_DIFFICULT",
             "GRID",
+            "GRID_ORDERING",
             "DE_SEARCH",
             "FINITE_DIFFERENCE",
             "BOUNDS",
@@ -409,44 +419,71 @@ class NumericalProbeDefinition:
 
 
 @dataclass(frozen=True, slots=True)
-class ObjectiveRequestAccounting:
+class AuthoritativeObjectiveAccounting:
     """Authoritative evaluator requests, distinct from backend diagnostics."""
 
     workflow_requests: int
     materialization_requests: int
-    requests_completed: int
+    fresh_evaluations: int
+    cache_served_requests: int
     requests_refused: int
-    cache_hits: int
-    cache_misses: int
+    failure_kinds: tuple[RequestFailureKind, ...]
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         values = (
             self.workflow_requests,
             self.materialization_requests,
-            self.requests_completed,
+            self.fresh_evaluations,
+            self.cache_served_requests,
             self.requests_refused,
-            self.cache_hits,
-            self.cache_misses,
         )
         if any(
             isinstance(value, bool) or not isinstance(value, int) or value < 0
             for value in values
         ):
             raise ValueError("Objective-request counters must be non-negative integers")
-        if self.requests_completed + self.requests_refused != self.requests_received:
+        if any(
+            kind not in {"INVALID_INPUT", "EVALUATION_FAILURE", "NON_FINITE_RESULT"}
+            for kind in self.failure_kinds
+        ):
+            raise ValueError("Unknown authoritative request failure kind")
+        if (
+            self.fresh_evaluations
+            + self.cache_served_requests
+            + self.requests_refused
+            + self.requests_failed
+            != self.requests_received
+        ):
             raise ValueError("Objective requests do not reconcile with terminal counts")
-        if self.cache_hits + self.cache_misses != self.requests_completed:
-            raise ValueError("Objective cache accounting does not reconcile")
         object.__setattr__(
             self,
             "identity",
-            _identity("probe-objective-accounting", values),
+            _identity(
+                "probe-authoritative-objective-accounting",
+                (values, self.failure_kinds),
+            ),
         )
 
     @property
     def requests_received(self) -> int:
         return self.workflow_requests + self.materialization_requests
+
+    @property
+    def requests_completed(self) -> int:
+        return self.fresh_evaluations + self.cache_served_requests
+
+    @property
+    def requests_failed(self) -> int:
+        return len(self.failure_kinds)
+
+    @property
+    def cache_hits(self) -> int:
+        return self.cache_served_requests
+
+    @property
+    def cache_misses(self) -> int:
+        return self.fresh_evaluations
 
     def to_record(self) -> dict[str, object]:
         return {
@@ -454,14 +491,18 @@ class ObjectiveRequestAccounting:
             "materialization_requests": self.materialization_requests,
             "requests_received": self.requests_received,
             "requests_completed": self.requests_completed,
+            "fresh_evaluations": self.fresh_evaluations,
+            "cache_served_requests": self.cache_served_requests,
             "requests_refused": self.requests_refused,
-            "cache_hits": self.cache_hits,
-            "cache_misses": self.cache_misses,
+            "requests_failed": self.requests_failed,
+            "failure_kinds": list(self.failure_kinds),
             "identity": self.identity,
         }
 
     @classmethod
-    def from_record(cls, record: Mapping[str, object]) -> ObjectiveRequestAccounting:
+    def from_record(
+        cls, record: Mapping[str, object]
+    ) -> AuthoritativeObjectiveAccounting:
         _exact_keys(
             record,
             {
@@ -469,13 +510,20 @@ class ObjectiveRequestAccounting:
                 "materialization_requests",
                 "requests_received",
                 "requests_completed",
+                "fresh_evaluations",
+                "cache_served_requests",
                 "requests_refused",
-                "cache_hits",
-                "cache_misses",
+                "requests_failed",
+                "failure_kinds",
                 "identity",
             },
             "Objective request accounting",
         )
+        raw_failures = record.get("failure_kinds")
+        if not isinstance(raw_failures, list) or any(
+            not isinstance(value, str) for value in raw_failures
+        ):
+            raise TypeError("Objective request failure kinds must be strings")
         accounting = cls(
             _record_nonnegative_int(
                 record.get("workflow_requests"), "workflow requests"
@@ -484,19 +532,25 @@ class ObjectiveRequestAccounting:
                 record.get("materialization_requests"),
                 "materialization requests",
             ),
+            _record_nonnegative_int(record.get("fresh_evaluations"), "evaluations"),
             _record_nonnegative_int(
-                record.get("requests_completed"), "completed requests"
+                record.get("cache_served_requests"), "cache-served requests"
             ),
             _record_nonnegative_int(record.get("requests_refused"), "refused requests"),
-            _record_nonnegative_int(record.get("cache_hits"), "cache hits"),
-            _record_nonnegative_int(record.get("cache_misses"), "cache misses"),
+            tuple(cast("list[RequestFailureKind]", raw_failures)),
         )
         if (
             record.get("requests_received") != accounting.requests_received
+            or record.get("requests_completed") != accounting.requests_completed
+            or record.get("requests_failed") != accounting.requests_failed
             or record.get("identity") != accounting.identity
         ):
             raise ValueError("Objective request accounting does not match its payload")
         return accounting
+
+
+# Compatibility name for the initial #591 draft; new code should use the explicit name.
+ObjectiveRequestAccounting = AuthoritativeObjectiveAccounting
 
 
 @dataclass(frozen=True, slots=True)
@@ -667,6 +721,10 @@ class SolverProbeEvidence:
             ),
         )
 
+    @property
+    def authoritative_accounting(self) -> AuthoritativeObjectiveAccounting:
+        return self.objective_accounting
+
     def to_record(self) -> dict[str, object]:
         return {
             "kind": "SOLVER",
@@ -821,7 +879,11 @@ class GridProbeEvidence:
             seed.ordinal
             for seed in sorted(
                 self.seeds,
-                key=lambda seed: (seed.solver.chi_square, seed.ordinal),
+                key=lambda seed: (
+                    seed.solver.chi_square,
+                    seed.solver.accepted,
+                    seed.ordinal,
+                ),
             )
         )
         if self.ordered_seed_ordinals != expected_order:
@@ -845,6 +907,10 @@ class GridProbeEvidence:
                 ),
             ),
         )
+
+    @property
+    def authoritative_accounting(self) -> AuthoritativeObjectiveAccounting:
+        return self.objective_accounting
 
     def to_record(self) -> dict[str, object]:
         return {
@@ -909,6 +975,181 @@ class GridProbeEvidence:
         )
         if record.get("identity") != evidence.identity:
             raise ValueError("GRID evidence identity does not match its payload")
+        return evidence
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class GridOrderingCandidate:
+    """One analytically declared candidate for the GRID ordering contract."""
+
+    ordinal: int
+    final_vector: tuple[float, ...]
+    chi_square: float
+    identity: str = field(init=False, compare=False)
+
+    def __post_init__(self) -> None:
+        _record_nonnegative_int(self.ordinal, "GRID ordering ordinal")
+        _vector_tokens(self.final_vector)
+        if not math.isfinite(self.chi_square) or self.chi_square < 0.0:
+            raise ValueError("GRID ordering chi square must be finite and non-negative")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "grid-ordering-candidate",
+                (
+                    self.ordinal,
+                    _vector_tokens(self.final_vector),
+                    _float_token(self.chi_square),
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "ordinal": self.ordinal,
+            "final_vector": list(_vector_tokens(self.final_vector)),
+            "chi_square": _float_token(self.chi_square),
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> GridOrderingCandidate:
+        _exact_keys(
+            record,
+            {"ordinal", "final_vector", "chi_square", "identity"},
+            "GRID ordering candidate",
+        )
+        candidate = cls(
+            _record_nonnegative_int(record.get("ordinal"), "GRID ordering ordinal"),
+            _vector_from_record(record.get("final_vector"), "GRID final vector"),
+            _float_from_record(record.get("chi_square"), "GRID chi square"),
+        )
+        if record.get("identity") != candidate.identity:
+            raise ValueError("GRID ordering candidate identity does not match payload")
+        return candidate
+
+
+@dataclass(frozen=True, slots=True)
+class GridOrderingProbeEvidence:
+    """Observed ordering retained separately from its predeclared expected truth."""
+
+    candidates: tuple[GridOrderingCandidate, ...]
+    observed_order: tuple[int, ...]
+    expected_order: tuple[int, ...]
+    selected_ordinal: int
+    objective_accounting: ObjectiveRequestAccounting
+    backend_diagnostics: BackendDiagnosticCounters
+    trajectory_fingerprint: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        ordinals = tuple(candidate.ordinal for candidate in self.candidates)
+        if not ordinals or ordinals != tuple(range(len(ordinals))):
+            raise ValueError("GRID ordering candidates must retain ordinal order")
+        if sorted(self.observed_order) != list(ordinals):
+            raise ValueError("Observed GRID ordering must be a candidate permutation")
+        if sorted(self.expected_order) != list(ordinals):
+            raise ValueError("Expected GRID ordering must be a candidate permutation")
+        if self.selected_ordinal != self.observed_order[0]:
+            raise ValueError(
+                "GRID ordering selection must match observed first candidate"
+            )
+        if len(self.trajectory_fingerprint) != 64:
+            raise ValueError("GRID ordering trajectory must be a SHA-256 digest")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "grid-ordering-probe-evidence",
+                (
+                    tuple(candidate.identity for candidate in self.candidates),
+                    self.observed_order,
+                    self.expected_order,
+                    self.selected_ordinal,
+                    self.objective_accounting.identity,
+                    self.backend_diagnostics.identity,
+                    self.trajectory_fingerprint,
+                ),
+            ),
+        )
+
+    @property
+    def authoritative_accounting(self) -> AuthoritativeObjectiveAccounting:
+        return self.objective_accounting
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "kind": "GRID_ORDERING",
+            "candidates": [candidate.to_record() for candidate in self.candidates],
+            "observed_order": list(self.observed_order),
+            "expected_order": list(self.expected_order),
+            "selected_ordinal": self.selected_ordinal,
+            "objective_accounting": self.objective_accounting.to_record(),
+            "backend_diagnostics": self.backend_diagnostics.to_record(),
+            "trajectory_fingerprint": self.trajectory_fingerprint,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> GridOrderingProbeEvidence:
+        _exact_keys(
+            record,
+            {
+                "kind",
+                "candidates",
+                "observed_order",
+                "expected_order",
+                "selected_ordinal",
+                "objective_accounting",
+                "backend_diagnostics",
+                "trajectory_fingerprint",
+                "identity",
+            },
+            "GRID ordering probe evidence",
+        )
+        raw_candidates = record.get("candidates")
+        raw_observed = record.get("observed_order")
+        raw_expected = record.get("expected_order")
+        raw_accounting = record.get("objective_accounting")
+        raw_diagnostics = record.get("backend_diagnostics")
+        if (
+            record.get("kind") != "GRID_ORDERING"
+            or not isinstance(raw_candidates, list)
+            or any(not isinstance(value, Mapping) for value in raw_candidates)
+            or not isinstance(raw_observed, list)
+            or any(not isinstance(value, int) for value in raw_observed)
+            or not isinstance(raw_expected, list)
+            or any(not isinstance(value, int) for value in raw_expected)
+            or not isinstance(raw_accounting, Mapping)
+            or not isinstance(raw_diagnostics, Mapping)
+        ):
+            raise TypeError("Malformed GRID ordering probe evidence")
+        evidence = cls(
+            tuple(
+                GridOrderingCandidate.from_record(
+                    cast("Mapping[str, object]", candidate)
+                )
+                for candidate in raw_candidates
+            ),
+            tuple(cast("list[int]", raw_observed)),
+            tuple(cast("list[int]", raw_expected)),
+            _record_nonnegative_int(
+                record.get("selected_ordinal"), "selected GRID ordering candidate"
+            ),
+            ObjectiveRequestAccounting.from_record(
+                cast("Mapping[str, object]", raw_accounting)
+            ),
+            BackendDiagnosticCounters.from_record(
+                cast("Mapping[str, object]", raw_diagnostics)
+            ),
+            _nonempty_string(
+                record.get("trajectory_fingerprint"),
+                "GRID ordering trajectory fingerprint",
+            ),
+        )
+        if record.get("identity") != evidence.identity:
+            raise ValueError("GRID ordering evidence identity does not match payload")
         return evidence
 
 
@@ -1040,6 +1281,12 @@ class DeProbeEvidence:
                 ),
             ),
         )
+
+    @property
+    def authoritative_search_accounting(
+        self,
+    ) -> AuthoritativeObjectiveAccounting:
+        return self.search_accounting
 
     def to_record(self) -> dict[str, object]:
         return {
@@ -1189,6 +1436,10 @@ class FiniteDifferenceProbeEvidence:
             ),
         )
 
+    @property
+    def authoritative_accounting(self) -> AuthoritativeObjectiveAccounting:
+        return self.objective_accounting
+
     def to_record(self) -> dict[str, object]:
         return {
             "kind": "FINITE_DIFFERENCE",
@@ -1321,6 +1572,10 @@ class SpectralRiskProbeEvidence:
             ),
         )
 
+    @property
+    def authoritative_accounting(self) -> AuthoritativeObjectiveAccounting:
+        return self.objective_accounting
+
     def to_record(self) -> dict[str, object]:
         return {
             "kind": "SPECTRAL_RISK",
@@ -1407,6 +1662,7 @@ class SpectralRiskProbeEvidence:
 type NumericalProbeEvidence = (
     SolverProbeEvidence
     | GridProbeEvidence
+    | GridOrderingProbeEvidence
     | DeProbeEvidence
     | FiniteDifferenceProbeEvidence
     | SpectralRiskProbeEvidence
@@ -1473,6 +1729,8 @@ class NumericalProbeArtifact:
             expected_evidence = SolverProbeEvidence
         elif definition.category == "GRID":
             expected_evidence = GridProbeEvidence
+        elif definition.category == "GRID_ORDERING":
+            expected_evidence = GridOrderingProbeEvidence
         elif definition.category == "DE_SEARCH":
             expected_evidence = DeProbeEvidence
         elif definition.category == "FINITE_DIFFERENCE":
@@ -1491,6 +1749,12 @@ class NumericalProbeArtifact:
             or self.satisfied_claims != definition.eligible_claims
         ):
             raise ValueError("Numerical probe artifact does not qualify its definition")
+        if (
+            definition.category == "GRID_ORDERING"
+            and isinstance(self.evidence, GridOrderingProbeEvidence)
+            and self.evidence.observed_order != self.evidence.expected_order
+        ):
+            raise ValueError("GRID ordering evidence differs from independent truth")
 
     def to_record(self) -> dict[str, object]:
         return {
@@ -1550,6 +1814,10 @@ class NumericalProbeArtifact:
             evidence = GridProbeEvidence.from_record(
                 cast("Mapping[str, object]", raw_evidence)
             )
+        elif evidence_kind == "GRID_ORDERING":
+            evidence = GridOrderingProbeEvidence.from_record(
+                cast("Mapping[str, object]", raw_evidence)
+            )
         elif evidence_kind == "DE_SEARCH":
             evidence = DeProbeEvidence.from_record(
                 cast("Mapping[str, object]", raw_evidence)
@@ -1578,43 +1846,66 @@ class NumericalProbeArtifact:
         return artifact
 
 
+class NumericalProbeQualificationError(RuntimeError):
+    """Typed rejection of evidence at the live lane-qualification seam."""
+
+    def __init__(self, terminal: str) -> None:
+        self.terminal = terminal
+        super().__init__(f"Numerical probe qualification rejected: {terminal}")
+
+
 @dataclass(frozen=True, slots=True)
 class NumericalProbeBaseline:
-    """Closed content-addressed manifest for the complete v1 probe catalogue."""
+    """Serializable observations; live lane authority is always supplied separately."""
 
     definitions: tuple[NumericalProbeDefinition, ...]
     artifacts: tuple[NumericalProbeArtifact, ...]
-    lane_reference: str = "unqualified-local-diagnostic-v1"
-    lane_attestation_identity: str | None = None
-    environment_identity: str | None = None
-    authority_role: Literal["QUALIFIED_LANE", "UNQUALIFIED_DIAGNOSTIC"] = (
-        "UNQUALIFIED_DIAGNOSTIC"
+    observed_lane_identity: str | None = None
+    observed_lane_role: LaneRole | None = None
+    observed_attestation_identity: str | None = None
+    observed_environment_identity: str | None = None
+    reference_manifest_identity: str | None = None
+    historical_qualification: Literal["CAPTURE_ONLY", "REFERENCE_MATCHED"] = (
+        "CAPTURE_ONLY"
     )
     manifest_identity: str = field(init=False)
     identity: str = field(init=False)
 
+    def _validate_historical_observation(self, manifest: str) -> None:
+        observation = (
+            self.observed_lane_identity,
+            self.observed_lane_role,
+            self.observed_attestation_identity,
+            self.observed_environment_identity,
+            self.reference_manifest_identity,
+        )
+        if self.historical_qualification == "CAPTURE_ONLY":
+            if any(value is not None for value in observation):
+                raise ValueError(
+                    "Capture-only numerical evidence cannot claim lane qualification"
+                )
+            return
+        if self.historical_qualification != "REFERENCE_MATCHED":
+            raise ValueError("Unknown numerical probe historical qualification")
+        for value, name in (
+            (self.observed_lane_identity, "observed lane identity"),
+            (self.observed_attestation_identity, "observed attestation identity"),
+            (self.observed_environment_identity, "observed environment identity"),
+            (self.reference_manifest_identity, "reference manifest identity"),
+        ):
+            if not isinstance(value, str) or len(value) != 64:
+                raise ValueError(f"Matched numerical evidence requires {name}")
+        if self.observed_lane_role not in {
+            "CANONICAL_NUMERICAL",
+            "PYTHON_COMPATIBILITY",
+        }:
+            raise ValueError("Matched numerical evidence requires a lane role")
+        if self.reference_manifest_identity != manifest:
+            raise ValueError("Historical reference does not match probe manifest")
+
     def __post_init__(self) -> None:
         definitions = tuple(self.definitions)
         artifacts = tuple(self.artifacts)
-        if self.authority_role == "QUALIFIED_LANE":
-            for value, name in (
-                (self.lane_reference, "lane reference"),
-                (self.lane_attestation_identity, "lane attestation identity"),
-                (self.environment_identity, "environment identity"),
-            ):
-                if not isinstance(value, str) or len(value) != 64:
-                    raise ValueError(f"Qualified probe baseline requires {name}")
-        elif self.authority_role == "UNQUALIFIED_DIAGNOSTIC":
-            if (
-                not self.lane_reference.startswith("unqualified-")
-                or self.lane_attestation_identity is not None
-                or self.environment_identity is not None
-            ):
-                raise ValueError(
-                    "Diagnostic probe baseline cannot carry qualified lane evidence"
-                )
-        else:
-            raise ValueError("Unknown numerical probe baseline authority role")
         if (
             not definitions
             or len(definitions) != len(artifacts)
@@ -1623,6 +1914,10 @@ class NumericalProbeBaseline:
         ):
             raise ValueError(
                 "Probe baseline requires one artifact per unique definition"
+            )
+        if definitions != numerical_probe_definitions():
+            raise ValueError(
+                "Probe baseline does not qualify the canonical probe catalogue"
             )
         for definition, artifact in zip(definitions, artifacts, strict=True):
             artifact.require_qualification(definition)
@@ -1635,17 +1930,16 @@ class NumericalProbeBaseline:
                     artifacts,
                     strict=True,
                 )
-            )
-            + (
-                (
-                    "lane",
-                    self.lane_reference,
-                    self.lane_attestation_identity,
-                    self.environment_identity,
-                    self.authority_role,
-                ),
             ),
         )
+        observation = (
+            self.observed_lane_identity,
+            self.observed_lane_role,
+            self.observed_attestation_identity,
+            self.observed_environment_identity,
+            self.reference_manifest_identity,
+        )
+        self._validate_historical_observation(manifest)
         object.__setattr__(self, "manifest_identity", manifest)
         object.__setattr__(
             self,
@@ -1654,15 +1948,21 @@ class NumericalProbeBaseline:
                 "numerical-probe-baseline",
                 (
                     manifest,
-                    self.lane_reference,
-                    self.lane_attestation_identity,
-                    self.environment_identity,
-                    self.authority_role,
+                    observation,
+                    self.historical_qualification,
                     tuple(definition.identity for definition in definitions),
                     tuple(artifact.identity for artifact in artifacts),
                 ),
             ),
         )
+
+    @property
+    def historically_satisfied_claims(self) -> tuple[str, ...]:
+        """Claims recorded at capture time, never a replacement for live authority."""
+
+        if self.historical_qualification == "REFERENCE_MATCHED":
+            return ("trajectory-manifest-compatible",)
+        return ()
 
     def to_record(self) -> dict[str, object]:
         return {
@@ -1670,10 +1970,12 @@ class NumericalProbeBaseline:
             "semantic_version": _SEMANTIC_VERSION,
             "definitions": [definition.to_record() for definition in self.definitions],
             "artifacts": [artifact.to_record() for artifact in self.artifacts],
-            "lane_reference": self.lane_reference,
-            "lane_attestation_identity": self.lane_attestation_identity,
-            "environment_identity": self.environment_identity,
-            "authority_role": self.authority_role,
+            "observed_lane_identity": self.observed_lane_identity,
+            "observed_lane_role": self.observed_lane_role,
+            "observed_attestation_identity": self.observed_attestation_identity,
+            "observed_environment_identity": self.observed_environment_identity,
+            "reference_manifest_identity": self.reference_manifest_identity,
+            "historical_qualification": self.historical_qualification,
             "manifest_identity": self.manifest_identity,
             "identity": self.identity,
         }
@@ -1687,10 +1989,12 @@ class NumericalProbeBaseline:
                 "semantic_version",
                 "definitions",
                 "artifacts",
-                "lane_reference",
-                "lane_attestation_identity",
-                "environment_identity",
-                "authority_role",
+                "observed_lane_identity",
+                "observed_lane_role",
+                "observed_attestation_identity",
+                "observed_environment_identity",
+                "reference_manifest_identity",
+                "historical_qualification",
                 "manifest_identity",
                 "identity",
             },
@@ -1729,19 +2033,21 @@ class NumericalProbeBaseline:
                 strict=True,
             )
         )
-        authority_role = record.get("authority_role")
-        if authority_role not in {"QUALIFIED_LANE", "UNQUALIFIED_DIAGNOSTIC"}:
-            raise ValueError("Unknown numerical probe baseline authority role")
+        historical = record.get("historical_qualification")
+        if historical not in {"CAPTURE_ONLY", "REFERENCE_MATCHED"}:
+            raise ValueError("Unknown numerical probe historical qualification")
+        lane_role = record.get("observed_lane_role")
+        if lane_role not in {None, "CANONICAL_NUMERICAL", "PYTHON_COMPATIBILITY"}:
+            raise ValueError("Unknown observed numerical lane role")
         baseline = cls(
             definitions,
             artifacts,
-            _nonempty_string(record.get("lane_reference"), "lane reference"),
-            cast("str | None", record.get("lane_attestation_identity")),
-            cast("str | None", record.get("environment_identity")),
-            cast(
-                "Literal['QUALIFIED_LANE', 'UNQUALIFIED_DIAGNOSTIC']",
-                authority_role,
-            ),
+            cast("str | None", record.get("observed_lane_identity")),
+            cast("LaneRole | None", lane_role),
+            cast("str | None", record.get("observed_attestation_identity")),
+            cast("str | None", record.get("observed_environment_identity")),
+            cast("str | None", record.get("reference_manifest_identity")),
+            cast("Literal['CAPTURE_ONLY', 'REFERENCE_MATCHED']", historical),
         )
         if (
             record.get("manifest_identity") != baseline.manifest_identity
@@ -1750,15 +2056,36 @@ class NumericalProbeBaseline:
             raise ValueError("Numerical probe baseline identity does not match payload")
         return baseline
 
-    def require_replay(self, expected_manifest_identity: str) -> None:
+    def require_live_qualification(
+        self,
+        authority: LiveLaneAuthority,
+        *,
+        expected_manifest_identity: str,
+        required_lane_role: LaneRole,
+    ) -> None:
+        """Validate this evidence using #588's exact process-owned capability."""
+
+        if not isinstance(authority, LiveLaneAuthority):
+            raise TypeError("Probe qualification requires live lane authority")
+        evidence = authority.evidence
         if len(expected_manifest_identity) != 64:
-            raise ValueError(
-                "Expected numerical probe manifest must be a SHA-256 digest"
-            )
+            raise ValueError("Expected probe manifest must be a SHA-256 digest")
+        if required_lane_role != "CANONICAL_NUMERICAL":
+            raise NumericalProbeQualificationError("EXPECTED_REFERENCE_UNAVAILABLE")
+        if expected_manifest_identity != CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY:
+            raise NumericalProbeQualificationError("EXPECTED_REFERENCE_MISMATCH")
         if self.manifest_identity != expected_manifest_identity:
-            raise ValueError(
-                "Numerical probe replay differs from the selected manifest"
-            )
+            raise NumericalProbeQualificationError("MANIFEST_MISMATCH")
+        if authority.lane_role != required_lane_role:
+            raise NumericalProbeQualificationError("LANE_ROLE_MISMATCH")
+        if self.historical_qualification == "REFERENCE_MATCHED" and (
+            self.observed_lane_identity != evidence.lane_identity
+            or self.observed_lane_role != authority.lane_role
+            or self.observed_attestation_identity != evidence.identity
+            or self.observed_environment_identity != evidence.environment_identity
+            or self.reference_manifest_identity != expected_manifest_identity
+        ):
+            raise NumericalProbeQualificationError("LANE_MISMATCH")
 
 
 class NumericalProbeExecutionError(RuntimeError):
@@ -1770,11 +2097,13 @@ class NumericalProbeExecutionError(RuntimeError):
         terminal: str,
         accounting: ObjectiveRequestAccounting,
         trajectory_fingerprint: str,
+        failure_kind: RequestFailureKind | None = None,
     ) -> None:
         self.definition_identity = definition_identity
         self.terminal = terminal
         self.accounting = accounting
         self.trajectory_fingerprint = trajectory_fingerprint
+        self.failure_kind = failure_kind
         super().__init__(f"Numerical probe terminated: {terminal}")
 
 
@@ -1789,6 +2118,34 @@ class _ProbeBudgetExhausted(RuntimeError):
         super().__init__("Probe objective-request budget exhausted")
 
 
+class _ProbeRequestFailed(RuntimeError):
+    def __init__(
+        self,
+        accounting: ObjectiveRequestAccounting,
+        trajectory_fingerprint: str,
+        failure_kind: RequestFailureKind,
+    ) -> None:
+        self.accounting = accounting
+        self.trajectory_fingerprint = trajectory_fingerprint
+        self.failure_kind = failure_kind
+        super().__init__("Authoritative probe objective request failed")
+
+
+class _ProbeBackendFailed(RuntimeError):
+    pass
+
+
+class _ProbeBackendExecutionFailed(RuntimeError):
+    def __init__(
+        self,
+        accounting: ObjectiveRequestAccounting,
+        trajectory_fingerprint: str,
+    ) -> None:
+        self.accounting = accounting
+        self.trajectory_fingerprint = trajectory_fingerprint
+        super().__init__("Probe backend execution failed")
+
+
 class _ObjectiveRecorder:
     def __init__(
         self,
@@ -1801,10 +2158,19 @@ class _ObjectiveRecorder:
         self._trace: list[object] = []
         self.workflow_requests = 0
         self.materialization_requests = 0
-        self.completed = 0
+        self.fresh_evaluations = 0
+        self.cache_served_requests = 0
         self.refused = 0
-        self.cache_hits = 0
-        self.cache_misses = 0
+        self.failure_kinds: list[RequestFailureKind] = []
+
+    def _fail(self, source: str, failure_kind: RequestFailureKind) -> Never:
+        self.failure_kinds.append(failure_kind)
+        self._trace.append((source, "failed", failure_kind))
+        raise _ProbeRequestFailed(
+            self.accounting,
+            self.trajectory_fingerprint,
+            failure_kind,
+        )
 
     def evaluate(self, vector: Array | Sequence[float], source: str) -> Array:
         if source == "solver":
@@ -1813,9 +2179,12 @@ class _ObjectiveRecorder:
             self.materialization_requests += 1
         else:
             raise ValueError("Unknown probe objective request source")
-        candidate = tuple(float(value) for value in vector)
-        key = _vector_tokens(candidate)
-        if self.completed >= self._budget:
+        try:
+            candidate = tuple(float(value) for value in vector)
+            key = _vector_tokens(candidate)
+        except (TypeError, ValueError, OverflowError):
+            self._fail(source, "INVALID_INPUT")
+        if self.requests_completed >= self._budget:
             self.refused += 1
             self._trace.append((source, key, "budget_refused"))
             raise _ProbeBudgetExhausted(
@@ -1825,31 +2194,76 @@ class _ObjectiveRecorder:
         cached = self._cache.get(key)
         disposition = "cache_hit"
         if cached is None:
-            cached = tuple(float(value) for value in self._residual(candidate))
-            _vector_tokens(cached)
+            try:
+                raw_result = self._residual(candidate)
+            except (
+                ArithmeticError,
+                LookupError,
+                RuntimeError,
+                TypeError,
+                ValueError,
+            ) as error:
+                try:
+                    self._fail(source, "EVALUATION_FAILURE")
+                except _ProbeRequestFailed as failure:
+                    raise failure from error
+            try:
+                cached = tuple(float(value) for value in raw_result)
+                _vector_tokens(cached)
+            except (TypeError, ValueError, OverflowError):
+                self._fail(source, "NON_FINITE_RESULT")
             self._cache[key] = cached
-            self.cache_misses += 1
+            self.fresh_evaluations += 1
             disposition = "cache_miss"
         else:
-            self.cache_hits += 1
-        self.completed += 1
+            self.cache_served_requests += 1
         self._trace.append((source, key, disposition, _vector_tokens(cached)))
         return np.asarray(cached, dtype=np.float64)
+
+    @property
+    def requests_completed(self) -> int:
+        return self.fresh_evaluations + self.cache_served_requests
 
     @property
     def accounting(self) -> ObjectiveRequestAccounting:
         return ObjectiveRequestAccounting(
             self.workflow_requests,
             self.materialization_requests,
-            self.completed,
+            self.fresh_evaluations,
+            self.cache_served_requests,
             self.refused,
-            self.cache_hits,
-            self.cache_misses,
+            tuple(self.failure_kinds),
         )
 
     @property
     def trajectory_fingerprint(self) -> str:
         return _identity("probe-objective-trajectory", tuple(self._trace))
+
+
+class _BackendObjectiveAdapter:
+    """Count SciPy calls without granting them ChemEx request authority."""
+
+    def __init__(
+        self,
+        residual: Callable[[tuple[float, ...]], tuple[float, ...]],
+        budget: int,
+    ) -> None:
+        self._residual = residual
+        self._budget = budget
+        self.calls = 0
+
+    def evaluate(self, vector: Array | Sequence[float]) -> Array:
+        if self.calls >= self._budget:
+            raise _ProbeBackendFailed
+        self.calls += 1
+        try:
+            candidate = tuple(float(value) for value in vector)
+            values = tuple(float(value) for value in self._residual(candidate))
+            _vector_tokens(candidate)
+            _vector_tokens(values)
+        except Exception as error:
+            raise _ProbeBackendFailed from error
+        return np.asarray(values, dtype=np.float64)
 
 
 def _budget_value(definition: NumericalProbeDefinition, field_name: str) -> int:
@@ -1894,25 +2308,34 @@ def _least_squares_evidence(
     lower: tuple[float, ...],
     upper: tuple[float, ...],
     residual: Callable[[tuple[float, ...]], tuple[float, ...]],
-    budget: int,
+    authoritative_budget: int,
+    backend_max_nfev: int,
     settings: _TrfSettings,
 ) -> tuple[SolverProbeEvidence, bool]:
-    recorder = _ObjectiveRecorder(residual, budget)
+    recorder = _ObjectiveRecorder(residual, authoritative_budget)
+    recorder.evaluate(start, "solver")
+    backend = _BackendObjectiveAdapter(residual, backend_max_nfev * (len(start) + 1))
 
-    result = least_squares(
-        lambda vector: recorder.evaluate(vector, "solver"),
-        np.asarray(start, dtype=np.float64),
-        bounds=(
-            np.asarray(lower, dtype=np.float64),
-            np.asarray(upper, dtype=np.float64),
-        ),
-        method="trf",
-        ftol=settings.ftol,
-        xtol=settings.xtol,
-        gtol=settings.gtol,
-        x_scale=settings.x_scale,
-        max_nfev=budget,
-    )
+    try:
+        result = least_squares(
+            backend.evaluate,
+            np.asarray(start, dtype=np.float64),
+            bounds=(
+                np.asarray(lower, dtype=np.float64),
+                np.asarray(upper, dtype=np.float64),
+            ),
+            method="trf",
+            ftol=settings.ftol,
+            xtol=settings.xtol,
+            gtol=settings.gtol,
+            x_scale=settings.x_scale,
+            max_nfev=backend_max_nfev,
+        )
+    except Exception as error:
+        raise _ProbeBackendExecutionFailed(
+            recorder.accounting,
+            recorder.trajectory_fingerprint,
+        ) from error
     accepted = tuple(float(value) for value in result.x)
     residuals = tuple(
         float(value) for value in recorder.evaluate(accepted, "materialization")
@@ -1937,7 +2360,7 @@ def _least_squares_evidence(
                 None if result.njev is None else int(result.njev),
                 None,
                 0,
-                0,
+                backend.calls,
             ),
             recorder.trajectory_fingerprint,
             candidate_fingerprint,
@@ -1952,10 +2375,10 @@ def _sum_accounting(
     return ObjectiveRequestAccounting(
         sum(item.workflow_requests for item in accounting),
         sum(item.materialization_requests for item in accounting),
-        sum(item.requests_completed for item in accounting),
+        sum(item.fresh_evaluations for item in accounting),
+        sum(item.cache_served_requests for item in accounting),
         sum(item.requests_refused for item in accounting),
-        sum(item.cache_hits for item in accounting),
-        sum(item.cache_misses for item in accounting),
+        tuple(kind for item in accounting for kind in item.failure_kinds),
     )
 
 
@@ -2032,7 +2455,10 @@ def _run_solver_probe(
         lower=lower,
         upper=upper,
         residual=residual,
-        budget=_budget_value(definition, "objective_requests"),
+        authoritative_budget=_budget_value(
+            definition, "authoritative_objective_requests"
+        ),
+        backend_max_nfev=_budget_value(definition, "backend_max_nfev"),
         settings=_TrfSettings.from_definition(definition),
     )
     qualified = succeeded and _solver_matches_truth(definition, evidence)
@@ -2069,7 +2495,10 @@ def _run_grid_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtif
             lower=lower,
             upper=upper,
             residual=residual,
-            budget=_budget_value(definition, "objective_requests_per_seed"),
+            authoritative_budget=_budget_value(
+                definition, "authoritative_objective_requests_per_seed"
+            ),
+            backend_max_nfev=_budget_value(definition, "backend_max_nfev_per_seed"),
             settings=_TrfSettings.from_definition(definition),
         )
         seeds.append(
@@ -2085,7 +2514,11 @@ def _run_grid_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtif
         seed.ordinal
         for seed in sorted(
             seed_evidence,
-            key=lambda seed: (seed.solver.chi_square, seed.ordinal),
+            key=lambda seed: (
+                seed.solver.chi_square,
+                seed.solver.accepted,
+                seed.ordinal,
+            ),
         )
     )
     evidence = GridProbeEvidence(
@@ -2122,6 +2555,81 @@ def _run_grid_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtif
     return artifact
 
 
+def _run_grid_ordering_probe(
+    definition: NumericalProbeDefinition,
+) -> NumericalProbeArtifact:
+    raw_candidates = _policy_record(definition).get("candidates")
+    if not isinstance(raw_candidates, list) or any(
+        not isinstance(value, Mapping) for value in raw_candidates
+    ):
+        raise TypeError("GRID ordering policy candidates must be records")
+    candidates: list[GridOrderingCandidate] = []
+    for index, raw_candidate in enumerate(raw_candidates):
+        candidate_record = cast("Mapping[str, object]", raw_candidate)
+        _exact_keys(
+            candidate_record,
+            {"ordinal", "final_vector", "chi_square"},
+            f"GRID ordering policy candidate {index}",
+        )
+        candidates.append(
+            GridOrderingCandidate(
+                _record_nonnegative_int(
+                    candidate_record.get("ordinal"), "GRID ordering ordinal"
+                ),
+                _semantic_vector(
+                    candidate_record.get("final_vector"),
+                    f"GRID ordering final_vector[{index}]",
+                ),
+                _semantic_float(
+                    candidate_record.get("chi_square"),
+                    f"GRID ordering chi_square[{index}]",
+                ),
+            )
+        )
+    candidate_evidence = tuple(candidates)
+    if len(candidate_evidence) != _budget_value(definition, "candidate_count"):
+        raise ValueError("GRID ordering policy differs from its declared budget")
+    if _policy_string(definition, "candidate_tie_break") != (
+        "chi-square-then-final-vector-then-seed-ordinal"
+    ):
+        raise ValueError("GRID ordering policy selects an unsupported tie break")
+    observed_order = tuple(
+        candidate.ordinal
+        for candidate in sorted(
+            candidate_evidence,
+            key=lambda candidate: (
+                candidate.chi_square,
+                candidate.final_vector,
+                candidate.ordinal,
+            ),
+        )
+    )
+    expected_order = _policy_int_vector(definition, "expected_order")
+    evidence = GridOrderingProbeEvidence(
+        candidate_evidence,
+        observed_order,
+        expected_order,
+        observed_order[0],
+        ObjectiveRequestAccounting(0, 0, 0, 0, 0, ()),
+        BackendDiagnosticCounters(0, None, None, 0, 0),
+        _identity(
+            "grid-ordering-trajectory",
+            tuple(candidate.identity for candidate in candidate_evidence),
+        ),
+    )
+    qualified = observed_order == expected_order
+    artifact = NumericalProbeArtifact(
+        definition.identity,
+        definition.probe_id,
+        "ORDERED" if qualified else "ORDERING_MISMATCH",
+        (),
+        definition.eligible_claims if qualified else (),
+        evidence,
+    )
+    artifact.validate_definition(definition)
+    return artifact
+
+
 def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifact:
     root_seed = definition.seed.to_record_value()
     if isinstance(root_seed, bool) or not isinstance(root_seed, int):
@@ -2138,11 +2646,15 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
 
     search_recorder = _ObjectiveRecorder(
         residual,
-        _budget_value(definition, "de_objective_requests"),
+        _budget_value(definition, "de_authoritative_objective_requests"),
+    )
+    backend = _BackendObjectiveAdapter(
+        residual,
+        _budget_value(definition, "de_backend_objective_calls"),
     )
 
     def objective(vector: Array) -> float:
-        values = search_recorder.evaluate(vector, "solver")
+        values = backend.evaluate(vector)
         return float(np.dot(values, values))
 
     callback_calls = 0
@@ -2160,24 +2672,31 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
     strategy = _policy_string(definition, "de_strategy")
     if strategy != "best1bin":
         raise ValueError("DE probe policy selects an unsupported strategy")
-    result = differential_evolution(
-        objective,
-        Bounds(np.asarray(lower), np.asarray(upper)),
-        strategy="best1bin",
-        maxiter=_policy_int(definition, "maximum_generations"),
-        popsize=_policy_int(definition, "population_multiplier"),
-        mutation=mutation,
-        recombination=_policy_float(definition, "recombination"),
-        tol=_policy_float(definition, "relative_tolerance"),
-        atol=_policy_float(definition, "absolute_tolerance"),
-        polish=_policy_bool(definition, "backend_polish"),
-        rng=np.random.default_rng(root_seed),
-        updating=cast(
-            "Literal['immediate', 'deferred']", _policy_string(definition, "updating")
-        ),
-        workers=_policy_int(definition, "workers"),
-        callback=count_callback,
-    )
+    try:
+        result = differential_evolution(
+            objective,
+            Bounds(np.asarray(lower), np.asarray(upper)),
+            strategy="best1bin",
+            maxiter=_policy_int(definition, "maximum_generations"),
+            popsize=_policy_int(definition, "population_multiplier"),
+            mutation=mutation,
+            recombination=_policy_float(definition, "recombination"),
+            tol=_policy_float(definition, "relative_tolerance"),
+            atol=_policy_float(definition, "absolute_tolerance"),
+            polish=_policy_bool(definition, "backend_polish"),
+            rng=np.random.default_rng(root_seed),
+            updating=cast(
+                "Literal['immediate', 'deferred']",
+                _policy_string(definition, "updating"),
+            ),
+            workers=_policy_int(definition, "workers"),
+            callback=count_callback,
+        )
+    except Exception as error:
+        raise _ProbeBackendExecutionFailed(
+            search_recorder.accounting,
+            search_recorder.trajectory_fingerprint,
+        ) from error
     population = tuple(
         DePopulationCandidate(
             index,
@@ -2205,7 +2724,10 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
         lower=lower,
         upper=upper,
         residual=residual,
-        budget=_budget_value(definition, "trf_objective_requests"),
+        authoritative_budget=_budget_value(
+            definition, "trf_authoritative_objective_requests"
+        ),
+        backend_max_nfev=_budget_value(definition, "trf_backend_max_nfev"),
         settings=_TrfSettings.from_definition(definition, "polish_"),
     )
     evidence = DeProbeEvidence(
@@ -2219,7 +2741,7 @@ def _run_de_probe(definition: NumericalProbeDefinition) -> NumericalProbeArtifac
             None,
             int(result.nit),
             callback_calls,
-            0,
+            backend.calls,
         ),
         polish,
         _identity(
@@ -2368,7 +2890,7 @@ def _run_finite_difference_probe(
 
     recorder = _ObjectiveRecorder(
         residual,
-        _budget_value(definition, "objective_requests"),
+        _budget_value(definition, "authoritative_objective_requests"),
     )
     sampled = tuple(
         float(recorder.evaluate((sample,), "solver")[0]) for sample in sample_points
@@ -2465,7 +2987,7 @@ def _run_spectral_risk_probe(
         condition,
         condition_limit,
         risks,
-        ObjectiveRequestAccounting(0, 0, 0, 0, 0, 0),
+        ObjectiveRequestAccounting(0, 0, 0, 0, 0, ()),
         BackendDiagnosticCounters(0, None, None, 0, 1),
         _identity(
             "spectral-probe-trajectory",
@@ -2525,6 +3047,7 @@ def run_numerical_probe(
         "TRF_ROUTINE": _run_solver_probe,
         "TRF_DIFFICULT": _run_solver_probe,
         "GRID": _run_grid_probe,
+        "GRID_ORDERING": _run_grid_ordering_probe,
         "DE_SEARCH": _run_de_probe,
         "FINITE_DIFFERENCE": _run_finite_difference_probe,
         "BOUNDS": _run_solver_probe,
@@ -2540,33 +3063,55 @@ def run_numerical_probe(
             error.accounting,
             error.trajectory_fingerprint,
         ) from error
+    except _ProbeRequestFailed as error:
+        raise NumericalProbeExecutionError(
+            definition.identity,
+            "REQUEST_FAILED",
+            error.accounting,
+            error.trajectory_fingerprint,
+            error.failure_kind,
+        ) from error
+    except _ProbeBackendExecutionFailed as error:
+        raise NumericalProbeExecutionError(
+            definition.identity,
+            "BACKEND_FAILURE",
+            error.accounting,
+            error.trajectory_fingerprint,
+        ) from error
 
 
 def run_numerical_probe_baseline(
     authority: LiveLaneAuthority | None = None,
     *,
     expected_manifest_identity: str | None = None,
+    required_lane_role: LaneRole = "CANONICAL_NUMERICAL",
 ) -> NumericalProbeBaseline:
-    """Execute the closed v1 catalogue into one immutable typed manifest."""
+    """Capture the closed catalogue and optionally record a live-qualified replay."""
     definitions = numerical_probe_definitions()
     artifacts = tuple(run_numerical_probe(definition) for definition in definitions)
+    capture = NumericalProbeBaseline(definitions, artifacts)
+    if expected_manifest_identity is None:
+        return capture
     if authority is None:
-        baseline = NumericalProbeBaseline(definitions, artifacts)
-    else:
-        if not isinstance(authority, LiveLaneAuthority):
-            raise TypeError("Qualified numerical probes require live lane authority")
-        evidence = authority.evidence
-        baseline = NumericalProbeBaseline(
-            definitions,
-            artifacts,
-            evidence.lane_identity,
-            evidence.identity,
-            evidence.environment_identity,
-            "QUALIFIED_LANE",
+        raise TypeError(
+            "Qualified numerical replay requires live authority and expected manifest"
         )
-    if expected_manifest_identity is not None:
-        baseline.require_replay(expected_manifest_identity)
-    return baseline
+    capture.require_live_qualification(
+        authority,
+        expected_manifest_identity=expected_manifest_identity,
+        required_lane_role=required_lane_role,
+    )
+    evidence = authority.evidence
+    return NumericalProbeBaseline(
+        definitions,
+        artifacts,
+        evidence.lane_identity,
+        authority.lane_role,
+        evidence.identity,
+        evidence.environment_identity,
+        expected_manifest_identity,
+        "REFERENCE_MATCHED",
+    )
 
 
 def _definition(
@@ -2633,7 +3178,10 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 "truth_absolute_tolerance": 1.0e-8,
                 "maximum_chi_square": 1.0e-16,
             },
-            budget={"objective_requests": 64},
+            budget={
+                "authoritative_objective_requests": 2,
+                "backend_max_nfev": 64,
+            },
             seed="not-applicable",
             terminal="CONVERGED",
         ),
@@ -2657,19 +3205,21 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 "truth_absolute_tolerance": 1.0e-8,
                 "maximum_chi_square": 1.0e-16,
             },
-            budget={"objective_requests": 256},
+            budget={
+                "authoritative_objective_requests": 2,
+                "backend_max_nfev": 256,
+            },
             seed="not-applicable",
             terminal="CONVERGED",
         ),
         _definition(
-            "grid-27-seed-ordering-v1",
+            "grid-27-seed-coverage-v1",
             "GRID",
             parent_case="immutable 27-seed physical-coordinate grid",
-            reduction="Three three-point axes retain Cartesian order and tie policy.",
+            reduction="Three three-point axes retain complete Cartesian seed coverage.",
             truth_kind="ANALYTIC_DERIVATION",
             truth_reference="r(x,y,z)=(x-1,y+1,z-0.5); unique zero=(1,-1,0.5).",
             eligible_claims=(
-                "canonical-grid-candidate-ordering",
                 "grid-seed-coverage",
                 "solver-request-accounting",
             ),
@@ -2686,9 +3236,44 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 "truth_absolute_tolerance": 1.0e-8,
                 "maximum_chi_square": 1.0e-16,
             },
-            budget={"objective_requests_per_seed": 48, "seed_count": 27},
+            budget={
+                "authoritative_objective_requests_per_seed": 2,
+                "backend_max_nfev_per_seed": 48,
+                "seed_count": 27,
+            },
             seed="not-applicable",
             terminal="SELECTED",
+        ),
+        _definition(
+            "grid-candidate-ordering-v1",
+            "GRID_ORDERING",
+            parent_case="four-candidate deterministic GRID selection",
+            reduction=(
+                "Four analytically scored candidates isolate chi-square, final-vector, "
+                "and seed-ordinal ordering."
+            ),
+            truth_kind="ANALYTIC_DERIVATION",
+            truth_reference=(
+                "Candidates (ordinal,chi2,vector)=(0,1,(1,0)),(1,0,(0,0)),"
+                "(2,1,(0,1)),(3,1,(-1,0)); lexicographic ordering by "
+                "(chi2,vector,ordinal) is exactly (1,3,2,0)."
+            ),
+            eligible_claims=("canonical-grid-candidate-ordering",),
+            policy={
+                "candidate_tie_break": (
+                    "chi-square-then-final-vector-then-seed-ordinal"
+                ),
+                "candidates": [
+                    {"ordinal": 0, "chi_square": 1.0, "final_vector": [1.0, 0.0]},
+                    {"ordinal": 1, "chi_square": 0.0, "final_vector": [0.0, 0.0]},
+                    {"ordinal": 2, "chi_square": 1.0, "final_vector": [0.0, 1.0]},
+                    {"ordinal": 3, "chi_square": 1.0, "final_vector": [-1.0, 0.0]},
+                ],
+                "expected_order": [1, 3, 2, 0],
+            },
+            budget={"candidate_count": 4},
+            seed="not-applicable",
+            terminal="ORDERED",
         ),
         _definition(
             "de-bounded-search-v1",
@@ -2731,7 +3316,12 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 "truth_absolute_tolerance": 1.0e-8,
                 "maximum_chi_square": 1.0e-16,
             },
-            budget={"de_objective_requests": 128, "trf_objective_requests": 48},
+            budget={
+                "de_authoritative_objective_requests": 5,
+                "de_backend_objective_calls": 128,
+                "trf_authoritative_objective_requests": 2,
+                "trf_backend_max_nfev": 48,
+            },
             seed=591,
             terminal="POLISHED",
         ),
@@ -2754,7 +3344,7 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 "step": 1.0e-4,
                 "absolute_tolerance": 1.0e-10,
             },
-            budget={"objective_requests": 5},
+            budget={"authoritative_objective_requests": 5},
             seed="not-applicable",
             terminal="RELIABLE",
         ),
@@ -2778,7 +3368,10 @@ def numerical_probe_definitions() -> tuple[NumericalProbeDefinition, ...]:
                 "truth_absolute_tolerance": 1.0e-8,
                 "expected_active_mask": [1],
             },
-            budget={"objective_requests": 64},
+            budget={
+                "authoritative_objective_requests": 2,
+                "backend_max_nfev": 64,
+            },
             seed="not-applicable",
             terminal="CONVERGED",
             required_risks=("ACTIVE_BOUND",),

--- a/src/chemex/optimize/numerical_probes.py
+++ b/src/chemex/optimize/numerical_probes.py
@@ -20,7 +20,13 @@ from scipy.linalg import svd
 from scipy.optimize import Bounds, OptimizeResult, differential_evolution, least_squares
 
 from chemex.baselines import CanonicalBaselineValue
-from chemex.numerical_lanes import LaneRole, LiveLaneAuthority, canonical_lanes
+from chemex.numerical_lanes import (
+    LaneRole,
+    LiveLaneAuthority,
+    _LiveLaneAuthorityMismatch,
+    _validate_live_lane_authority,
+    canonical_lanes,
+)
 from chemex.typing import Array
 
 _SCHEMA_VERSION = 2
@@ -2067,7 +2073,6 @@ class NumericalProbeBaseline:
 
         if not isinstance(authority, LiveLaneAuthority):
             raise TypeError("Probe qualification requires live lane authority")
-        evidence = authority.evidence
         if len(expected_manifest_identity) != 64:
             raise ValueError("Expected probe manifest must be a SHA-256 digest")
         if required_lane_role != "CANONICAL_NUMERICAL":
@@ -2076,21 +2081,33 @@ class NumericalProbeBaseline:
             raise NumericalProbeQualificationError("EXPECTED_REFERENCE_MISMATCH")
         if self.manifest_identity != expected_manifest_identity:
             raise NumericalProbeQualificationError("MANIFEST_MISMATCH")
-        if authority.lane_role != required_lane_role:
-            raise NumericalProbeQualificationError("LANE_ROLE_MISMATCH")
         required_lane = next(
             lane for lane in canonical_lanes() if lane.role == required_lane_role
         )
-        if authority.lane_identity != required_lane.identity:
-            raise NumericalProbeQualificationError("LANE_MISMATCH")
-        if self.historical_qualification == "REFERENCE_MATCHED" and (
-            self.observed_lane_identity != evidence.lane_identity
-            or self.observed_lane_role != authority.lane_role
-            or self.observed_attestation_identity != evidence.identity
-            or self.observed_environment_identity != evidence.environment_identity
+        historical = self.historical_qualification == "REFERENCE_MATCHED"
+        if historical and (
+            self.observed_lane_identity != required_lane.identity
+            or self.observed_lane_role != required_lane_role
             or self.reference_manifest_identity != expected_manifest_identity
         ):
             raise NumericalProbeQualificationError("LANE_MISMATCH")
+        try:
+            _validate_live_lane_authority(
+                authority,
+                required_lane_identity=required_lane.identity,
+                required_lane_role=required_lane_role,
+                required_attestation_identity=(
+                    self.observed_attestation_identity if historical else None
+                ),
+                required_environment_identity=(
+                    self.observed_environment_identity if historical else None
+                ),
+            )
+        except _LiveLaneAuthorityMismatch as error:
+            terminal = (
+                "LANE_ROLE_MISMATCH" if error.fact == "lane_role" else "LANE_MISMATCH"
+            )
+            raise NumericalProbeQualificationError(terminal) from error
 
 
 class NumericalProbeExecutionError(RuntimeError):
@@ -3100,12 +3117,12 @@ def run_numerical_probe_baseline(
         expected_manifest_identity=expected_manifest_identity,
         required_lane_role=required_lane_role,
     )
-    evidence = authority.evidence
+    evidence = _validate_live_lane_authority(authority)
     return NumericalProbeBaseline(
         definitions,
         artifacts,
         evidence.lane_identity,
-        authority.lane_role,
+        required_lane_role,
         evidence.identity,
         evidence.environment_identity,
         expected_manifest_identity,

--- a/tests/fixtures/canonical_numerical_probe_baseline.json
+++ b/tests/fixtures/canonical_numerical_probe_baseline.json
@@ -1,0 +1,3239 @@
+{
+  "artifacts": [
+    {
+      "definition_identity": "3a9caa3e786d4d6af3143a27a3f5fd26186157fc52cc501045e1611232e8614f",
+      "evidence": {
+        "accepted": [
+          "0x1.7fffffffffef9p+0",
+          "-0x1.0000000000000p-1"
+        ],
+        "active_mask": [
+          0,
+          0
+        ],
+        "backend_diagnostics": {
+          "callback_calls": 0,
+          "diagnostic_evaluations": 18,
+          "identity": "6141cad49187cfd70835c78f9dc7a1c7fce77dcf655f1eba99b4abd8b7fbe19c",
+          "iterations": null,
+          "nfev": 6,
+          "njev": 6
+        },
+        "candidate_fingerprint": "4c17b4c45ee5757fd02b116817885a250bea490274efe5c5771357768a9cb2d2",
+        "chi_square": "0x1.0e31000000000p-88",
+        "identity": "8f1fde50e068bca92aafb7a08f8801c4f3e4de16ddc3fe6b1e9acc1b0d1cfd5c",
+        "kind": "SOLVER",
+        "lower_bounds": [
+          "-0x1.0000000000000p+2",
+          "-0x1.0000000000000p+2"
+        ],
+        "objective_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 2,
+          "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+          "materialization_requests": 1,
+          "requests_completed": 2,
+          "requests_failed": 0,
+          "requests_received": 2,
+          "requests_refused": 0,
+          "workflow_requests": 1
+        },
+        "residuals": [
+          "-0x1.0700000000000p-44",
+          "0x0.0p+0"
+        ],
+        "start": [
+          "0x0.0p+0",
+          "0x0.0p+0"
+        ],
+        "trajectory_fingerprint": "d3fed7502fda0e7f5088ff608c5585717ad627b3dc6fc593fe253d83e0dda140",
+        "upper_bounds": [
+          "0x1.0000000000000p+2",
+          "0x1.0000000000000p+2"
+        ]
+      },
+      "identity": "b0c2c2da92eceea253d4b07d776492fa0a4338a2476b37aa4ff003e5e4cbf295",
+      "probe_id": "trf-routine-quadratic-v1",
+      "risks": [],
+      "satisfied_claims": [
+        "deterministic-trajectory-fingerprint",
+        "routine-trf-convergence",
+        "solver-request-accounting"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "CONVERGED"
+    },
+    {
+      "definition_identity": "77d6de95605268c0d2049cc746e70c807d0aebd808d3b8dbcb96e38616703954",
+      "evidence": {
+        "accepted": [
+          "0x1.0000000000000p+0",
+          "0x1.0000000000000p+0"
+        ],
+        "active_mask": [
+          0,
+          0
+        ],
+        "backend_diagnostics": {
+          "callback_calls": 0,
+          "diagnostic_evaluations": 58,
+          "identity": "7a5fe97ad85a11de041a076cb117a57b7ab580d44d865b0b534675e1fe8cacc6",
+          "iterations": null,
+          "nfev": 20,
+          "njev": 19
+        },
+        "candidate_fingerprint": "be58104409637e1eea6d66040ab20191b577744084af40c3821d7f867aac32d6",
+        "chi_square": "0x0.0p+0",
+        "identity": "a4a0aabac0fa45997fe450b86c4f7f668515cb0f76bc8859155ffaa79fe978bf",
+        "kind": "SOLVER",
+        "lower_bounds": [
+          "-0x1.8000000000000p+1",
+          "-0x1.8000000000000p+1"
+        ],
+        "objective_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 2,
+          "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+          "materialization_requests": 1,
+          "requests_completed": 2,
+          "requests_failed": 0,
+          "requests_received": 2,
+          "requests_refused": 0,
+          "workflow_requests": 1
+        },
+        "residuals": [
+          "0x0.0p+0",
+          "0x0.0p+0"
+        ],
+        "start": [
+          "-0x1.3333333333333p+0",
+          "0x1.0000000000000p+0"
+        ],
+        "trajectory_fingerprint": "767526074473a958ffba29c103167d26fc2944e2a0a4fee128e6895e9d93169a",
+        "upper_bounds": [
+          "0x1.8000000000000p+1",
+          "0x1.8000000000000p+1"
+        ]
+      },
+      "identity": "3aa26c5ab875a2b130147ef3aa2915177cfb1637fbf74f33b3fbfd2b00936731",
+      "probe_id": "trf-difficult-rosenbrock-v1",
+      "risks": [],
+      "satisfied_claims": [
+        "deterministic-trajectory-fingerprint",
+        "difficult-trf-convergence",
+        "solver-request-accounting"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "CONVERGED"
+    },
+    {
+      "definition_identity": "a8404a6445c124a520a9b4c0322bb991bb4df202efa8184f6d3b29047610e404",
+      "evidence": {
+        "backend_diagnostics": {
+          "callback_calls": 0,
+          "diagnostic_evaluations": 724,
+          "identity": "24b07d04cb9ad176cc9d5658be60ca6a5f5d9fed1c82b2b056bb6899766f5846",
+          "iterations": null,
+          "nfev": 181,
+          "njev": 181
+        },
+        "identity": "a2675b301c04670684d7373a581d969664dcbc8d3b56362e5a52db2af3086d7c",
+        "kind": "GRID",
+        "objective_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 54,
+          "identity": "db9e95f28ec8025b0284021e2491e707c30df814e96a957a72b77397d83a973b",
+          "materialization_requests": 27,
+          "requests_completed": 54,
+          "requests_failed": 0,
+          "requests_received": 54,
+          "requests_refused": 0,
+          "workflow_requests": 27
+        },
+        "ordered_seed_ordinals": [
+          9,
+          12,
+          18,
+          19,
+          21,
+          20,
+          10,
+          22,
+          11,
+          23,
+          13,
+          14,
+          0,
+          1,
+          2,
+          3,
+          5,
+          15,
+          17,
+          24,
+          25,
+          26,
+          6,
+          7,
+          8,
+          4,
+          16
+        ],
+        "seeds": [
+          {
+            "identity": "4073fd6dc82674f4310ac3f0f29a0ff374f50a672d889a6dc35e9382f9227949",
+            "ordinal": 0,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.fffffffffff8ep-1",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "fe2ef070b81ec1ef9896f3008580de6d92b5c4c2b1b05397e9edb5392cfc3c6a",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "2063ddbfff8ad5e4f7fcfc9a981294f4b1b5d44da5d95dea4d09e56931e4e2f7",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.c800000000000p-47",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "b3357f698976b9c7eb6c93d30085a259248acf7ede3c670dc721ca181d4891f0",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "a76e268d9445ddc0051b8088490b57ea78d1db4a8263848751b2d1ab8f56c843",
+            "ordinal": 1,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.fffffffffff8ep-1",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "fe2ef070b81ec1ef9896f3008580de6d92b5c4c2b1b05397e9edb5392cfc3c6a",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "f0989d277e2855e220e0c9d584d7fc2707953c52b5cde6d34f40c8c3db5e001f",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.c800000000000p-47",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "60dcce00fc5713f73bf14e2e0a0cf9a2bf7c7243552db00935f07073c97b04b3",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "3844b1810e829c2366db32f8d986efe73bb55b795bbdfea027ea02d552b8a937",
+            "ordinal": 2,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.fffffffffff8ep-1",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "fe2ef070b81ec1ef9896f3008580de6d92b5c4c2b1b05397e9edb5392cfc3c6a",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "c79cc574b3838b34964782d4e62d8c8483191ab2ab3e32e2b1ba5c12ad49e5b5",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.c800000000000p-47",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "50124cd44919478318c38f3413422497ca05f7d4b998d38fbd8c5b25b1544ee7",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "1bf59405aa7bc19321df1d0114813d995e2e2d46f6f5c5d2484bdb2e737e270a",
+            "ordinal": 3,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "0x0.0p+0",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.fffffffffff8ep-1",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "fe2ef070b81ec1ef9896f3008580de6d92b5c4c2b1b05397e9edb5392cfc3c6a",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "af0bbf4ade2d2b64b35f0c2f42d3b5b2aab9fa5428d139e8a7212dc43bfd1415",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.c800000000000p-47",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "0x0.0p+0",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "5feed1399f4a1c910c331c62eab488502689a157438a4bb8890eba98d53ad41e",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "8cf1543b201d0f4591085f193b0b9395499a5dc935efcdd89994b74a1166e126",
+            "ordinal": 4,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "0x0.0p+0",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.ffffffffffc3bp-1",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "35d04f1977f56bc734f0128532f0e6d1a9288c320f347edc5624013c7d051ffd",
+              "chi_square": "0x1.c6b3200000000p-87",
+              "identity": "ce7038efecdb552d1dcb24b25c151d20714c339969a1b44a77b71d71ab310936",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.e280000000000p-44",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "67897c750559d25d36c89f054423a1c64575039ec1dc9487d9503e970f85e767",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "d5947345d2d82db00b7b9617d1961737a5ffcfe70d88482b3190aff5b7d44c88",
+            "ordinal": 5,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "0x0.0p+0",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.fffffffffff8ep-1",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "fe2ef070b81ec1ef9896f3008580de6d92b5c4c2b1b05397e9edb5392cfc3c6a",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "250eb4272cf087bfc8e65a44d144f74cc7a1de5f6508153f8a2999b2b52e5fd8",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.c800000000000p-47",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "0x0.0p+0",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "aef6a9f9a10256ee4636906a6d5f4ca7b872da74efe9530f9eb33c18541f82e0",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "0b96f322f8d456fdf54b3af4a9b1b3bac442123d2625ad62c87bcc6b2866a35d",
+            "ordinal": 6,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.fffffffffff8ep-1",
+                "-0x1.fffffffffff8ep-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "f2a288a27c3f65143d9a95c5ad0ab8d7e4291fa5a7e57a06d959df4298f998fe",
+              "chi_square": "0x1.9620000000000p-92",
+              "identity": "6f5b42c7fce4744cc4b19bc11514c5de0b1c8ebe02edf855a77d011e91851041",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.c800000000000p-47",
+                "0x1.c800000000000p-47",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "4fa0205888e8eb44189d082dc4663d4fa9194c34bcf2841b32142c9fefcf25a1",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "cce46f4032d155832abe5e7365a6c7c7a89ee2edad0595b3b615b89960b7403d",
+            "ordinal": 7,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "0x1.0000000000000p+1",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.fffffffffff8ep-1",
+                "-0x1.fffffffffff8ep-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "f2a288a27c3f65143d9a95c5ad0ab8d7e4291fa5a7e57a06d959df4298f998fe",
+              "chi_square": "0x1.9620000000000p-92",
+              "identity": "08c1bbfe7b4e72fa4caa0e681a3612b3ba4f4e7957b9ddc3d2931acc9e2d381f",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.c800000000000p-47",
+                "0x1.c800000000000p-47",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "0x1.0000000000000p+1",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "5a3af6ae1d06e6ce0ccd09f1b82aa67cb666e3372a3c6b3eaa9170dde2d8881b",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "0ef55048483fd638b20c2c2d8f8f37185c2ac5fb2e3add77a1cc0a7398749550",
+            "ordinal": 8,
+            "seed": [
+              "-0x1.0000000000000p+1",
+              "0x1.0000000000000p+1",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.fffffffffff8ep-1",
+                "-0x1.fffffffffff8ep-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "f2a288a27c3f65143d9a95c5ad0ab8d7e4291fa5a7e57a06d959df4298f998fe",
+              "chi_square": "0x1.9620000000000p-92",
+              "identity": "a23c6dbfad94a184a6c0fd3f5a2081ca9dd9f38e8327eb3dfa594767a4a5f7a0",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.c800000000000p-47",
+                "0x1.c800000000000p-47",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "-0x1.0000000000000p+1",
+                "0x1.0000000000000p+1",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "2037a1dc7bdd20ef8a9e37a541c971a1177f64becd73415ce1f9509ad9bf39f9",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "7e732da52ed4f5c564a76470d2ab9fb5cf97114d2547fee61127074c6c9cf45b",
+            "ordinal": 9,
+            "seed": [
+              "0x0.0p+0",
+              "-0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "0732c932061bdbf004ec4b756b845f26b4467ef1aa11861052df4286f5a5e238",
+              "chi_square": "0x0.0p+0",
+              "identity": "95e70c9a9b01b67d3bc0ecebeffd4d66a29464e931f6bee483795d7f01a10776",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "-0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "a37bc7dc5f035d1ef014f0f4fc3af225d8972c45d44cb6d2b7363b494247c844",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "173cfec4e637689cd00dd8a25f5ae120286c9ecf43b3d15cd826fa68fe4bb28b",
+            "ordinal": 10,
+            "seed": [
+              "0x0.0p+0",
+              "-0x1.0000000000000p+1",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.ffffffffffff6p-1",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 24,
+                "identity": "f516c4d26f005842cba029d2e942922cf4ed7f2dd80ba71c7205e17a280b3f5b",
+                "iterations": null,
+                "nfev": 6,
+                "njev": 6
+              },
+              "candidate_fingerprint": "7e8306a85cbb1046051876fd2785c9d32cd9c993ec5843ab15d2f110a28adc7e",
+              "chi_square": "0x1.9000000000000p-100",
+              "identity": "09d6025c90ad89f27db39a9284f1188f314aef6f499d5f7811dd35bafbb169d1",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.4000000000000p-50",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "-0x1.0000000000000p+1",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "eb54802464c5401fab9d330b4990aa5c89f87546c7ae54318dba30a295a1005c",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "071bfe24125fe44b6b65e445c4bead79aa0f880f6296829c7f9496ca81e51fbd",
+            "ordinal": 11,
+            "seed": [
+              "0x0.0p+0",
+              "-0x1.0000000000000p+1",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.ffffffffffff6p-1",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000001p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 24,
+                "identity": "f516c4d26f005842cba029d2e942922cf4ed7f2dd80ba71c7205e17a280b3f5b",
+                "iterations": null,
+                "nfev": 6,
+                "njev": 6
+              },
+              "candidate_fingerprint": "8d0289f1a0f794128cbf54ec2da4bdc0b7d5c4585df44f63aa8aa1df0dca8afe",
+              "chi_square": "0x1.9400000000000p-100",
+              "identity": "dce0d605d5588d5b1d6084337fd1d6b09dbd9cb74f0b7da91899d5367f01b2e9",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.4000000000000p-50",
+                "0x0.0p+0",
+                "0x1.0000000000000p-53"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "-0x1.0000000000000p+1",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "084a6f2c7eee4b72c594466988f7fc1ec5b91773ce405bed4246259cb3be2bf1",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "7cf7d439088aa3be79f114ddd837033f8fe4384369d77bfb62558495ab8c4731",
+            "ordinal": 12,
+            "seed": [
+              "0x0.0p+0",
+              "0x0.0p+0",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "0732c932061bdbf004ec4b756b845f26b4467ef1aa11861052df4286f5a5e238",
+              "chi_square": "0x0.0p+0",
+              "identity": "e4b91839213083c0e4fc3b035c4331beb4d42de50b591ec2458a2dd299270d7d",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "c14c9de2a309ebfab6c357c0bbbab97bc83e6b1caf17cac8f948e9e1d453c7fd",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "eccd89f05264acc2d79c61414eb3f20fd17d3bb980cce3f18443d87b352b9dc6",
+            "ordinal": 13,
+            "seed": [
+              "0x0.0p+0",
+              "0x0.0p+0",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.ffffffffffff6p-1",
+                "-0x1.ffffffffffff6p-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 24,
+                "identity": "f516c4d26f005842cba029d2e942922cf4ed7f2dd80ba71c7205e17a280b3f5b",
+                "iterations": null,
+                "nfev": 6,
+                "njev": 6
+              },
+              "candidate_fingerprint": "a173498737f81654cb404bbc121475dcf9cd4eb8c725d60e5efc67beb47140b5",
+              "chi_square": "0x1.9000000000000p-99",
+              "identity": "930be88bf862927938517ddc14b3f6a31669e7a9beaa5405d60b1b52ab91fd70",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.4000000000000p-50",
+                "0x1.4000000000000p-50",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "7f98df5185e85e89d0e97af83beb0c63c80a0d04b593b08c14c0587172e73797",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "36d072043baf9e494f2991f739230363f3cf19dbf79197a5164033828c3a12aa",
+            "ordinal": 14,
+            "seed": [
+              "0x0.0p+0",
+              "0x0.0p+0",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.ffffffffffff6p-1",
+                "-0x1.ffffffffffff6p-1",
+                "0x1.0000000000001p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 24,
+                "identity": "f516c4d26f005842cba029d2e942922cf4ed7f2dd80ba71c7205e17a280b3f5b",
+                "iterations": null,
+                "nfev": 6,
+                "njev": 6
+              },
+              "candidate_fingerprint": "d413aac60d9046bb778eff1be39929c924b7e5406674d5ddb1f232d6acd67d99",
+              "chi_square": "0x1.9200000000000p-99",
+              "identity": "e293d81c67d03c3b1484301579289ba3fb64630fe7d36c142fd81211f5af2d79",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "-0x1.4000000000000p-50",
+                "0x1.4000000000000p-50",
+                "0x1.0000000000000p-53"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "b46315ee1ce12525e28c963c92fcc8a8554111f0cffc99801980fddf4af18512",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "d7bb244c22fb84021a717dd82197986653fb76853fda175caa4ed3052e27e93c",
+            "ordinal": 15,
+            "seed": [
+              "0x0.0p+0",
+              "0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.fffffffffff8ep-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "6ab77d85b937760a40ca11b78aebe150f0757f5e7fa4dc6fa9b68e8b60247a7f",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "ccbd72f140d618e228aeb7dec577e6cdfbf4f2bdf9efd8ad8cfaac71c1740131",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x1.c800000000000p-47",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "11291c4c040d9e24dc89fe46efae74a5ca8bf515be9fa4653b2ea8b8dd4612da",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "58831ef58cd753db9089e699288b31517faceffb06bf008efbc92aaee80a5b73",
+            "ordinal": 16,
+            "seed": [
+              "0x0.0p+0",
+              "0x1.0000000000000p+1",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.ffffffffffc3bp-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "7796f6c982deba40e21e76ae2d355881d43ccc1289d15ebbf67f9189027bb89d",
+              "chi_square": "0x1.c6b3200000000p-87",
+              "identity": "4afa565b0ba30b6712aef5c803a9da68a2d31d8d9de9b82e1e196f1b17bdcbcd",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x1.e280000000000p-44",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "0x1.0000000000000p+1",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "14fb3639e9a269b805f22759abaf232e061de3b5f24ad24495f503c1c0e70d92",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "3d81340b782c55f352ba0fbb28bd3a4d4128204d65843eab25f21ed82cbd20d1",
+            "ordinal": 17,
+            "seed": [
+              "0x0.0p+0",
+              "0x1.0000000000000p+1",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.fffffffffff8ep-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "6ab77d85b937760a40ca11b78aebe150f0757f5e7fa4dc6fa9b68e8b60247a7f",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "07ed2f7dd10bc39d1120d0cdf790b5104cccbe0883db4cfc01250d0a1a615ea4",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x1.c800000000000p-47",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x0.0p+0",
+                "0x1.0000000000000p+1",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "9e0aa1616e8c8ea28fce7d4884eaf87ef791b5d17bdb5706244e002da1533a7d",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "642beec87736f369fdc0ccac7131617a28c875cb77628b6e25ef86535d79ff2e",
+            "ordinal": 18,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "0732c932061bdbf004ec4b756b845f26b4467ef1aa11861052df4286f5a5e238",
+              "chi_square": "0x0.0p+0",
+              "identity": "8a33336cf7a3e8faa0bee960d77b5556efddac3bfbdebac7ab997fcce8e9d03a",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "2c39b1588f7799f757cff561e8ec52f9b2d9922c6a049c890741ec3ffb88d777",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "9de309b18fd0ab271d8f26491b966d7bd5f0c92f1b6109611422b4825234f38c",
+            "ordinal": 19,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 24,
+                "identity": "f516c4d26f005842cba029d2e942922cf4ed7f2dd80ba71c7205e17a280b3f5b",
+                "iterations": null,
+                "nfev": 6,
+                "njev": 6
+              },
+              "candidate_fingerprint": "0732c932061bdbf004ec4b756b845f26b4467ef1aa11861052df4286f5a5e238",
+              "chi_square": "0x0.0p+0",
+              "identity": "607865507d5f30699232cd31fe55f3749d4a2fe087947bc6a01e480ef70b20e2",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "524f0d082649cfa95c726513403697cabc384db627e9c5c8ab5464349632575f",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "55b2d4b0a3805e351a7157b49052682a6df03be05e8af72c5921a0677593c224",
+            "ordinal": 20,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000001p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 24,
+                "identity": "f516c4d26f005842cba029d2e942922cf4ed7f2dd80ba71c7205e17a280b3f5b",
+                "iterations": null,
+                "nfev": 6,
+                "njev": 6
+              },
+              "candidate_fingerprint": "df4c4162ee29f6ac9ecf2785f9e7f00a52b66af5cf0766c8ee58428a4f757fea",
+              "chi_square": "0x1.0000000000000p-106",
+              "identity": "319b2d99a02b495fc12be7876ee64c69bbe3ef63a2404df35186eb483f95cfef",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "0x1.0000000000000p-53"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "132b83f439358527cca2e647f4e818ded5b450576e5519cc825bc207d24c0d80",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "49ac345ae12cdfcc7bbca7e42cb694cdc9492bebfba8ba904869acc5346a6518",
+            "ordinal": 21,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "0x0.0p+0",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.0000000000000p+0",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "0732c932061bdbf004ec4b756b845f26b4467ef1aa11861052df4286f5a5e238",
+              "chi_square": "0x0.0p+0",
+              "identity": "10cc0dce2c7d2e7b795f72c03c0201eff79cfc2755cd6b649d46ee5223bd0d80",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "0x0.0p+0",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "9bfea974293bcc09c2c3b2ebcbd308b0d70e80bc804b9c9fdbcfbd889fbf508a",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "4c1c1e4d8671cb876f39b30e007e792c4bc0450b99de7440e315036e37536eba",
+            "ordinal": 22,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "0x0.0p+0",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.ffffffffffff6p-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 24,
+                "identity": "f516c4d26f005842cba029d2e942922cf4ed7f2dd80ba71c7205e17a280b3f5b",
+                "iterations": null,
+                "nfev": 6,
+                "njev": 6
+              },
+              "candidate_fingerprint": "37372751c1ce65fdbc9aef7b1512bb2d092cd31f742877473ae28a15f7c470ab",
+              "chi_square": "0x1.9000000000000p-100",
+              "identity": "a934bbb88fb29157406c978fa83db656b3f8108c8b872555a800f1e81e23784a",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x1.4000000000000p-50",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "0x0.0p+0",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "5d92e1633634c4494eee58ac2e20190ef5ec431e98d464134235777c123f6456",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "7770f42f645505825532d903483bb93b9dda323d1a3a68a2fa4f09c15142f119",
+            "ordinal": 23,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "0x0.0p+0",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.ffffffffffff6p-1",
+                "0x1.0000000000001p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 24,
+                "identity": "f516c4d26f005842cba029d2e942922cf4ed7f2dd80ba71c7205e17a280b3f5b",
+                "iterations": null,
+                "nfev": 6,
+                "njev": 6
+              },
+              "candidate_fingerprint": "cc7cdbb979f6c1fb01998dfac61af7308f0c950fd40069e6a49dfce7e83567da",
+              "chi_square": "0x1.9400000000000p-100",
+              "identity": "be0ef8760808080f0f4409c4f7bca058f1ed21d83e80b480c62136c6434db22d",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x1.4000000000000p-50",
+                "0x1.0000000000000p-53"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "0x0.0p+0",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "e23f4abbd8e04486387839afc551e73cbb8df36f9adb35c40b0f1393eb988544",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "d7be950751b592e9bb39c2fce5f35e3fb9d6d88a6744e4d991700741dd78a8e4",
+            "ordinal": 24,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "0x1.0000000000000p+1",
+              "-0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.fffffffffff8ep-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "6ab77d85b937760a40ca11b78aebe150f0757f5e7fa4dc6fa9b68e8b60247a7f",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "32e1c56b64dc0636ea0e8e24233fbfb68090a76827c1fdff1f9c7a25d65c632c",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x1.c800000000000p-47",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "0x1.0000000000000p+1",
+                "-0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "2ba306be47715f19cd5ced9bd7d65ddc59a5350bc0a816ec14709b7a967dd86b",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "a0ebda44aeae568fbd8f594a0535ad6f4e831d658e0d46c19e11a4dbd3052020",
+            "ordinal": 25,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "0x1.0000000000000p+1",
+              "0x0.0p+0"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.fffffffffff8ep-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "6ab77d85b937760a40ca11b78aebe150f0757f5e7fa4dc6fa9b68e8b60247a7f",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "b63ab5e079093b30dc1094adfc637b806f80c8b1735fb0c0fe01c5aa587c27e4",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x1.c800000000000p-47",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "0x1.0000000000000p+1",
+                "0x0.0p+0"
+              ],
+              "trajectory_fingerprint": "74e65e94a5edba21afe94226655200f6e0b3c75d1cc5e1dd9e53aaa8aaba3e01",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          },
+          {
+            "identity": "5c45971a04c770632822f912fb9ab5a6510c7f28e7653b9bb6a0e3d1ea7854a0",
+            "ordinal": 26,
+            "seed": [
+              "0x1.0000000000000p+1",
+              "0x1.0000000000000p+1",
+              "0x1.0000000000000p+1"
+            ],
+            "solver": {
+              "accepted": [
+                "0x1.0000000000000p+0",
+                "-0x1.fffffffffff8ep-1",
+                "0x1.0000000000000p-1"
+              ],
+              "active_mask": [
+                0,
+                0,
+                0
+              ],
+              "backend_diagnostics": {
+                "callback_calls": 0,
+                "diagnostic_evaluations": 28,
+                "identity": "b2e2e4d51b1ce7cb29dd443788d6d9dabd66171a4df7619c88749022991ee74c",
+                "iterations": null,
+                "nfev": 7,
+                "njev": 7
+              },
+              "candidate_fingerprint": "6ab77d85b937760a40ca11b78aebe150f0757f5e7fa4dc6fa9b68e8b60247a7f",
+              "chi_square": "0x1.9620000000000p-93",
+              "identity": "bd76bed7ae15fb9c63de564da13f42cc430622ed8cf9ea76cafae473832c012a",
+              "kind": "SOLVER",
+              "lower_bounds": [
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1",
+                "-0x1.8000000000000p+1"
+              ],
+              "objective_accounting": {
+                "cache_served_requests": 0,
+                "failure_kinds": [],
+                "fresh_evaluations": 2,
+                "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+                "materialization_requests": 1,
+                "requests_completed": 2,
+                "requests_failed": 0,
+                "requests_received": 2,
+                "requests_refused": 0,
+                "workflow_requests": 1
+              },
+              "residuals": [
+                "0x0.0p+0",
+                "0x1.c800000000000p-47",
+                "0x0.0p+0"
+              ],
+              "start": [
+                "0x1.0000000000000p+1",
+                "0x1.0000000000000p+1",
+                "0x1.0000000000000p+1"
+              ],
+              "trajectory_fingerprint": "555e1599687ded49c069218404ae44909009f056bc687858d95ff61a5166fbde",
+              "upper_bounds": [
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1",
+                "0x1.8000000000000p+1"
+              ]
+            },
+            "terminal": "CONVERGED"
+          }
+        ],
+        "selected_seed_ordinal": 9,
+        "trajectory_fingerprint": "83e5bc6279616061e4e1794e25aa8ddc3d86ea712dc01ceeaedd3c55c6f215e4"
+      },
+      "identity": "da1e5f5aab27e8789ffe43fd88824fe22f221810e3cc3722c61d47afe07f2ac5",
+      "probe_id": "grid-27-seed-coverage-v1",
+      "risks": [],
+      "satisfied_claims": [
+        "grid-seed-coverage",
+        "solver-request-accounting"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "SELECTED"
+    },
+    {
+      "definition_identity": "23655ad11bc5439deae2564b1df8a00f297b93a1971bbbe167acac31a60610b7",
+      "evidence": {
+        "backend_diagnostics": {
+          "callback_calls": 0,
+          "diagnostic_evaluations": 0,
+          "identity": "538d54d1cb038569b1e33f3400035fce17930bd151b069876a003386028d02a8",
+          "iterations": null,
+          "nfev": 0,
+          "njev": null
+        },
+        "candidates": [
+          {
+            "chi_square": "0x1.0000000000000p+0",
+            "final_vector": [
+              "0x1.0000000000000p+0",
+              "0x0.0p+0"
+            ],
+            "identity": "f2d155510db1066d98e321b94e993d5db589752cda666b4cc113d2fd3e1a060f",
+            "ordinal": 0
+          },
+          {
+            "chi_square": "0x0.0p+0",
+            "final_vector": [
+              "0x0.0p+0",
+              "0x0.0p+0"
+            ],
+            "identity": "1f9927ab9b693549aa86127f233e764051dceb0232d5e200c1bf781c73c6b780",
+            "ordinal": 1
+          },
+          {
+            "chi_square": "0x1.0000000000000p+0",
+            "final_vector": [
+              "0x0.0p+0",
+              "0x1.0000000000000p+0"
+            ],
+            "identity": "2389962901bac2c6e0282bbfd370bdb386d598e883c5ad7907c89721d14b1f59",
+            "ordinal": 2
+          },
+          {
+            "chi_square": "0x1.0000000000000p+0",
+            "final_vector": [
+              "-0x1.0000000000000p+0",
+              "0x0.0p+0"
+            ],
+            "identity": "48b0296d0b113858ac7aa144e241a4209e9ee5764436420a14a589bd66cfcef3",
+            "ordinal": 3
+          }
+        ],
+        "expected_order": [
+          1,
+          3,
+          2,
+          0
+        ],
+        "identity": "455c703cbf8910c99c98b1b02d78477153930ac0763993f7d9e6b60310e62030",
+        "kind": "GRID_ORDERING",
+        "objective_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 0,
+          "identity": "b227cb8551136ac40087f4a088a7452bb0d3dbe29261705954249103738db2b6",
+          "materialization_requests": 0,
+          "requests_completed": 0,
+          "requests_failed": 0,
+          "requests_received": 0,
+          "requests_refused": 0,
+          "workflow_requests": 0
+        },
+        "observed_order": [
+          1,
+          3,
+          2,
+          0
+        ],
+        "selected_ordinal": 1,
+        "trajectory_fingerprint": "48ca4b9ea22fd8bc86ef184a7c88de2c7cfb5a08908c9ff92e6530fc2de1a330"
+      },
+      "identity": "15528cf2ea4d374afe85fa31196107cc39322ca7be62553ce0c399c751a32ac3",
+      "probe_id": "grid-candidate-ordering-v1",
+      "risks": [],
+      "satisfied_claims": [
+        "canonical-grid-candidate-ordering"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "ORDERED"
+    },
+    {
+      "definition_identity": "a78f3c27aa29cbc2bfa6d414fbc6b49f8020cfabcdf185b07b6e53b245fe59a4",
+      "evidence": {
+        "final_population": [
+          {
+            "backend_objective": "0x1.4d8729831dbe3p-16",
+            "fingerprint": "5c789c97cd0d12a03a174431695f6c5c40814a036e7096aaf31517173204d3db",
+            "objective": "0x1.4d8729831dbe3p-16",
+            "population_index": 0,
+            "vector": [
+              "0x1.01b217732a6a8p-2"
+            ]
+          },
+          {
+            "backend_objective": "0x1.daac96945a5bfp-12",
+            "fingerprint": "a7be2791d4a8ff7b31a79b323a1d9980ce8ed7e777bdbdf646d26d81438343e3",
+            "objective": "0x1.daac96945a5bfp-12",
+            "population_index": 1,
+            "vector": [
+              "0x1.efd0397fd3af0p-3"
+            ]
+          },
+          {
+            "backend_objective": "0x1.e142d9d14d7bdp-15",
+            "fingerprint": "b1ae07f39dce686623a34a1824cb4f8ffbaaabf7e586203943f9246e5fb5baff",
+            "objective": "0x1.e142d9d14d7bdp-15",
+            "population_index": 2,
+            "vector": [
+              "0x1.fa3d1cf701d50p-3"
+            ]
+          },
+          {
+            "backend_objective": "0x1.af0de0058df4cp-14",
+            "fingerprint": "e067d8470a10de9907f8943112a6975d576e80990157de3965aa9e826c8468e3",
+            "objective": "0x1.af0de0058df4cp-14",
+            "population_index": 3,
+            "vector": [
+              "0x1.f849f23049ff0p-3"
+            ]
+          },
+          {
+            "backend_objective": "0x1.78cc565b4338ep-13",
+            "fingerprint": "187e6cd482321f7e63997c9714c7e88c3ce16c94582f6bd08754f8aba6c0b447",
+            "objective": "0x1.78cc565b4338ep-13",
+            "population_index": 4,
+            "vector": [
+              "0x1.05191da2e53d0p-2"
+            ]
+          }
+        ],
+        "identity": "d851c52a9fd82b0d4174c1aeeee6f846926099cdd2f40956c94b5b0caab925d7",
+        "kind": "DE_SEARCH",
+        "ordered_population_indices": [
+          0,
+          2,
+          3,
+          4,
+          1
+        ],
+        "polish": {
+          "accepted": [
+            "0x1.0000000002bdep-2"
+          ],
+          "active_mask": [
+            0
+          ],
+          "backend_diagnostics": {
+            "callback_calls": 0,
+            "diagnostic_evaluations": 6,
+            "identity": "add1708e341630b1a8f2083e59352a81e25b7d5aab62acd6b88ed2139c6b0b1e",
+            "iterations": null,
+            "nfev": 3,
+            "njev": 3
+          },
+          "candidate_fingerprint": "86042579ae0a4bfa36a1732efa493df7e0d16f76d03420f274115248323c5342",
+          "chi_square": "0x1.b3fb25e800000p-79",
+          "identity": "5a961146a816b18ce7cd73f6d6b722e12c4f105176826052608838d600f3b507",
+          "kind": "SOLVER",
+          "lower_bounds": [
+            "-0x1.0000000000000p+1"
+          ],
+          "objective_accounting": {
+            "cache_served_requests": 0,
+            "failure_kinds": [],
+            "fresh_evaluations": 2,
+            "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+            "materialization_requests": 1,
+            "requests_completed": 2,
+            "requests_failed": 0,
+            "requests_received": 2,
+            "requests_refused": 0,
+            "workflow_requests": 1
+          },
+          "residuals": [
+            "0x1.5ef0000000000p-41",
+            "0x1.b6ac000000000p-40"
+          ],
+          "start": [
+            "0x1.01b217732a6a8p-2"
+          ],
+          "trajectory_fingerprint": "10d1d58c3ff02c5f6470c21b1cd8b79d1939cc4e163bca14814a2479317361c8",
+          "upper_bounds": [
+            "0x1.0000000000000p+1"
+          ]
+        },
+        "root_seed": 591,
+        "search_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 5,
+          "identity": "e71e76c1262ef2e2bef3d2578cf660e7eccaff2151a53e97992dd5169b6cc46e",
+          "materialization_requests": 5,
+          "requests_completed": 5,
+          "requests_failed": 0,
+          "requests_received": 5,
+          "requests_refused": 0,
+          "workflow_requests": 0
+        },
+        "search_diagnostics": {
+          "callback_calls": 6,
+          "diagnostic_evaluations": 35,
+          "identity": "0646add834f73d704ea76265997bcf6b358412d62f5fce29dff66a7020f3daf5",
+          "iterations": 6,
+          "nfev": 35,
+          "njev": null
+        },
+        "selected_population_index": 0,
+        "trajectory_fingerprint": "81a44a5c684ad738b305a5029833e47a0602228aa07fea80e17e4383ba2cb737"
+      },
+      "identity": "4a1a506d59e657d045719fba8a7e6d0ceb700477bdcb69732820292693e34b96",
+      "probe_id": "de-bounded-search-v1",
+      "risks": [],
+      "satisfied_claims": [
+        "de-seeded-replay",
+        "de-to-trf-candidate-ordering",
+        "solver-request-accounting"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "POLISHED"
+    },
+    {
+      "definition_identity": "e4f3adfd98b85aa583a8ac2ed9483df9329a1eceb192af0fb19fa17e8340185e",
+      "evidence": {
+        "absolute_error": "0x1.9640000000000p-40",
+        "absolute_tolerance": "0x1.b7cdfd9d7bdbbp-34",
+        "actual_steps": [
+          "-0x1.a36e2eb1c4000p-13",
+          "-0x1.a36e2eb1c4000p-14",
+          "0x0.0p+0",
+          "0x1.a36e2eb1c4000p-14",
+          "0x1.a36e2eb1c4000p-13"
+        ],
+        "backend_diagnostics": {
+          "callback_calls": 0,
+          "diagnostic_evaluations": 0,
+          "identity": "538d54d1cb038569b1e33f3400035fce17930bd151b069876a003386028d02a8",
+          "iterations": null,
+          "nfev": 0,
+          "njev": null
+        },
+        "estimate": "0x1.a61298e1e2000p+0",
+        "identity": "23141ace30f17115605bbf8376f442c0f1d5832e78f82ea965b7a423eae38672",
+        "kind": "FINITE_DIFFERENCE",
+        "objective_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 5,
+          "identity": "9025f9a628010034ca6a325e3a0c4563ba653c840763859ad3665f09d217e4db",
+          "materialization_requests": 0,
+          "requests_completed": 5,
+          "requests_failed": 0,
+          "requests_received": 5,
+          "requests_refused": 0,
+          "workflow_requests": 5
+        },
+        "point": "0x1.0000000000000p-1",
+        "sampled_values": [
+          "0x1.a5fcfd3eb4242p+0",
+          "0x1.a607caece33e1p+0",
+          "0x1.a61298e1e069cp+0",
+          "0x1.a61d671dad774p+0",
+          "0x1.a62835a04c36bp+0"
+        ],
+        "trajectory_fingerprint": "68b5c27efda570802125c3d23c29af643fe273960d5c41fb63ab03b5c59795fe",
+        "truth": "0x1.a61298e1e069cp+0",
+        "weights": [
+          "0x1.a0aaaaaaaadd3p+9",
+          "-0x1.a0aaaaaaaadd1p+12",
+          "0x0.0p+0",
+          "0x1.a0aaaaaaaadd1p+12",
+          "-0x1.a0aaaaaaaadd1p+9"
+        ]
+      },
+      "identity": "582038af31913010942780184e2d4e339c4b4a49c0d85856de1e4185ac657ced",
+      "probe_id": "finite-difference-reliability-v1",
+      "risks": [],
+      "satisfied_claims": [
+        "finite-difference-reliability",
+        "stencil-request-accounting",
+        "stencil-trajectory-fingerprint"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "RELIABLE"
+    },
+    {
+      "definition_identity": "f561a7c8818b5aff09c2f01182398ac14ffcc933ba4563c52978612ad9133670",
+      "evidence": {
+        "accepted": [
+          "0x1.ffffffffffffbp-1"
+        ],
+        "active_mask": [
+          1
+        ],
+        "backend_diagnostics": {
+          "callback_calls": 0,
+          "diagnostic_evaluations": 12,
+          "identity": "65c9d0823000dbde3241282d729a226044dad334466ee1f8d134e93dbcb68848",
+          "iterations": null,
+          "nfev": 6,
+          "njev": 6
+        },
+        "candidate_fingerprint": "741d92ceabeac89b054a3df93ba9e3ca29546e96610a37851bee2d099423e3f4",
+        "chi_square": "0x1.0000000000004p+0",
+        "identity": "660294a68c52c82e9f6c39855fc6abf4ac0e8c89c8b5fbe2f888b8cf861da99a",
+        "kind": "SOLVER",
+        "lower_bounds": [
+          "0x0.0p+0"
+        ],
+        "objective_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 2,
+          "identity": "6b6165e07de7ae46fd9818f8d56d308bb18b81d5273849803ada5503655f558e",
+          "materialization_requests": 1,
+          "requests_completed": 2,
+          "requests_failed": 0,
+          "requests_received": 2,
+          "requests_refused": 0,
+          "workflow_requests": 1
+        },
+        "residuals": [
+          "-0x1.0000000000002p+0"
+        ],
+        "start": [
+          "0x1.0000000000000p-1"
+        ],
+        "trajectory_fingerprint": "3f6decb27ae7c17b09f98db8f2afa78edcff9ce1883c857b5ecf65414bf9af51",
+        "upper_bounds": [
+          "0x1.0000000000000p+0"
+        ]
+      },
+      "identity": "7785985454434825d980b73cf65024c2d6f3fa1c7a85d9c5a51e496e94ec8ad1",
+      "probe_id": "trf-active-bound-v1",
+      "risks": [
+        "ACTIVE_BOUND"
+      ],
+      "satisfied_claims": [
+        "active-bound-detection",
+        "bound-safe-trf-convergence",
+        "solver-request-accounting"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "CONVERGED"
+    },
+    {
+      "definition_identity": "2f11a47aab231bf73dd84735256cd2b3fcbbd72842770e0c5268299b913efe07",
+      "evidence": {
+        "backend_diagnostics": {
+          "callback_calls": 0,
+          "diagnostic_evaluations": 1,
+          "identity": "aeb193762c1d553ef5752f694c5da2c8cd964d57e53ff87aa29aa1a3a4ac65d8",
+          "iterations": null,
+          "nfev": 0,
+          "njev": null
+        },
+        "condition": null,
+        "condition_limit": "0x1.d1a94a2000000p+39",
+        "dimension": 2,
+        "identity": "056c7cd13e41a5c4f43383aa7ca56b34da1f2fc5360dd8b97d171528320c8447",
+        "jacobian": [
+          [
+            "0x1.0000000000000p+0",
+            "0x1.0000000000000p+0"
+          ],
+          [
+            "0x1.0000000000000p+1",
+            "0x1.0000000000000p+1"
+          ]
+        ],
+        "kind": "SPECTRAL_RISK",
+        "objective_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 0,
+          "identity": "b227cb8551136ac40087f4a088a7452bb0d3dbe29261705954249103738db2b6",
+          "materialization_requests": 0,
+          "requests_completed": 0,
+          "requests_failed": 0,
+          "requests_received": 0,
+          "requests_refused": 0,
+          "workflow_requests": 0
+        },
+        "rank": 1,
+        "risks": [
+          "RANK_DEFICIENT"
+        ],
+        "singular_values": [
+          "0x1.94c583ada5b54p+1",
+          "0x1.6a09e667f3bccp-53"
+        ],
+        "trajectory_fingerprint": "b42da726069cd9db0b9ce42e0f855b71c9ad489d70a191ab4dd871ed4310dc87"
+      },
+      "identity": "866d3982e6c2d437bfe9c36bcf81d13d48163cc6ce9afad8b40026abd501c7f9",
+      "probe_id": "rank-deficient-linearization-v1",
+      "risks": [
+        "RANK_DEFICIENT"
+      ],
+      "satisfied_claims": [
+        "rank-risk-detection"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "RISK_DETECTED"
+    },
+    {
+      "definition_identity": "cc95615e114ec9e3548af2599749c87da59e9a7da6851d50bd04eb5032c972a6",
+      "evidence": {
+        "backend_diagnostics": {
+          "callback_calls": 0,
+          "diagnostic_evaluations": 1,
+          "identity": "aeb193762c1d553ef5752f694c5da2c8cd964d57e53ff87aa29aa1a3a4ac65d8",
+          "iterations": null,
+          "nfev": 0,
+          "njev": null
+        },
+        "condition": "0x1.7d78400000000p+26",
+        "condition_limit": "0x1.e848000000000p+19",
+        "dimension": 2,
+        "identity": "844aa8641f70ca82f70bd4befacdbc22743b37d51ccb53b23d71280e708831fc",
+        "jacobian": [
+          [
+            "0x1.0000000000000p+0",
+            "0x0.0p+0"
+          ],
+          [
+            "0x0.0p+0",
+            "0x1.5798ee2308c3ap-27"
+          ]
+        ],
+        "kind": "SPECTRAL_RISK",
+        "objective_accounting": {
+          "cache_served_requests": 0,
+          "failure_kinds": [],
+          "fresh_evaluations": 0,
+          "identity": "b227cb8551136ac40087f4a088a7452bb0d3dbe29261705954249103738db2b6",
+          "materialization_requests": 0,
+          "requests_completed": 0,
+          "requests_failed": 0,
+          "requests_received": 0,
+          "requests_refused": 0,
+          "workflow_requests": 0
+        },
+        "rank": 2,
+        "risks": [
+          "ILL_CONDITIONED"
+        ],
+        "singular_values": [
+          "0x1.0000000000000p+0",
+          "0x1.5798ee2308c3ap-27"
+        ],
+        "trajectory_fingerprint": "dc9f885670019ba528b9d099ec42bfa6fb4ae48267d733b004d40246975a0695"
+      },
+      "identity": "01885f64d3494a08b9548030dc8a6582c7bf7b31b1e890eb26d35ed053bd4f9c",
+      "probe_id": "ill-conditioned-linearization-v1",
+      "risks": [
+        "ILL_CONDITIONED"
+      ],
+      "satisfied_claims": [
+        "conditioning-risk-detection"
+      ],
+      "schema_version": 2,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "terminal": "RISK_DETECTED"
+    }
+  ],
+  "definitions": [
+    {
+      "budget": {
+        "authoritative_objective_requests": 2,
+        "backend_max_nfev": 64
+      },
+      "category": "TRF_ROUTINE",
+      "derivation": {
+        "identity": "80f9f444e460aa751bc7122811f42eb1f3b90f62ae7da7d53e33d30e8826acd5",
+        "parent_case": "analytic bounded linear residual",
+        "reduction": "Two independent coordinates retain routine TRF convergence.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "deterministic-trajectory-fingerprint",
+        "routine-trf-convergence",
+        "solver-request-accounting"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [],
+          "terminal": "CONVERGED"
+        }
+      ],
+      "identity": "3a9caa3e786d4d6af3143a27a3f5fd26186157fc52cc501045e1611232e8614f",
+      "policy": {
+        "backend": "scipy.optimize.least_squares",
+        "bounds": [
+          [
+            {
+              "binary64": "-0x1.0000000000000p+2"
+            },
+            {
+              "binary64": "0x1.0000000000000p+2"
+            }
+          ],
+          [
+            {
+              "binary64": "-0x1.0000000000000p+2"
+            },
+            {
+              "binary64": "0x1.0000000000000p+2"
+            }
+          ]
+        ],
+        "ftol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "gtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "maximum_chi_square": {
+          "binary64": "0x1.cd2b297d889bcp-54"
+        },
+        "method": "trf",
+        "start": [
+          {
+            "binary64": "0x0.0p+0"
+          },
+          {
+            "binary64": "0x0.0p+0"
+          }
+        ],
+        "truth": [
+          {
+            "binary64": "0x1.8000000000000p+0"
+          },
+          {
+            "binary64": "-0x1.0000000000000p-1"
+          }
+        ],
+        "truth_absolute_tolerance": {
+          "binary64": "0x1.5798ee2308c3ap-27"
+        },
+        "x_scale": {
+          "binary64": "0x1.0000000000000p+0"
+        },
+        "xtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        }
+      },
+      "probe_id": "trf-routine-quadratic-v1",
+      "schema_version": 2,
+      "seed": "not-applicable",
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "bf594f2dca14a5a28a79e6b9743e9623f8b660923a09b19de5947570cb39bc10",
+        "identity": "f5bcb4695227e70ad0c4d29c853c3bbc04494a7b3a89a82f172b6406d76218ae",
+        "kind": "ANALYTIC_DERIVATION",
+        "reference": "r(x,y)=(x-1.5,y+0.5); unique minimizer=(1.5,-0.5)."
+      }
+    },
+    {
+      "budget": {
+        "authoritative_objective_requests": 2,
+        "backend_max_nfev": 256
+      },
+      "category": "TRF_DIFFICULT",
+      "derivation": {
+        "identity": "d75969a72fedcb39a707073972d39ff6a5826e63075432e2cc60e3bab51b4002",
+        "parent_case": "Rosenbrock least-squares valley",
+        "reduction": "Canonical poor start retains curved-valley TRF behavior.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "deterministic-trajectory-fingerprint",
+        "difficult-trf-convergence",
+        "solver-request-accounting"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [],
+          "terminal": "CONVERGED"
+        }
+      ],
+      "identity": "77d6de95605268c0d2049cc746e70c807d0aebd808d3b8dbcb96e38616703954",
+      "policy": {
+        "backend": "scipy.optimize.least_squares",
+        "bounds": [
+          [
+            {
+              "binary64": "-0x1.8000000000000p+1"
+            },
+            {
+              "binary64": "0x1.8000000000000p+1"
+            }
+          ],
+          [
+            {
+              "binary64": "-0x1.8000000000000p+1"
+            },
+            {
+              "binary64": "0x1.8000000000000p+1"
+            }
+          ]
+        ],
+        "ftol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "gtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "maximum_chi_square": {
+          "binary64": "0x1.cd2b297d889bcp-54"
+        },
+        "method": "trf",
+        "start": [
+          {
+            "binary64": "-0x1.3333333333333p+0"
+          },
+          {
+            "binary64": "0x1.0000000000000p+0"
+          }
+        ],
+        "truth": [
+          {
+            "binary64": "0x1.0000000000000p+0"
+          },
+          {
+            "binary64": "0x1.0000000000000p+0"
+          }
+        ],
+        "truth_absolute_tolerance": {
+          "binary64": "0x1.5798ee2308c3ap-27"
+        },
+        "x_scale": {
+          "binary64": "0x1.0000000000000p+0"
+        },
+        "xtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        }
+      },
+      "probe_id": "trf-difficult-rosenbrock-v1",
+      "schema_version": 2,
+      "seed": "not-applicable",
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "e96708b77a25bb398f9641e0616036e33cb82f10e987be710d70e784e5e3eb95",
+        "identity": "5f86f8e80b4b1814656aec18af796f382990731f17b93e60d2c15279c9cc5a82",
+        "kind": "ANALYTIC_DERIVATION",
+        "reference": "r(x,y)=(10*(y-x^2),1-x); unique zero=(1,1)."
+      }
+    },
+    {
+      "budget": {
+        "authoritative_objective_requests_per_seed": 2,
+        "backend_max_nfev_per_seed": 48,
+        "seed_count": 27
+      },
+      "category": "GRID",
+      "derivation": {
+        "identity": "daa3f8df2fd59bd33fd90b6386afbdff996bbc09fbdb5e95e65cb0e5e74b78a0",
+        "parent_case": "immutable 27-seed physical-coordinate grid",
+        "reduction": "Three three-point axes retain complete Cartesian seed coverage.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "grid-seed-coverage",
+        "solver-request-accounting"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [],
+          "terminal": "SELECTED"
+        }
+      ],
+      "identity": "a8404a6445c124a520a9b4c0322bb991bb4df202efa8184f6d3b29047610e404",
+      "policy": {
+        "backend": "scipy.optimize.least_squares",
+        "bounds": [
+          [
+            {
+              "binary64": "-0x1.8000000000000p+1"
+            },
+            {
+              "binary64": "0x1.8000000000000p+1"
+            }
+          ],
+          [
+            {
+              "binary64": "-0x1.8000000000000p+1"
+            },
+            {
+              "binary64": "0x1.8000000000000p+1"
+            }
+          ],
+          [
+            {
+              "binary64": "-0x1.8000000000000p+1"
+            },
+            {
+              "binary64": "0x1.8000000000000p+1"
+            }
+          ]
+        ],
+        "candidate_tie_break": "chi-square-then-seed-ordinal",
+        "ftol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "gtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "maximum_chi_square": {
+          "binary64": "0x1.cd2b297d889bcp-54"
+        },
+        "method": "trf",
+        "physical_axes": [
+          [
+            {
+              "binary64": "-0x1.0000000000000p+1"
+            },
+            {
+              "binary64": "0x0.0p+0"
+            },
+            {
+              "binary64": "0x1.0000000000000p+1"
+            }
+          ],
+          [
+            {
+              "binary64": "-0x1.0000000000000p+1"
+            },
+            {
+              "binary64": "0x0.0p+0"
+            },
+            {
+              "binary64": "0x1.0000000000000p+1"
+            }
+          ],
+          [
+            {
+              "binary64": "-0x1.0000000000000p+1"
+            },
+            {
+              "binary64": "0x0.0p+0"
+            },
+            {
+              "binary64": "0x1.0000000000000p+1"
+            }
+          ]
+        ],
+        "truth": [
+          {
+            "binary64": "0x1.0000000000000p+0"
+          },
+          {
+            "binary64": "-0x1.0000000000000p+0"
+          },
+          {
+            "binary64": "0x1.0000000000000p-1"
+          }
+        ],
+        "truth_absolute_tolerance": {
+          "binary64": "0x1.5798ee2308c3ap-27"
+        },
+        "x_scale": {
+          "binary64": "0x1.0000000000000p+0"
+        },
+        "xtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        }
+      },
+      "probe_id": "grid-27-seed-coverage-v1",
+      "schema_version": 2,
+      "seed": "not-applicable",
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "11f45d8bab2dae067aa66fa022ed590a1468a4095d2551094933db10a40616bd",
+        "identity": "e360715d02a9c80e66ee66f398b10ceae934a3119edd374c284908302d604eac",
+        "kind": "ANALYTIC_DERIVATION",
+        "reference": "r(x,y,z)=(x-1,y+1,z-0.5); unique zero=(1,-1,0.5)."
+      }
+    },
+    {
+      "budget": {
+        "candidate_count": 4
+      },
+      "category": "GRID_ORDERING",
+      "derivation": {
+        "identity": "ce202bc5af4b8a91881620b0777cac6901a145733dc5abb96d52f60380c79432",
+        "parent_case": "four-candidate deterministic GRID selection",
+        "reduction": "Four analytically scored candidates isolate chi-square, final-vector, and seed-ordinal ordering.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "canonical-grid-candidate-ordering"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [],
+          "terminal": "ORDERED"
+        }
+      ],
+      "identity": "23655ad11bc5439deae2564b1df8a00f297b93a1971bbbe167acac31a60610b7",
+      "policy": {
+        "candidate_tie_break": "chi-square-then-final-vector-then-seed-ordinal",
+        "candidates": [
+          {
+            "chi_square": {
+              "binary64": "0x1.0000000000000p+0"
+            },
+            "final_vector": [
+              {
+                "binary64": "0x1.0000000000000p+0"
+              },
+              {
+                "binary64": "0x0.0p+0"
+              }
+            ],
+            "ordinal": 0
+          },
+          {
+            "chi_square": {
+              "binary64": "0x0.0p+0"
+            },
+            "final_vector": [
+              {
+                "binary64": "0x0.0p+0"
+              },
+              {
+                "binary64": "0x0.0p+0"
+              }
+            ],
+            "ordinal": 1
+          },
+          {
+            "chi_square": {
+              "binary64": "0x1.0000000000000p+0"
+            },
+            "final_vector": [
+              {
+                "binary64": "0x0.0p+0"
+              },
+              {
+                "binary64": "0x1.0000000000000p+0"
+              }
+            ],
+            "ordinal": 2
+          },
+          {
+            "chi_square": {
+              "binary64": "0x1.0000000000000p+0"
+            },
+            "final_vector": [
+              {
+                "binary64": "-0x1.0000000000000p+0"
+              },
+              {
+                "binary64": "0x0.0p+0"
+              }
+            ],
+            "ordinal": 3
+          }
+        ],
+        "expected_order": [
+          1,
+          3,
+          2,
+          0
+        ]
+      },
+      "probe_id": "grid-candidate-ordering-v1",
+      "schema_version": 2,
+      "seed": "not-applicable",
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "5c30248c42441707e34c4cb40dd4f7a2b45a50a892965849a10b072040b990b5",
+        "identity": "a1bbdcb426ad69c6888d712482948691ff5845c71f03b299458ba851c8631cd9",
+        "kind": "ANALYTIC_DERIVATION",
+        "reference": "Candidates (ordinal,chi2,vector)=(0,1,(1,0)),(1,0,(0,0)),(2,1,(0,1)),(3,1,(-1,0)); lexicographic ordering by (chi2,vector,ordinal) is exactly (1,3,2,0)."
+      }
+    },
+    {
+      "budget": {
+        "de_authoritative_objective_requests": 5,
+        "de_backend_objective_calls": 128,
+        "trf_authoritative_objective_requests": 2,
+        "trf_backend_max_nfev": 48
+      },
+      "category": "DE_SEARCH",
+      "derivation": {
+        "identity": "83d660a16caf19027ccafb99d3910eb6b653c4cda7d7bf67b36c371ed08c675c",
+        "parent_case": "bounded multimodal basin search",
+        "reduction": "One selected coordinate retains oscillatory local basins, seeded DE, and separate TRF polish.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "de-seeded-replay",
+        "de-to-trf-candidate-ordering",
+        "solver-request-accounting"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [],
+          "terminal": "POLISHED"
+        }
+      ],
+      "identity": "a78f3c27aa29cbc2bfa6d414fbc6b49f8020cfabcdf185b07b6e53b245fe59a4",
+      "policy": {
+        "absolute_tolerance": {
+          "binary64": "0x0.0p+0"
+        },
+        "backend_polish": false,
+        "bounds": [
+          [
+            {
+              "binary64": "-0x1.0000000000000p+1"
+            },
+            {
+              "binary64": "0x1.0000000000000p+1"
+            }
+          ]
+        ],
+        "de_strategy": "best1bin",
+        "maximum_chi_square": {
+          "binary64": "0x1.cd2b297d889bcp-54"
+        },
+        "maximum_generations": 6,
+        "mutation": [
+          {
+            "binary64": "0x1.0000000000000p-1"
+          },
+          {
+            "binary64": "0x1.0000000000000p+0"
+          }
+        ],
+        "oscillation_amplitude": {
+          "binary64": "0x1.0000000000000p-1"
+        },
+        "oscillation_frequency": {
+          "binary64": "0x1.4000000000000p+2"
+        },
+        "polish_ftol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "polish_gtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "polish_x_scale": {
+          "binary64": "0x1.0000000000000p+0"
+        },
+        "polish_xtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "population_multiplier": 5,
+        "recombination": {
+          "binary64": "0x1.6666666666666p-1"
+        },
+        "relative_tolerance": {
+          "binary64": "0x0.0p+0"
+        },
+        "truth": [
+          {
+            "binary64": "0x1.0000000000000p-2"
+          }
+        ],
+        "truth_absolute_tolerance": {
+          "binary64": "0x1.5798ee2308c3ap-27"
+        },
+        "updating": "immediate",
+        "workers": 1,
+        "workflow_polish": "trf"
+      },
+      "probe_id": "de-bounded-search-v1",
+      "schema_version": 2,
+      "seed": 591,
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "3b9dc5d9e97f5ce24ae98c528c5bc2fb07f7d30423be32cdd5d4f22ee81a3bdc",
+        "identity": "e07ddc4d862534f1b83ec047f95912fd6f7cca4605f31b983d49d6397fb56937",
+        "kind": "ANALYTIC_DERIVATION",
+        "reference": "f(x)=(x-0.25)^2+0.25 sin^2(5(x-0.25)); its non-negative first term makes x=0.25 the unique bounded global minimizer."
+      }
+    },
+    {
+      "budget": {
+        "authoritative_objective_requests": 5
+      },
+      "category": "FINITE_DIFFERENCE",
+      "derivation": {
+        "identity": "8e4e6672abfc8bea0337eb6f64a81b1dee91469924ff8a7ed3ee0b06d83dc1c7",
+        "parent_case": "analytic exponential derivative",
+        "reduction": "Five-point centered stencil retains actual-step reliability.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "finite-difference-reliability",
+        "stencil-request-accounting",
+        "stencil-trajectory-fingerprint"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [],
+          "terminal": "RELIABLE"
+        }
+      ],
+      "identity": "e4f3adfd98b85aa583a8ac2ed9483df9329a1eceb192af0fb19fa17e8340185e",
+      "policy": {
+        "absolute_tolerance": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "point": {
+          "binary64": "0x1.0000000000000p-1"
+        },
+        "stencil": "centered-five-point",
+        "step": {
+          "binary64": "0x1.a36e2eb1c432dp-14"
+        },
+        "weight_derivation": "lagrange-first-derivative-at-zero"
+      },
+      "probe_id": "finite-difference-reliability-v1",
+      "schema_version": 2,
+      "seed": "not-applicable",
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "a2bfde1e826dd79f51bda36ad1411f54cbee6bc036a1f7ba6e18cd9e561033fc",
+        "identity": "ad1d16bf57bd6757abc026ada89b5d4b4946a5b2d7b9f906e561bb01c54537ca",
+        "kind": "ANALYTIC_DERIVATION",
+        "reference": "d exp(x)/dx at x=0.5 equals exp(0.5)."
+      }
+    },
+    {
+      "budget": {
+        "authoritative_objective_requests": 2,
+        "backend_max_nfev": 64
+      },
+      "category": "BOUNDS",
+      "derivation": {
+        "identity": "21278f44f4ea47eb5cb1331f52d08554b4b54005dd3152ede69c6d6101595c48",
+        "parent_case": "bounded scalar residual",
+        "reduction": "An infeasible unconstrained optimum retains active-bound truth.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "active-bound-detection",
+        "bound-safe-trf-convergence",
+        "solver-request-accounting"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [
+            "ACTIVE_BOUND"
+          ],
+          "terminal": "CONVERGED"
+        }
+      ],
+      "identity": "f561a7c8818b5aff09c2f01182398ac14ffcc933ba4563c52978612ad9133670",
+      "policy": {
+        "backend": "scipy.optimize.least_squares",
+        "bounds": [
+          [
+            {
+              "binary64": "0x0.0p+0"
+            },
+            {
+              "binary64": "0x1.0000000000000p+0"
+            }
+          ]
+        ],
+        "expected_active_mask": [
+          1
+        ],
+        "ftol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "gtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        },
+        "method": "trf",
+        "start": [
+          {
+            "binary64": "0x1.0000000000000p-1"
+          }
+        ],
+        "truth": [
+          {
+            "binary64": "0x1.0000000000000p+0"
+          }
+        ],
+        "truth_absolute_tolerance": {
+          "binary64": "0x1.5798ee2308c3ap-27"
+        },
+        "x_scale": {
+          "binary64": "0x1.0000000000000p+0"
+        },
+        "xtol": {
+          "binary64": "0x1.b7cdfd9d7bdbbp-34"
+        }
+      },
+      "probe_id": "trf-active-bound-v1",
+      "schema_version": 2,
+      "seed": "not-applicable",
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "32c4f90382bb8ca9dfd22546e6b208ef4d8723b02b270c8f849981a35e77aa4f",
+        "identity": "96386025ff951787a7ea694d7dea63b471e4ad80edb2fbad05fd491b39c3387a",
+        "kind": "ANALYTIC_DERIVATION",
+        "reference": "r(x)=x-2 on [0,1]; constrained minimizer x=1."
+      }
+    },
+    {
+      "budget": {
+        "svd_decompositions": 1
+      },
+      "category": "RANK",
+      "derivation": {
+        "identity": "d045312409b87273c492219eff846a4783cd478ed6fbaa8050fbd2ce09d595e7",
+        "parent_case": "exact rank-one Jacobian",
+        "reduction": "A duplicated column retains fail-closed rank diagnosis.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "rank-risk-detection"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [
+            "RANK_DEFICIENT"
+          ],
+          "terminal": "RISK_DETECTED"
+        }
+      ],
+      "identity": "2f11a47aab231bf73dd84735256cd2b3fcbbd72842770e0c5268299b913efe07",
+      "policy": {
+        "conditioning_limit": {
+          "binary64": "0x1.d1a94a2000000p+39"
+        },
+        "expected_rank": 1,
+        "rank_relative_tolerance": {
+          "binary64": "0x1.19799812dea11p-40"
+        },
+        "svd_driver": "gesdd"
+      },
+      "probe_id": "rank-deficient-linearization-v1",
+      "schema_version": 2,
+      "seed": "not-applicable",
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "b7d5255b9f5a9b92c7ef6baab5f1ec76bf07217bae5b7d3039142c3248fa7062",
+        "identity": "d76106ed173fa5d4744334a0a056a1bdc904ac4039762e0185f9d213ffe51494",
+        "kind": "EXACT_LINEAR_ALGEBRA",
+        "reference": "J=((1,1),(2,2)); exact rank=1 < 2."
+      }
+    },
+    {
+      "budget": {
+        "svd_decompositions": 1
+      },
+      "category": "CONDITIONING",
+      "derivation": {
+        "identity": "c0e19b1b3b1b492f65fb13a2bf880f282c12ffb75dc917b280653014e7d4c486",
+        "parent_case": "exact diagonal Jacobian spectrum",
+        "reduction": "Two separated singular values retain conditioning diagnosis.",
+        "source_issue": 591,
+        "source_revision": "700cb71df950fc54c268c0bca199403e5621269d"
+      },
+      "eligible_claims": [
+        "conditioning-risk-detection"
+      ],
+      "failure_expectations": [
+        {
+          "required_risks": [
+            "ILL_CONDITIONED"
+          ],
+          "terminal": "RISK_DETECTED"
+        }
+      ],
+      "identity": "cc95615e114ec9e3548af2599749c87da59e9a7da6851d50bd04eb5032c972a6",
+      "policy": {
+        "condition_relative_tolerance": {
+          "binary64": "0x1.19799812dea11p-40"
+        },
+        "conditioning_limit": {
+          "binary64": "0x1.e848000000000p+19"
+        },
+        "expected_condition": {
+          "binary64": "0x1.7d78400000000p+26"
+        },
+        "expected_rank": 2,
+        "svd_driver": "gesdd"
+      },
+      "probe_id": "ill-conditioned-linearization-v1",
+      "schema_version": 2,
+      "seed": "not-applicable",
+      "semantic_version": "chemex-numerical-probes-v2",
+      "truth": {
+        "derivation_digest": "891aaa36a0848751cc469211234ccc7d9f3e26b360ef92cc1ecc756569caf6c9",
+        "identity": "ce411e4ac869d3f8030128f397f07861fd451436ea39d19e76007ae9d8e44717",
+        "kind": "EXACT_LINEAR_ALGEBRA",
+        "reference": "J=diag(1,1e-8); exact kappa_2(J)=1e8."
+      }
+    }
+  ],
+  "historical_qualification": "REFERENCE_MATCHED",
+  "identity": "d11f9caa404b8ce3fa96e041659939446e205aae9376b08d6a137ed40cf0bdb0",
+  "manifest_identity": "cbc5dbc9a0b432b6dbbd053f49769bb4dc84d322c409a84da26f8f892298b839",
+  "observed_attestation_identity": "3b3e0bc184826d61ec6652194486c907a5faa4c64b68ec03bbe60b63c660d687",
+  "observed_environment_identity": "cc5359f90df35ec9b60fd56e483911745209519ecce37d69e17c4edd6ea3604f",
+  "observed_lane_identity": "4f1e7dab3384f88149fd33befb09ba3e96730dc336e9427b224a39a8a7167e4f",
+  "observed_lane_role": "CANONICAL_NUMERICAL",
+  "reference_manifest_identity": "cbc5dbc9a0b432b6dbbd053f49769bb4dc84d322c409a84da26f8f892298b839",
+  "schema_version": 2,
+  "semantic_version": "chemex-numerical-probes-v2"
+}

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -194,9 +194,10 @@ def test_genuine_current_process_authority_qualifies_a_matching_occurrence(
         )
 
     occurrence = Occurrence.requested(specification, case, "qualified", authority)
+    evidence = LaneAttestation.from_record(authority.to_record())
 
     assert occurrence.lane_reference == lane.identity
-    assert occurrence.lane_attestation_identity == authority.evidence.identity
+    assert occurrence.lane_attestation_identity == evidence.identity
     assert Occurrence.from_record(occurrence.to_record(), specification) == occurrence
     with pytest.raises(ValueError, match="cannot carry lane authority"):
         Occurrence.requested(_specification(case), case, "retroactive", authority)

--- a/tests/test_numerical_lanes.py
+++ b/tests/test_numerical_lanes.py
@@ -235,9 +235,30 @@ def test_only_current_process_probe_can_mint_live_authority_and_evidence_round_t
 
     assert isinstance(authority, LiveLaneAuthority)
     assert not isinstance(evidence, LiveLaneAuthority)
-    assert evidence == authority.evidence
+    assert evidence.to_record() == authority.to_record()
     assert evidence.lane_identity == lane.identity
     assert evidence.environment_identity == RuntimeEnvironment(lane.semantics).identity
+
+
+def test_process_registry_binding_cannot_be_mutated_in_place(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = _attestation(monkeypatch, _lane())
+    binding = numerical_lanes._LIVE_LANE_BINDINGS[authority]
+
+    assert isinstance(binding, tuple)
+    for field, value in (
+        ("lane_identity", "a" * 64),
+        ("lane_role", "PYTHON_COMPATIBILITY"),
+        ("attestation_identity", "b" * 64),
+        ("environment_identity", "c" * 64),
+        ("workers", 8),
+        ("native_threads", 8),
+    ):
+        with pytest.raises(AttributeError):
+            object.__setattr__(binding, field, value)
+
+    assert comparison_scope(authority, authority).kind == "WITHIN_LANE_BITWISE"
 
 
 def test_post_import_attestation_rejects_any_actual_process_mismatch(
@@ -281,8 +302,8 @@ def test_comparison_scopes_require_attested_lanes_and_round_trip(
             "UNKNOWN",  # type: ignore[arg-type]
             python_313.identity,
             python_314.identity,
-            attestation_313.identity,
-            attestation_314.identity,
+            LaneAttestation.from_record(attestation_313.to_record()).identity,
+            LaneAttestation.from_record(attestation_314.to_record()).identity,
         )
 
 

--- a/tests/test_numerical_probes.py
+++ b/tests/test_numerical_probes.py
@@ -4,23 +4,44 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+from collections.abc import Callable
+from types import SimpleNamespace
 from typing import cast
 
+import numpy as np
 import pytest
 
-from chemex.numerical_probes import (
+from chemex.numerical_lanes import (
+    LiveLaneAuthority,
+    RuntimeEnvironment,
+    canonical_lanes,
+)
+from chemex.optimize.numerical_probes import (
     DeProbeEvidence,
     FiniteDifferenceProbeEvidence,
     GridProbeEvidence,
     NumericalProbeArtifact,
     NumericalProbeBaseline,
     NumericalProbeDefinition,
+    NumericalProbeExecutionError,
     SolverProbeEvidence,
     SpectralRiskProbeEvidence,
     numerical_probe_definitions,
     run_numerical_probe,
     run_numerical_probe_baseline,
 )
+from chemex.typing import Array
+
+
+def _live_authority(monkeypatch: pytest.MonkeyPatch) -> LiveLaneAuthority:
+    lane = canonical_lanes()[0]
+    environment = RuntimeEnvironment(lane.semantics)
+    monkeypatch.setattr(
+        RuntimeEnvironment,
+        "from_current_process",
+        classmethod(lambda cls, image_digest, provenance_path=None: environment),
+    )
+    return lane.attest_current_process(lane.semantics.image_digest)
 
 
 def test_probe_catalogue_freezes_required_truth_and_execution_contracts() -> None:
@@ -99,6 +120,7 @@ def test_trf_probes_replay_with_authoritative_request_accounting(
     assert accounting.materialization_requests == 1
     assert accounting.cache_hits >= 1
     assert accounting.workflow_requests > first.evidence.backend_diagnostics.nfev
+    assert first.evidence.backend_diagnostics.callback_calls > 0
     assert first.evidence.trajectory_fingerprint == (
         replay.evidence.trajectory_fingerprint
     )
@@ -119,7 +141,9 @@ def test_finite_difference_probe_retains_truth_steps_and_request_fingerprint() -
         abs=first.evidence.absolute_tolerance,
     )
     assert first.evidence.actual_steps == pytest.approx(
-        (-2.0e-4, -1.0e-4, 0.0, 1.0e-4, 2.0e-4)
+        (-2.0e-4, -1.0e-4, 0.0, 1.0e-4, 2.0e-4),
+        rel=0.0,
+        abs=1.0e-16,
     )
     assert first.evidence.objective_accounting.requests_received == 5
     assert first.evidence.backend_diagnostics.nfev == 0
@@ -149,8 +173,16 @@ def test_bound_rank_and_conditioning_probes_fail_closed_against_exact_truth() ->
     assert isinstance(conditioning.evidence, SpectralRiskProbeEvidence)
     assert conditioning.terminal == "RISK_DETECTED"
     assert conditioning.evidence.rank == 2
-    assert conditioning.evidence.condition == pytest.approx(1.0e8)
-    assert conditioning.evidence.condition_limit == pytest.approx(1.0e6)
+    assert conditioning.evidence.condition == pytest.approx(
+        1.0e8,
+        rel=1.0e-12,
+        abs=0.0,
+    )
+    assert conditioning.evidence.condition_limit == pytest.approx(
+        1.0e6,
+        rel=0.0,
+        abs=0.0,
+    )
     assert conditioning.risks == ("ILL_CONDITIONED",)
 
     for definition, artifact in zip(
@@ -220,11 +252,68 @@ def test_de_probe_retains_seeded_population_order_and_separate_trf_polish() -> N
     )
     assert first.evidence.search_accounting.requests_received > 0
     assert first.evidence.search_diagnostics.nfev > 0
+    assert first.evidence.search_diagnostics.callback_calls == 6
+    assert first.evidence.search_diagnostics.iterations == 6
     assert first.evidence.polish.accepted == pytest.approx((0.25,), abs=1.0e-8)
     assert first.evidence.trajectory_fingerprint == (
         replay.evidence.trajectory_fingerprint
     )
     assert first.identity == replay.identity
+
+
+def test_backend_success_cannot_mint_truth_claims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = numerical_probe_definitions()[0]
+
+    def false_success(*_args: object, **_kwargs: object) -> object:
+        return SimpleNamespace(
+            x=np.asarray((0.0, 0.0)),
+            active_mask=np.asarray((0, 0)),
+            nfev=1,
+            njev=0,
+            success=True,
+        )
+
+    monkeypatch.setattr(
+        "chemex.optimize.numerical_probes.least_squares",
+        false_success,
+    )
+
+    artifact = run_numerical_probe(definition)
+
+    assert artifact.terminal == "TRUTH_MISMATCH"
+    assert artifact.satisfied_claims == ()
+    with pytest.raises(ValueError, match="qualify"):
+        NumericalProbeBaseline((definition,), (artifact,))
+
+
+def test_budget_exhaustion_retains_refused_request_and_trajectory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = numerical_probe_definitions()[0]
+
+    def exhaust_budget(
+        fun: Callable[[Array], Array],
+        _start: object,
+        **_kwargs: object,
+    ) -> object:
+        for _index in range(65):
+            fun(np.asarray((0.0, 0.0)))
+        raise AssertionError("Budget should terminate before backend completion")
+
+    monkeypatch.setattr(
+        "chemex.optimize.numerical_probes.least_squares",
+        exhaust_budget,
+    )
+
+    with pytest.raises(NumericalProbeExecutionError) as captured:
+        run_numerical_probe(definition)
+
+    assert captured.value.terminal == "BUDGET_EXHAUSTED"
+    assert captured.value.accounting.requests_completed == 64
+    assert captured.value.accounting.requests_refused == 1
+    assert len(captured.value.trajectory_fingerprint) == 64
 
 
 def test_probe_baseline_manifest_replays_round_trips_and_rejects_tampering() -> None:
@@ -237,7 +326,15 @@ def test_probe_baseline_manifest_replays_round_trips_and_rejects_tampering() -> 
     )
     assert first.manifest_identity == replay.manifest_identity
     assert first.identity == replay.identity
+    assert first.authority_role == "UNQUALIFIED_DIAGNOSTIC"
+    assert first.lane_reference.startswith("unqualified-")
     assert NumericalProbeBaseline.from_record(first.to_record()) == first
+    assert (
+        run_numerical_probe_baseline(expected_manifest_identity=first.manifest_identity)
+        == first
+    )
+    with pytest.raises(ValueError, match="differs"):
+        run_numerical_probe_baseline(expected_manifest_identity="0" * 64)
 
     tampered = copy.deepcopy(first.to_record())
     artifacts = tampered["artifacts"]
@@ -249,3 +346,17 @@ def test_probe_baseline_manifest_replays_round_trips_and_rejects_tampering() -> 
 
     with pytest.raises(ValueError, match="accounting|payload"):
         NumericalProbeBaseline.from_record(tampered)
+
+
+def test_probe_baseline_retains_live_lane_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = _live_authority(monkeypatch)
+
+    baseline = run_numerical_probe_baseline(authority)
+
+    assert baseline.authority_role == "QUALIFIED_LANE"
+    assert baseline.lane_reference == authority.lane_identity
+    assert baseline.lane_attestation_identity == authority.identity
+    assert baseline.environment_identity == authority.environment_identity
+    assert NumericalProbeBaseline.from_record(baseline.to_record()) == baseline

--- a/tests/test_numerical_probes.py
+++ b/tests/test_numerical_probes.py
@@ -463,8 +463,10 @@ def test_invalid_authoritative_request_has_typed_reconciled_failure(
     assert error.accounting.requests_refused == 0
 
 
-def test_evaluator_failure_after_issued_request_is_typed_and_reconciled(
+@pytest.mark.parametrize("failure_type", [OSError, RuntimeError])
+def test_ordinary_evaluator_failure_after_issued_request_is_typed_and_reconciled(
     monkeypatch: pytest.MonkeyPatch,
+    failure_type: type[Exception],
 ) -> None:
     definition = next(
         item
@@ -473,7 +475,7 @@ def test_evaluator_failure_after_issued_request_is_typed_and_reconciled(
     )
 
     def evaluator_failure(_value: float) -> float:
-        raise ArithmeticError
+        raise failure_type("ordinary evaluator failure")
 
     monkeypatch.setattr(
         "chemex.optimize.numerical_probes.math.exp",
@@ -489,6 +491,34 @@ def test_evaluator_failure_after_issued_request_is_typed_and_reconciled(
     assert error.accounting.requests_received == 1
     assert error.accounting.requests_failed == 1
     assert error.accounting.requests_completed == 0
+    assert error.accounting.requests_refused == 0
+    assert error.accounting.requests_received == (
+        error.accounting.fresh_evaluations
+        + error.accounting.cache_served_requests
+        + error.accounting.requests_refused
+        + error.accounting.requests_failed
+    )
+
+
+def test_evaluator_keyboard_interrupt_retains_process_control_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = next(
+        item
+        for item in numerical_probe_definitions()
+        if item.probe_id == "finite-difference-reliability-v1"
+    )
+
+    def interrupt(_value: float) -> float:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        "chemex.optimize.numerical_probes.math.exp",
+        interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_numerical_probe(definition)
 
 
 def test_nonfinite_authoritative_result_is_typed_and_never_qualifies(
@@ -737,6 +767,34 @@ def test_foreign_live_authority_does_not_match_historical_lane_evidence(
     assert rejected.value.terminal == "LANE_MISMATCH"
 
 
+def test_renamed_canonical_lane_cannot_qualify_fresh_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = run_numerical_probe_baseline()
+    canonical = canonical_lanes()[0]
+    renamed = dataclasses.replace(
+        canonical,
+        name="renamed-canonical-numerical-lane",
+    )
+    environment = RuntimeEnvironment(renamed.semantics)
+    monkeypatch.setattr(
+        RuntimeEnvironment,
+        "from_current_process",
+        classmethod(lambda cls, image_digest, provenance_path=None: environment),
+    )
+    authority = renamed.attest_current_process(renamed.semantics.image_digest)
+
+    assert authority.lane_identity != canonical.identity
+    with pytest.raises(NumericalProbeQualificationError) as rejected:
+        capture.require_live_qualification(
+            authority,
+            expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+            required_lane_role="CANONICAL_NUMERICAL",
+        )
+
+    assert rejected.value.terminal == "LANE_MISMATCH"
+
+
 def test_serialized_probe_baseline_never_recreates_live_lane_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -765,15 +823,24 @@ def test_serialized_probe_baseline_never_recreates_live_lane_authority(
     with pytest.raises(TypeError):
         copy.copy(authority)
     with pytest.raises(TypeError):
+        copy.deepcopy(authority)
+    with pytest.raises(TypeError):
         pickle.dumps(authority)
 
 
-def test_foreign_or_compatibility_authority_cannot_qualify_canonical_capture(
+def test_compatibility_authority_role_mutation_cannot_qualify_canonical_capture(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     capture = run_numerical_probe_baseline()
     compatibility = _live_authority(monkeypatch, 1)
 
+    with pytest.raises(AttributeError):
+        object.__setattr__(
+            compatibility,
+            "_lane_role",
+            "CANONICAL_NUMERICAL",
+        )
+    assert compatibility.lane_role == "PYTHON_COMPATIBILITY"
     with pytest.raises(NumericalProbeQualificationError) as rejected:
         capture.require_live_qualification(
             compatibility,

--- a/tests/test_numerical_probes.py
+++ b/tests/test_numerical_probes.py
@@ -14,6 +14,8 @@ import numpy as np
 import pytest
 
 from chemex.numerical_lanes import (
+    LaneAttestation,
+    LaneAuthorityError,
     LiveLaneAuthority,
     RuntimeEnvironment,
     canonical_lanes,
@@ -51,6 +53,10 @@ def _live_authority(
         classmethod(lambda cls, image_digest, provenance_path=None: environment),
     )
     return lane.attest_current_process(lane.semantics.image_digest)
+
+
+def _detached_evidence(authority: LiveLaneAuthority) -> LaneAttestation:
+    return LaneAttestation.from_record(authority.to_record())
 
 
 def test_probe_catalogue_freezes_required_truth_and_execution_contracts() -> None:
@@ -783,8 +789,22 @@ def test_renamed_canonical_lane_cannot_qualify_fresh_capture(
         classmethod(lambda cls, image_digest, provenance_path=None: environment),
     )
     authority = renamed.attest_current_process(renamed.semantics.image_digest)
+    canonical_authority = canonical.attest_current_process(
+        canonical.semantics.image_digest
+    )
+    evidence = _detached_evidence(authority)
+    canonical_evidence = _detached_evidence(canonical_authority)
 
-    assert authority.lane_identity != canonical.identity
+    assert evidence.lane_identity != canonical.identity
+    for field in (
+        "lane_identity",
+        "environment_identity",
+        "workers",
+        "native_threads",
+        "method",
+        "identity",
+    ):
+        object.__setattr__(evidence, field, getattr(canonical_evidence, field))
     with pytest.raises(NumericalProbeQualificationError) as rejected:
         capture.require_live_qualification(
             authority,
@@ -793,6 +813,29 @@ def test_renamed_canonical_lane_cannot_qualify_fresh_capture(
         )
 
     assert rejected.value.terminal == "LANE_MISMATCH"
+
+
+@pytest.mark.parametrize(
+    "accessor",
+    [
+        "_binding",
+        "evidence",
+        "lane_identity",
+        "environment_identity",
+        "lane_role",
+        "workers",
+        "native_threads",
+        "identity",
+    ],
+)
+def test_live_lane_authority_exposes_no_authority_bearing_facts(
+    monkeypatch: pytest.MonkeyPatch,
+    accessor: str,
+) -> None:
+    authority = _live_authority(monkeypatch)
+
+    with pytest.raises(AttributeError):
+        getattr(authority, accessor)
 
 
 def test_serialized_probe_baseline_never_recreates_live_lane_authority(
@@ -804,9 +847,10 @@ def test_serialized_probe_baseline_never_recreates_live_lane_authority(
         expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
     )
     restored = pickle.loads(pickle.dumps(baseline))  # noqa: S301 - trusted self-record
+    evidence = _detached_evidence(authority)
 
     assert restored.historical_qualification == "REFERENCE_MATCHED"
-    assert restored.observed_lane_identity == authority.lane_identity
+    assert restored.observed_lane_identity == evidence.lane_identity
     assert not isinstance(restored, LiveLaneAuthority)
     restored.require_live_qualification(
         authority,
@@ -833,14 +877,36 @@ def test_compatibility_authority_role_mutation_cannot_qualify_canonical_capture(
 ) -> None:
     capture = run_numerical_probe_baseline()
     compatibility = _live_authority(monkeypatch, 1)
+    canonical = _live_authority(monkeypatch)
+    compatibility_evidence = _detached_evidence(compatibility)
+    canonical_evidence = _detached_evidence(canonical)
 
-    with pytest.raises(AttributeError):
+    attempted_fields = {
+        "_binding": object(),
+        "evidence": canonical_evidence,
+        "lane_identity": canonical_evidence.lane_identity,
+        "environment_identity": canonical_evidence.environment_identity,
+        "lane_role": "CANONICAL_NUMERICAL",
+        "identity": canonical_evidence.identity,
+    }
+    for field, value in attempted_fields.items():
+        with pytest.raises(AttributeError):
+            setattr(compatibility, field, value)
+        with pytest.raises(AttributeError):
+            object.__setattr__(compatibility, field, value)
+    for field in (
+        "lane_identity",
+        "environment_identity",
+        "workers",
+        "native_threads",
+        "method",
+        "identity",
+    ):
         object.__setattr__(
-            compatibility,
-            "_lane_role",
-            "CANONICAL_NUMERICAL",
+            compatibility_evidence,
+            field,
+            getattr(canonical_evidence, field),
         )
-    assert compatibility.lane_role == "PYTHON_COMPATIBILITY"
     with pytest.raises(NumericalProbeQualificationError) as rejected:
         capture.require_live_qualification(
             compatibility,
@@ -849,3 +915,39 @@ def test_compatibility_authority_role_mutation_cannot_qualify_canonical_capture(
         )
 
     assert rejected.value.terminal == "LANE_ROLE_MISMATCH"
+
+
+def test_detached_evidence_mutation_cannot_change_canonical_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = run_numerical_probe_baseline()
+    authority = _live_authority(monkeypatch)
+    evidence_record = authority.to_record()
+    evidence = LaneAttestation.from_record(evidence_record)
+
+    evidence_record.update(
+        lane_identity="a" * 64,
+        environment_identity="b" * 64,
+        identity="c" * 64,
+    )
+    object.__setattr__(evidence, "lane_identity", "d" * 64)
+    object.__setattr__(evidence, "environment_identity", "e" * 64)
+    object.__setattr__(evidence, "identity", "f" * 64)
+
+    capture.require_live_qualification(
+        authority,
+        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+        required_lane_role="CANONICAL_NUMERICAL",
+    )
+
+
+def test_authority_absent_from_live_registry_fails_closed() -> None:
+    capture = run_numerical_probe_baseline()
+    authority = object.__new__(LiveLaneAuthority)
+
+    with pytest.raises(LaneAuthorityError, match="process-owned"):
+        capture.require_live_qualification(
+            authority,
+            expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+            required_lane_role="CANONICAL_NUMERICAL",
+        )

--- a/tests/test_numerical_probes.py
+++ b/tests/test_numerical_probes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import math
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import cast
@@ -111,7 +112,7 @@ def test_trf_probes_replay_with_authoritative_request_accounting(
     assert first.risks == ()
     assert first.satisfied_claims == definition.eligible_claims
     assert isinstance(first.evidence, SolverProbeEvidence)
-    assert first.evidence.accepted == pytest.approx(expected, abs=1.0e-8)
+    assert first.evidence.accepted == pytest.approx(expected, rel=0.0, abs=1.0e-8)
     accounting = first.evidence.objective_accounting
     assert accounting.requests_received == accounting.requests_completed
     assert accounting.cache_hits + accounting.cache_misses == (
@@ -120,7 +121,8 @@ def test_trf_probes_replay_with_authoritative_request_accounting(
     assert accounting.materialization_requests == 1
     assert accounting.cache_hits >= 1
     assert accounting.workflow_requests > first.evidence.backend_diagnostics.nfev
-    assert first.evidence.backend_diagnostics.callback_calls > 0
+    # SciPy 1.15 has no least_squares callback API, so its absence is explicit.
+    assert first.evidence.backend_diagnostics.callback_calls == 0
     assert first.evidence.trajectory_fingerprint == (
         replay.evidence.trajectory_fingerprint
     )
@@ -138,12 +140,22 @@ def test_finite_difference_probe_retains_truth_steps_and_request_fingerprint() -
     assert isinstance(first.evidence, FiniteDifferenceProbeEvidence)
     assert first.evidence.estimate == pytest.approx(
         first.evidence.truth,
+        rel=0.0,
         abs=first.evidence.absolute_tolerance,
     )
-    assert first.evidence.actual_steps == pytest.approx(
-        (-2.0e-4, -1.0e-4, 0.0, 1.0e-4, 2.0e-4),
-        rel=0.0,
-        abs=1.0e-16,
+    expected_steps = tuple(
+        (0.5 + nominal_step) - 0.5
+        for nominal_step in (-2.0e-4, -1.0e-4, 0.0, 1.0e-4, 2.0e-4)
+    )
+    assert first.evidence.actual_steps == expected_steps
+    assert first.evidence.actual_steps[3] != 1.0e-4
+    assert first.evidence.estimate == math.fsum(
+        weight * value
+        for weight, value in zip(
+            first.evidence.weights,
+            first.evidence.sampled_values,
+            strict=True,
+        )
     )
     assert first.evidence.objective_accounting.requests_received == 5
     assert first.evidence.backend_diagnostics.nfev == 0
@@ -160,7 +172,7 @@ def test_bound_rank_and_conditioning_probes_fail_closed_against_exact_truth() ->
     conditioning = run_numerical_probe(definitions[7])
 
     assert isinstance(boundary.evidence, SolverProbeEvidence)
-    assert boundary.evidence.accepted == pytest.approx((1.0,), abs=1.0e-8)
+    assert boundary.evidence.accepted == pytest.approx((1.0,), rel=0.0, abs=1.0e-8)
     assert boundary.evidence.active_mask == (1,)
     assert boundary.risks == ("ACTIVE_BOUND",)
 
@@ -218,7 +230,9 @@ def test_grid_probe_retains_all_physical_seeds_and_canonical_candidate_order() -
         == (first.evidence.ordered_seed_ordinals[0])
     )
     selected = first.evidence.seeds[first.evidence.selected_seed_ordinal]
-    assert selected.solver.accepted == pytest.approx((1.0, -1.0, 0.5), abs=1.0e-8)
+    assert selected.solver.accepted == pytest.approx(
+        (1.0, -1.0, 0.5), rel=0.0, abs=1.0e-8
+    )
     assert first.evidence.objective_accounting.requests_received == sum(
         seed.solver.objective_accounting.requests_received
         for seed in first.evidence.seeds
@@ -251,10 +265,21 @@ def test_de_probe_retains_seeded_population_order_and_separate_trf_polish() -> N
         == (first.evidence.ordered_population_indices[0])
     )
     assert first.evidence.search_accounting.requests_received > 0
+    assert first.evidence.search_accounting.materialization_requests == len(
+        first.evidence.final_population
+    )
     assert first.evidence.search_diagnostics.nfev > 0
     assert first.evidence.search_diagnostics.callback_calls == 6
     assert first.evidence.search_diagnostics.iterations == 6
-    assert first.evidence.polish.accepted == pytest.approx((0.25,), abs=1.0e-8)
+    for candidate in first.evidence.final_population:
+        displacement = candidate.vector[0] - 0.25
+        expected_objective = displacement**2 + 0.25 * math.sin(5.0 * displacement) ** 2
+        assert candidate.objective == pytest.approx(
+            expected_objective,
+            rel=0.0,
+            abs=1.0e-16,
+        )
+    assert first.evidence.polish.accepted == pytest.approx((0.25,), rel=0.0, abs=1.0e-8)
     assert first.evidence.trajectory_fingerprint == (
         replay.evidence.trajectory_fingerprint
     )
@@ -293,27 +318,52 @@ def test_budget_exhaustion_retains_refused_request_and_trajectory(
 ) -> None:
     definition = numerical_probe_definitions()[0]
 
-    def exhaust_budget(
-        fun: Callable[[Array], Array],
-        _start: object,
-        **_kwargs: object,
-    ) -> object:
-        for _index in range(65):
-            fun(np.asarray((0.0, 0.0)))
-        raise AssertionError("Budget should terminate before backend completion")
+    def exhauster(refused: tuple[float, float]) -> Callable[..., object]:
+        def exhaust_budget(
+            fun: Callable[[Array], Array],
+            _start: object,
+            **_kwargs: object,
+        ) -> object:
+            for _index in range(64):
+                fun(np.asarray((0.0, 0.0)))
+            fun(np.asarray(refused))
+            raise AssertionError("Budget should terminate before backend completion")
+
+        return exhaust_budget
 
     monkeypatch.setattr(
         "chemex.optimize.numerical_probes.least_squares",
-        exhaust_budget,
+        exhauster((1.0, 1.0)),
     )
 
-    with pytest.raises(NumericalProbeExecutionError) as captured:
+    with pytest.raises(NumericalProbeExecutionError) as first:
+        run_numerical_probe(definition)
+    monkeypatch.setattr(
+        "chemex.optimize.numerical_probes.least_squares",
+        exhauster((2.0, 2.0)),
+    )
+    with pytest.raises(NumericalProbeExecutionError) as second:
         run_numerical_probe(definition)
 
-    assert captured.value.terminal == "BUDGET_EXHAUSTED"
-    assert captured.value.accounting.requests_completed == 64
-    assert captured.value.accounting.requests_refused == 1
-    assert len(captured.value.trajectory_fingerprint) == 64
+    assert first.value.terminal == "BUDGET_EXHAUSTED"
+    assert first.value.accounting.requests_completed == 64
+    assert first.value.accounting.requests_refused == 1
+    assert len(first.value.trajectory_fingerprint) == 64
+    assert first.value.trajectory_fingerprint != second.value.trajectory_fingerprint
+
+
+def test_probe_baseline_rejects_evidence_from_another_category() -> None:
+    baseline = run_numerical_probe_baseline()
+    wrong = dataclasses.replace(
+        baseline.artifacts[0],
+        evidence=baseline.artifacts[3].evidence,
+    )
+
+    with pytest.raises(TypeError, match="category"):
+        NumericalProbeBaseline(
+            baseline.definitions,
+            (wrong, *baseline.artifacts[1:]),
+        )
 
 
 def test_probe_baseline_manifest_replays_round_trips_and_rejects_tampering() -> None:

--- a/tests/test_numerical_probes.py
+++ b/tests/test_numerical_probes.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import json
 import math
 import pickle
 from collections.abc import Callable
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
@@ -57,6 +59,18 @@ def _live_authority(
 
 def _detached_evidence(authority: LiveLaneAuthority) -> LaneAttestation:
     return LaneAttestation.from_record(authority.to_record())
+
+
+def _canonical_probe_baseline() -> NumericalProbeBaseline:
+    record = json.loads(
+        (
+            Path(__file__).parent
+            / "fixtures"
+            / "canonical_numerical_probe_baseline.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert isinstance(record, dict)
+    return NumericalProbeBaseline.from_record(record)
 
 
 def test_probe_catalogue_freezes_required_truth_and_execution_contracts() -> None:
@@ -648,28 +662,20 @@ def test_serialized_backend_grid_trajectory_and_manifest_tampering_is_rejected()
             NumericalProbeBaseline.from_record(record)
 
 
-def test_matching_external_manifest_is_recorded_but_remains_evidence_only(
+def test_fresh_capture_is_content_addressed_but_remains_capture_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     capture = run_numerical_probe_baseline()
-    assert capture.manifest_identity == CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY
+    assert len(capture.manifest_identity) == 64
+    int(capture.manifest_identity, 16)
+    assert capture.historical_qualification == "CAPTURE_ONLY"
+    assert capture.historically_satisfied_claims == ()
     authority = _live_authority(monkeypatch)
 
     authority_without_reference = run_numerical_probe_baseline(authority)
     assert authority_without_reference.historical_qualification == "CAPTURE_ONLY"
     assert authority_without_reference.historically_satisfied_claims == ()
 
-    matched = run_numerical_probe_baseline(
-        authority,
-        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
-    )
-
-    assert matched.historical_qualification == "REFERENCE_MATCHED"
-    assert matched.historically_satisfied_claims == ("trajectory-manifest-compatible",)
-    tampered_role = copy.deepcopy(matched.to_record())
-    tampered_role["observed_lane_role"] = "PYTHON_COMPATIBILITY"
-    with pytest.raises(ValueError, match="identity"):
-        NumericalProbeBaseline.from_record(tampered_role)
     with pytest.raises(NumericalProbeQualificationError) as mismatch:
         capture.require_live_qualification(
             authority,
@@ -677,6 +683,25 @@ def test_matching_external_manifest_is_recorded_but_remains_evidence_only(
             required_lane_role="CANONICAL_NUMERICAL",
         )
     assert mismatch.value.terminal == "EXPECTED_REFERENCE_MISMATCH"
+
+
+def test_frozen_canonical_reference_records_historical_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    matched = _canonical_probe_baseline()
+    authority = _live_authority(monkeypatch)
+
+    matched.require_live_qualification(
+        authority,
+        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+        required_lane_role="CANONICAL_NUMERICAL",
+    )
+    assert matched.historical_qualification == "REFERENCE_MATCHED"
+    assert matched.historically_satisfied_claims == ("trajectory-manifest-compatible",)
+    tampered_role = copy.deepcopy(matched.to_record())
+    tampered_role["observed_lane_role"] = "PYTHON_COMPATIBILITY"
+    with pytest.raises(ValueError, match="identity"):
+        NumericalProbeBaseline.from_record(tampered_role)
 
 
 def test_live_run_cannot_mint_a_new_manifest_from_backend_drift(
@@ -717,7 +742,7 @@ def test_live_run_cannot_mint_a_new_manifest_from_backend_drift(
 def test_fabricated_serialized_lane_facts_cannot_gain_live_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    capture = run_numerical_probe_baseline()
+    capture = _canonical_probe_baseline()
     fabricated = NumericalProbeBaseline(
         capture.definitions,
         capture.artifacts,
@@ -744,11 +769,7 @@ def test_fabricated_serialized_lane_facts_cannot_gain_live_authority(
 def test_foreign_live_authority_does_not_match_historical_lane_evidence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    canonical = _live_authority(monkeypatch)
-    matched = run_numerical_probe_baseline(
-        canonical,
-        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
-    )
+    matched = _canonical_probe_baseline()
     foreign_lane = dataclasses.replace(
         canonical_lanes()[0],
         name="foreign-canonical-numerical-lane",
@@ -842,10 +863,7 @@ def test_serialized_probe_baseline_never_recreates_live_lane_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     authority = _live_authority(monkeypatch)
-    baseline = run_numerical_probe_baseline(
-        authority,
-        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
-    )
+    baseline = _canonical_probe_baseline()
     restored = pickle.loads(pickle.dumps(baseline))  # noqa: S301 - trusted self-record
     evidence = _detached_evidence(authority)
 
@@ -920,7 +938,7 @@ def test_compatibility_authority_role_mutation_cannot_qualify_canonical_capture(
 def test_detached_evidence_mutation_cannot_change_canonical_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    capture = run_numerical_probe_baseline()
+    capture = _canonical_probe_baseline()
     authority = _live_authority(monkeypatch)
     evidence_record = authority.to_record()
     evidence = LaneAttestation.from_record(evidence_record)

--- a/tests/test_numerical_probes.py
+++ b/tests/test_numerical_probes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import math
+import pickle
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import cast
@@ -18,13 +19,17 @@ from chemex.numerical_lanes import (
     canonical_lanes,
 )
 from chemex.optimize.numerical_probes import (
+    CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+    AuthoritativeObjectiveAccounting,
     DeProbeEvidence,
     FiniteDifferenceProbeEvidence,
+    GridOrderingProbeEvidence,
     GridProbeEvidence,
     NumericalProbeArtifact,
     NumericalProbeBaseline,
     NumericalProbeDefinition,
     NumericalProbeExecutionError,
+    NumericalProbeQualificationError,
     SolverProbeEvidence,
     SpectralRiskProbeEvidence,
     numerical_probe_definitions,
@@ -34,8 +39,11 @@ from chemex.optimize.numerical_probes import (
 from chemex.typing import Array
 
 
-def _live_authority(monkeypatch: pytest.MonkeyPatch) -> LiveLaneAuthority:
-    lane = canonical_lanes()[0]
+def _live_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    lane_index: int = 0,
+) -> LiveLaneAuthority:
+    lane = canonical_lanes()[lane_index]
     environment = RuntimeEnvironment(lane.semantics)
     monkeypatch.setattr(
         RuntimeEnvironment,
@@ -51,7 +59,8 @@ def test_probe_catalogue_freezes_required_truth_and_execution_contracts() -> Non
     assert tuple(definition.probe_id for definition in definitions) == (
         "trf-routine-quadratic-v1",
         "trf-difficult-rosenbrock-v1",
-        "grid-27-seed-ordering-v1",
+        "grid-27-seed-coverage-v1",
+        "grid-candidate-ordering-v1",
         "de-bounded-search-v1",
         "finite-difference-reliability-v1",
         "trf-active-bound-v1",
@@ -62,6 +71,7 @@ def test_probe_catalogue_freezes_required_truth_and_execution_contracts() -> Non
         "TRF_ROUTINE",
         "TRF_DIFFICULT",
         "GRID",
+        "GRID_ORDERING",
         "DE_SEARCH",
         "FINITE_DIFFERENCE",
         "BOUNDS",
@@ -113,14 +123,17 @@ def test_trf_probes_replay_with_authoritative_request_accounting(
     assert first.satisfied_claims == definition.eligible_claims
     assert isinstance(first.evidence, SolverProbeEvidence)
     assert first.evidence.accepted == pytest.approx(expected, rel=0.0, abs=1.0e-8)
-    accounting = first.evidence.objective_accounting
+    accounting = first.evidence.authoritative_accounting
     assert accounting.requests_received == accounting.requests_completed
     assert accounting.cache_hits + accounting.cache_misses == (
         accounting.requests_completed
     )
+    assert accounting.workflow_requests == 1
     assert accounting.materialization_requests == 1
-    assert accounting.cache_hits >= 1
-    assert accounting.workflow_requests > first.evidence.backend_diagnostics.nfev
+    assert accounting.requests_received == 2
+    assert first.evidence.backend_diagnostics.diagnostic_evaluations > (
+        accounting.requests_received
+    )
     # SciPy 1.15 has no least_squares callback API, so its absence is explicit.
     assert first.evidence.backend_diagnostics.callback_calls == 0
     assert first.evidence.trajectory_fingerprint == (
@@ -131,7 +144,11 @@ def test_trf_probes_replay_with_authoritative_request_accounting(
 
 
 def test_finite_difference_probe_retains_truth_steps_and_request_fingerprint() -> None:
-    definition = numerical_probe_definitions()[4]
+    definition = next(
+        item
+        for item in numerical_probe_definitions()
+        if item.probe_id == "finite-difference-reliability-v1"
+    )
 
     first = run_numerical_probe(definition)
     replay = run_numerical_probe(definition)
@@ -157,7 +174,7 @@ def test_finite_difference_probe_retains_truth_steps_and_request_fingerprint() -
             strict=True,
         )
     )
-    assert first.evidence.objective_accounting.requests_received == 5
+    assert first.evidence.authoritative_accounting.requests_received == 5
     assert first.evidence.backend_diagnostics.nfev == 0
     assert first.evidence.trajectory_fingerprint == (
         replay.evidence.trajectory_fingerprint
@@ -166,10 +183,20 @@ def test_finite_difference_probe_retains_truth_steps_and_request_fingerprint() -
 
 def test_bound_rank_and_conditioning_probes_fail_closed_against_exact_truth() -> None:
     definitions = numerical_probe_definitions()
+    selected = {
+        definition.probe_id: definition
+        for definition in definitions
+        if definition.probe_id
+        in {
+            "trf-active-bound-v1",
+            "rank-deficient-linearization-v1",
+            "ill-conditioned-linearization-v1",
+        }
+    }
 
-    boundary = run_numerical_probe(definitions[5])
-    rank = run_numerical_probe(definitions[6])
-    conditioning = run_numerical_probe(definitions[7])
+    boundary = run_numerical_probe(selected["trf-active-bound-v1"])
+    rank = run_numerical_probe(selected["rank-deficient-linearization-v1"])
+    conditioning = run_numerical_probe(selected["ill-conditioned-linearization-v1"])
 
     assert isinstance(boundary.evidence, SolverProbeEvidence)
     assert boundary.evidence.accepted == pytest.approx((1.0,), rel=0.0, abs=1.0e-8)
@@ -198,7 +225,11 @@ def test_bound_rank_and_conditioning_probes_fail_closed_against_exact_truth() ->
     assert conditioning.risks == ("ILL_CONDITIONED",)
 
     for definition, artifact in zip(
-        definitions[5:],
+        (
+            selected["trf-active-bound-v1"],
+            selected["rank-deficient-linearization-v1"],
+            selected["ill-conditioned-linearization-v1"],
+        ),
         (boundary, rank, conditioning),
         strict=True,
     ):
@@ -208,7 +239,7 @@ def test_bound_rank_and_conditioning_probes_fail_closed_against_exact_truth() ->
         )
 
 
-def test_grid_probe_retains_all_physical_seeds_and_canonical_candidate_order() -> None:
+def test_grid_probe_retains_all_physical_seeds_and_observed_candidate_order() -> None:
     definition = numerical_probe_definitions()[2]
 
     first = run_numerical_probe(definition)
@@ -222,7 +253,11 @@ def test_grid_probe_retains_all_physical_seeds_and_canonical_candidate_order() -
         seed.ordinal
         for seed in sorted(
             first.evidence.seeds,
-            key=lambda seed: (seed.solver.chi_square, seed.ordinal),
+            key=lambda seed: (
+                seed.solver.chi_square,
+                seed.solver.accepted,
+                seed.ordinal,
+            ),
         )
     )
     assert (
@@ -234,7 +269,7 @@ def test_grid_probe_retains_all_physical_seeds_and_canonical_candidate_order() -
         (1.0, -1.0, 0.5), rel=0.0, abs=1.0e-8
     )
     assert first.evidence.objective_accounting.requests_received == sum(
-        seed.solver.objective_accounting.requests_received
+        seed.solver.authoritative_accounting.requests_received
         for seed in first.evidence.seeds
     )
     assert first.evidence.trajectory_fingerprint == (
@@ -243,8 +278,43 @@ def test_grid_probe_retains_all_physical_seeds_and_canonical_candidate_order() -
     assert first.identity == replay.identity
 
 
+def test_grid_ordering_claim_uses_predeclared_truth_not_observed_candidates() -> None:
+    definition = next(
+        item
+        for item in numerical_probe_definitions()
+        if item.probe_id == "grid-candidate-ordering-v1"
+    )
+
+    artifact = run_numerical_probe(definition)
+
+    assert artifact.terminal == "ORDERED"
+    assert isinstance(artifact.evidence, GridOrderingProbeEvidence)
+    assert artifact.evidence.expected_order == (1, 3, 2, 0)
+    assert artifact.evidence.observed_order == artifact.evidence.expected_order
+    for wrong_order in ((1, 0, 2, 3), (3, 1, 2, 0)):
+        wrong_evidence = dataclasses.replace(
+            artifact.evidence,
+            observed_order=wrong_order,
+            selected_ordinal=wrong_order[0],
+        )
+        wrong = dataclasses.replace(artifact, evidence=wrong_evidence)
+        with pytest.raises(ValueError, match="ordering"):
+            wrong.require_qualification(definition)
+
+    reordered = copy.deepcopy(artifact.to_record())
+    raw_evidence = cast("dict[str, object]", reordered["evidence"])
+    candidates = cast("list[object]", raw_evidence["candidates"])
+    candidates[0], candidates[1] = candidates[1], candidates[0]
+    with pytest.raises(ValueError, match="ordinal order"):
+        NumericalProbeArtifact.from_record(reordered, definition)
+
+
 def test_de_probe_retains_seeded_population_order_and_separate_trf_polish() -> None:
-    definition = numerical_probe_definitions()[3]
+    definition = next(
+        item
+        for item in numerical_probe_definitions()
+        if item.probe_id == "de-bounded-search-v1"
+    )
 
     first = run_numerical_probe(definition)
     replay = run_numerical_probe(definition)
@@ -264,9 +334,10 @@ def test_de_probe_retains_seeded_population_order_and_separate_trf_polish() -> N
         first.evidence.selected_population_index
         == (first.evidence.ordered_population_indices[0])
     )
-    assert first.evidence.search_accounting.requests_received > 0
-    assert first.evidence.search_accounting.materialization_requests == len(
-        first.evidence.final_population
+    assert first.evidence.authoritative_search_accounting.requests_received > 0
+    assert (
+        first.evidence.authoritative_search_accounting.materialization_requests
+        == len(first.evidence.final_population)
     )
     assert first.evidence.search_diagnostics.nfev > 0
     assert first.evidence.search_diagnostics.callback_calls == 6
@@ -313,43 +384,151 @@ def test_backend_success_cannot_mint_truth_claims(
         NumericalProbeBaseline((definition,), (artifact,))
 
 
-def test_budget_exhaustion_retains_refused_request_and_trajectory(
+def test_backend_call_pattern_does_not_change_authoritative_request_accounting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     definition = numerical_probe_definitions()[0]
 
-    def exhauster(refused: tuple[float, float]) -> Callable[..., object]:
-        def exhaust_budget(
+    def backend(call_count: int) -> Callable[..., object]:
+        def solve(
             fun: Callable[[Array], Array],
-            _start: object,
+            start: object,
             **_kwargs: object,
         ) -> object:
-            for _index in range(64):
-                fun(np.asarray((0.0, 0.0)))
-            fun(np.asarray(refused))
-            raise AssertionError("Budget should terminate before backend completion")
+            for _index in range(call_count):
+                fun(np.asarray(start))
+            return SimpleNamespace(
+                x=np.asarray((1.5, -0.5)),
+                active_mask=np.asarray((0, 0)),
+                nfev=call_count,
+                njev=1,
+                success=True,
+            )
 
-        return exhaust_budget
+        return solve
 
     monkeypatch.setattr(
         "chemex.optimize.numerical_probes.least_squares",
-        exhauster((1.0, 1.0)),
+        backend(1),
     )
-
-    with pytest.raises(NumericalProbeExecutionError) as first:
-        run_numerical_probe(definition)
+    first = run_numerical_probe(definition)
     monkeypatch.setattr(
         "chemex.optimize.numerical_probes.least_squares",
-        exhauster((2.0, 2.0)),
+        backend(7),
     )
-    with pytest.raises(NumericalProbeExecutionError) as second:
+    second = run_numerical_probe(definition)
+
+    assert isinstance(first.evidence, SolverProbeEvidence)
+    assert isinstance(second.evidence, SolverProbeEvidence)
+    assert first.evidence.authoritative_accounting == (
+        second.evidence.authoritative_accounting
+    )
+    assert first.evidence.trajectory_fingerprint == (
+        second.evidence.trajectory_fingerprint
+    )
+    assert first.evidence.backend_diagnostics.nfev == 1
+    assert second.evidence.backend_diagnostics.nfev == 7
+    assert first.evidence.backend_diagnostics.diagnostic_evaluations == 1
+    assert second.evidence.backend_diagnostics.diagnostic_evaluations == 7
+
+
+def test_invalid_authoritative_request_has_typed_reconciled_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = numerical_probe_definitions()[0]
+
+    def invalid_result(*_args: object, **_kwargs: object) -> object:
+        return SimpleNamespace(
+            x=np.asarray((float("nan"), 0.0)),
+            active_mask=np.asarray((0, 0)),
+            nfev=1,
+            njev=0,
+            success=True,
+        )
+
+    monkeypatch.setattr(
+        "chemex.optimize.numerical_probes.least_squares",
+        invalid_result,
+    )
+
+    with pytest.raises(NumericalProbeExecutionError) as captured:
         run_numerical_probe(definition)
 
-    assert first.value.terminal == "BUDGET_EXHAUSTED"
-    assert first.value.accounting.requests_completed == 64
-    assert first.value.accounting.requests_refused == 1
-    assert len(first.value.trajectory_fingerprint) == 64
-    assert first.value.trajectory_fingerprint != second.value.trajectory_fingerprint
+    error = captured.value
+    assert error.terminal == "REQUEST_FAILED"
+    assert error.failure_kind == "INVALID_INPUT"
+    assert error.accounting.requests_received == 2
+    assert error.accounting.requests_failed == 1
+    assert error.accounting.requests_completed == 1
+    assert error.accounting.requests_refused == 0
+
+
+def test_evaluator_failure_after_issued_request_is_typed_and_reconciled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = next(
+        item
+        for item in numerical_probe_definitions()
+        if item.probe_id == "finite-difference-reliability-v1"
+    )
+
+    def evaluator_failure(_value: float) -> float:
+        raise ArithmeticError
+
+    monkeypatch.setattr(
+        "chemex.optimize.numerical_probes.math.exp",
+        evaluator_failure,
+    )
+
+    with pytest.raises(NumericalProbeExecutionError) as captured:
+        run_numerical_probe(definition)
+
+    error = captured.value
+    assert error.terminal == "REQUEST_FAILED"
+    assert error.failure_kind == "EVALUATION_FAILURE"
+    assert error.accounting.requests_received == 1
+    assert error.accounting.requests_failed == 1
+    assert error.accounting.requests_completed == 0
+
+
+def test_nonfinite_authoritative_result_is_typed_and_never_qualifies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = next(
+        item
+        for item in numerical_probe_definitions()
+        if item.probe_id == "finite-difference-reliability-v1"
+    )
+    monkeypatch.setattr(
+        "chemex.optimize.numerical_probes.math.exp",
+        lambda _value: float("inf"),
+    )
+
+    with pytest.raises(NumericalProbeExecutionError) as captured:
+        run_numerical_probe(definition)
+
+    assert captured.value.terminal == "REQUEST_FAILED"
+    assert captured.value.failure_kind == "NON_FINITE_RESULT"
+    assert captured.value.accounting.requests_received == 1
+    assert captured.value.accounting.requests_failed == 1
+
+
+def test_authoritative_request_outcomes_form_a_closed_accounting_vocabulary() -> None:
+    refused = AuthoritativeObjectiveAccounting(1, 0, 0, 0, 1, ())
+    failed = AuthoritativeObjectiveAccounting(
+        0,
+        1,
+        0,
+        0,
+        0,
+        ("EVALUATION_FAILURE",),
+    )
+
+    assert refused.requests_received == refused.requests_refused == 1
+    assert failed.requests_received == failed.requests_failed == 1
+    assert AuthoritativeObjectiveAccounting.from_record(refused.to_record()) == refused
+    with pytest.raises(ValueError, match="reconcile"):
+        AuthoritativeObjectiveAccounting(1, 0, 0, 0, 0, ())
 
 
 def test_probe_baseline_rejects_evidence_from_another_category() -> None:
@@ -370,21 +549,17 @@ def test_probe_baseline_manifest_replays_round_trips_and_rejects_tampering() -> 
     first = run_numerical_probe_baseline()
     replay = run_numerical_probe_baseline()
 
-    assert len(first.definitions) == 8
+    assert len(first.definitions) == 9
     assert tuple(artifact.probe_id for artifact in first.artifacts) == tuple(
         definition.probe_id for definition in first.definitions
     )
     assert first.manifest_identity == replay.manifest_identity
     assert first.identity == replay.identity
-    assert first.authority_role == "UNQUALIFIED_DIAGNOSTIC"
-    assert first.lane_reference.startswith("unqualified-")
+    assert first.historical_qualification == "CAPTURE_ONLY"
+    assert first.historically_satisfied_claims == ()
     assert NumericalProbeBaseline.from_record(first.to_record()) == first
-    assert (
+    with pytest.raises(TypeError, match="live authority"):
         run_numerical_probe_baseline(expected_manifest_identity=first.manifest_identity)
-        == first
-    )
-    with pytest.raises(ValueError, match="differs"):
-        run_numerical_probe_baseline(expected_manifest_identity="0" * 64)
 
     tampered = copy.deepcopy(first.to_record())
     artifacts = tampered["artifacts"]
@@ -392,21 +567,218 @@ def test_probe_baseline_manifest_replays_round_trips_and_rejects_tampering() -> 
     artifact = cast("dict[str, object]", artifacts[0])
     evidence = cast("dict[str, object]", artifact["evidence"])
     accounting = cast("dict[str, object]", evidence["objective_accounting"])
-    accounting["cache_hits"] = cast("int", accounting["cache_hits"]) + 1
+    accounting["fresh_evaluations"] = cast("int", accounting["fresh_evaluations"]) + 1
 
-    with pytest.raises(ValueError, match="accounting|payload"):
+    with pytest.raises(ValueError, match="accounting|payload|reconcile"):
         NumericalProbeBaseline.from_record(tampered)
 
 
-def test_probe_baseline_retains_live_lane_authority(
+def test_serialized_backend_grid_trajectory_and_manifest_tampering_is_rejected() -> (
+    None
+):
+    baseline = run_numerical_probe_baseline()
+    records: list[dict[str, object]] = []
+
+    backend = copy.deepcopy(baseline.to_record())
+    backend_artifacts = cast("list[dict[str, object]]", backend["artifacts"])
+    backend_evidence = cast("dict[str, object]", backend_artifacts[0]["evidence"])
+    diagnostics = cast("dict[str, object]", backend_evidence["backend_diagnostics"])
+    diagnostics["nfev"] = cast("int", diagnostics["nfev"]) + 1
+    records.append(backend)
+
+    trajectory = copy.deepcopy(baseline.to_record())
+    trajectory_artifacts = cast("list[dict[str, object]]", trajectory["artifacts"])
+    trajectory_evidence = cast("dict[str, object]", trajectory_artifacts[0]["evidence"])
+    trajectory_evidence["trajectory_fingerprint"] = "0" * 64
+    records.append(trajectory)
+
+    grid = copy.deepcopy(baseline.to_record())
+    grid_artifacts = cast("list[dict[str, object]]", grid["artifacts"])
+    grid_index = next(
+        index
+        for index, definition in enumerate(baseline.definitions)
+        if definition.probe_id == "grid-candidate-ordering-v1"
+    )
+    grid_evidence = cast("dict[str, object]", grid_artifacts[grid_index]["evidence"])
+    grid_evidence["expected_order"] = [1, 2, 3, 0]
+    records.append(grid)
+
+    manifest = copy.deepcopy(baseline.to_record())
+    manifest["manifest_identity"] = "0" * 64
+    records.append(manifest)
+
+    for record in records:
+        with pytest.raises(ValueError):
+            NumericalProbeBaseline.from_record(record)
+
+
+def test_matching_external_manifest_is_recorded_but_remains_evidence_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = run_numerical_probe_baseline()
+    assert capture.manifest_identity == CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY
+    authority = _live_authority(monkeypatch)
+
+    authority_without_reference = run_numerical_probe_baseline(authority)
+    assert authority_without_reference.historical_qualification == "CAPTURE_ONLY"
+    assert authority_without_reference.historically_satisfied_claims == ()
+
+    matched = run_numerical_probe_baseline(
+        authority,
+        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+    )
+
+    assert matched.historical_qualification == "REFERENCE_MATCHED"
+    assert matched.historically_satisfied_claims == ("trajectory-manifest-compatible",)
+    tampered_role = copy.deepcopy(matched.to_record())
+    tampered_role["observed_lane_role"] = "PYTHON_COMPATIBILITY"
+    with pytest.raises(ValueError, match="identity"):
+        NumericalProbeBaseline.from_record(tampered_role)
+    with pytest.raises(NumericalProbeQualificationError) as mismatch:
+        capture.require_live_qualification(
+            authority,
+            expected_manifest_identity="0" * 64,
+            required_lane_role="CANONICAL_NUMERICAL",
+        )
+    assert mismatch.value.terminal == "EXPECTED_REFERENCE_MISMATCH"
+
+
+def test_live_run_cannot_mint_a_new_manifest_from_backend_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = run_numerical_probe_baseline()
+    first_artifact = capture.artifacts[0]
+    assert isinstance(first_artifact.evidence, SolverProbeEvidence)
+    diagnostics = dataclasses.replace(
+        first_artifact.evidence.backend_diagnostics,
+        nfev=first_artifact.evidence.backend_diagnostics.nfev + 1,
+    )
+    drifted_evidence = dataclasses.replace(
+        first_artifact.evidence,
+        backend_diagnostics=diagnostics,
+    )
+    drifted_artifact = dataclasses.replace(
+        first_artifact,
+        evidence=drifted_evidence,
+    )
+    drifted = NumericalProbeBaseline(
+        capture.definitions,
+        (drifted_artifact, *capture.artifacts[1:]),
+    )
+    authority = _live_authority(monkeypatch)
+
+    assert drifted.manifest_identity != CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY
+    with pytest.raises(NumericalProbeQualificationError) as rejected:
+        drifted.require_live_qualification(
+            authority,
+            expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+            required_lane_role="CANONICAL_NUMERICAL",
+        )
+
+    assert rejected.value.terminal == "MANIFEST_MISMATCH"
+
+
+def test_fabricated_serialized_lane_facts_cannot_gain_live_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = run_numerical_probe_baseline()
+    fabricated = NumericalProbeBaseline(
+        capture.definitions,
+        capture.artifacts,
+        "a" * 64,
+        "CANONICAL_NUMERICAL",
+        "b" * 64,
+        "c" * 64,
+        CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+        "REFERENCE_MATCHED",
+    )
+    restored = NumericalProbeBaseline.from_record(fabricated.to_record())
+    authority = _live_authority(monkeypatch)
+
+    with pytest.raises(NumericalProbeQualificationError) as rejected:
+        restored.require_live_qualification(
+            authority,
+            expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+            required_lane_role="CANONICAL_NUMERICAL",
+        )
+
+    assert rejected.value.terminal == "LANE_MISMATCH"
+
+
+def test_foreign_live_authority_does_not_match_historical_lane_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical = _live_authority(monkeypatch)
+    matched = run_numerical_probe_baseline(
+        canonical,
+        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+    )
+    foreign_lane = dataclasses.replace(
+        canonical_lanes()[0],
+        name="foreign-canonical-numerical-lane",
+    )
+    foreign_environment = RuntimeEnvironment(foreign_lane.semantics)
+    monkeypatch.setattr(
+        RuntimeEnvironment,
+        "from_current_process",
+        classmethod(
+            lambda cls, image_digest, provenance_path=None: foreign_environment
+        ),
+    )
+    foreign = foreign_lane.attest_current_process(foreign_lane.semantics.image_digest)
+
+    with pytest.raises(NumericalProbeQualificationError) as rejected:
+        matched.require_live_qualification(
+            foreign,
+            expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+            required_lane_role="CANONICAL_NUMERICAL",
+        )
+
+    assert rejected.value.terminal == "LANE_MISMATCH"
+
+
+def test_serialized_probe_baseline_never_recreates_live_lane_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     authority = _live_authority(monkeypatch)
+    baseline = run_numerical_probe_baseline(
+        authority,
+        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+    )
+    restored = pickle.loads(pickle.dumps(baseline))  # noqa: S301 - trusted self-record
 
-    baseline = run_numerical_probe_baseline(authority)
+    assert restored.historical_qualification == "REFERENCE_MATCHED"
+    assert restored.observed_lane_identity == authority.lane_identity
+    assert not isinstance(restored, LiveLaneAuthority)
+    restored.require_live_qualification(
+        authority,
+        expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+        required_lane_role="CANONICAL_NUMERICAL",
+    )
 
-    assert baseline.authority_role == "QUALIFIED_LANE"
-    assert baseline.lane_reference == authority.lane_identity
-    assert baseline.lane_attestation_identity == authority.identity
-    assert baseline.environment_identity == authority.environment_identity
-    assert NumericalProbeBaseline.from_record(baseline.to_record()) == baseline
+    with pytest.raises(TypeError, match="live"):
+        restored.require_live_qualification(  # type: ignore[arg-type]
+            restored,
+            expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+            required_lane_role="CANONICAL_NUMERICAL",
+        )
+    with pytest.raises(TypeError):
+        copy.copy(authority)
+    with pytest.raises(TypeError):
+        pickle.dumps(authority)
+
+
+def test_foreign_or_compatibility_authority_cannot_qualify_canonical_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = run_numerical_probe_baseline()
+    compatibility = _live_authority(monkeypatch, 1)
+
+    with pytest.raises(NumericalProbeQualificationError) as rejected:
+        capture.require_live_qualification(
+            compatibility,
+            expected_manifest_identity=CANONICAL_NUMERICAL_PROBE_MANIFEST_IDENTITY,
+            required_lane_role="CANONICAL_NUMERICAL",
+        )
+
+    assert rejected.value.terminal == "LANE_ROLE_MISMATCH"

--- a/tests/test_numerical_probes.py
+++ b/tests/test_numerical_probes.py
@@ -1,0 +1,251 @@
+"""Truth-backed numerical baseline probes for migration qualification (#591)."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+from typing import cast
+
+import pytest
+
+from chemex.numerical_probes import (
+    DeProbeEvidence,
+    FiniteDifferenceProbeEvidence,
+    GridProbeEvidence,
+    NumericalProbeArtifact,
+    NumericalProbeBaseline,
+    NumericalProbeDefinition,
+    SolverProbeEvidence,
+    SpectralRiskProbeEvidence,
+    numerical_probe_definitions,
+    run_numerical_probe,
+    run_numerical_probe_baseline,
+)
+
+
+def test_probe_catalogue_freezes_required_truth_and_execution_contracts() -> None:
+    definitions = numerical_probe_definitions()
+
+    assert tuple(definition.probe_id for definition in definitions) == (
+        "trf-routine-quadratic-v1",
+        "trf-difficult-rosenbrock-v1",
+        "grid-27-seed-ordering-v1",
+        "de-bounded-search-v1",
+        "finite-difference-reliability-v1",
+        "trf-active-bound-v1",
+        "rank-deficient-linearization-v1",
+        "ill-conditioned-linearization-v1",
+    )
+    assert {definition.category for definition in definitions} == {
+        "TRF_ROUTINE",
+        "TRF_DIFFICULT",
+        "GRID",
+        "DE_SEARCH",
+        "FINITE_DIFFERENCE",
+        "BOUNDS",
+        "RANK",
+        "CONDITIONING",
+    }
+    assert all(definition.derivation.source_issue == 591 for definition in definitions)
+    assert all(definition.derivation.source_revision for definition in definitions)
+    assert all(definition.derivation.reduction for definition in definitions)
+    assert all(definition.truth.reference for definition in definitions)
+    assert all(definition.eligible_claims for definition in definitions)
+    assert all(definition.failure_expectations for definition in definitions)
+    assert all(definition.budget.to_record_value() for definition in definitions)
+    assert all(definition.policy.to_record_value() for definition in definitions)
+    assert all(
+        NumericalProbeDefinition.from_record(definition.to_record()) == definition
+        for definition in definitions
+    )
+    assert len({definition.identity for definition in definitions}) == len(definitions)
+
+    altered = dataclasses.replace(
+        definitions[0],
+        eligible_claims=("altered-claim",),
+    )
+    with pytest.raises(ValueError, match="predeclared"):
+        run_numerical_probe(altered)
+
+
+@pytest.mark.parametrize(
+    ("probe_id", "expected"),
+    (
+        ("trf-routine-quadratic-v1", (1.5, -0.5)),
+        ("trf-difficult-rosenbrock-v1", (1.0, 1.0)),
+    ),
+)
+def test_trf_probes_replay_with_authoritative_request_accounting(
+    probe_id: str,
+    expected: tuple[float, ...],
+) -> None:
+    definition = next(
+        item for item in numerical_probe_definitions() if item.probe_id == probe_id
+    )
+
+    first = run_numerical_probe(definition)
+    replay = run_numerical_probe(definition)
+
+    assert first.terminal == "CONVERGED"
+    assert first.risks == ()
+    assert first.satisfied_claims == definition.eligible_claims
+    assert isinstance(first.evidence, SolverProbeEvidence)
+    assert first.evidence.accepted == pytest.approx(expected, abs=1.0e-8)
+    accounting = first.evidence.objective_accounting
+    assert accounting.requests_received == accounting.requests_completed
+    assert accounting.cache_hits + accounting.cache_misses == (
+        accounting.requests_completed
+    )
+    assert accounting.materialization_requests == 1
+    assert accounting.cache_hits >= 1
+    assert accounting.workflow_requests > first.evidence.backend_diagnostics.nfev
+    assert first.evidence.trajectory_fingerprint == (
+        replay.evidence.trajectory_fingerprint
+    )
+    assert first.identity == replay.identity
+    assert NumericalProbeArtifact.from_record(first.to_record(), definition) == first
+
+
+def test_finite_difference_probe_retains_truth_steps_and_request_fingerprint() -> None:
+    definition = numerical_probe_definitions()[4]
+
+    first = run_numerical_probe(definition)
+    replay = run_numerical_probe(definition)
+
+    assert first.terminal == "RELIABLE"
+    assert isinstance(first.evidence, FiniteDifferenceProbeEvidence)
+    assert first.evidence.estimate == pytest.approx(
+        first.evidence.truth,
+        abs=first.evidence.absolute_tolerance,
+    )
+    assert first.evidence.actual_steps == pytest.approx(
+        (-2.0e-4, -1.0e-4, 0.0, 1.0e-4, 2.0e-4)
+    )
+    assert first.evidence.objective_accounting.requests_received == 5
+    assert first.evidence.backend_diagnostics.nfev == 0
+    assert first.evidence.trajectory_fingerprint == (
+        replay.evidence.trajectory_fingerprint
+    )
+
+
+def test_bound_rank_and_conditioning_probes_fail_closed_against_exact_truth() -> None:
+    definitions = numerical_probe_definitions()
+
+    boundary = run_numerical_probe(definitions[5])
+    rank = run_numerical_probe(definitions[6])
+    conditioning = run_numerical_probe(definitions[7])
+
+    assert isinstance(boundary.evidence, SolverProbeEvidence)
+    assert boundary.evidence.accepted == pytest.approx((1.0,), abs=1.0e-8)
+    assert boundary.evidence.active_mask == (1,)
+    assert boundary.risks == ("ACTIVE_BOUND",)
+
+    assert isinstance(rank.evidence, SpectralRiskProbeEvidence)
+    assert rank.terminal == "RISK_DETECTED"
+    assert rank.evidence.rank == 1
+    assert rank.evidence.dimension == 2
+    assert rank.risks == ("RANK_DEFICIENT",)
+
+    assert isinstance(conditioning.evidence, SpectralRiskProbeEvidence)
+    assert conditioning.terminal == "RISK_DETECTED"
+    assert conditioning.evidence.rank == 2
+    assert conditioning.evidence.condition == pytest.approx(1.0e8)
+    assert conditioning.evidence.condition_limit == pytest.approx(1.0e6)
+    assert conditioning.risks == ("ILL_CONDITIONED",)
+
+    for definition, artifact in zip(
+        definitions[5:],
+        (boundary, rank, conditioning),
+        strict=True,
+    ):
+        assert (
+            NumericalProbeArtifact.from_record(artifact.to_record(), definition)
+            == artifact
+        )
+
+
+def test_grid_probe_retains_all_physical_seeds_and_canonical_candidate_order() -> None:
+    definition = numerical_probe_definitions()[2]
+
+    first = run_numerical_probe(definition)
+    replay = run_numerical_probe(definition)
+
+    assert first.terminal == "SELECTED"
+    assert isinstance(first.evidence, GridProbeEvidence)
+    assert tuple(seed.ordinal for seed in first.evidence.seeds) == tuple(range(27))
+    assert len({seed.seed for seed in first.evidence.seeds}) == 27
+    assert first.evidence.ordered_seed_ordinals == tuple(
+        seed.ordinal
+        for seed in sorted(
+            first.evidence.seeds,
+            key=lambda seed: (seed.solver.chi_square, seed.ordinal),
+        )
+    )
+    assert (
+        first.evidence.selected_seed_ordinal
+        == (first.evidence.ordered_seed_ordinals[0])
+    )
+    selected = first.evidence.seeds[first.evidence.selected_seed_ordinal]
+    assert selected.solver.accepted == pytest.approx((1.0, -1.0, 0.5), abs=1.0e-8)
+    assert first.evidence.objective_accounting.requests_received == sum(
+        seed.solver.objective_accounting.requests_received
+        for seed in first.evidence.seeds
+    )
+    assert first.evidence.trajectory_fingerprint == (
+        replay.evidence.trajectory_fingerprint
+    )
+    assert first.identity == replay.identity
+
+
+def test_de_probe_retains_seeded_population_order_and_separate_trf_polish() -> None:
+    definition = numerical_probe_definitions()[3]
+
+    first = run_numerical_probe(definition)
+    replay = run_numerical_probe(definition)
+
+    assert first.terminal == "POLISHED"
+    assert isinstance(first.evidence, DeProbeEvidence)
+    assert first.evidence.root_seed == 591
+    assert len(first.evidence.final_population) == 5
+    assert first.evidence.ordered_population_indices == tuple(
+        candidate.population_index
+        for candidate in sorted(
+            first.evidence.final_population,
+            key=lambda candidate: (candidate.objective, candidate.population_index),
+        )
+    )
+    assert (
+        first.evidence.selected_population_index
+        == (first.evidence.ordered_population_indices[0])
+    )
+    assert first.evidence.search_accounting.requests_received > 0
+    assert first.evidence.search_diagnostics.nfev > 0
+    assert first.evidence.polish.accepted == pytest.approx((0.25,), abs=1.0e-8)
+    assert first.evidence.trajectory_fingerprint == (
+        replay.evidence.trajectory_fingerprint
+    )
+    assert first.identity == replay.identity
+
+
+def test_probe_baseline_manifest_replays_round_trips_and_rejects_tampering() -> None:
+    first = run_numerical_probe_baseline()
+    replay = run_numerical_probe_baseline()
+
+    assert len(first.definitions) == 8
+    assert tuple(artifact.probe_id for artifact in first.artifacts) == tuple(
+        definition.probe_id for definition in first.definitions
+    )
+    assert first.manifest_identity == replay.manifest_identity
+    assert first.identity == replay.identity
+    assert NumericalProbeBaseline.from_record(first.to_record()) == first
+
+    tampered = copy.deepcopy(first.to_record())
+    artifacts = tampered["artifacts"]
+    assert isinstance(artifacts, list)
+    artifact = cast("dict[str, object]", artifacts[0])
+    evidence = cast("dict[str, object]", artifact["evidence"])
+    accounting = cast("dict[str, object]", evidence["objective_accounting"])
+    accounting["cache_hits"] = cast("int", accounting["cache_hits"]) + 1
+
+    with pytest.raises(ValueError, match="accounting|payload"):
+        NumericalProbeBaseline.from_record(tampered)


### PR DESCRIPTION
Closes #591.

## Summary

Adds truth-backed numerical and optimizer qualification probes for the native ChemEx stack.

The probe set covers:

* routine and difficult TRF behavior;
* GRID seed coverage and independently defined candidate ordering;
* seeded multimodal DE;
* finite-difference reliability;
* active bounds;
* rank deficiency;
* conditioning risk.

Each probe carries explicit truth provenance, policies, budgets, seeds, failure expectations, deterministic fingerprints, and typed accounting.

## Qualification model

Probe execution now clearly separates:

* independently declared truth;
* observed serializable evidence;
* ChemEx-authoritative objective requests;
* backend/SciPy diagnostic activity;
* live numerical-lane authority.

Capture-only runs retain observed fingerprints and accounting but cannot qualify trajectory compatibility by using their own execution as truth.

Trajectory qualification requires the repository-frozen expected manifest:

`cbc5dbc9a0b432b6dbbd053f49769bb4dc84d322c409a84da26f8f892298b839`

GRID candidate-ordering qualification uses an independent analytic four-candidate reference with expected ordering:

`(1, 3, 2, 0)`

under the canonical `(chi2, final vector, seed ordinal)` ordering rule.

## Lane authority

Current qualification requires the exact live process-owned numerical-lane capability.

`LiveLaneAuthority` is now an opaque token:

* authority-bearing facts live only in a private process-local registry;
* lane identity, role, attestation, and environment bindings cannot be reconstructed from serialized evidence;
* detached or mutated evidence is non-authoritative;
* foreign, renamed, compatibility, copied, pickled, fabricated, and deserialized authority paths fail closed.

## Objective accounting

ChemEx-authoritative objective requests are distinct from backend solver activity.

For the routine TRF probe, for example:

* authoritative requests: `2`;
* SciPy `nfev`: `6`;
* actual SciPy function calls: `18`;
* callbacks: `0`.

Changing backend diagnostic activity does not change authoritative request accounting or its trajectory fingerprint.

Every issued authoritative request has exactly one typed outcome:

`issued = fresh + cache-served + refused + failed`

Invalid inputs, evaluator failures, and non-finite results are recorded through closed typed failure outcomes. Ordinary evaluator exceptions cannot disappear from accounting, while process-control exceptions such as `KeyboardInterrupt` retain their control semantics.

## Numerical qualification

Representative results include:

* finite-difference error: `1.44e-12` against a `1e-10` tolerance;
* 27-seed GRID coverage;
* seeded multimodal DE;
* active-bound behavior;
* rank-1 / rank-2 distinction;
* conditioning case at approximately `1e8`.

## Scope

This is qualification infrastructure only.

No changes to:

* production optimizer behavior;
* scientific calculations or intensities;
* CLI or TOML;
* parameter behavior;
* uncertainty calculations;
* output formats.

## Validation

* Full suite: **764 passed**
* Numerical lanes/probes and adjacent baselines: **72 passed**
* `ty`: passed
* Ruff lint and format checks: passed
* `git diff --check`: passed
* Graphify refreshed

One existing non-failing `emcee` runtime warning remains.

Independent adversarial review: **MERGE**

* Standards: CLEAN
* Spec: CLEAN
* No Blocking or Important findings.
