### PR TITLE
Add deterministic native resampling evidence

### DIFF
--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -1292,6 +1292,20 @@ class _Workspace:
         self.cache.clear()
 
 
+@dataclass(frozen=True, slots=True)
+class ResampledProfileBinding:
+    """Exact root-kernel rows used by one transformed resampling profile."""
+
+    root_profile_index: int
+    root_observation_indices: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if self.root_profile_index < 0 or not self.root_observation_indices:
+            raise ValueError("Resampled profile binding requires root observations")
+        if any(index < 0 for index in self.root_observation_indices):
+            raise ValueError("Resampled observation indices must be non-negative")
+
+
 def _build_plan(
     experiments: Experiments,
     parameterization: ActiveParameterization,
@@ -1435,6 +1449,9 @@ class EvaluationEngine:
         # source objects, and callers cannot alter a future workspace by
         # mutating the legacy occurrence after it was bound.
         self._sources = tuple(deepcopy(source) for _e, _p, source in sources)
+        self._templates = tuple(
+            _NativeKernelCapability.from_profile(source) for source in self._sources
+        )
         self.compatibility_identity = _compatibility_identity(plan)
 
     @classmethod
@@ -1521,6 +1538,68 @@ class EvaluationEngine:
         )
         return EvaluationEngine(plan, self._parameterization, sources)
 
+    def resampled_observation_metadata(self, binding: ResampledProfileBinding) -> str:
+        """Return the canonical metadata descriptor for exact selected root rows."""
+        if binding.root_profile_index >= len(self._templates):
+            raise ValueError("Resampled profile names a foreign root profile")
+        metadata = self._templates[binding.root_profile_index].metadata
+        if any(index >= len(metadata) for index in binding.root_observation_indices):
+            raise ValueError("Resampled profile names a foreign root observation")
+        return _semantic_json(metadata[list(binding.root_observation_indices)].tolist())
+
+    def resampled(
+        self,
+        plan: EvaluationPlan,
+        bindings: Sequence[ResampledProfileBinding],
+    ) -> EvaluationEngine:
+        """Bind a transformed plan to fresh copies of exact trusted root kernels."""
+        if plan.parameterization_identity != self._parameterization.evaluator_identity:
+            raise ValueError("Resampled plan belongs to another parameterization")
+        if (
+            plan.constraint_program_identity
+            != self._parameterization.program.fingerprint
+            or plan.resolved_ids != self._parameterization.scope_ids
+            or len(plan.profiles) != len(bindings)
+        ):
+            raise ValueError("Resampled plan has incompatible native lineage")
+        _validate_plan_runtime_versions(plan)
+        templates: list[_NativeKernelCapability] = []
+        expected_offset = 0
+        for descriptor, binding in zip(plan.profiles, bindings, strict=True):
+            if binding.root_profile_index >= len(self.plan.profiles):
+                raise ValueError("Resampled binding names a foreign root profile")
+            root = self.plan.profiles[binding.root_profile_index]
+            if (
+                descriptor.observation_offset != expected_offset
+                or descriptor.observation_count != len(binding.root_observation_indices)
+                or descriptor.local_inputs != root.local_inputs
+                or descriptor.is_scaled != root.is_scaled
+                or descriptor.kernel_identity != root.kernel_identity
+                or descriptor.kernel_configuration != root.kernel_configuration
+                or descriptor.spectrometer_configuration
+                != root.spectrometer_configuration
+                or descriptor.observation_metadata
+                != self.resampled_observation_metadata(binding)
+                or descriptor.output_shape != (descriptor.observation_count,)
+            ):
+                raise ValueError(
+                    "Resampled plan differs from its trusted root-kernel binding"
+                )
+            template = deepcopy(self._templates[binding.root_profile_index])
+            template.metadata = np.array(
+                template.metadata[list(binding.root_observation_indices)], copy=True
+            )
+            template.output_size = descriptor.observation_count
+            templates.append(template)
+            expected_offset += descriptor.observation_count
+        engine = object.__new__(EvaluationEngine)
+        engine.plan = plan
+        engine._parameterization = self._parameterization
+        engine._sources = ()
+        engine._templates = tuple(templates)
+        engine.compatibility_identity = _compatibility_identity(plan)
+        return engine
+
     def new_evaluator(self) -> BoundEvaluator:
         """Create an empty single-owner workspace from trusted implementations."""
         return BoundEvaluator(
@@ -1528,14 +1607,8 @@ class EvaluationEngine:
             self._parameterization,
             self.compatibility_identity,
             _Workspace(
-                tuple(
-                    _NativeKernelCapability.from_profile(profile)
-                    for profile in self._sources
-                ),
-                tuple(
-                    _NativeKernelCapability.from_profile(profile)
-                    for profile in self._sources
-                ),
+                tuple(deepcopy(template) for template in self._templates),
+                tuple(deepcopy(template) for template in self._templates),
             ),
         )
 

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -1,0 +1,1598 @@
+"""Deterministic native resampling evidence qualification (#599).
+
+This module is an isolated qualification seam.  It plans identity-derived
+Monte Carlo, bootstrap, and nucleus-bootstrap replicates; delegates each draw
+to an evidence-only projected optimization callback; freezes every terminal
+replicate outcome; and derives summaries from one common complete-scope sample
+set.  Production fitting and reporting do not consume these artifacts yet.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import warnings
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import StrEnum
+from numbers import Real
+
+import numpy as np
+
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    accepted_occurrence_is_authoritative,
+)
+from chemex.runtime import ExecutionSettings
+from chemex.runtime.execution import native_thread_environment
+
+_SCHEMA_VERSION = 1
+_SEED_POLICY_VERSION = "sha256-structural-u64-v1"
+_RNG_ALGORITHM = "numpy-pcg64-v1"
+_GENERATION_POLICY_VERSION = "chemex-mc-bs-bsn-v1"
+_SUMMARY_POLICY_VERSION = "complete-scope-percentile-v1"
+_MAX_U64 = (1 << 64) - 1
+
+
+class ResamplingConstructionError(ValueError):
+    """Raised when a native resampling policy or artifact is malformed."""
+
+
+class ResamplingScheme(StrEnum):
+    """Closed scientific replicate-generation schemes retained by ChemEx."""
+
+    MONTE_CARLO = "mc"
+    BOOTSTRAP = "bs"
+    NUCLEUS_BOOTSTRAP = "bsn"
+
+
+class OptimizationStrategy(StrEnum):
+    """Closed projected optimization strategies available to a replicate."""
+
+    DIRECT_TRF = "direct_trf"
+    GRID_DIRECT_TRF = "grid_direct_trf"
+    DE_DIRECT_TRF = "de_direct_trf"
+
+
+class ReplicateDisposition(StrEnum):
+    """Terminal disposition of one actually executed replicate."""
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+
+
+class ResamplingLifecycle(StrEnum):
+    """Lifecycle of an evidence artifact containing genuine outcomes."""
+
+    COMPLETED = "completed"
+    PARTIAL = "partial"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+
+
+class OperationTerminal(StrEnum):
+    """Terminal disposition of the overall resampling operation."""
+
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+
+
+class SummaryTerminal(StrEnum):
+    """Terminal disposition of a scope-atomic resampling summary request."""
+
+    COMPLETED = "completed"
+    INSUFFICIENT_COVERAGE = "insufficient_coverage"
+    SOURCE_INVALID = "source_invalid"
+
+
+class CorrelationAvailability(StrEnum):
+    """Availability of one empirical correlation entry."""
+
+    AVAILABLE = "available"
+    ZERO_VARIANCE = "zero_variance"
+
+
+class ClaimState(StrEnum):
+    """Closed assessment state for a resampling validity claim."""
+
+    SATISFIED = "satisfied"
+    VIOLATED = "violated"
+    INDETERMINATE = "indeterminate"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimAssessment:
+    """One versioned lifecycle, integrity, or scientific validity claim."""
+
+    name: str
+    state: ClaimState
+    policy_identity: str
+    details: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.policy_identity:
+            raise ResamplingConstructionError(
+                "Claim assessment requires a name and policy identity"
+            )
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "record": record, "schema_version": _SCHEMA_VERSION},
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _finite(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ResamplingConstructionError(f"{name} must be a real binary64 scalar")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ResamplingConstructionError(f"{name} must be finite")
+    return 0.0 if result == 0.0 else result
+
+
+def _float_token(value: float) -> str:
+    return float(value).hex()
+
+
+def _items_tokens(items: Sequence[tuple[str, float]]) -> tuple[tuple[str, str], ...]:
+    return tuple((param_id, _float_token(value)) for param_id, value in items)
+
+
+def _non_empty_identity(value: str, *, name: str) -> str:
+    if not value:
+        raise ResamplingConstructionError(f"{name} must not be empty")
+    return value
+
+
+def _canonical_scope(scope: Sequence[str]) -> tuple[str, ...]:
+    result = tuple(scope)
+    if (
+        not result
+        or any(not item for item in result)
+        or len(set(result)) != len(result)
+    ):
+        raise ResamplingConstructionError(
+            "Resampling output scope must be non-empty, ordered, and unique"
+        )
+    return result
+
+
+def _positive_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ResamplingConstructionError(f"{name} must be a positive integer")
+    return value
+
+
+def _unsigned_seed(value: object, *, name: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > _MAX_U64
+    ):
+        raise ResamplingConstructionError(f"{name} must be an unsigned 64-bit seed")
+    return value
+
+
+def _canonical_field(value: bytes) -> bytes:
+    return len(value).to_bytes(8, "big") + value
+
+
+def _derive_seed(
+    *,
+    root_seed: int,
+    stage_identity: str,
+    work_unit_kind: str,
+    structural_identity: str,
+) -> int:
+    fields = (
+        b"chemex-native-seed",
+        _SEED_POLICY_VERSION.encode("ascii"),
+        root_seed.to_bytes(8, "big"),
+        stage_identity.encode("ascii"),
+        work_unit_kind.encode("ascii"),
+        structural_identity.encode("ascii"),
+    )
+    digest = hashlib.sha256(
+        b"".join(_canonical_field(item) for item in fields)
+    ).digest()
+    return int.from_bytes(digest[:8], "big", signed=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ReplicateRequest:
+    """One canonical structural replicate identity and its derived seed."""
+
+    plan_identity: str
+    ordinal: int
+    structural_identity: str
+    seed: int
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.ordinal < 0:
+            raise ResamplingConstructionError("Replicate ordinal must be non-negative")
+        _unsigned_seed(self.seed, name="replicate seed")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-replicate-request",
+                (
+                    self.plan_identity,
+                    self.ordinal,
+                    self.structural_identity,
+                    self.seed,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingPlan:
+    """Immutable accepted-anchor resampling population and validity contract."""
+
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
+    scheme: ResamplingScheme
+    replicate_count: int
+    root_seed: int
+    source_dataset_identity: str
+    output_scope: tuple[str, ...]
+    optimization_projection_identity: str
+    minimum_successful_count: int
+    seed_policy_version: str = _SEED_POLICY_VERSION
+    rng_algorithm: str = _RNG_ALGORITHM
+    generation_policy_version: str = _GENERATION_POLICY_VERSION
+    identity: str = field(init=False)
+    replicates: tuple[ReplicateRequest, ...] = field(init=False)
+
+    def __post_init__(self) -> None:
+        count = _positive_integer(self.replicate_count, name="replicate count")
+        minimum = _positive_integer(
+            self.minimum_successful_count,
+            name="minimum successful replicate count",
+        )
+        if minimum > count:
+            raise ResamplingConstructionError(
+                "Minimum successful replicate count cannot exceed the population"
+            )
+        root_seed = _unsigned_seed(self.root_seed, name="root seed")
+        scope = _canonical_scope(self.output_scope)
+        for name, value in (
+            ("accepted result identity", self.accepted_result_identity),
+            ("accepted occurrence identity", self.accepted_occurrence_identity),
+            ("source dataset identity", self.source_dataset_identity),
+            ("optimization projection identity", self.optimization_projection_identity),
+            ("seed policy version", self.seed_policy_version),
+            ("RNG algorithm", self.rng_algorithm),
+            ("generation policy version", self.generation_policy_version),
+        ):
+            _non_empty_identity(value, name=name)
+        identity = _identity(
+            "native-resampling-plan",
+            (
+                self.accepted_result_identity,
+                self.accepted_occurrence_identity,
+                self.scheme.value,
+                count,
+                root_seed,
+                self.source_dataset_identity,
+                scope,
+                self.optimization_projection_identity,
+                minimum,
+                self.seed_policy_version,
+                self.rng_algorithm,
+                self.generation_policy_version,
+            ),
+        )
+        requests: list[ReplicateRequest] = []
+        for ordinal in range(count):
+            structural_identity = _identity(
+                "native-resampling-replicate-structure",
+                (identity, ordinal),
+            )
+            seed = _derive_seed(
+                root_seed=root_seed,
+                stage_identity=identity,
+                work_unit_kind="resampling-replicate",
+                structural_identity=structural_identity,
+            )
+            requests.append(
+                ReplicateRequest(identity, ordinal, structural_identity, seed)
+            )
+        seeds = tuple(item.seed for item in requests)
+        if len(set(seeds)) != len(seeds):
+            raise ResamplingConstructionError(
+                "Distinct resampling work units produced a derived-seed collision"
+            )
+        object.__setattr__(self, "replicate_count", count)
+        object.__setattr__(self, "minimum_successful_count", minimum)
+        object.__setattr__(self, "root_seed", root_seed)
+        object.__setattr__(self, "output_scope", scope)
+        object.__setattr__(self, "identity", identity)
+        object.__setattr__(self, "replicates", tuple(requests))
+
+    @classmethod
+    def for_accepted(
+        cls,
+        accepted: AcceptedFitResult,
+        *,
+        scheme: ResamplingScheme,
+        replicate_count: int,
+        root_seed: int,
+        source_dataset_identity: str,
+        output_scope: Sequence[str],
+        optimization_projection_identity: str,
+        minimum_successful_count: int,
+    ) -> ResamplingPlan:
+        """Bind a deterministic replicate population to one accepted occurrence."""
+        if not accepted_occurrence_is_authoritative(accepted):
+            raise ResamplingConstructionError(
+                "Resampling planning requires an exact authoritative accepted occurrence"
+            )
+        return cls(
+            accepted.identity,
+            accepted.occurrence_identity,
+            scheme,
+            replicate_count,
+            root_seed,
+            source_dataset_identity,
+            tuple(output_scope),
+            optimization_projection_identity,
+            minimum_successful_count,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingPopulation:
+    """Canonical source values needed by all three retained schemes."""
+
+    source_dataset_identity: str
+    observed: tuple[float, ...]
+    calculated: tuple[float, ...]
+    standard_errors: tuple[float, ...]
+    mask: tuple[bool, ...]
+    references: tuple[bool, ...]
+    nucleus_groups: tuple[str, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        _non_empty_identity(
+            self.source_dataset_identity,
+            name="source dataset identity",
+        )
+        size = len(self.observed)
+        if size < 1 or any(
+            len(values) != size
+            for values in (
+                self.calculated,
+                self.standard_errors,
+                self.mask,
+                self.references,
+                self.nucleus_groups,
+            )
+        ):
+            raise ResamplingConstructionError(
+                "Resampling population fields must have one common non-zero size"
+            )
+        observed = tuple(
+            _finite(value, name=f"observed[{index}]")
+            for index, value in enumerate(self.observed)
+        )
+        calculated = tuple(
+            _finite(value, name=f"calculated[{index}]")
+            for index, value in enumerate(self.calculated)
+        )
+        errors = tuple(
+            _finite(value, name=f"standard_errors[{index}]")
+            for index, value in enumerate(self.standard_errors)
+        )
+        if any(value < 0.0 for value in errors):
+            raise ResamplingConstructionError(
+                "Resampling standard errors must be non-negative"
+            )
+        if any(type(value) is not bool for value in (*self.mask, *self.references)):
+            raise ResamplingConstructionError(
+                "Mask and reference flags must be Boolean"
+            )
+        if any(not group for group in self.nucleus_groups):
+            raise ResamplingConstructionError(
+                "Nucleus group identities must not be empty"
+            )
+        object.__setattr__(self, "observed", observed)
+        object.__setattr__(self, "calculated", calculated)
+        object.__setattr__(self, "standard_errors", errors)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-population",
+                (
+                    self.source_dataset_identity,
+                    tuple(_float_token(value) for value in observed),
+                    tuple(_float_token(value) for value in calculated),
+                    tuple(_float_token(value) for value in errors),
+                    self.mask,
+                    self.references,
+                    self.nucleus_groups,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingDraw:
+    """One immutable seeded transformation with exact source selection."""
+
+    population_identity: str
+    scheme: ResamplingScheme
+    seed: int
+    observations: tuple[float, ...]
+    standard_errors: tuple[float, ...]
+    mask: tuple[bool, ...]
+    references: tuple[bool, ...]
+    nucleus_groups: tuple[str, ...]
+    source_indices: tuple[int, ...]
+    sampled_nucleus_groups: tuple[str, ...] = ()
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        _unsigned_seed(self.seed, name="draw seed")
+        size = len(self.observations)
+        if any(
+            len(values) != size
+            for values in (
+                self.standard_errors,
+                self.mask,
+                self.references,
+                self.nucleus_groups,
+                self.source_indices,
+            )
+        ):
+            raise ResamplingConstructionError(
+                "Resampling draw fields must preserve one common row extent"
+            )
+        observations = tuple(
+            _finite(value, name=f"draw observation[{index}]")
+            for index, value in enumerate(self.observations)
+        )
+        errors = tuple(
+            _finite(value, name=f"draw error[{index}]")
+            for index, value in enumerate(self.standard_errors)
+        )
+        object.__setattr__(self, "observations", observations)
+        object.__setattr__(self, "standard_errors", errors)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-draw",
+                (
+                    self.population_identity,
+                    self.scheme.value,
+                    self.seed,
+                    tuple(_float_token(value) for value in observations),
+                    tuple(_float_token(value) for value in errors),
+                    self.mask,
+                    self.references,
+                    self.nucleus_groups,
+                    self.source_indices,
+                    self.sampled_nucleus_groups,
+                ),
+            ),
+        )
+
+
+def generate_resampling_draw(
+    population: ResamplingPopulation,
+    scheme: ResamplingScheme,
+    *,
+    seed: int,
+) -> ResamplingDraw:
+    """Apply one retained scientific generation scheme with explicit PCG64 state."""
+    normalized_seed = _unsigned_seed(seed, name="draw seed")
+    rng = np.random.Generator(np.random.PCG64(normalized_seed))
+    size = len(population.observed)
+    if scheme is ResamplingScheme.MONTE_CARLO:
+        observations = tuple(
+            float(value)
+            for value in rng.normal(population.calculated, population.standard_errors)
+        )
+        return ResamplingDraw(
+            population.identity,
+            scheme,
+            normalized_seed,
+            observations,
+            population.standard_errors,
+            population.mask,
+            population.references,
+            population.nucleus_groups,
+            tuple(range(size)),
+        )
+    if scheme is ResamplingScheme.BOOTSTRAP:
+        masked = tuple(index for index, active in enumerate(population.mask) if active)
+        reference_pool = tuple(
+            index for index in masked if population.references[index]
+        )
+        non_reference_pool = tuple(
+            index for index in masked if not population.references[index]
+        )
+        selected = sorted(
+            (
+                *(
+                    int(value)
+                    for value in rng.choice(
+                        reference_pool,
+                        size=len(reference_pool),
+                        replace=True,
+                    )
+                ),
+                *(
+                    int(value)
+                    for value in rng.choice(
+                        non_reference_pool,
+                        size=len(non_reference_pool),
+                        replace=True,
+                    )
+                ),
+            )
+        )
+        source_indices = list(range(size))
+        for target, source in zip(masked, selected, strict=True):
+            source_indices[target] = source
+        indexes = tuple(source_indices)
+        return ResamplingDraw(
+            population.identity,
+            scheme,
+            normalized_seed,
+            tuple(population.observed[index] for index in indexes),
+            tuple(population.standard_errors[index] for index in indexes),
+            population.mask,
+            tuple(population.references[index] for index in indexes),
+            population.nucleus_groups,
+            indexes,
+        )
+    canonical_groups = tuple(sorted(set(population.nucleus_groups)))
+    sampled_groups = tuple(
+        str(value)
+        for value in rng.choice(
+            canonical_groups,
+            size=len(canonical_groups),
+            replace=True,
+        )
+    )
+    indexes = tuple(
+        index
+        for group in sampled_groups
+        for index, source_group in enumerate(population.nucleus_groups)
+        if source_group == group
+    )
+    return ResamplingDraw(
+        population.identity,
+        scheme,
+        normalized_seed,
+        tuple(population.observed[index] for index in indexes),
+        tuple(population.standard_errors[index] for index in indexes),
+        tuple(population.mask[index] for index in indexes),
+        tuple(population.references[index] for index in indexes),
+        tuple(population.nucleus_groups[index] for index in indexes),
+        indexes,
+        sampled_groups,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedOptimizationSuccess:
+    """Complete projected candidate evidence with no acceptance or commit authority."""
+
+    transformed_data_identity: str
+    evaluation_plan_identity: str
+    problem_identity: str
+    invocation_identity: str
+    execution_identity: str
+    strategy: OptimizationStrategy
+    component_outcome_identities: tuple[str, ...]
+    resolved_items: tuple[tuple[str, float], ...]
+    chi_square: float
+    expected_output_scope: tuple[str, ...] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("transformed data identity", self.transformed_data_identity),
+            ("evaluation plan identity", self.evaluation_plan_identity),
+            ("problem identity", self.problem_identity),
+            ("invocation identity", self.invocation_identity),
+            ("execution identity", self.execution_identity),
+        ):
+            _non_empty_identity(value, name=name)
+        if not self.component_outcome_identities or any(
+            not item for item in self.component_outcome_identities
+        ):
+            raise ResamplingConstructionError(
+                "Projected optimization requires complete component outcomes"
+            )
+        items = tuple(
+            (param_id, _finite(value, name=f"resolved value {param_id!r}"))
+            for param_id, value in self.resolved_items
+        )
+        ids = tuple(param_id for param_id, _value in items)
+        if (
+            not ids
+            or any(not param_id for param_id in ids)
+            or len(set(ids)) != len(ids)
+        ):
+            raise ResamplingConstructionError(
+                "Projected optimization requires unique resolved output IDs"
+            )
+        if self.expected_output_scope is not None and ids != tuple(
+            self.expected_output_scope
+        ):
+            raise ResamplingConstructionError(
+                "Projected optimization must resolve the complete output scope"
+            )
+        chi_square = _finite(self.chi_square, name="projected chi-square")
+        if chi_square < 0.0:
+            raise ResamplingConstructionError(
+                "Projected chi-square must be non-negative"
+            )
+        object.__setattr__(self, "resolved_items", items)
+        object.__setattr__(self, "chi_square", chi_square)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-projected-optimization-success",
+                (
+                    self.transformed_data_identity,
+                    self.evaluation_plan_identity,
+                    self.problem_identity,
+                    self.invocation_identity,
+                    self.execution_identity,
+                    self.strategy.value,
+                    self.component_outcome_identities,
+                    _items_tokens(items),
+                    _float_token(chi_square),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedOptimizationFailure:
+    """Typed unsuccessful projected path retaining all available lineage."""
+
+    transformed_data_identity: str
+    disposition: ReplicateDisposition
+    category: str
+    message: str
+    evaluation_plan_identity: str | None = None
+    problem_identity: str | None = None
+    execution_identity: str | None = None
+    component_outcome_identities: tuple[str, ...] = ()
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.disposition is ReplicateDisposition.SUCCEEDED:
+            raise ResamplingConstructionError(
+                "Projected failure cannot use the successful disposition"
+            )
+        if not self.transformed_data_identity or not self.category or not self.message:
+            raise ResamplingConstructionError(
+                "Projected failure requires data identity, category, and message"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-projected-optimization-failure",
+                (
+                    self.transformed_data_identity,
+                    self.disposition.value,
+                    self.category,
+                    self.message,
+                    self.evaluation_plan_identity,
+                    self.problem_identity,
+                    self.execution_identity,
+                    self.component_outcome_identities,
+                ),
+            ),
+        )
+
+
+type ProjectedOptimizationResult = (
+    ProjectedOptimizationSuccess | ProjectedOptimizationFailure
+)
+
+
+type ReplicateExecutor = Callable[
+    [ReplicateRequest, ResamplingDraw],
+    ProjectedOptimizationResult,
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ReplicateOutcome:
+    """One genuine terminal outcome in canonical replicate order."""
+
+    plan_identity: str
+    request_identity: str
+    ordinal: int
+    seed: int
+    draw_identity: str
+    disposition: ReplicateDisposition
+    success: ProjectedOptimizationSuccess | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    failure: ProjectedOptimizationFailure | None = None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        succeeded = self.disposition is ReplicateDisposition.SUCCEEDED
+        if succeeded != (self.success is not None) or succeeded == (
+            self.failure is not None
+        ):
+            raise ResamplingConstructionError(
+                "Replicate outcome must contain exactly its typed terminal payload"
+            )
+        payload = self.success if self.success is not None else self.failure
+        if payload is None:
+            raise ResamplingConstructionError(
+                "Replicate outcome lacks a terminal payload"
+            )
+        if payload.transformed_data_identity != self.draw_identity:
+            raise ResamplingConstructionError(
+                "Replicate outcome and projected path use different transformed data"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-replicate-outcome",
+                (
+                    self.plan_identity,
+                    self.request_identity,
+                    self.ordinal,
+                    self.seed,
+                    self.draw_identity,
+                    self.disposition.value,
+                    payload.identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingEvidence:
+    """Exact frozen outcome set with separate coverage and lifecycle claims."""
+
+    plan: ResamplingPlan = field(repr=False, compare=False)
+    population_identity: str
+    outcomes: tuple[ReplicateOutcome, ...]
+    operation_terminal: OperationTerminal = OperationTerminal.COMPLETED
+    lifecycle: ResamplingLifecycle = field(init=False)
+    completed_count: int = field(init=False)
+    successful_count: int = field(init=False)
+    failed_count: int = field(init=False)
+    coverage_satisfied: bool = field(init=False)
+    claims: tuple[ClaimAssessment, ...] = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.outcomes:
+            raise ResamplingConstructionError(
+                "Resampling evidence requires at least one genuine replicate outcome"
+            )
+        ordinals = tuple(outcome.ordinal for outcome in self.outcomes)
+        if ordinals != tuple(sorted(ordinals)) or len(set(ordinals)) != len(ordinals):
+            raise ResamplingConstructionError(
+                "Resampling outcomes must use unique canonical ordinal order"
+            )
+        if any(
+            ordinal >= self.plan.replicate_count
+            or outcome.plan_identity != self.plan.identity
+            or outcome.request_identity != self.plan.replicates[ordinal].identity
+            or outcome.seed != self.plan.replicates[ordinal].seed
+            for ordinal, outcome in zip(ordinals, self.outcomes, strict=True)
+        ):
+            raise ResamplingConstructionError(
+                "Resampling outcomes differ from their planned replicate identities"
+            )
+        for outcome in self.outcomes:
+            if (
+                outcome.success is not None
+                and tuple(
+                    param_id for param_id, _value in outcome.success.resolved_items
+                )
+                != self.plan.output_scope
+            ):
+                raise ResamplingConstructionError(
+                    "Successful replicate must resolve the complete output scope"
+                )
+        completed = len(self.outcomes)
+        successful = sum(
+            outcome.disposition is ReplicateDisposition.SUCCEEDED
+            for outcome in self.outcomes
+        )
+        failed = sum(
+            outcome.disposition is ReplicateDisposition.FAILED
+            for outcome in self.outcomes
+        )
+        if self.operation_terminal is OperationTerminal.INTERRUPTED:
+            lifecycle = ResamplingLifecycle.INTERRUPTED
+        elif self.operation_terminal is OperationTerminal.CANCELLED:
+            lifecycle = ResamplingLifecycle.CANCELLED
+        elif completed == self.plan.replicate_count:
+            lifecycle = ResamplingLifecycle.COMPLETED
+        else:
+            lifecycle = ResamplingLifecycle.PARTIAL
+        object.__setattr__(self, "completed_count", completed)
+        object.__setattr__(self, "successful_count", successful)
+        object.__setattr__(self, "failed_count", failed)
+        object.__setattr__(
+            self,
+            "coverage_satisfied",
+            successful >= self.plan.minimum_successful_count,
+        )
+        claims = (
+            ClaimAssessment(
+                "STRUCTURAL_INTEGRITY",
+                ClaimState.SATISFIED,
+                self.plan.identity,
+                (f"terminal_outcomes={completed}",),
+            ),
+            ClaimAssessment(
+                "INTENDED_POPULATION_TERMINAL",
+                (
+                    ClaimState.SATISFIED
+                    if completed == self.plan.replicate_count
+                    else ClaimState.VIOLATED
+                ),
+                self.plan.identity,
+                (
+                    f"intended={self.plan.replicate_count}",
+                    f"terminal={completed}",
+                ),
+            ),
+            ClaimAssessment(
+                "MINIMUM_SUCCESSFUL_COVERAGE",
+                (
+                    ClaimState.SATISFIED
+                    if successful >= self.plan.minimum_successful_count
+                    else ClaimState.VIOLATED
+                ),
+                self.plan.identity,
+                (
+                    f"required={self.plan.minimum_successful_count}",
+                    f"successful={successful}",
+                ),
+            ),
+            ClaimAssessment(
+                "COMPLETE_SCOPE_SUCCESS_ROWS",
+                (ClaimState.SATISFIED if successful > 0 else ClaimState.NOT_APPLICABLE),
+                self.plan.identity,
+                (f"scope={','.join(self.plan.output_scope)}",),
+            ),
+        )
+        object.__setattr__(self, "claims", claims)
+        object.__setattr__(self, "lifecycle", lifecycle)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-evidence",
+                (
+                    self.plan.identity,
+                    self.population_identity,
+                    tuple(outcome.identity for outcome in self.outcomes),
+                    lifecycle.value,
+                    completed,
+                    successful,
+                    failed,
+                    successful >= self.plan.minimum_successful_count,
+                    tuple(
+                        (
+                            claim.name,
+                            claim.state.value,
+                            claim.policy_identity,
+                            claim.details,
+                        )
+                        for claim in claims
+                    ),
+                ),
+            ),
+        )
+
+    def claim(self, name: str) -> ClaimState:
+        """Return one exact named claim; unknown claims fail closed."""
+        for claim in self.claims:
+            if claim.name == name:
+                return claim.state
+        return ClaimState.INDETERMINATE
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingOperation:
+    """Operation record plus optional truthfully frozen evidence artifact."""
+
+    plan_identity: str
+    terminal: OperationTerminal
+    evidence: ResamplingEvidence | None
+    unstarted_ordinals: tuple[int, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.evidence is None and not self.unstarted_ordinals:
+            raise ResamplingConstructionError(
+                "An empty operation must retain its planned unstarted population"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-operation",
+                (
+                    self.plan_identity,
+                    self.terminal.value,
+                    None if self.evidence is None else self.evidence.identity,
+                    self.unstarted_ordinals,
+                ),
+            ),
+        )
+
+
+def _execute_replicate(
+    plan: ResamplingPlan,
+    population: ResamplingPopulation,
+    executor: ReplicateExecutor,
+    request: ReplicateRequest,
+) -> ReplicateOutcome:
+    try:
+        draw = generate_resampling_draw(population, plan.scheme, seed=request.seed)
+        projected = executor(request, draw)
+    except KeyboardInterrupt:
+        failure = ProjectedOptimizationFailure(
+            draw.identity,
+            ReplicateDisposition.INTERRUPTED,
+            "asynchronous_interruption",
+            "Replicate projected optimization was interrupted",
+        )
+        return ReplicateOutcome(
+            plan.identity,
+            request.identity,
+            request.ordinal,
+            request.seed,
+            draw.identity,
+            failure.disposition,
+            failure=failure,
+        )
+    except Exception as error:  # noqa: BLE001 - freeze typed replicate failure
+        draw_identity = (
+            draw.identity
+            if "draw" in locals()
+            else _identity(
+                "native-resampling-draw-failure",
+                (population.identity, plan.scheme.value, request.seed),
+            )
+        )
+        failure = ProjectedOptimizationFailure(
+            draw_identity,
+            ReplicateDisposition.FAILED,
+            "projected_execution_failure",
+            f"{type(error).__name__}: {error}",
+        )
+        return ReplicateOutcome(
+            plan.identity,
+            request.identity,
+            request.ordinal,
+            request.seed,
+            draw_identity,
+            failure.disposition,
+            failure=failure,
+        )
+    if isinstance(projected, ProjectedOptimizationSuccess):
+        if tuple(param_id for param_id, _value in projected.resolved_items) != (
+            plan.output_scope
+        ):
+            failure = ProjectedOptimizationFailure(
+                draw.identity,
+                ReplicateDisposition.FAILED,
+                "incomplete_output_scope",
+                "Projected optimization did not resolve the complete output scope",
+                projected.evaluation_plan_identity,
+                projected.problem_identity,
+                projected.execution_identity,
+                projected.component_outcome_identities,
+            )
+            return ReplicateOutcome(
+                plan.identity,
+                request.identity,
+                request.ordinal,
+                request.seed,
+                draw.identity,
+                failure.disposition,
+                failure=failure,
+            )
+        payload: ProjectedOptimizationResult = projected
+    elif isinstance(projected, ProjectedOptimizationFailure):
+        payload = projected
+    else:
+        failure = ProjectedOptimizationFailure(
+            draw.identity,
+            ReplicateDisposition.FAILED,
+            "invalid_projected_outcome",
+            "Projected optimization returned an unsupported outcome type",
+        )
+        payload = failure
+    if payload.transformed_data_identity != draw.identity:
+        mismatch = ProjectedOptimizationFailure(
+            draw.identity,
+            ReplicateDisposition.FAILED,
+            "transformed_data_lineage_mismatch",
+            "Projected optimization used a different transformed-data identity",
+        )
+        payload = mismatch
+    if isinstance(payload, ProjectedOptimizationSuccess):
+        return ReplicateOutcome(
+            plan.identity,
+            request.identity,
+            request.ordinal,
+            request.seed,
+            draw.identity,
+            ReplicateDisposition.SUCCEEDED,
+            success=payload,
+        )
+    return ReplicateOutcome(
+        plan.identity,
+        request.identity,
+        request.ordinal,
+        request.seed,
+        draw.identity,
+        payload.disposition,
+        failure=payload,
+    )
+
+
+def _execute_serial_replicates(
+    plan: ResamplingPlan,
+    population: ResamplingPopulation,
+    executor: ReplicateExecutor,
+    cancellation_probe: Callable[[], bool] | None,
+) -> tuple[list[ReplicateOutcome], OperationTerminal]:
+    outcomes: list[ReplicateOutcome] = []
+    terminal = OperationTerminal.COMPLETED
+    for request in plan.replicates:
+        if cancellation_probe is not None and cancellation_probe():
+            return outcomes, OperationTerminal.CANCELLED
+        outcome = _execute_replicate(plan, population, executor, request)
+        outcomes.append(outcome)
+        if outcome.disposition is ReplicateDisposition.CANCELLED:
+            return outcomes, OperationTerminal.CANCELLED
+        if outcome.disposition is ReplicateDisposition.INTERRUPTED:
+            return outcomes, OperationTerminal.INTERRUPTED
+    return outcomes, terminal
+
+
+def _execute_parallel_replicates(
+    plan: ResamplingPlan,
+    population: ResamplingPopulation,
+    executor: ReplicateExecutor,
+    execution: ExecutionSettings,
+) -> tuple[list[ReplicateOutcome], OperationTerminal]:
+    worker_count = min(execution.workers, plan.replicate_count)
+    with (
+        native_thread_environment(execution.native_thread_env(parallel=True)),
+        ThreadPoolExecutor(max_workers=worker_count) as pool,
+    ):
+        outcomes = list(
+            pool.map(
+                lambda request: _execute_replicate(
+                    plan,
+                    population,
+                    executor,
+                    request,
+                ),
+                plan.replicates,
+            )
+        )
+    if any(
+        outcome.disposition is ReplicateDisposition.INTERRUPTED for outcome in outcomes
+    ):
+        return outcomes, OperationTerminal.INTERRUPTED
+    if any(
+        outcome.disposition is ReplicateDisposition.CANCELLED for outcome in outcomes
+    ):
+        return outcomes, OperationTerminal.CANCELLED
+    return outcomes, OperationTerminal.COMPLETED
+
+
+def execute_resampling_evidence(
+    accepted: AcceptedFitResult,
+    plan: ResamplingPlan,
+    population: ResamplingPopulation,
+    executor: ReplicateExecutor,
+    *,
+    execution: ExecutionSettings | None = None,
+    cancellation_probe: Callable[[], bool] | None = None,
+) -> ResamplingOperation:
+    """Execute canonical evidence-only replicates without analysis-state authority."""
+    if (
+        not accepted_occurrence_is_authoritative(accepted)
+        or accepted.identity != plan.accepted_result_identity
+        or accepted.occurrence_identity != plan.accepted_occurrence_identity
+    ):
+        raise ResamplingConstructionError(
+            "Resampling execution requires the plan's exact authoritative anchor"
+        )
+    if population.source_dataset_identity != plan.source_dataset_identity:
+        raise ResamplingConstructionError(
+            "Resampling population belongs to a different source dataset"
+        )
+    settings = ExecutionSettings() if execution is None else execution
+    if cancellation_probe is not None and cancellation_probe():
+        return ResamplingOperation(
+            plan.identity,
+            OperationTerminal.CANCELLED,
+            None,
+            tuple(range(plan.replicate_count)),
+        )
+    if settings.workers == 1 or cancellation_probe is not None:
+        outcomes, terminal = _execute_serial_replicates(
+            plan,
+            population,
+            executor,
+            cancellation_probe,
+        )
+    else:
+        outcomes, terminal = _execute_parallel_replicates(
+            plan,
+            population,
+            executor,
+            settings,
+        )
+    evidence = (
+        ResamplingEvidence(plan, population.identity, tuple(outcomes), terminal)
+        if outcomes
+        else None
+    )
+    completed_ordinals = {outcome.ordinal for outcome in outcomes}
+    unstarted = tuple(
+        request.ordinal
+        for request in plan.replicates
+        if request.ordinal not in completed_ordinals
+    )
+    return ResamplingOperation(plan.identity, terminal, evidence, unstarted)
+
+
+@dataclass(frozen=True, slots=True)
+class SummaryFailure:
+    """Typed reason why no resampling summary artifact was produced."""
+
+    category: str
+    message: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.category or not self.message:
+            raise ResamplingConstructionError(
+                "Summary failure requires category and message"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-summary-failure", (self.category, self.message)
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SummarySample:
+    """One complete-scope row included in a joint empirical distribution."""
+
+    ordinal: int
+    outcome_identity: str
+    items: tuple[tuple[str, float], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingExclusion:
+    """One explicit unsuccessful source outcome excluded by policy."""
+
+    ordinal: int
+    outcome_identity: str
+    disposition: ReplicateDisposition
+    category: str
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterDistribution:
+    """One parameter's summary over the exact common included sample set."""
+
+    parameter_id: str
+    mean: float
+    standard_deviation: float
+    median: float
+    percentile_95_lower: float
+    percentile_95_upper: float
+
+    def __post_init__(self) -> None:
+        if not self.parameter_id:
+            raise ResamplingConstructionError(
+                "Parameter distribution requires a stable parameter ID"
+            )
+        for name in (
+            "mean",
+            "standard_deviation",
+            "median",
+            "percentile_95_lower",
+            "percentile_95_upper",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite(getattr(self, name), name=f"distribution {name}"),
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class CovarianceEntry:
+    """One finite empirical covariance entry over the common sample set."""
+
+    parameter_a: str
+    parameter_b: str
+    value: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "value",
+            _finite(self.value, name="empirical covariance"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationEntry:
+    """One empirical correlation or an explicit typed unavailability."""
+
+    parameter_a: str
+    parameter_b: str
+    availability: CorrelationAvailability
+    value: float | None
+
+    def __post_init__(self) -> None:
+        if (self.availability is CorrelationAvailability.AVAILABLE) != (
+            self.value is not None
+        ):
+            raise ResamplingConstructionError(
+                "Correlation availability and value are inconsistent"
+            )
+        if self.value is not None:
+            object.__setattr__(
+                self,
+                "value",
+                _finite(self.value, name="empirical correlation"),
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingSummary:
+    """Qualified joint empirical summary with one inclusion denominator."""
+
+    evidence_identity: str
+    output_scope: tuple[str, ...]
+    included_ordinals: tuple[int, ...]
+    exclusions: tuple[ResamplingExclusion, ...]
+    samples: tuple[SummarySample, ...]
+    distributions: tuple[ParameterDistribution, ...]
+    covariance: tuple[CovarianceEntry, ...]
+    correlations: tuple[CorrelationEntry, ...]
+    policy_version: str = _SUMMARY_POLICY_VERSION
+    claims: tuple[ClaimAssessment, ...] = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        policy_identity = _identity(
+            "native-resampling-summary-policy",
+            (
+                self.policy_version,
+                self.evidence_identity,
+                self.output_scope,
+                self.included_ordinals,
+            ),
+        )
+        claims = (
+            ClaimAssessment(
+                "COMMON_SCOPE_INCLUSION",
+                ClaimState.SATISFIED,
+                policy_identity,
+                (
+                    f"scope={','.join(self.output_scope)}",
+                    f"included={len(self.included_ordinals)}",
+                ),
+            ),
+            ClaimAssessment(
+                "MINIMUM_SUCCESSFUL_COVERAGE",
+                ClaimState.SATISFIED,
+                policy_identity,
+                (f"included={len(self.included_ordinals)}",),
+            ),
+            ClaimAssessment(
+                "FINITE_EMPIRICAL_SUMMARY",
+                ClaimState.SATISFIED,
+                policy_identity,
+            ),
+        )
+        object.__setattr__(self, "claims", claims)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-summary",
+                (
+                    self.evidence_identity,
+                    self.output_scope,
+                    self.included_ordinals,
+                    tuple(
+                        (
+                            item.ordinal,
+                            item.outcome_identity,
+                            _items_tokens(item.items),
+                        )
+                        for item in self.samples
+                    ),
+                    tuple(
+                        (
+                            item.ordinal,
+                            item.outcome_identity,
+                            item.disposition.value,
+                            item.category,
+                        )
+                        for item in self.exclusions
+                    ),
+                    tuple(
+                        (
+                            item.parameter_id,
+                            _float_token(item.mean),
+                            _float_token(item.standard_deviation),
+                            _float_token(item.median),
+                            _float_token(item.percentile_95_lower),
+                            _float_token(item.percentile_95_upper),
+                        )
+                        for item in self.distributions
+                    ),
+                    tuple(
+                        (
+                            item.parameter_a,
+                            item.parameter_b,
+                            _float_token(item.value),
+                        )
+                        for item in self.covariance
+                    ),
+                    tuple(
+                        (
+                            item.parameter_a,
+                            item.parameter_b,
+                            item.availability.value,
+                            None if item.value is None else _float_token(item.value),
+                        )
+                        for item in self.correlations
+                    ),
+                    self.policy_version,
+                    tuple(
+                        (
+                            claim.name,
+                            claim.state.value,
+                            claim.policy_identity,
+                            claim.details,
+                        )
+                        for claim in claims
+                    ),
+                ),
+            ),
+        )
+
+    def claim(self, name: str) -> ClaimState:
+        """Return one exact named claim; unknown claims fail closed."""
+        for claim in self.claims:
+            if claim.name == name:
+                return claim.state
+        return ClaimState.INDETERMINATE
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingSummaryOutcome:
+    """Closed result union for one summary derivation request."""
+
+    terminal: SummaryTerminal
+    evidence_identity: str
+    summary: ResamplingSummary | None = None
+    failure: SummaryFailure | None = None
+
+    def __post_init__(self) -> None:
+        completed = self.terminal is SummaryTerminal.COMPLETED
+        if completed != (self.summary is not None) or completed == (
+            self.failure is not None
+        ):
+            raise ResamplingConstructionError(
+                "Summary outcome must contain exactly its typed terminal payload"
+            )
+
+
+def _build_summary_statistics(
+    matrix: np.ndarray,
+    output_scope: tuple[str, ...],
+) -> tuple[
+    tuple[ParameterDistribution, ...],
+    tuple[CovarianceEntry, ...],
+    tuple[CorrelationEntry, ...],
+]:
+    distributions: list[ParameterDistribution] = []
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        with np.errstate(over="raise", invalid="raise", divide="raise"):
+            for index, param_id in enumerate(output_scope):
+                values = matrix[:, index]
+                lower, median, upper = np.percentile(values, (2.5, 50.0, 97.5))
+                distributions.append(
+                    ParameterDistribution(
+                        param_id,
+                        float(np.mean(values)),
+                        float(np.std(values, ddof=1)),
+                        float(median),
+                        float(lower),
+                        float(upper),
+                    )
+                )
+            centered = matrix - np.mean(matrix, axis=0)
+            covariance_matrix = (centered.T @ centered) / float(len(matrix) - 1)
+    covariance = tuple(
+        CovarianceEntry(param_a, param_b, float(covariance_matrix[row, column]))
+        for row, param_a in enumerate(output_scope)
+        for column, param_b in enumerate(output_scope)
+    )
+    variances = np.diag(covariance_matrix)
+    correlations: list[CorrelationEntry] = []
+    for row, param_a in enumerate(output_scope):
+        for column, param_b in enumerate(output_scope):
+            denominator = math.sqrt(float(variances[row])) * math.sqrt(
+                float(variances[column])
+            )
+            if not math.isfinite(denominator):
+                raise ResamplingConstructionError(
+                    "Empirical correlation denominator must be finite"
+                )
+            if denominator == 0.0:
+                correlations.append(
+                    CorrelationEntry(
+                        param_a,
+                        param_b,
+                        CorrelationAvailability.ZERO_VARIANCE,
+                        None,
+                    )
+                )
+            else:
+                correlations.append(
+                    CorrelationEntry(
+                        param_a,
+                        param_b,
+                        CorrelationAvailability.AVAILABLE,
+                        float(covariance_matrix[row, column] / denominator),
+                    )
+                )
+    return tuple(distributions), covariance, tuple(correlations)
+
+
+def summarize_resampling_evidence(
+    evidence: ResamplingEvidence,
+) -> ResamplingSummaryOutcome:
+    """Derive one summary from all and only complete successful scope rows."""
+    successful = tuple(
+        outcome for outcome in evidence.outcomes if outcome.success is not None
+    )
+    if len(successful) < evidence.plan.minimum_successful_count:
+        failure = SummaryFailure(
+            "insufficient_successful_coverage",
+            "Successful complete-scope replicate coverage is below the declared minimum",
+        )
+        return ResamplingSummaryOutcome(
+            SummaryTerminal.INSUFFICIENT_COVERAGE,
+            evidence.identity,
+            failure=failure,
+        )
+    samples = tuple(
+        SummarySample(
+            outcome.ordinal,
+            outcome.identity,
+            outcome.success.resolved_items,
+        )
+        for outcome in successful
+        if outcome.success is not None
+    )
+    if any(
+        tuple(param_id for param_id, _value in sample.items)
+        != evidence.plan.output_scope
+        for sample in samples
+    ):
+        failure = SummaryFailure(
+            "source_scope_mismatch",
+            "Successful source outcomes do not share the declared complete scope",
+        )
+        return ResamplingSummaryOutcome(
+            SummaryTerminal.SOURCE_INVALID,
+            evidence.identity,
+            failure=failure,
+        )
+    matrix = np.asarray(
+        [[value for _param_id, value in sample.items] for sample in samples],
+        dtype=np.float64,
+    )
+    if not np.all(np.isfinite(matrix)):
+        failure = SummaryFailure(
+            "non_finite_source_sample",
+            "A source sample contains a non-finite complete-scope value",
+        )
+        return ResamplingSummaryOutcome(
+            SummaryTerminal.SOURCE_INVALID,
+            evidence.identity,
+            failure=failure,
+        )
+    try:
+        distributions, covariance, correlations = _build_summary_statistics(
+            matrix,
+            evidence.plan.output_scope,
+        )
+    except (FloatingPointError, RuntimeWarning, OverflowError, ValueError) as error:
+        failure = SummaryFailure(
+            "non_finite_summary_arithmetic",
+            f"Summary arithmetic did not produce finite binary64 evidence: {error}",
+        )
+        return ResamplingSummaryOutcome(
+            SummaryTerminal.SOURCE_INVALID,
+            evidence.identity,
+            failure=failure,
+        )
+    exclusions = tuple(
+        ResamplingExclusion(
+            outcome.ordinal,
+            outcome.identity,
+            outcome.disposition,
+            outcome.failure.category if outcome.failure is not None else "unknown",
+        )
+        for outcome in evidence.outcomes
+        if outcome.failure is not None
+    )
+    summary = ResamplingSummary(
+        evidence.identity,
+        evidence.plan.output_scope,
+        tuple(outcome.ordinal for outcome in successful),
+        exclusions,
+        samples,
+        distributions,
+        covariance,
+        correlations,
+    )
+    return ResamplingSummaryOutcome(
+        SummaryTerminal.COMPLETED,
+        evidence.identity,
+        summary=summary,
+    )

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -27,6 +27,7 @@ from chemex.optimize.direct_trf import (
 )
 from chemex.runtime import ExecutionSettings
 from chemex.runtime.execution import native_thread_environment
+from chemex.typing import Array
 
 _SCHEMA_VERSION = 1
 _SEED_POLICY_VERSION = "sha256-structural-u64-v1"
@@ -120,6 +121,13 @@ class ClaimAssessment:
             raise ResamplingConstructionError(
                 "Claim assessment requires a name and policy identity"
             )
+
+
+def _claim_state(claims: Sequence[ClaimAssessment], name: str) -> ClaimState:
+    for claim in claims:
+        if claim.name == name:
+            return claim.state
+    return ClaimState.INDETERMINATE
 
 
 def _identity(kind: str, record: object) -> str:
@@ -248,6 +256,7 @@ class ResamplingPlan:
     accepted_occurrence_identity: str
     scheme: ResamplingScheme
     replicate_count: int
+    replicate_structural_identities: tuple[str, ...]
     root_seed: int
     source_dataset_identity: str
     output_scope: tuple[str, ...]
@@ -269,6 +278,16 @@ class ResamplingPlan:
             raise ResamplingConstructionError(
                 "Minimum successful replicate count cannot exceed the population"
             )
+        supplied_structural_identities = tuple(self.replicate_structural_identities)
+        if (
+            len(supplied_structural_identities) != count
+            or any(not item for item in supplied_structural_identities)
+            or len(set(supplied_structural_identities)) != count
+        ):
+            raise ResamplingConstructionError(
+                "Resampling requires one unique structural identity per replicate"
+            )
+        structural_identities = tuple(sorted(supplied_structural_identities))
         root_seed = _unsigned_seed(self.root_seed, name="root seed")
         scope = _canonical_scope(self.output_scope)
         for name, value in (
@@ -288,6 +307,7 @@ class ResamplingPlan:
                 self.accepted_occurrence_identity,
                 self.scheme.value,
                 count,
+                structural_identities,
                 root_seed,
                 self.source_dataset_identity,
                 scope,
@@ -299,11 +319,7 @@ class ResamplingPlan:
             ),
         )
         requests: list[ReplicateRequest] = []
-        for ordinal in range(count):
-            structural_identity = _identity(
-                "native-resampling-replicate-structure",
-                (identity, ordinal),
-            )
+        for ordinal, structural_identity in enumerate(structural_identities):
             seed = _derive_seed(
                 root_seed=root_seed,
                 stage_identity=identity,
@@ -319,6 +335,11 @@ class ResamplingPlan:
                 "Distinct resampling work units produced a derived-seed collision"
             )
         object.__setattr__(self, "replicate_count", count)
+        object.__setattr__(
+            self,
+            "replicate_structural_identities",
+            structural_identities,
+        )
         object.__setattr__(self, "minimum_successful_count", minimum)
         object.__setattr__(self, "root_seed", root_seed)
         object.__setattr__(self, "output_scope", scope)
@@ -332,6 +353,7 @@ class ResamplingPlan:
         *,
         scheme: ResamplingScheme,
         replicate_count: int,
+        replicate_structural_identities: Sequence[str],
         root_seed: int,
         source_dataset_identity: str,
         output_scope: Sequence[str],
@@ -348,6 +370,7 @@ class ResamplingPlan:
             accepted.occurrence_identity,
             scheme,
             replicate_count,
+            tuple(replicate_structural_identities),
             root_seed,
             source_dataset_identity,
             tuple(output_scope),
@@ -367,6 +390,7 @@ class ResamplingPopulation:
     mask: tuple[bool, ...]
     references: tuple[bool, ...]
     nucleus_groups: tuple[str, ...]
+    profile_blocks: tuple[str, ...]
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -383,6 +407,7 @@ class ResamplingPopulation:
                 self.mask,
                 self.references,
                 self.nucleus_groups,
+                self.profile_blocks,
             )
         ):
             raise ResamplingConstructionError(
@@ -412,6 +437,10 @@ class ResamplingPopulation:
             raise ResamplingConstructionError(
                 "Nucleus group identities must not be empty"
             )
+        if any(not block for block in self.profile_blocks):
+            raise ResamplingConstructionError(
+                "Profile block identities must not be empty"
+            )
         object.__setattr__(self, "observed", observed)
         object.__setattr__(self, "calculated", calculated)
         object.__setattr__(self, "standard_errors", errors)
@@ -428,6 +457,7 @@ class ResamplingPopulation:
                     self.mask,
                     self.references,
                     self.nucleus_groups,
+                    self.profile_blocks,
                 ),
             ),
         )
@@ -445,6 +475,7 @@ class ResamplingDraw:
     mask: tuple[bool, ...]
     references: tuple[bool, ...]
     nucleus_groups: tuple[str, ...]
+    profile_blocks: tuple[str, ...]
     source_indices: tuple[int, ...]
     sampled_nucleus_groups: tuple[str, ...] = ()
     identity: str = field(init=False)
@@ -459,6 +490,7 @@ class ResamplingDraw:
                 self.mask,
                 self.references,
                 self.nucleus_groups,
+                self.profile_blocks,
                 self.source_indices,
             )
         ):
@@ -489,6 +521,7 @@ class ResamplingDraw:
                     self.mask,
                     self.references,
                     self.nucleus_groups,
+                    self.profile_blocks,
                     self.source_indices,
                     self.sampled_nucleus_groups,
                 ),
@@ -520,39 +553,45 @@ def generate_resampling_draw(
             population.mask,
             population.references,
             population.nucleus_groups,
+            population.profile_blocks,
             tuple(range(size)),
         )
     if scheme is ResamplingScheme.BOOTSTRAP:
-        masked = tuple(index for index, active in enumerate(population.mask) if active)
-        reference_pool = tuple(
-            index for index in masked if population.references[index]
-        )
-        non_reference_pool = tuple(
-            index for index in masked if not population.references[index]
-        )
-        selected = sorted(
-            (
-                *(
-                    int(value)
-                    for value in rng.choice(
-                        reference_pool,
-                        size=len(reference_pool),
-                        replace=True,
-                    )
-                ),
-                *(
-                    int(value)
-                    for value in rng.choice(
-                        non_reference_pool,
-                        size=len(non_reference_pool),
-                        replace=True,
-                    )
-                ),
-            )
-        )
         source_indices = list(range(size))
-        for target, source in zip(masked, selected, strict=True):
-            source_indices[target] = source
+        for block in dict.fromkeys(population.profile_blocks):
+            masked = tuple(
+                index
+                for index, active in enumerate(population.mask)
+                if active and population.profile_blocks[index] == block
+            )
+            reference_pool = tuple(
+                index for index in masked if population.references[index]
+            )
+            non_reference_pool = tuple(
+                index for index in masked if not population.references[index]
+            )
+            selected = sorted(
+                (
+                    *(
+                        int(value)
+                        for value in rng.choice(
+                            reference_pool,
+                            size=len(reference_pool),
+                            replace=True,
+                        )
+                    ),
+                    *(
+                        int(value)
+                        for value in rng.choice(
+                            non_reference_pool,
+                            size=len(non_reference_pool),
+                            replace=True,
+                        )
+                    ),
+                )
+            )
+            for target, source in zip(masked, selected, strict=True):
+                source_indices[target] = source
         indexes = tuple(source_indices)
         return ResamplingDraw(
             population.identity,
@@ -563,6 +602,7 @@ def generate_resampling_draw(
             population.mask,
             tuple(population.references[index] for index in indexes),
             population.nucleus_groups,
+            population.profile_blocks,
             indexes,
         )
     canonical_groups = tuple(sorted(set(population.nucleus_groups)))
@@ -589,6 +629,7 @@ def generate_resampling_draw(
         tuple(population.mask[index] for index in indexes),
         tuple(population.references[index] for index in indexes),
         tuple(population.nucleus_groups[index] for index in indexes),
+        tuple(population.profile_blocks[index] for index in indexes),
         indexes,
         sampled_groups,
     )
@@ -924,10 +965,7 @@ class ResamplingEvidence:
 
     def claim(self, name: str) -> ClaimState:
         """Return one exact named claim; unknown claims fail closed."""
-        for claim in self.claims:
-            if claim.name == name:
-                return claim.state
-        return ClaimState.INDETERMINATE
+        return _claim_state(self.claims, name)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1301,6 +1339,7 @@ class ResamplingSummary:
     evidence_identity: str
     output_scope: tuple[str, ...]
     included_ordinals: tuple[int, ...]
+    unstarted_ordinals: tuple[int, ...]
     exclusions: tuple[ResamplingExclusion, ...]
     samples: tuple[SummarySample, ...]
     distributions: tuple[ParameterDistribution, ...]
@@ -1318,6 +1357,7 @@ class ResamplingSummary:
                 self.evidence_identity,
                 self.output_scope,
                 self.included_ordinals,
+                self.unstarted_ordinals,
             ),
         )
         claims = (
@@ -1352,6 +1392,7 @@ class ResamplingSummary:
                     self.evidence_identity,
                     self.output_scope,
                     self.included_ordinals,
+                    self.unstarted_ordinals,
                     tuple(
                         (
                             item.ordinal,
@@ -1413,10 +1454,7 @@ class ResamplingSummary:
 
     def claim(self, name: str) -> ClaimState:
         """Return one exact named claim; unknown claims fail closed."""
-        for claim in self.claims:
-            if claim.name == name:
-                return claim.state
-        return ClaimState.INDETERMINATE
+        return _claim_state(self.claims, name)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1439,7 +1477,7 @@ class ResamplingSummaryOutcome:
 
 
 def _build_summary_statistics(
-    matrix: np.ndarray,
+    matrix: Array,
     output_scope: tuple[str, ...],
 ) -> tuple[
     tuple[ParameterDistribution, ...],
@@ -1585,6 +1623,11 @@ def summarize_resampling_evidence(
         evidence.identity,
         evidence.plan.output_scope,
         tuple(outcome.ordinal for outcome in successful),
+        tuple(
+            request.ordinal
+            for request in evidence.plan.replicates
+            if request.ordinal not in {outcome.ordinal for outcome in evidence.outcomes}
+        ),
         exclusions,
         samples,
         distributions,

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -1285,9 +1285,16 @@ def _execute_parallel_replicates(
         except KeyboardInterrupt:
             terminal = OperationTerminal.INTERRUPTED
         finally:
+            cancelled_before_start: set[Future[ReplicateOutcome]] = set()
             for future in pending:
-                future.cancel()
+                if future.cancel():
+                    cancelled_before_start.add(future)
             pool.shutdown(wait=True, cancel_futures=True)
+            outcomes.extend(
+                future.result()
+                for future in pending - cancelled_before_start
+                if not future.cancelled()
+            )
     outcomes.sort(key=lambda outcome: outcome.ordinal)
     return outcomes, terminal
 

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -13,18 +13,24 @@ import hashlib
 import json
 import math
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from enum import StrEnum
 from numbers import Real
+from threading import Lock
+from typing import Literal, cast
 
 import numpy as np
 
+from chemex.evaluation.native import EvaluationPlan, ProfilePlan
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
+    ComponentProblemDerivation,
+    OptimizationProblem,
     accepted_occurrence_is_authoritative,
 )
+from chemex.parameters.parameterization import ActiveParameterization
 from chemex.runtime import ExecutionSettings
 from chemex.runtime.execution import native_thread_environment
 from chemex.typing import Array
@@ -64,6 +70,19 @@ class ReplicateDisposition(StrEnum):
     FAILED = "failed"
     CANCELLED = "cancelled"
     INTERRUPTED = "interrupted"
+    NOT_STARTED = "not_started"
+
+
+class ReplicateStage(StrEnum):
+    """Last truthful execution stage reached by a planned replicate."""
+
+    PLANNED = "planned"
+    GENERATING = "generating"
+    DRAW_READY = "draw_ready"
+    EXECUTOR_CREATING = "executor_creating"
+    EXECUTING = "executing"
+    VALIDATING = "validating"
+    TERMINAL = "terminal"
 
 
 class ResamplingLifecycle(StrEnum):
@@ -138,6 +157,16 @@ def _identity(kind: str, record: object) -> str:
         separators=(",", ":"),
         sort_keys=True,
     ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _evaluation_identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"schema": 1, "kind": kind, "record": record},
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
     return hashlib.sha256(encoded).hexdigest()
 
 
@@ -224,6 +253,9 @@ class ReplicateRequest:
     """One canonical structural replicate identity and its derived seed."""
 
     plan_identity: str
+    source_dataset_identity: str
+    scheme: ResamplingScheme
+    generation_policy_version: str
     ordinal: int
     structural_identity: str
     optimization_projection_identity: str
@@ -254,6 +286,9 @@ class ReplicateRequest:
                 "native-resampling-replicate-request",
                 (
                     self.plan_identity,
+                    self.source_dataset_identity,
+                    self.scheme.value,
+                    self.generation_policy_version,
                     self.ordinal,
                     self.structural_identity,
                     self.optimization_projection_identity,
@@ -270,22 +305,28 @@ class ResamplingPlan:
 
     accepted_result_identity: str
     accepted_occurrence_identity: str
+    dataset: ResamplingDatasetManifest = field(repr=False, compare=False)
+    source_problem: OptimizationProblem = field(repr=False, compare=False)
+    parameterization: ActiveParameterization = field(repr=False, compare=False)
     scheme: ResamplingScheme
     replicate_count: int
     replicate_structural_identities: tuple[str, ...]
     replicate_component_identities: tuple[tuple[str, ...], ...]
     root_seed: int
-    source_dataset_identity: str
     output_scope: tuple[str, ...]
-    optimization_projection_identity: str
+    output_units: tuple[str, ...]
     minimum_successful_count: int
+    strategy: OptimizationStrategy = OptimizationStrategy.DIRECT_TRF
+    strategy_settings: tuple[tuple[str, str], ...] = ()
     seed_policy_version: str = _SEED_POLICY_VERSION
     rng_algorithm: str = _RNG_ALGORITHM
     generation_policy_version: str = _GENERATION_POLICY_VERSION
     identity: str = field(init=False)
     replicates: tuple[ReplicateRequest, ...] = field(init=False)
+    source_dataset_identity: str = field(init=False)
+    optimization_projection_identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: C901 - complete plan invariant
         count = _positive_integer(self.replicate_count, name="replicate count")
         minimum = _positive_integer(
             self.minimum_successful_count,
@@ -329,11 +370,50 @@ class ResamplingPlan:
         component_identities = tuple(item[1] for item in canonical_work_units)
         root_seed = _unsigned_seed(self.root_seed, name="root seed")
         scope = _canonical_scope(self.output_scope)
+        units = tuple(self.output_units)
+        if len(units) != len(scope) or any(not unit for unit in units):
+            raise ResamplingConstructionError(
+                "Resampling output units must cover the exact ordered scope"
+            )
+        settings = tuple(sorted(self.strategy_settings))
+        if any(not key or not value for key, value in settings) or len(
+            {key for key, _value in settings}
+        ) != len(settings):
+            raise ResamplingConstructionError(
+                "Optimization strategy settings require unique non-empty keys"
+            )
+        if (
+            self.dataset.evaluation_plan.identity
+            != self.source_problem.evaluation_plan_identity
+            or self.source_problem.parameterization_identity
+            != self.parameterization.identity
+            or self.source_problem.evaluator_parameterization_identity
+            != self.parameterization.evaluator_identity
+            or self.source_problem.constraint_program_identity
+            != self.parameterization.program.fingerprint
+        ):
+            raise ResamplingConstructionError(
+                "Source dataset, problem, and parameterization lineage differ"
+            )
+        if tuple(scope) != self.source_problem.commit_scope:
+            raise ResamplingConstructionError(
+                "Resampling output scope must equal the exact source problem scope"
+            )
+        projection_identity = _identity(
+            "native-resampling-optimization-projection",
+            (
+                self.source_problem.identity,
+                self.parameterization.identity,
+                self.strategy.value,
+                settings,
+                component_identities,
+                scope,
+                units,
+            ),
+        )
         for name, value in (
             ("accepted result identity", self.accepted_result_identity),
             ("accepted occurrence identity", self.accepted_occurrence_identity),
-            ("source dataset identity", self.source_dataset_identity),
-            ("optimization projection identity", self.optimization_projection_identity),
             ("seed policy version", self.seed_policy_version),
             ("RNG algorithm", self.rng_algorithm),
             ("generation policy version", self.generation_policy_version),
@@ -349,10 +429,15 @@ class ResamplingPlan:
                 structural_identities,
                 component_identities,
                 root_seed,
-                self.source_dataset_identity,
+                self.dataset.identity,
+                self.source_problem.identity,
+                self.parameterization.identity,
                 scope,
-                self.optimization_projection_identity,
+                units,
+                projection_identity,
                 minimum,
+                self.strategy.value,
+                settings,
                 self.seed_policy_version,
                 self.rng_algorithm,
                 self.generation_policy_version,
@@ -371,9 +456,12 @@ class ResamplingPlan:
             requests.append(
                 ReplicateRequest(
                     identity,
+                    self.dataset.identity,
+                    self.scheme,
+                    self.generation_policy_version,
                     ordinal,
                     structural_identity,
-                    self.optimization_projection_identity,
+                    projection_identity,
                     components,
                     seed,
                 )
@@ -397,6 +485,12 @@ class ResamplingPlan:
         object.__setattr__(self, "minimum_successful_count", minimum)
         object.__setattr__(self, "root_seed", root_seed)
         object.__setattr__(self, "output_scope", scope)
+        object.__setattr__(self, "output_units", units)
+        object.__setattr__(self, "strategy_settings", settings)
+        object.__setattr__(self, "source_dataset_identity", self.dataset.identity)
+        object.__setattr__(
+            self, "optimization_projection_identity", projection_identity
+        )
         object.__setattr__(self, "identity", identity)
         object.__setattr__(self, "replicates", tuple(requests))
 
@@ -405,126 +499,254 @@ class ResamplingPlan:
         cls,
         accepted: AcceptedFitResult,
         *,
+        dataset: ResamplingDatasetManifest,
+        source_problem: OptimizationProblem,
+        parameterization: ActiveParameterization,
         scheme: ResamplingScheme,
         replicate_count: int,
         replicate_structural_identities: Sequence[str],
         replicate_component_identities: Sequence[Sequence[str]],
         root_seed: int,
-        source_dataset_identity: str,
         output_scope: Sequence[str],
-        optimization_projection_identity: str,
+        output_units: Sequence[str],
         minimum_successful_count: int,
+        strategy: OptimizationStrategy = OptimizationStrategy.DIRECT_TRF,
+        strategy_settings: Sequence[tuple[str, str]] = (),
     ) -> ResamplingPlan:
         """Bind a deterministic replicate population to one accepted occurrence."""
         if not accepted_occurrence_is_authoritative(accepted):
             raise ResamplingConstructionError(
                 "Resampling planning requires an exact authoritative accepted occurrence"
             )
+        _validate_accepted_source(
+            accepted,
+            dataset,
+            source_problem,
+            parameterization,
+        )
         return cls(
             accepted.identity,
             accepted.occurrence_identity,
+            dataset,
+            source_problem,
+            parameterization,
             scheme,
             replicate_count,
             tuple(replicate_structural_identities),
             tuple(tuple(items) for items in replicate_component_identities),
             root_seed,
-            source_dataset_identity,
             tuple(output_scope),
-            optimization_projection_identity,
+            tuple(output_units),
             minimum_successful_count,
+            strategy,
+            tuple(strategy_settings),
+        )
+
+
+def _validate_accepted_source(
+    accepted: AcceptedFitResult,
+    dataset: ResamplingDatasetManifest,
+    source_problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+) -> None:
+    snapshot = source_problem.source_snapshot
+    if (
+        accepted.problem_identity != source_problem.identity
+        or accepted.parameterization_identity != parameterization.identity
+        or accepted.evaluator_parameterization_identity
+        != parameterization.evaluator_identity
+        or accepted.source_occurrence_identity != snapshot.occurrence_identity
+        or accepted.source_revision != snapshot.revision
+        or accepted.evaluation_result.plan_identity != dataset.evaluation_plan.identity
+        or accepted.evaluation_result.parameterization_identity
+        != parameterization.evaluator_identity
+        or tuple(
+            float(value) for value in accepted.evaluation_result.normalized_calculations
+        )
+        != dataset.calculated
+        or accepted.controlled_ids != source_problem.controlled_ids
+        or accepted.vector != source_problem.start
+        or accepted.commit_scope != source_problem.commit_scope
+        or accepted.commit_items
+        != accepted.evaluation_result.resolved_values.ordered_items()
+    ):
+        raise ResamplingConstructionError(
+            "Resampling source does not match the exact accepted native lineage"
         )
 
 
 @dataclass(frozen=True, slots=True)
-class ResamplingPopulation:
-    """Canonical source values needed by all three retained schemes."""
+class ResamplingDatasetManifest:
+    """Canonical by-value source population owned by one resampling request."""
 
-    source_dataset_identity: str
-    observed: tuple[float, ...]
+    evaluation_plan: EvaluationPlan
     calculated: tuple[float, ...]
-    standard_errors: tuple[float, ...]
-    mask: tuple[bool, ...]
     references: tuple[bool, ...]
     nucleus_groups: tuple[str, ...]
-    profile_blocks: tuple[str, ...]
+    observation_descriptors: tuple[str, ...]
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
-        _non_empty_identity(
-            self.source_dataset_identity,
-            name="source dataset identity",
+    @property
+    def observed(self) -> tuple[float, ...]:
+        return tuple(
+            value
+            for profile in self.evaluation_plan.profiles
+            for value in profile.experimental_values
         )
-        size = len(self.observed)
+
+    @property
+    def standard_errors(self) -> tuple[float, ...]:
+        return tuple(
+            value
+            for profile in self.evaluation_plan.profiles
+            for value in profile.uncertainties
+        )
+
+    @property
+    def mask(self) -> tuple[bool, ...]:
+        return tuple(
+            value for profile in self.evaluation_plan.profiles for value in profile.mask
+        )
+
+    @property
+    def profile_blocks(self) -> tuple[str, ...]:
+        return tuple(
+            profile.identity
+            for profile in self.evaluation_plan.profiles
+            for _ in range(profile.observation_count)
+        )
+
+    def __post_init__(self) -> None:
+        try:
+            evaluation_plan = EvaluationPlan.from_record(
+                self.evaluation_plan.to_record()
+            )
+        except (TypeError, ValueError) as error:
+            raise ResamplingConstructionError(
+                "Source dataset requires a canonical EvaluationPlan descriptor"
+            ) from error
+        size = evaluation_plan.observation_count
         if size < 1 or any(
             len(values) != size
             for values in (
                 self.calculated,
-                self.standard_errors,
-                self.mask,
                 self.references,
                 self.nucleus_groups,
-                self.profile_blocks,
+                self.observation_descriptors,
             )
         ):
             raise ResamplingConstructionError(
-                "Resampling population fields must have one common non-zero size"
+                "Source dataset fields must match the EvaluationPlan population"
             )
-        observed = tuple(
-            _finite(value, name=f"observed[{index}]")
-            for index, value in enumerate(self.observed)
-        )
         calculated = tuple(
             _finite(value, name=f"calculated[{index}]")
             for index, value in enumerate(self.calculated)
         )
-        errors = tuple(
-            _finite(value, name=f"standard_errors[{index}]")
-            for index, value in enumerate(self.standard_errors)
-        )
-        if any(value < 0.0 for value in errors):
+        if any(type(value) is not bool for value in self.references):
+            raise ResamplingConstructionError("Reference flags must be Boolean")
+        if any(value < 0.0 for value in self.standard_errors):
             raise ResamplingConstructionError(
-                "Resampling standard errors must be non-negative"
-            )
-        if any(type(value) is not bool for value in (*self.mask, *self.references)):
-            raise ResamplingConstructionError(
-                "Mask and reference flags must be Boolean"
+                "Source dataset uncertainties must be non-negative"
             )
         if any(not group for group in self.nucleus_groups):
             raise ResamplingConstructionError(
                 "Nucleus group identities must not be empty"
             )
-        if any(not block for block in self.profile_blocks):
+        if any(not descriptor for descriptor in self.observation_descriptors):
             raise ResamplingConstructionError(
-                "Profile block identities must not be empty"
+                "Observation descriptors must not be empty"
             )
-        object.__setattr__(self, "observed", observed)
+        object.__setattr__(self, "evaluation_plan", evaluation_plan)
         object.__setattr__(self, "calculated", calculated)
-        object.__setattr__(self, "standard_errors", errors)
         object.__setattr__(
             self,
             "identity",
             _identity(
-                "native-resampling-population",
+                "native-resampling-source-dataset",
                 (
-                    self.source_dataset_identity,
-                    tuple(_float_token(value) for value in observed),
+                    self.evaluation_plan.identity,
                     tuple(_float_token(value) for value in calculated),
-                    tuple(_float_token(value) for value in errors),
-                    self.mask,
                     self.references,
                     self.nucleus_groups,
-                    self.profile_blocks,
+                    self.observation_descriptors,
                 ),
             ),
         )
+
+    def to_record(self) -> dict[str, object]:
+        """Return a canonical record whose digest can be independently verified."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "evaluation_plan": self.evaluation_plan.to_record(),
+            "calculated": [_float_token(value) for value in self.calculated],
+            "references": list(self.references),
+            "nucleus_groups": list(self.nucleus_groups),
+            "observation_descriptors": list(self.observation_descriptors),
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> ResamplingDatasetManifest:
+        """Restore a source manifest only after recomputing its exact identity."""
+        expected_keys = {
+            "schema_version",
+            "evaluation_plan",
+            "calculated",
+            "references",
+            "nucleus_groups",
+            "observation_descriptors",
+            "identity",
+        }
+        if (
+            set(record) != expected_keys
+            or record.get("schema_version") != _SCHEMA_VERSION
+        ):
+            raise ValueError("Malformed native resampling dataset record")
+        plan_record = record.get("evaluation_plan")
+        if not isinstance(plan_record, Mapping):
+            raise TypeError("Resampling dataset EvaluationPlan must be a mapping")
+        try:
+            calculated_record = cast("list[object]", record["calculated"])
+            references_record = cast("list[bool]", record["references"])
+            groups_record = cast("list[object]", record["nucleus_groups"])
+            descriptors_record = cast("list[object]", record["observation_descriptors"])
+            if not all(
+                isinstance(value, list)
+                for value in (
+                    calculated_record,
+                    references_record,
+                    groups_record,
+                    descriptors_record,
+                )
+            ):
+                raise TypeError("Resampling dataset vectors must be lists")
+            manifest = cls(
+                EvaluationPlan.from_record(cast("Mapping[str, object]", plan_record)),
+                tuple(float.fromhex(str(value)) for value in calculated_record),
+                tuple(references_record),
+                tuple(str(value) for value in groups_record),
+                tuple(str(value) for value in descriptors_record),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("Malformed native resampling dataset payload") from error
+        if record.get("identity") != manifest.identity:
+            raise ValueError("Resampling dataset identity does not match its content")
+        return manifest
+
+
+_DRAW_CONSTRUCTION_KEY = object()
 
 
 @dataclass(frozen=True, slots=True)
 class ResamplingDraw:
     """One immutable seeded transformation with exact source selection."""
 
-    population_identity: str
+    _construction_key: object = field(repr=False, compare=False)
+    request_identity: str
+    ordinal: int
+    source_dataset_identity: str
     scheme: ResamplingScheme
+    generation_policy_version: str
     seed: int
     observations: tuple[float, ...]
     standard_errors: tuple[float, ...]
@@ -537,6 +759,10 @@ class ResamplingDraw:
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        if self._construction_key is not _DRAW_CONSTRUCTION_KEY:
+            raise ResamplingConstructionError(
+                "Resampling draws must be produced by canonical generation"
+            )
         _unsigned_seed(self.seed, name="draw seed")
         size = len(self.observations)
         if any(
@@ -569,8 +795,11 @@ class ResamplingDraw:
             _identity(
                 "native-resampling-draw",
                 (
-                    self.population_identity,
+                    self.request_identity,
+                    self.ordinal,
+                    self.source_dataset_identity,
                     self.scheme.value,
+                    self.generation_policy_version,
                     self.seed,
                     tuple(_float_token(value) for value in observations),
                     tuple(_float_token(value) for value in errors),
@@ -586,45 +815,51 @@ class ResamplingDraw:
 
 
 def generate_resampling_draw(
-    population: ResamplingPopulation,
-    scheme: ResamplingScheme,
-    *,
-    seed: int,
+    dataset: ResamplingDatasetManifest,
+    request: ReplicateRequest,
 ) -> ResamplingDraw:
     """Apply one retained scientific generation scheme with explicit PCG64 state."""
-    normalized_seed = _unsigned_seed(seed, name="draw seed")
+    if request.source_dataset_identity != dataset.identity:
+        raise ResamplingConstructionError(
+            "Replicate request belongs to another source dataset"
+        )
+    normalized_seed = _unsigned_seed(request.seed, name="draw seed")
     rng = np.random.Generator(np.random.PCG64(normalized_seed))
-    size = len(population.observed)
-    if scheme is ResamplingScheme.MONTE_CARLO:
+    size = len(dataset.observed)
+    if request.scheme is ResamplingScheme.MONTE_CARLO:
         observations = tuple(
             float(value)
-            for value in rng.normal(population.calculated, population.standard_errors)
+            for value in rng.normal(dataset.calculated, dataset.standard_errors)
         )
         return ResamplingDraw(
-            population.identity,
-            scheme,
+            _DRAW_CONSTRUCTION_KEY,
+            request.identity,
+            request.ordinal,
+            dataset.identity,
+            request.scheme,
+            request.generation_policy_version,
             normalized_seed,
             observations,
-            population.standard_errors,
-            population.mask,
-            population.references,
-            population.nucleus_groups,
-            population.profile_blocks,
+            dataset.standard_errors,
+            dataset.mask,
+            dataset.references,
+            dataset.nucleus_groups,
+            dataset.profile_blocks,
             tuple(range(size)),
         )
-    if scheme is ResamplingScheme.BOOTSTRAP:
+    if request.scheme is ResamplingScheme.BOOTSTRAP:
         source_indices = list(range(size))
-        for block in dict.fromkeys(population.profile_blocks):
+        for block in dict.fromkeys(dataset.profile_blocks):
             masked = tuple(
                 index
-                for index, active in enumerate(population.mask)
-                if active and population.profile_blocks[index] == block
+                for index, active in enumerate(dataset.mask)
+                if active and dataset.profile_blocks[index] == block
             )
             reference_pool = tuple(
-                index for index in masked if population.references[index]
+                index for index in masked if dataset.references[index]
             )
             non_reference_pool = tuple(
-                index for index in masked if not population.references[index]
+                index for index in masked if not dataset.references[index]
             )
             selected = sorted(
                 (
@@ -650,18 +885,22 @@ def generate_resampling_draw(
                 source_indices[target] = source
         indexes = tuple(source_indices)
         return ResamplingDraw(
-            population.identity,
-            scheme,
+            _DRAW_CONSTRUCTION_KEY,
+            request.identity,
+            request.ordinal,
+            dataset.identity,
+            request.scheme,
+            request.generation_policy_version,
             normalized_seed,
-            tuple(population.observed[index] for index in indexes),
-            tuple(population.standard_errors[index] for index in indexes),
-            population.mask,
-            tuple(population.references[index] for index in indexes),
-            population.nucleus_groups,
-            population.profile_blocks,
+            tuple(dataset.observed[index] for index in indexes),
+            tuple(dataset.standard_errors[index] for index in indexes),
+            dataset.mask,
+            tuple(dataset.references[index] for index in indexes),
+            dataset.nucleus_groups,
+            dataset.profile_blocks,
             indexes,
         )
-    canonical_groups = tuple(sorted(set(population.nucleus_groups)))
+    canonical_groups = tuple(sorted(set(dataset.nucleus_groups)))
     sampled_groups = tuple(
         str(value)
         for value in rng.choice(
@@ -673,56 +912,323 @@ def generate_resampling_draw(
     indexes = tuple(
         index
         for group in sampled_groups
-        for index, source_group in enumerate(population.nucleus_groups)
+        for index, source_group in enumerate(dataset.nucleus_groups)
         if source_group == group
     )
     return ResamplingDraw(
-        population.identity,
-        scheme,
+        _DRAW_CONSTRUCTION_KEY,
+        request.identity,
+        request.ordinal,
+        dataset.identity,
+        request.scheme,
+        request.generation_policy_version,
         normalized_seed,
-        tuple(population.observed[index] for index in indexes),
-        tuple(population.standard_errors[index] for index in indexes),
-        tuple(population.mask[index] for index in indexes),
-        tuple(population.references[index] for index in indexes),
-        tuple(population.nucleus_groups[index] for index in indexes),
-        tuple(population.profile_blocks[index] for index in indexes),
+        tuple(dataset.observed[index] for index in indexes),
+        tuple(dataset.standard_errors[index] for index in indexes),
+        tuple(dataset.mask[index] for index in indexes),
+        tuple(dataset.references[index] for index in indexes),
+        tuple(dataset.nucleus_groups[index] for index in indexes),
+        tuple(dataset.profile_blocks[index] for index in indexes),
         indexes,
         sampled_groups,
     )
 
 
+def _transformed_evaluation_plan(
+    dataset: ResamplingDatasetManifest,
+    draw: ResamplingDraw,
+) -> EvaluationPlan:
+    source_profiles = {
+        profile.identity: profile for profile in dataset.evaluation_plan.profiles
+    }
+    profiles: list[ProfilePlan] = []
+    offset = 0
+    index = 0
+    while index < len(draw.observations):
+        block_identity = draw.profile_blocks[index]
+        stop = index + 1
+        while stop < len(draw.observations) and (
+            draw.profile_blocks[stop] == block_identity
+        ):
+            stop += 1
+        source = source_profiles[block_identity]
+        source_identity = _identity(
+            "native-resampling-transformed-profile-source",
+            (
+                dataset.identity,
+                draw.identity,
+                source.identity,
+                len(profiles),
+                tuple(draw.source_indices[index:stop]),
+                tuple(_float_token(value) for value in draw.observations[index:stop]),
+                tuple(
+                    _float_token(value) for value in draw.standard_errors[index:stop]
+                ),
+                tuple(draw.mask[index:stop]),
+                tuple(draw.references[index:stop]),
+                tuple(draw.nucleus_groups[index:stop]),
+            ),
+        )
+        profile_ordinal = len(profiles)
+        profile_identity = _evaluation_identity(
+            "profile-plan",
+            (source_identity, source.experiment_ordinal, profile_ordinal, offset),
+        )
+        profiles.append(
+            ProfilePlan(
+                profile_identity,
+                source_identity,
+                source.experiment_ordinal,
+                profile_ordinal,
+                offset,
+                source.local_inputs,
+                source.is_scaled,
+                draw.observations[index:stop],
+                draw.standard_errors[index:stop],
+                draw.mask[index:stop],
+                source.kernel_identity,
+                source.kernel_configuration,
+                source.spectrometer_configuration,
+                _identity(
+                    "native-resampling-observation-metadata",
+                    tuple(
+                        dataset.observation_descriptors[source_index]
+                        for source_index in draw.source_indices[index:stop]
+                    ),
+                ),
+                (stop - index,),
+            )
+        )
+        offset += stop - index
+        index = stop
+    source_plan = dataset.evaluation_plan
+    return EvaluationPlan(
+        source_plan.parameterization_identity,
+        source_plan.constraint_program_identity,
+        tuple(profiles),
+        source_plan.resolved_ids,
+        source_plan.scalar_version,
+        source_plan.normalization_version,
+        source_plan.residual_version,
+        source_plan.masking_version,
+        source_plan.ordering_version,
+        source_plan.failure_version,
+        source_plan.diagnostics_version,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ReplicateExecutionPlan:
+    """Exact non-authoritative native problem prepared for one generated draw."""
+
+    plan_identity: str
+    request: ReplicateRequest
+    draw: ResamplingDraw
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
+    source_snapshot_occurrence_identity: str
+    source_snapshot_revision: int
+    evaluation_plan: EvaluationPlan = field(repr=False, compare=False)
+    problem: OptimizationProblem = field(repr=False, compare=False)
+    parameterization: ActiveParameterization = field(repr=False, compare=False)
+    strategy: OptimizationStrategy
+    workflow_identity: str
+    invocation_identity: str
+    component_identities: tuple[str, ...]
+    output_scope: tuple[str, ...]
+    output_units: tuple[str, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            self.draw.request_identity != self.request.identity
+            or self.draw.source_dataset_identity != self.request.source_dataset_identity
+            or self.evaluation_plan.identity != self.problem.evaluation_plan_identity
+            or self.problem.parameterization_identity != self.parameterization.identity
+            or self.problem.evaluator_parameterization_identity
+            != self.parameterization.evaluator_identity
+            or self.problem.constraint_program_identity
+            != self.parameterization.program.fingerprint
+            or self.problem.acceptance_authority
+            or self.problem.commit_scope != self.output_scope
+            or len(self.output_units) != len(self.output_scope)
+        ):
+            raise ResamplingConstructionError(
+                "Prepared replicate native lineage is internally inconsistent"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-prepared-replicate",
+                (
+                    self.plan_identity,
+                    self.request.identity,
+                    self.draw.identity,
+                    self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
+                    self.source_snapshot_occurrence_identity,
+                    self.source_snapshot_revision,
+                    self.evaluation_plan.identity,
+                    self.problem.identity,
+                    self.parameterization.identity,
+                    self.parameterization.evaluator_identity,
+                    self.parameterization.program.fingerprint,
+                    self.strategy.value,
+                    self.workflow_identity,
+                    self.invocation_identity,
+                    self.component_identities,
+                    self.output_scope,
+                    self.output_units,
+                ),
+            ),
+        )
+
+    @classmethod
+    def prepare(
+        cls,
+        plan: ResamplingPlan,
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ReplicateExecutionPlan:
+        """Derive every projected identity before executor construction."""
+        if (
+            request.plan_identity != plan.identity
+            or draw.request_identity != request.identity
+        ):
+            raise ResamplingConstructionError(
+                "Cannot prepare a replicate from foreign request or draw lineage"
+            )
+        if draw != generate_resampling_draw(plan.dataset, request):
+            raise ResamplingConstructionError(
+                "Prepared replicate draw differs from canonical seeded generation"
+            )
+        evaluation_plan = _transformed_evaluation_plan(plan.dataset, draw)
+        derivation = ComponentProblemDerivation(
+            plan.source_problem.identity,
+            plan.source_problem.affine_feasibility_identity,
+            request.structural_identity,
+            "native-resampling-complete-scope-v1",
+            evaluation_plan.identity,
+            plan.source_problem.controlled_ids,
+            plan.source_problem.held_items,
+        )
+        problem = plan.source_problem.derive_child(
+            controlled_ids=plan.source_problem.controlled_ids,
+            start=plan.source_problem.start,
+            derivation=derivation,
+        )
+        workflow_identity = _identity(
+            "native-resampling-projected-workflow",
+            (
+                plan.optimization_projection_identity,
+                plan.strategy.value,
+                plan.strategy_settings,
+                problem.identity,
+                request.component_identities,
+            ),
+        )
+        invocation_identity = _identity(
+            "native-resampling-invocation-contract",
+            (
+                problem.identity,
+                workflow_identity,
+                plan.strategy.value,
+                plan.strategy_settings,
+                request.identity,
+            ),
+        )
+        snapshot = problem.source_snapshot
+        return cls(
+            plan.identity,
+            request,
+            draw,
+            plan.accepted_result_identity,
+            plan.accepted_occurrence_identity,
+            snapshot.occurrence_identity,
+            snapshot.revision,
+            evaluation_plan,
+            problem,
+            plan.parameterization,
+            plan.strategy,
+            workflow_identity,
+            invocation_identity,
+            request.component_identities,
+            plan.output_scope,
+            plan.output_units,
+        )
+
+    def resolve_candidate(
+        self, candidate_vector: Sequence[float]
+    ) -> tuple[tuple[str, float], ...]:
+        """Freshly apply the exact problem feasibility and constraint program."""
+        frame = self.problem.lifecycle_frame(candidate_vector, self.parameterization)
+        resolved = self.parameterization.resolve(frame)
+        return tuple((param_id, resolved[param_id]) for param_id in self.output_scope)
+
+
 @dataclass(frozen=True, slots=True)
 class ProjectedOptimizationSuccess:
-    """Complete projected candidate evidence with no acceptance or commit authority."""
+    """Executor-returned native candidate evidence, not a resolved sample."""
 
+    prepared_replicate_identity: str
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
+    source_snapshot_occurrence_identity: str
+    source_snapshot_revision: int
     transformed_data_identity: str
     optimization_projection_identity: str
     evaluation_plan_identity: str
     problem_identity: str
+    parameterization_identity: str
+    evaluator_parameterization_identity: str
+    constraint_program_identity: str
+    workflow_identity: str
     invocation_identity: str
     execution_identity: str
     strategy: OptimizationStrategy
     component_identities: tuple[str, ...]
     component_outcome_identities: tuple[str, ...]
-    resolved_items: tuple[tuple[str, float], ...]
+    candidate_identity: str
+    materialization_identity: str
+    evaluation_identity: str
+    requested_output_scope: tuple[str, ...]
+    requested_output_units: tuple[str, ...]
+    candidate_vector: tuple[float, ...]
     chi_square: float
-    expected_output_scope: tuple[str, ...] | None = field(
-        default=None,
-        repr=False,
-        compare=False,
-    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         for name, value in (
+            ("prepared replicate identity", self.prepared_replicate_identity),
+            ("accepted result identity", self.accepted_result_identity),
+            ("accepted occurrence identity", self.accepted_occurrence_identity),
+            (
+                "source snapshot occurrence identity",
+                self.source_snapshot_occurrence_identity,
+            ),
             ("transformed data identity", self.transformed_data_identity),
             ("optimization projection identity", self.optimization_projection_identity),
             ("evaluation plan identity", self.evaluation_plan_identity),
             ("problem identity", self.problem_identity),
+            ("parameterization identity", self.parameterization_identity),
+            (
+                "evaluator parameterization identity",
+                self.evaluator_parameterization_identity,
+            ),
+            ("constraint program identity", self.constraint_program_identity),
+            ("workflow identity", self.workflow_identity),
             ("invocation identity", self.invocation_identity),
             ("execution identity", self.execution_identity),
+            ("candidate identity", self.candidate_identity),
+            ("materialization identity", self.materialization_identity),
+            ("evaluation identity", self.evaluation_identity),
         ):
             _non_empty_identity(value, name=name)
+        if self.source_snapshot_revision < 0:
+            raise ResamplingConstructionError(
+                "Source snapshot revision must be non-negative"
+            )
         if (
             not self.component_outcome_identities
             or any(not item for item in self.component_outcome_identities)
@@ -739,31 +1245,24 @@ class ProjectedOptimizationSuccess:
             raise ResamplingConstructionError(
                 "Projected optimization requires unique component identities"
             )
-        items = tuple(
-            (param_id, _finite(value, name=f"resolved value {param_id!r}"))
-            for param_id, value in self.resolved_items
+        vector = tuple(
+            _finite(value, name=f"candidate vector[{index}]")
+            for index, value in enumerate(self.candidate_vector)
         )
-        ids = tuple(param_id for param_id, _value in items)
-        if (
-            not ids
-            or any(not param_id for param_id in ids)
-            or len(set(ids)) != len(ids)
-        ):
+        scope = _canonical_scope(self.requested_output_scope)
+        units = tuple(self.requested_output_units)
+        if len(units) != len(scope) or any(not unit for unit in units):
             raise ResamplingConstructionError(
-                "Projected optimization requires unique resolved output IDs"
-            )
-        if self.expected_output_scope is not None and ids != tuple(
-            self.expected_output_scope
-        ):
-            raise ResamplingConstructionError(
-                "Projected optimization must resolve the complete output scope"
+                "Projected output units must cover the requested scope"
             )
         chi_square = _finite(self.chi_square, name="projected chi-square")
         if chi_square < 0.0:
             raise ResamplingConstructionError(
                 "Projected chi-square must be non-negative"
             )
-        object.__setattr__(self, "resolved_items", items)
+        object.__setattr__(self, "candidate_vector", vector)
+        object.__setattr__(self, "requested_output_scope", scope)
+        object.__setattr__(self, "requested_output_units", units)
         object.__setattr__(self, "chi_square", chi_square)
         object.__setattr__(
             self,
@@ -771,19 +1270,115 @@ class ProjectedOptimizationSuccess:
             _identity(
                 "native-projected-optimization-success",
                 (
+                    self.prepared_replicate_identity,
+                    self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
+                    self.source_snapshot_occurrence_identity,
+                    self.source_snapshot_revision,
                     self.transformed_data_identity,
                     self.optimization_projection_identity,
                     self.evaluation_plan_identity,
                     self.problem_identity,
+                    self.parameterization_identity,
+                    self.evaluator_parameterization_identity,
+                    self.constraint_program_identity,
+                    self.workflow_identity,
                     self.invocation_identity,
                     self.execution_identity,
                     self.strategy.value,
                     self.component_identities,
                     self.component_outcome_identities,
-                    _items_tokens(items),
+                    self.candidate_identity,
+                    self.materialization_identity,
+                    self.evaluation_identity,
+                    scope,
+                    units,
+                    tuple(_float_token(value) for value in vector),
                     _float_token(chi_square),
                 ),
             ),
+        )
+
+    @classmethod
+    def for_prepared(
+        cls,
+        prepared: ReplicateExecutionPlan,
+        *,
+        candidate_vector: Sequence[float],
+        chi_square: float,
+    ) -> ProjectedOptimizationSuccess:
+        """Construct exact callback evidence for a prepared native replicate."""
+        vector = tuple(float(value) for value in candidate_vector)
+        resolved = prepared.resolve_candidate(vector)
+        candidate_identity = _identity(
+            "native-resampling-candidate",
+            (
+                prepared.identity,
+                tuple(_float_token(value) for value in vector),
+                _float_token(float(chi_square)),
+            ),
+        )
+        component_outcomes = tuple(
+            _identity(
+                "native-resampling-component-outcome",
+                (prepared.identity, component_identity, candidate_identity),
+            )
+            for component_identity in prepared.component_identities
+        )
+        execution_identity = _identity(
+            "native-resampling-execution",
+            (
+                prepared.identity,
+                prepared.invocation_identity,
+                candidate_identity,
+                component_outcomes,
+            ),
+        )
+        evaluation_identity = _identity(
+            "native-resampling-candidate-evaluation",
+            (
+                prepared.evaluation_plan.identity,
+                prepared.parameterization.evaluator_identity,
+                candidate_identity,
+                _items_tokens(resolved),
+            ),
+        )
+        materialization_identity = _identity(
+            "native-resampling-candidate-materialization",
+            (
+                prepared.problem.identity,
+                prepared.invocation_identity,
+                execution_identity,
+                candidate_identity,
+                evaluation_identity,
+            ),
+        )
+        return cls(
+            prepared.identity,
+            prepared.accepted_result_identity,
+            prepared.accepted_occurrence_identity,
+            prepared.source_snapshot_occurrence_identity,
+            prepared.source_snapshot_revision,
+            prepared.draw.identity,
+            prepared.request.optimization_projection_identity,
+            prepared.evaluation_plan.identity,
+            prepared.problem.identity,
+            prepared.parameterization.identity,
+            prepared.parameterization.evaluator_identity,
+            prepared.parameterization.program.fingerprint,
+            prepared.workflow_identity,
+            prepared.invocation_identity,
+            execution_identity,
+            prepared.strategy,
+            prepared.component_identities,
+            component_outcomes,
+            candidate_identity,
+            materialization_identity,
+            evaluation_identity,
+            prepared.output_scope,
+            prepared.output_units,
+            vector,
+            chi_square,
         )
 
 
@@ -791,13 +1386,16 @@ class ProjectedOptimizationSuccess:
 class ProjectedOptimizationFailure:
     """Typed unsuccessful projected path retaining all available lineage."""
 
-    transformed_data_identity: str
+    transformed_data_identity: str | None
     disposition: ReplicateDisposition
     category: str
     message: str
     optimization_projection_identity: str = field(kw_only=True)
+    stage: ReplicateStage = ReplicateStage.EXECUTING
+    prepared_replicate_identity: str | None = None
     evaluation_plan_identity: str | None = None
     problem_identity: str | None = None
+    invocation_identity: str | None = None
     execution_identity: str | None = None
     component_outcome_identities: tuple[str, ...] = ()
     identity: str = field(init=False)
@@ -807,9 +1405,9 @@ class ProjectedOptimizationFailure:
             raise ResamplingConstructionError(
                 "Projected failure cannot use the successful disposition"
             )
-        if not self.transformed_data_identity or not self.category or not self.message:
+        if not self.category or not self.message:
             raise ResamplingConstructionError(
-                "Projected failure requires data identity, category, and message"
+                "Projected failure requires category and message"
             )
         _non_empty_identity(
             self.optimization_projection_identity,
@@ -826,8 +1424,11 @@ class ProjectedOptimizationFailure:
                     self.category,
                     self.message,
                     self.optimization_projection_identity,
+                    self.stage.value,
+                    self.prepared_replicate_identity,
                     self.evaluation_plan_identity,
                     self.problem_identity,
+                    self.invocation_identity,
                     self.execution_identity,
                     self.component_outcome_identities,
                 ),
@@ -841,9 +1442,61 @@ type ProjectedOptimizationResult = (
 
 
 type ReplicateExecutor = Callable[
-    [ReplicateRequest, ResamplingDraw],
+    [ReplicateExecutionPlan],
     ProjectedOptimizationResult,
 ]
+
+type ReplicateExecutorFactory = Callable[[ReplicateExecutionPlan], ReplicateExecutor]
+
+
+class _ExecutorOwnershipRegistry:
+    """Operation-local guard against reusing one executor/workspace instance."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._executors: list[ReplicateExecutor] = []
+
+    def claim(self, executor: ReplicateExecutor) -> None:
+        with self._lock:
+            if any(existing is executor for existing in self._executors):
+                raise ResamplingConstructionError(
+                    "Executor factory reused one single-owner executor instance"
+                )
+            self._executors.append(executor)
+
+
+_VALIDATED_SUCCESS_CONSTRUCTION_KEY = object()
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedReplicateSuccess:
+    """Resampling-owned complete sample after exact lineage and resolution checks."""
+
+    _construction_key: object = field(repr=False, compare=False)
+    prepared_replicate_identity: str
+    projected_outcome_identity: str
+    resolved_items: tuple[tuple[str, float], ...]
+    chi_square: float
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self._construction_key is not _VALIDATED_SUCCESS_CONSTRUCTION_KEY:
+            raise ResamplingConstructionError(
+                "Successful samples require resampling-owned validation"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-validated-success",
+                (
+                    self.prepared_replicate_identity,
+                    self.projected_outcome_identity,
+                    _items_tokens(self.resolved_items),
+                    _float_token(self.chi_square),
+                ),
+            ),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -854,9 +1507,10 @@ class ReplicateOutcome:
     request_identity: str
     ordinal: int
     seed: int
-    draw_identity: str
+    draw_identity: str | None
+    stage: ReplicateStage
     disposition: ReplicateDisposition
-    success: ProjectedOptimizationSuccess | None = field(
+    success: ValidatedReplicateSuccess | None = field(
         default=None,
         repr=False,
         compare=False,
@@ -877,9 +1531,16 @@ class ReplicateOutcome:
             raise ResamplingConstructionError(
                 "Replicate outcome lacks a terminal payload"
             )
-        if payload.transformed_data_identity != self.draw_identity:
+        if (
+            self.failure is not None
+            and self.failure.transformed_data_identity != self.draw_identity
+        ):
             raise ResamplingConstructionError(
                 "Replicate outcome and projected path use different transformed data"
+            )
+        if self.success is not None and self.draw_identity is None:
+            raise ResamplingConstructionError(
+                "Successful replicate outcome requires a generated draw"
             )
         object.__setattr__(
             self,
@@ -892,6 +1553,7 @@ class ReplicateOutcome:
                     self.ordinal,
                     self.seed,
                     self.draw_identity,
+                    self.stage.value,
                     self.disposition.value,
                     payload.identity,
                 ),
@@ -926,11 +1588,12 @@ class ResamplingEvidence:
                 "Resampling outcomes must use unique canonical ordinal order"
             )
         if any(
-            ordinal >= self.plan.replicate_count
+            outcome.ordinal >= self.plan.replicate_count
             or outcome.plan_identity != self.plan.identity
-            or outcome.request_identity != self.plan.replicates[ordinal].identity
-            or outcome.seed != self.plan.replicates[ordinal].seed
-            for ordinal, outcome in zip(ordinals, self.outcomes, strict=True)
+            or outcome.request_identity
+            != self.plan.replicates[outcome.ordinal].identity
+            or outcome.seed != self.plan.replicates[outcome.ordinal].seed
+            for outcome in self.outcomes
         ):
             raise ResamplingConstructionError(
                 "Resampling outcomes differ from their planned replicate identities"
@@ -946,7 +1609,10 @@ class ResamplingEvidence:
                 raise ResamplingConstructionError(
                     "Successful replicate must resolve the complete output scope"
                 )
-        completed = len(self.outcomes)
+        completed = sum(
+            outcome.disposition is not ReplicateDisposition.NOT_STARTED
+            for outcome in self.outcomes
+        )
         successful = sum(
             outcome.disposition is ReplicateDisposition.SUCCEEDED
             for outcome in self.outcomes
@@ -1075,154 +1741,315 @@ class ResamplingOperation:
         )
 
 
-def _execute_replicate(
+def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
     plan: ResamplingPlan,
-    population: ResamplingPopulation,
-    executor: ReplicateExecutor,
+    executor_factory: ReplicateExecutorFactory,
+    ownership: _ExecutorOwnershipRegistry,
     request: ReplicateRequest,
 ) -> ReplicateOutcome:
-    try:
-        draw = generate_resampling_draw(population, plan.scheme, seed=request.seed)
-        projected = executor(request, draw)
-    except KeyboardInterrupt:
+    draw: ResamplingDraw | None = None
+    prepared: ReplicateExecutionPlan | None = None
+
+    def failure_outcome(
+        disposition: ReplicateDisposition,
+        stage: ReplicateStage,
+        category: str,
+        message: str,
+        *,
+        projected: ProjectedOptimizationSuccess | None = None,
+    ) -> ReplicateOutcome:
         failure = ProjectedOptimizationFailure(
-            draw.identity,
-            ReplicateDisposition.INTERRUPTED,
-            "asynchronous_interruption",
-            "Replicate projected optimization was interrupted",
-            optimization_projection_identity=request.optimization_projection_identity,
+            None if draw is None else draw.identity,
+            disposition,
+            category,
+            message,
+            optimization_projection_identity=(request.optimization_projection_identity),
+            stage=stage,
+            prepared_replicate_identity=(
+                None if prepared is None else prepared.identity
+            ),
+            evaluation_plan_identity=(
+                None if projected is None else projected.evaluation_plan_identity
+            ),
+            problem_identity=(
+                None if projected is None else projected.problem_identity
+            ),
+            invocation_identity=(
+                None if projected is None else projected.invocation_identity
+            ),
+            execution_identity=(
+                None if projected is None else projected.execution_identity
+            ),
+            component_outcome_identities=(
+                () if projected is None else projected.component_outcome_identities
+            ),
         )
         return ReplicateOutcome(
             plan.identity,
             request.identity,
             request.ordinal,
             request.seed,
-            draw.identity,
-            failure.disposition,
+            None if draw is None else draw.identity,
+            stage,
+            disposition,
             failure=failure,
+        )
+
+    try:
+        draw = generate_resampling_draw(plan.dataset, request)
+    except KeyboardInterrupt:
+        return failure_outcome(
+            ReplicateDisposition.INTERRUPTED,
+            ReplicateStage.GENERATING,
+            "generation_interrupted",
+            "Replicate draw generation was interrupted",
+        )
+    except Exception as error:  # noqa: BLE001 - typed generation failure
+        return failure_outcome(
+            ReplicateDisposition.FAILED,
+            ReplicateStage.GENERATING,
+            "generation_failure",
+            f"{type(error).__name__}: {error}",
+        )
+
+    try:
+        prepared = ReplicateExecutionPlan.prepare(plan, request, draw)
+    except KeyboardInterrupt:
+        return failure_outcome(
+            ReplicateDisposition.INTERRUPTED,
+            ReplicateStage.DRAW_READY,
+            "preparation_interrupted",
+            "Replicate native preparation was interrupted after draw creation",
+        )
+    except Exception as error:  # noqa: BLE001 - typed preparation failure
+        return failure_outcome(
+            ReplicateDisposition.FAILED,
+            ReplicateStage.DRAW_READY,
+            "preparation_failure",
+            f"{type(error).__name__}: {error}",
+        )
+
+    try:
+        executor = executor_factory(prepared)
+        ownership.claim(executor)
+    except KeyboardInterrupt:
+        return failure_outcome(
+            ReplicateDisposition.INTERRUPTED,
+            ReplicateStage.EXECUTOR_CREATING,
+            "executor_creation_interrupted",
+            "Replicate executor creation was interrupted",
+        )
+    except Exception as error:  # noqa: BLE001 - typed executor construction failure
+        return failure_outcome(
+            ReplicateDisposition.FAILED,
+            ReplicateStage.EXECUTOR_CREATING,
+            "executor_creation_failure",
+            f"{type(error).__name__}: {error}",
+        )
+
+    try:
+        projected = executor(prepared)
+    except KeyboardInterrupt:
+        return failure_outcome(
+            ReplicateDisposition.INTERRUPTED,
+            ReplicateStage.EXECUTING,
+            "optimization_interrupted",
+            "Replicate projected optimization was interrupted",
         )
     except Exception as error:  # noqa: BLE001 - freeze typed replicate failure
-        draw_identity = (
-            draw.identity
-            if "draw" in locals()
-            else _identity(
-                "native-resampling-draw-failure",
-                (population.identity, plan.scheme.value, request.seed),
-            )
-        )
-        failure = ProjectedOptimizationFailure(
-            draw_identity,
+        return failure_outcome(
             ReplicateDisposition.FAILED,
+            ReplicateStage.EXECUTING,
             "projected_execution_failure",
             f"{type(error).__name__}: {error}",
-            optimization_projection_identity=request.optimization_projection_identity,
         )
+
+    if isinstance(projected, ProjectedOptimizationFailure):
+        if projected.transformed_data_identity != draw.identity:
+            return failure_outcome(
+                ReplicateDisposition.FAILED,
+                ReplicateStage.VALIDATING,
+                "transformed_data_lineage_mismatch",
+                "Projected failure used a different transformed dataset",
+            )
         return ReplicateOutcome(
             plan.identity,
             request.identity,
             request.ordinal,
             request.seed,
-            draw_identity,
-            failure.disposition,
-            failure=failure,
-        )
-    if isinstance(projected, ProjectedOptimizationSuccess):
-        if tuple(param_id for param_id, _value in projected.resolved_items) != (
-            plan.output_scope
-        ):
-            failure = ProjectedOptimizationFailure(
-                draw.identity,
-                ReplicateDisposition.FAILED,
-                "incomplete_output_scope",
-                "Projected optimization did not resolve the complete output scope",
-                projected.evaluation_plan_identity,
-                projected.problem_identity,
-                projected.execution_identity,
-                projected.component_outcome_identities,
-                optimization_projection_identity=(
-                    request.optimization_projection_identity
-                ),
-            )
-            return ReplicateOutcome(
-                plan.identity,
-                request.identity,
-                request.ordinal,
-                request.seed,
-                draw.identity,
-                failure.disposition,
-                failure=failure,
-            )
-        payload: ProjectedOptimizationResult = projected
-    elif isinstance(projected, ProjectedOptimizationFailure):
-        payload = projected
-    else:
-        failure = ProjectedOptimizationFailure(
             draw.identity,
+            projected.stage,
+            projected.disposition,
+            failure=projected,
+        )
+    if not isinstance(projected, ProjectedOptimizationSuccess):
+        return failure_outcome(
             ReplicateDisposition.FAILED,
+            ReplicateStage.VALIDATING,
             "invalid_projected_outcome",
             "Projected optimization returned an unsupported outcome type",
-            optimization_projection_identity=request.optimization_projection_identity,
         )
-        payload = failure
-    if payload.transformed_data_identity != draw.identity:
-        mismatch = ProjectedOptimizationFailure(
-            draw.identity,
+
+    try:
+        expected = ProjectedOptimizationSuccess.for_prepared(
+            prepared,
+            candidate_vector=projected.candidate_vector,
+            chi_square=projected.chi_square,
+        )
+    except KeyboardInterrupt:
+        return failure_outcome(
+            ReplicateDisposition.INTERRUPTED,
+            ReplicateStage.VALIDATING,
+            "validation_interrupted",
+            "Fresh candidate validation was interrupted",
+            projected=projected,
+        )
+    except Exception as error:  # noqa: BLE001 - ordinary constraint resolution
+        return failure_outcome(
             ReplicateDisposition.FAILED,
-            "transformed_data_lineage_mismatch",
-            "Projected optimization used a different transformed-data identity",
-            optimization_projection_identity=request.optimization_projection_identity,
+            ReplicateStage.VALIDATING,
+            "candidate_resolution_failure",
+            f"{type(error).__name__}: {error}",
+            projected=projected,
         )
-        payload = mismatch
-    if (
-        payload.optimization_projection_identity
-        != request.optimization_projection_identity
-    ):
-        payload = ProjectedOptimizationFailure(
-            draw.identity,
+    lineage_fields = (
+        (
+            "prepared_replicate",
+            projected.prepared_replicate_identity,
+            expected.prepared_replicate_identity,
+        ),
+        (
+            "accepted_result",
+            projected.accepted_result_identity,
+            expected.accepted_result_identity,
+        ),
+        (
+            "accepted_occurrence",
+            projected.accepted_occurrence_identity,
+            expected.accepted_occurrence_identity,
+        ),
+        (
+            "source_snapshot_occurrence",
+            projected.source_snapshot_occurrence_identity,
+            expected.source_snapshot_occurrence_identity,
+        ),
+        (
+            "source_snapshot_revision",
+            projected.source_snapshot_revision,
+            expected.source_snapshot_revision,
+        ),
+        (
+            "transformed_data",
+            projected.transformed_data_identity,
+            expected.transformed_data_identity,
+        ),
+        (
+            "optimization_projection",
+            projected.optimization_projection_identity,
+            expected.optimization_projection_identity,
+        ),
+        (
+            "evaluation_plan",
+            projected.evaluation_plan_identity,
+            expected.evaluation_plan_identity,
+        ),
+        ("optimization_problem", projected.problem_identity, expected.problem_identity),
+        (
+            "parameterization",
+            projected.parameterization_identity,
+            expected.parameterization_identity,
+        ),
+        (
+            "evaluator_parameterization",
+            projected.evaluator_parameterization_identity,
+            expected.evaluator_parameterization_identity,
+        ),
+        (
+            "constraint_program",
+            projected.constraint_program_identity,
+            expected.constraint_program_identity,
+        ),
+        ("workflow", projected.workflow_identity, expected.workflow_identity),
+        ("invocation", projected.invocation_identity, expected.invocation_identity),
+        ("strategy", projected.strategy, expected.strategy),
+        ("components", projected.component_identities, expected.component_identities),
+        (
+            "component_outcomes",
+            projected.component_outcome_identities,
+            expected.component_outcome_identities,
+        ),
+        ("execution", projected.execution_identity, expected.execution_identity),
+        ("candidate", projected.candidate_identity, expected.candidate_identity),
+        (
+            "materialization",
+            projected.materialization_identity,
+            expected.materialization_identity,
+        ),
+        ("evaluation", projected.evaluation_identity, expected.evaluation_identity),
+        (
+            "requested_scope",
+            projected.requested_output_scope,
+            expected.requested_output_scope,
+        ),
+        (
+            "requested_units",
+            projected.requested_output_units,
+            expected.requested_output_units,
+        ),
+    )
+    mismatch = next(
+        (name for name, actual, exact in lineage_fields if actual != exact),
+        None,
+    )
+    if mismatch is not None:
+        return failure_outcome(
             ReplicateDisposition.FAILED,
-            "optimization_projection_lineage_mismatch",
-            "Projected optimization used a different declared projection",
-            optimization_projection_identity=request.optimization_projection_identity,
+            ReplicateStage.VALIDATING,
+            f"{mismatch}_lineage_mismatch",
+            f"Projected optimization returned foreign {mismatch} lineage",
+            projected=projected,
         )
-    if isinstance(payload, ProjectedOptimizationSuccess) and (
-        payload.component_identities != request.component_identities
-    ):
-        payload = ProjectedOptimizationFailure(
-            draw.identity,
+    try:
+        resolved_items = prepared.resolve_candidate(projected.candidate_vector)
+    except KeyboardInterrupt:
+        return failure_outcome(
+            ReplicateDisposition.INTERRUPTED,
+            ReplicateStage.VALIDATING,
+            "validation_interrupted",
+            "Fresh candidate resolution was interrupted",
+            projected=projected,
+        )
+    except Exception as error:  # noqa: BLE001 - typed final resolution failure
+        return failure_outcome(
             ReplicateDisposition.FAILED,
-            "incomplete_component_projection",
-            "Projected optimization did not return every planned component",
-            optimization_projection_identity=request.optimization_projection_identity,
-            evaluation_plan_identity=payload.evaluation_plan_identity,
-            problem_identity=payload.problem_identity,
-            execution_identity=payload.execution_identity,
-            component_outcome_identities=payload.component_outcome_identities,
+            ReplicateStage.VALIDATING,
+            "candidate_resolution_failure",
+            f"{type(error).__name__}: {error}",
+            projected=projected,
         )
-    if isinstance(payload, ProjectedOptimizationSuccess):
-        return ReplicateOutcome(
-            plan.identity,
-            request.identity,
-            request.ordinal,
-            request.seed,
-            draw.identity,
-            ReplicateDisposition.SUCCEEDED,
-            success=payload,
-        )
+    success = ValidatedReplicateSuccess(
+        _VALIDATED_SUCCESS_CONSTRUCTION_KEY,
+        prepared.identity,
+        projected.identity,
+        resolved_items,
+        projected.chi_square,
+    )
     return ReplicateOutcome(
         plan.identity,
         request.identity,
         request.ordinal,
         request.seed,
         draw.identity,
-        payload.disposition,
-        failure=payload,
+        ReplicateStage.TERMINAL,
+        ReplicateDisposition.SUCCEEDED,
+        success=success,
     )
 
 
 def _execute_serial_replicates(
     plan: ResamplingPlan,
-    population: ResamplingPopulation,
-    executor: ReplicateExecutor,
+    executor_factory: ReplicateExecutorFactory,
+    ownership: _ExecutorOwnershipRegistry,
     cancellation_probe: Callable[[], bool] | None,
 ) -> tuple[list[ReplicateOutcome], OperationTerminal]:
     outcomes: list[ReplicateOutcome] = []
@@ -1230,7 +2057,7 @@ def _execute_serial_replicates(
     for request in plan.replicates:
         if cancellation_probe is not None and cancellation_probe():
             return outcomes, OperationTerminal.CANCELLED
-        outcome = _execute_replicate(plan, population, executor, request)
+        outcome = _execute_replicate(plan, executor_factory, ownership, request)
         outcomes.append(outcome)
         if outcome.disposition is ReplicateDisposition.CANCELLED:
             return outcomes, OperationTerminal.CANCELLED
@@ -1255,8 +2082,8 @@ def _replicate_terminal(
 
 def _execute_parallel_replicates(
     plan: ResamplingPlan,
-    population: ResamplingPopulation,
-    executor: ReplicateExecutor,
+    executor_factory: ReplicateExecutorFactory,
+    ownership: _ExecutorOwnershipRegistry,
     execution: ExecutionSettings,
     cancellation_probe: Callable[[], bool] | None,
 ) -> tuple[list[ReplicateOutcome], OperationTerminal]:
@@ -1265,10 +2092,19 @@ def _execute_parallel_replicates(
     terminal = OperationTerminal.COMPLETED
     with native_thread_environment(execution.native_thread_env(parallel=True)):
         pool = ThreadPoolExecutor(max_workers=worker_count)
-        pending: set[Future[ReplicateOutcome]] = {
-            pool.submit(_execute_replicate, plan, population, executor, request)
-            for request in plan.replicates
-        }
+        next_ordinal = 0
+        pending: set[Future[ReplicateOutcome]] = set()
+        while next_ordinal < worker_count:
+            pending.add(
+                pool.submit(
+                    _execute_replicate,
+                    plan,
+                    executor_factory,
+                    ownership,
+                    plan.replicates[next_ordinal],
+                )
+            )
+            next_ordinal += 1
         try:
             while pending:
                 done, pending = wait(
@@ -1282,6 +2118,19 @@ def _execute_parallel_replicates(
                     terminal = OperationTerminal.CANCELLED
                 if terminal is not OperationTerminal.COMPLETED:
                     break
+                while (
+                    len(pending) < worker_count and next_ordinal < plan.replicate_count
+                ):
+                    pending.add(
+                        pool.submit(
+                            _execute_replicate,
+                            plan,
+                            executor_factory,
+                            ownership,
+                            plan.replicates[next_ordinal],
+                        )
+                    )
+                    next_ordinal += 1
         except KeyboardInterrupt:
             terminal = OperationTerminal.INTERRUPTED
         finally:
@@ -1302,8 +2151,7 @@ def _execute_parallel_replicates(
 def execute_resampling_evidence(
     accepted: AcceptedFitResult,
     plan: ResamplingPlan,
-    population: ResamplingPopulation,
-    executor: ReplicateExecutor,
+    executor_factory: ReplicateExecutorFactory,
     *,
     execution: ExecutionSettings | None = None,
     cancellation_probe: Callable[[], bool] | None = None,
@@ -1317,43 +2165,66 @@ def execute_resampling_evidence(
         raise ResamplingConstructionError(
             "Resampling execution requires the plan's exact authoritative anchor"
         )
-    if population.source_dataset_identity != plan.source_dataset_identity:
-        raise ResamplingConstructionError(
-            "Resampling population belongs to a different source dataset"
-        )
+    _validate_accepted_source(
+        accepted,
+        plan.dataset,
+        plan.source_problem,
+        plan.parameterization,
+    )
     settings = ExecutionSettings() if execution is None else execution
+    ownership = _ExecutorOwnershipRegistry()
     if cancellation_probe is not None and cancellation_probe():
-        return ResamplingOperation(
-            plan.identity,
-            OperationTerminal.CANCELLED,
-            None,
-            tuple(range(plan.replicate_count)),
-        )
-    if settings.workers == 1:
+        outcomes: list[ReplicateOutcome] = []
+        terminal = OperationTerminal.CANCELLED
+    elif settings.workers == 1:
         outcomes, terminal = _execute_serial_replicates(
             plan,
-            population,
-            executor,
+            executor_factory,
+            ownership,
             cancellation_probe,
         )
     else:
         outcomes, terminal = _execute_parallel_replicates(
             plan,
-            population,
-            executor,
+            executor_factory,
+            ownership,
             settings,
             cancellation_probe,
         )
-    evidence = (
-        ResamplingEvidence(plan, population.identity, tuple(outcomes), terminal)
-        if outcomes
-        else None
-    )
     completed_ordinals = {outcome.ordinal for outcome in outcomes}
     unstarted = tuple(
         request.ordinal
         for request in plan.replicates
         if request.ordinal not in completed_ordinals
+    )
+    for ordinal in unstarted:
+        request = plan.replicates[ordinal]
+        failure = ProjectedOptimizationFailure(
+            None,
+            ReplicateDisposition.NOT_STARTED,
+            "not_started_after_terminal",
+            "Replicate was not started after operation termination",
+            optimization_projection_identity=(request.optimization_projection_identity),
+            stage=ReplicateStage.PLANNED,
+        )
+        outcomes.append(
+            ReplicateOutcome(
+                plan.identity,
+                request.identity,
+                request.ordinal,
+                request.seed,
+                None,
+                ReplicateStage.PLANNED,
+                ReplicateDisposition.NOT_STARTED,
+                failure=failure,
+            )
+        )
+    outcomes.sort(key=lambda outcome: outcome.ordinal)
+    evidence = ResamplingEvidence(
+        plan,
+        plan.dataset.identity,
+        tuple(outcomes),
+        terminal,
     )
     return ResamplingOperation(plan.identity, terminal, evidence, unstarted)
 
@@ -1362,12 +2233,13 @@ def execute_resampling_evidence(
 class SummaryFailure:
     """Typed reason why no resampling summary artifact was produced."""
 
+    source_evidence_identity: str
     category: str
     message: str
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        if not self.category or not self.message:
+        if not self.source_evidence_identity or not self.category or not self.message:
             raise ResamplingConstructionError(
                 "Summary failure requires category and message"
             )
@@ -1375,7 +2247,61 @@ class SummaryFailure:
             self,
             "identity",
             _identity(
-                "native-resampling-summary-failure", (self.category, self.message)
+                "native-resampling-summary-failure",
+                (self.source_evidence_identity, self.category, self.message),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingSummaryPolicy:
+    """Explicit complete-case percentile/covariance convention."""
+
+    percentile_lower: float = 2.5
+    percentile_median: float = 50.0
+    percentile_upper: float = 97.5
+    percentile_method: Literal["linear"] = "linear"
+    covariance_delta_degrees_of_freedom: int = 1
+    version: str = _SUMMARY_POLICY_VERSION
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        values = tuple(
+            _finite(value, name="summary percentile")
+            for value in (
+                self.percentile_lower,
+                self.percentile_median,
+                self.percentile_upper,
+            )
+        )
+        if not 0.0 <= values[0] < values[1] < values[2] <= 100.0:
+            raise ResamplingConstructionError(
+                "Summary percentiles must be strictly ordered in [0, 100]"
+            )
+        if self.covariance_delta_degrees_of_freedom != 1:
+            raise ResamplingConstructionError(
+                "Native resampling covariance uses the declared sample denominator"
+            )
+        if self.percentile_method != "linear":
+            raise ResamplingConstructionError(
+                "Native resampling percentiles use the declared linear convention"
+            )
+        _non_empty_identity(self.version, name="summary policy version")
+        object.__setattr__(self, "percentile_lower", values[0])
+        object.__setattr__(self, "percentile_median", values[1])
+        object.__setattr__(self, "percentile_upper", values[2])
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-resampling-summary-policy",
+                (
+                    tuple(_float_token(value) for value in values),
+                    self.percentile_method,
+                    self.covariance_delta_degrees_of_freedom,
+                    self.version,
+                    "common-complete-sample-set",
+                ),
             ),
         )
 
@@ -1469,12 +2395,17 @@ class CorrelationEntry:
             )
 
 
+_SUMMARY_CONSTRUCTION_KEY = object()
+
+
 @dataclass(frozen=True, slots=True)
 class ResamplingSummary:
-    """Qualified joint empirical summary with one inclusion denominator."""
+    """Canonical joint summary reconstructed from one exact evidence artifact."""
 
+    _construction_key: object = field(repr=False, compare=False)
     evidence_identity: str
     output_scope: tuple[str, ...]
+    output_units: tuple[str, ...]
     included_ordinals: tuple[int, ...]
     unstarted_ordinals: tuple[int, ...]
     exclusions: tuple[ResamplingExclusion, ...]
@@ -1482,111 +2413,258 @@ class ResamplingSummary:
     distributions: tuple[ParameterDistribution, ...]
     covariance: tuple[CovarianceEntry, ...]
     correlations: tuple[CorrelationEntry, ...]
-    policy_version: str = _SUMMARY_POLICY_VERSION
+    policy_identity: str
+    policy_version: str
     claims: tuple[ClaimAssessment, ...] = field(init=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        policy_identity = _identity(
-            "native-resampling-summary-policy",
-            (
-                self.policy_version,
-                self.evidence_identity,
-                self.output_scope,
-                self.included_ordinals,
-                self.unstarted_ordinals,
-            ),
-        )
+        if self._construction_key is not _SUMMARY_CONSTRUCTION_KEY:
+            raise ResamplingConstructionError(
+                "Resampling summaries must be constructed from source evidence"
+            )
         claims = (
             ClaimAssessment(
                 "COMMON_SCOPE_INCLUSION",
                 ClaimState.SATISFIED,
-                policy_identity,
+                self.policy_identity,
                 (
                     f"scope={','.join(self.output_scope)}",
+                    f"units={','.join(self.output_units)}",
                     f"included={len(self.included_ordinals)}",
                 ),
             ),
             ClaimAssessment(
                 "MINIMUM_SUCCESSFUL_COVERAGE",
                 ClaimState.SATISFIED,
-                policy_identity,
+                self.policy_identity,
                 (f"included={len(self.included_ordinals)}",),
             ),
             ClaimAssessment(
                 "FINITE_EMPIRICAL_SUMMARY",
                 ClaimState.SATISFIED,
-                policy_identity,
+                self.policy_identity,
             ),
         )
         object.__setattr__(self, "claims", claims)
         object.__setattr__(
             self,
             "identity",
-            _identity(
-                "native-resampling-summary",
-                (
-                    self.evidence_identity,
-                    self.output_scope,
-                    self.included_ordinals,
-                    self.unstarted_ordinals,
-                    tuple(
-                        (
-                            item.ordinal,
-                            item.outcome_identity,
-                            _items_tokens(item.items),
-                        )
-                        for item in self.samples
-                    ),
-                    tuple(
-                        (
-                            item.ordinal,
-                            item.outcome_identity,
-                            item.disposition.value,
-                            item.category,
-                        )
-                        for item in self.exclusions
-                    ),
-                    tuple(
-                        (
-                            item.parameter_id,
-                            _float_token(item.mean),
-                            _float_token(item.standard_deviation),
-                            _float_token(item.median),
-                            _float_token(item.percentile_95_lower),
-                            _float_token(item.percentile_95_upper),
-                        )
-                        for item in self.distributions
-                    ),
-                    tuple(
-                        (
-                            item.parameter_a,
-                            item.parameter_b,
-                            _float_token(item.value),
-                        )
-                        for item in self.covariance
-                    ),
-                    tuple(
-                        (
-                            item.parameter_a,
-                            item.parameter_b,
-                            item.availability.value,
-                            None if item.value is None else _float_token(item.value),
-                        )
-                        for item in self.correlations
-                    ),
-                    self.policy_version,
-                    tuple(
-                        (
-                            claim.name,
-                            claim.state.value,
-                            claim.policy_identity,
-                            claim.details,
-                        )
-                        for claim in claims
-                    ),
-                ),
+            _identity("native-resampling-summary", self._identity_record(claims)),
+        )
+
+    def _identity_record(
+        self, claims: Sequence[ClaimAssessment] | None = None
+    ) -> object:
+        exact_claims = self.claims if claims is None else claims
+        return (
+            self.evidence_identity,
+            self.output_scope,
+            self.output_units,
+            self.included_ordinals,
+            self.unstarted_ordinals,
+            tuple(
+                (item.ordinal, item.outcome_identity, _items_tokens(item.items))
+                for item in self.samples
             ),
+            tuple(
+                (
+                    item.ordinal,
+                    item.outcome_identity,
+                    item.disposition.value,
+                    item.category,
+                )
+                for item in self.exclusions
+            ),
+            tuple(
+                (
+                    item.parameter_id,
+                    _float_token(item.mean),
+                    _float_token(item.standard_deviation),
+                    _float_token(item.median),
+                    _float_token(item.percentile_95_lower),
+                    _float_token(item.percentile_95_upper),
+                )
+                for item in self.distributions
+            ),
+            tuple(
+                (item.parameter_a, item.parameter_b, _float_token(item.value))
+                for item in self.covariance
+            ),
+            tuple(
+                (
+                    item.parameter_a,
+                    item.parameter_b,
+                    item.availability.value,
+                    None if item.value is None else _float_token(item.value),
+                )
+                for item in self.correlations
+            ),
+            self.policy_identity,
+            self.policy_version,
+            tuple(
+                (claim.name, claim.state.value, claim.policy_identity, claim.details)
+                for claim in exact_claims
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize every derived field for exact reconstruction checks."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "evidence_identity": self.evidence_identity,
+            "output_scope": list(self.output_scope),
+            "output_units": list(self.output_units),
+            "included_ordinals": list(self.included_ordinals),
+            "unstarted_ordinals": list(self.unstarted_ordinals),
+            "samples": [
+                {
+                    "ordinal": item.ordinal,
+                    "outcome_identity": item.outcome_identity,
+                    "items": [[key, _float_token(value)] for key, value in item.items],
+                }
+                for item in self.samples
+            ],
+            "exclusions": [
+                {
+                    "ordinal": item.ordinal,
+                    "outcome_identity": item.outcome_identity,
+                    "disposition": item.disposition.value,
+                    "category": item.category,
+                }
+                for item in self.exclusions
+            ],
+            "distributions": [
+                {
+                    "parameter_id": item.parameter_id,
+                    "mean": _float_token(item.mean),
+                    "standard_deviation": _float_token(item.standard_deviation),
+                    "median": _float_token(item.median),
+                    "percentile_95_lower": _float_token(item.percentile_95_lower),
+                    "percentile_95_upper": _float_token(item.percentile_95_upper),
+                }
+                for item in self.distributions
+            ],
+            "covariance": [
+                {
+                    "parameter_a": item.parameter_a,
+                    "parameter_b": item.parameter_b,
+                    "value": _float_token(item.value),
+                }
+                for item in self.covariance
+            ],
+            "correlations": [
+                {
+                    "parameter_a": item.parameter_a,
+                    "parameter_b": item.parameter_b,
+                    "availability": item.availability.value,
+                    "value": None if item.value is None else _float_token(item.value),
+                }
+                for item in self.correlations
+            ],
+            "policy_identity": self.policy_identity,
+            "policy_version": self.policy_version,
+            "claims": [
+                {
+                    "name": claim.name,
+                    "state": claim.state.value,
+                    "policy_identity": claim.policy_identity,
+                    "details": list(claim.details),
+                }
+                for claim in self.claims
+            ],
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        source_evidence: ResamplingEvidence,
+        policy: ResamplingSummaryPolicy,
+    ) -> ResamplingSummary:
+        """Recompute and reject any independently altered derived summary field."""
+        expected = cls.from_evidence(source_evidence, policy)
+        if record != expected.to_record():
+            raise ResamplingConstructionError(
+                "Stored resampling summary differs from canonical source evidence"
+            )
+        return expected
+
+    @classmethod
+    def from_evidence(
+        cls,
+        evidence: ResamplingEvidence,
+        policy: ResamplingSummaryPolicy,
+    ) -> ResamplingSummary:
+        """Compute all summary fields from one common complete successful set."""
+        successful = tuple(
+            outcome for outcome in evidence.outcomes if outcome.success is not None
+        )
+        if len(successful) < evidence.plan.minimum_successful_count:
+            raise ResamplingConstructionError(
+                "Successful complete-scope coverage is below the declared minimum"
+            )
+        samples = tuple(
+            SummarySample(
+                outcome.ordinal,
+                outcome.identity,
+                outcome.success.resolved_items,
+            )
+            for outcome in successful
+            if outcome.success is not None
+        )
+        if any(
+            tuple(param_id for param_id, _value in sample.items)
+            != evidence.plan.output_scope
+            for sample in samples
+        ):
+            raise ResamplingConstructionError(
+                "Successful source outcomes do not share the complete scope"
+            )
+        matrix = np.asarray(
+            [[value for _param_id, value in sample.items] for sample in samples],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(matrix)):
+            raise ResamplingConstructionError(
+                "A source sample contains a non-finite complete-scope value"
+            )
+        distributions, covariance, correlations = _build_summary_statistics(
+            matrix,
+            evidence.plan.output_scope,
+            policy,
+        )
+        unstarted = tuple(
+            outcome.ordinal
+            for outcome in evidence.outcomes
+            if outcome.disposition is ReplicateDisposition.NOT_STARTED
+        )
+        exclusions = tuple(
+            ResamplingExclusion(
+                outcome.ordinal,
+                outcome.identity,
+                outcome.disposition,
+                outcome.failure.category if outcome.failure is not None else "unknown",
+            )
+            for outcome in evidence.outcomes
+            if outcome.failure is not None
+            and outcome.disposition is not ReplicateDisposition.NOT_STARTED
+        )
+        return cls(
+            _SUMMARY_CONSTRUCTION_KEY,
+            evidence.identity,
+            evidence.plan.output_scope,
+            evidence.plan.output_units,
+            tuple(outcome.ordinal for outcome in successful),
+            unstarted,
+            exclusions,
+            samples,
+            distributions,
+            covariance,
+            correlations,
+            policy.identity,
+            policy.version,
         )
 
     def claim(self, name: str) -> ClaimState:
@@ -1596,12 +2674,18 @@ class ResamplingSummary:
 
 @dataclass(frozen=True, slots=True)
 class ResamplingSummaryOutcome:
-    """Closed result union for one summary derivation request."""
+    """Closed result whose evidence identity comes only from its exact payload."""
 
     terminal: SummaryTerminal
-    evidence_identity: str
     summary: ResamplingSummary | None = None
     failure: SummaryFailure | None = None
+    claimed_evidence_identity: str | None = field(
+        default=None,
+        kw_only=True,
+        repr=False,
+        compare=False,
+    )
+    evidence_identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         completed = self.terminal is SummaryTerminal.COMPLETED
@@ -1611,11 +2695,27 @@ class ResamplingSummaryOutcome:
             raise ResamplingConstructionError(
                 "Summary outcome must contain exactly its typed terminal payload"
             )
+        identity = (
+            self.summary.evidence_identity
+            if self.summary is not None
+            else self.failure.source_evidence_identity
+            if self.failure is not None
+            else ""
+        )
+        if (
+            self.claimed_evidence_identity is not None
+            and self.claimed_evidence_identity != identity
+        ):
+            raise ResamplingConstructionError(
+                "Summary outcome evidence identity differs from its payload"
+            )
+        object.__setattr__(self, "evidence_identity", identity)
 
 
 def _build_summary_statistics(
     matrix: Array,
     output_scope: tuple[str, ...],
+    policy: ResamplingSummaryPolicy,
 ) -> tuple[
     tuple[ParameterDistribution, ...],
     tuple[CovarianceEntry, ...],
@@ -1627,19 +2727,34 @@ def _build_summary_statistics(
         with np.errstate(over="raise", invalid="raise", divide="raise"):
             for index, param_id in enumerate(output_scope):
                 values = matrix[:, index]
-                lower, median, upper = np.percentile(values, (2.5, 50.0, 97.5))
+                lower, median, upper = np.percentile(
+                    values,
+                    (
+                        policy.percentile_lower,
+                        policy.percentile_median,
+                        policy.percentile_upper,
+                    ),
+                    method=policy.percentile_method,
+                )
                 distributions.append(
                     ParameterDistribution(
                         param_id,
                         float(np.mean(values)),
-                        float(np.std(values, ddof=1)),
+                        float(
+                            np.std(
+                                values,
+                                ddof=policy.covariance_delta_degrees_of_freedom,
+                            )
+                        ),
                         float(median),
                         float(lower),
                         float(upper),
                     )
                 )
             centered = matrix - np.mean(matrix, axis=0)
-            covariance_matrix = (centered.T @ centered) / float(len(matrix) - 1)
+            covariance_matrix = (centered.T @ centered) / float(
+                len(matrix) - policy.covariance_delta_degrees_of_freedom
+            )
     covariance = tuple(
         CovarianceEntry(param_a, param_b, float(covariance_matrix[row, column]))
         for row, param_a in enumerate(output_scope)
@@ -1679,100 +2794,38 @@ def _build_summary_statistics(
 
 def summarize_resampling_evidence(
     evidence: ResamplingEvidence,
+    policy: ResamplingSummaryPolicy | None = None,
 ) -> ResamplingSummaryOutcome:
     """Derive one summary from all and only complete successful scope rows."""
-    successful = tuple(
-        outcome for outcome in evidence.outcomes if outcome.success is not None
-    )
-    if len(successful) < evidence.plan.minimum_successful_count:
+    exact_policy = ResamplingSummaryPolicy() if policy is None else policy
+    if evidence.successful_count < evidence.plan.minimum_successful_count:
         failure = SummaryFailure(
+            evidence.identity,
             "insufficient_successful_coverage",
             "Successful complete-scope replicate coverage is below the declared minimum",
         )
         return ResamplingSummaryOutcome(
             SummaryTerminal.INSUFFICIENT_COVERAGE,
-            evidence.identity,
-            failure=failure,
-        )
-    samples = tuple(
-        SummarySample(
-            outcome.ordinal,
-            outcome.identity,
-            outcome.success.resolved_items,
-        )
-        for outcome in successful
-        if outcome.success is not None
-    )
-    if any(
-        tuple(param_id for param_id, _value in sample.items)
-        != evidence.plan.output_scope
-        for sample in samples
-    ):
-        failure = SummaryFailure(
-            "source_scope_mismatch",
-            "Successful source outcomes do not share the declared complete scope",
-        )
-        return ResamplingSummaryOutcome(
-            SummaryTerminal.SOURCE_INVALID,
-            evidence.identity,
-            failure=failure,
-        )
-    matrix = np.asarray(
-        [[value for _param_id, value in sample.items] for sample in samples],
-        dtype=np.float64,
-    )
-    if not np.all(np.isfinite(matrix)):
-        failure = SummaryFailure(
-            "non_finite_source_sample",
-            "A source sample contains a non-finite complete-scope value",
-        )
-        return ResamplingSummaryOutcome(
-            SummaryTerminal.SOURCE_INVALID,
-            evidence.identity,
             failure=failure,
         )
     try:
-        distributions, covariance, correlations = _build_summary_statistics(
-            matrix,
-            evidence.plan.output_scope,
-        )
-    except (FloatingPointError, RuntimeWarning, OverflowError, ValueError) as error:
+        summary = ResamplingSummary.from_evidence(evidence, exact_policy)
+    except (
+        FloatingPointError,
+        RuntimeWarning,
+        OverflowError,
+        ValueError,
+    ) as error:
         failure = SummaryFailure(
+            evidence.identity,
             "non_finite_summary_arithmetic",
             f"Summary arithmetic did not produce finite binary64 evidence: {error}",
         )
         return ResamplingSummaryOutcome(
             SummaryTerminal.SOURCE_INVALID,
-            evidence.identity,
             failure=failure,
         )
-    exclusions = tuple(
-        ResamplingExclusion(
-            outcome.ordinal,
-            outcome.identity,
-            outcome.disposition,
-            outcome.failure.category if outcome.failure is not None else "unknown",
-        )
-        for outcome in evidence.outcomes
-        if outcome.failure is not None
-    )
-    summary = ResamplingSummary(
-        evidence.identity,
-        evidence.plan.output_scope,
-        tuple(outcome.ordinal for outcome in successful),
-        tuple(
-            request.ordinal
-            for request in evidence.plan.replicates
-            if request.ordinal not in {outcome.ordinal for outcome in evidence.outcomes}
-        ),
-        exclusions,
-        samples,
-        distributions,
-        covariance,
-        correlations,
-    )
     return ResamplingSummaryOutcome(
         SummaryTerminal.COMPLETED,
-        evidence.identity,
         summary=summary,
     )

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -2,8 +2,9 @@
 
 This module is an isolated qualification seam.  It plans identity-derived
 Monte Carlo, bootstrap, and nucleus-bootstrap replicates; delegates each draw
-to an evidence-only projected optimization callback; freezes every terminal
-replicate outcome; and derives summaries from one common complete-scope sample
+to an internally bound evidence-only native optimizer; freshly evaluates every
+eligible candidate in a separate replicate-local workspace; freezes every
+terminal outcome; and derives summaries from one common complete-scope sample
 set.  Production fitting and reporting do not consume these artifacts yet.
 """
 
@@ -18,17 +19,28 @@ from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from enum import StrEnum
 from numbers import Real
-from threading import Lock
 from typing import Literal, cast
 
 import numpy as np
 
-from chemex.evaluation.native import EvaluationPlan, ProfilePlan
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationPlan,
+    EvaluationResult,
+    ProfilePlan,
+    ResampledProfileBinding,
+)
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     ComponentProblemDerivation,
+    DirectTrfCandidateTerminal,
+    DirectTrfInvocation,
     OptimizationProblem,
     accepted_occurrence_is_authoritative,
+    canonical_chi_square,
+    execute_direct_trf_candidate,
 )
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.runtime import ExecutionSettings
@@ -308,6 +320,7 @@ class ResamplingPlan:
     dataset: ResamplingDatasetManifest = field(repr=False, compare=False)
     source_problem: OptimizationProblem = field(repr=False, compare=False)
     parameterization: ActiveParameterization = field(repr=False, compare=False)
+    source_engine: EvaluationEngine = field(repr=False, compare=False)
     scheme: ResamplingScheme
     replicate_count: int
     replicate_structural_identities: tuple[str, ...]
@@ -391,6 +404,7 @@ class ResamplingPlan:
             != self.parameterization.evaluator_identity
             or self.source_problem.constraint_program_identity
             != self.parameterization.program.fingerprint
+            or self.source_engine.plan.identity != self.dataset.evaluation_plan.identity
         ):
             raise ResamplingConstructionError(
                 "Source dataset, problem, and parameterization lineage differ"
@@ -502,6 +516,7 @@ class ResamplingPlan:
         dataset: ResamplingDatasetManifest,
         source_problem: OptimizationProblem,
         parameterization: ActiveParameterization,
+        source_engine: EvaluationEngine,
         scheme: ResamplingScheme,
         replicate_count: int,
         replicate_structural_identities: Sequence[str],
@@ -524,12 +539,17 @@ class ResamplingPlan:
             source_problem,
             parameterization,
         )
+        if source_engine.plan.identity != dataset.evaluation_plan.identity:
+            raise ResamplingConstructionError(
+                "Source evaluator belongs to another EvaluationPlan"
+            )
         return cls(
             accepted.identity,
             accepted.occurrence_identity,
             dataset,
             source_problem,
             parameterization,
+            source_engine,
             scheme,
             replicate_count,
             tuple(replicate_structural_identities),
@@ -937,11 +957,14 @@ def generate_resampling_draw(
 def _transformed_evaluation_plan(
     dataset: ResamplingDatasetManifest,
     draw: ResamplingDraw,
-) -> EvaluationPlan:
+    source_engine: EvaluationEngine,
+) -> tuple[EvaluationPlan, tuple[ResampledProfileBinding, ...]]:
     source_profiles = {
-        profile.identity: profile for profile in dataset.evaluation_plan.profiles
+        profile.identity: (profile_index, profile)
+        for profile_index, profile in enumerate(dataset.evaluation_plan.profiles)
     }
     profiles: list[ProfilePlan] = []
+    bindings: list[ResampledProfileBinding] = []
     offset = 0
     index = 0
     while index < len(draw.observations):
@@ -951,7 +974,12 @@ def _transformed_evaluation_plan(
             draw.profile_blocks[stop] == block_identity
         ):
             stop += 1
-        source = source_profiles[block_identity]
+        source_profile_index, source = source_profiles[block_identity]
+        root_indices = tuple(
+            source_index - source.observation_offset
+            for source_index in draw.source_indices[index:stop]
+        )
+        binding = ResampledProfileBinding(source_profile_index, root_indices)
         source_identity = _identity(
             "native-resampling-transformed-profile-source",
             (
@@ -989,16 +1017,11 @@ def _transformed_evaluation_plan(
                 source.kernel_identity,
                 source.kernel_configuration,
                 source.spectrometer_configuration,
-                _identity(
-                    "native-resampling-observation-metadata",
-                    tuple(
-                        dataset.observation_descriptors[source_index]
-                        for source_index in draw.source_indices[index:stop]
-                    ),
-                ),
+                source_engine.resampled_observation_metadata(binding),
                 (stop - index,),
             )
         )
+        bindings.append(binding)
         offset += stop - index
         index = stop
     source_plan = dataset.evaluation_plan
@@ -1014,7 +1037,7 @@ def _transformed_evaluation_plan(
         source_plan.ordering_version,
         source_plan.failure_version,
         source_plan.diagnostics_version,
-    )
+    ), tuple(bindings)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1029,8 +1052,12 @@ class ReplicateExecutionPlan:
     source_snapshot_occurrence_identity: str
     source_snapshot_revision: int
     evaluation_plan: EvaluationPlan = field(repr=False, compare=False)
+    profile_bindings: tuple[ResampledProfileBinding, ...] = field(
+        repr=False, compare=False
+    )
     problem: OptimizationProblem = field(repr=False, compare=False)
     parameterization: ActiveParameterization = field(repr=False, compare=False)
+    invocation: DirectTrfInvocation = field(repr=False, compare=False)
     strategy: OptimizationStrategy
     workflow_identity: str
     invocation_identity: str
@@ -1049,9 +1076,12 @@ class ReplicateExecutionPlan:
             != self.parameterization.evaluator_identity
             or self.problem.constraint_program_identity
             != self.parameterization.program.fingerprint
+            or self.invocation.problem_identity != self.problem.identity
+            or self.invocation.identity != self.invocation_identity
             or self.problem.acceptance_authority
             or self.problem.commit_scope != self.output_scope
             or len(self.output_units) != len(self.output_scope)
+            or len(self.profile_bindings) != len(self.evaluation_plan.profiles)
         ):
             raise ResamplingConstructionError(
                 "Prepared replicate native lineage is internally inconsistent"
@@ -1070,6 +1100,13 @@ class ReplicateExecutionPlan:
                     self.source_snapshot_occurrence_identity,
                     self.source_snapshot_revision,
                     self.evaluation_plan.identity,
+                    tuple(
+                        (
+                            binding.root_profile_index,
+                            binding.root_observation_indices,
+                        )
+                        for binding in self.profile_bindings
+                    ),
                     self.problem.identity,
                     self.parameterization.identity,
                     self.parameterization.evaluator_identity,
@@ -1103,7 +1140,9 @@ class ReplicateExecutionPlan:
             raise ResamplingConstructionError(
                 "Prepared replicate draw differs from canonical seeded generation"
             )
-        evaluation_plan = _transformed_evaluation_plan(plan.dataset, draw)
+        evaluation_plan, profile_bindings = _transformed_evaluation_plan(
+            plan.dataset, draw, plan.source_engine
+        )
         derivation = ComponentProblemDerivation(
             plan.source_problem.identity,
             plan.source_problem.affine_feasibility_identity,
@@ -1118,6 +1157,27 @@ class ReplicateExecutionPlan:
             start=plan.source_problem.start,
             derivation=derivation,
         )
+        if plan.strategy is not OptimizationStrategy.DIRECT_TRF:
+            raise ResamplingConstructionError(
+                "Qualified resampling currently supports the closed Direct-TRF binder"
+            )
+        settings = dict(plan.strategy_settings)
+        if set(settings) - {"objective_request_budget"}:
+            raise ResamplingConstructionError(
+                "Direct-TRF resampling received unsupported strategy settings"
+            )
+        try:
+            objective_request_budget = int(
+                settings.get("objective_request_budget", "100")
+            )
+        except ValueError as error:
+            raise ResamplingConstructionError(
+                "Direct-TRF objective request budget must be an integer"
+            ) from error
+        invocation = DirectTrfInvocation.for_problem(
+            problem,
+            objective_request_budget=objective_request_budget,
+        )
         workflow_identity = _identity(
             "native-resampling-projected-workflow",
             (
@@ -1128,16 +1188,7 @@ class ReplicateExecutionPlan:
                 request.component_identities,
             ),
         )
-        invocation_identity = _identity(
-            "native-resampling-invocation-contract",
-            (
-                problem.identity,
-                workflow_identity,
-                plan.strategy.value,
-                plan.strategy_settings,
-                request.identity,
-            ),
-        )
+        invocation_identity = invocation.identity
         snapshot = problem.source_snapshot
         return cls(
             plan.identity,
@@ -1148,8 +1199,10 @@ class ReplicateExecutionPlan:
             snapshot.occurrence_identity,
             snapshot.revision,
             evaluation_plan,
+            profile_bindings,
             problem,
             plan.parameterization,
+            invocation,
             plan.strategy,
             workflow_identity,
             invocation_identity,
@@ -1169,7 +1222,7 @@ class ReplicateExecutionPlan:
 
 @dataclass(frozen=True, slots=True)
 class ProjectedOptimizationSuccess:
-    """Executor-returned native candidate evidence, not a resolved sample."""
+    """Non-authoritative optimizer candidate with exact prepared lineage."""
 
     prepared_replicate_identity: str
     accepted_result_identity: str
@@ -1189,13 +1242,11 @@ class ProjectedOptimizationSuccess:
     strategy: OptimizationStrategy
     component_identities: tuple[str, ...]
     component_outcome_identities: tuple[str, ...]
+    controlled_ids: tuple[str, ...]
     candidate_identity: str
-    materialization_identity: str
-    evaluation_identity: str
-    requested_output_scope: tuple[str, ...]
-    requested_output_units: tuple[str, ...]
     candidate_vector: tuple[float, ...]
-    chi_square: float
+    backend_chi_square: float | None
+    backend_evaluation_identity: str | None = None
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -1221,8 +1272,6 @@ class ProjectedOptimizationSuccess:
             ("invocation identity", self.invocation_identity),
             ("execution identity", self.execution_identity),
             ("candidate identity", self.candidate_identity),
-            ("materialization identity", self.materialization_identity),
-            ("evaluation identity", self.evaluation_identity),
         ):
             _non_empty_identity(value, name=name)
         if self.source_snapshot_revision < 0:
@@ -1249,21 +1298,28 @@ class ProjectedOptimizationSuccess:
             _finite(value, name=f"candidate vector[{index}]")
             for index, value in enumerate(self.candidate_vector)
         )
-        scope = _canonical_scope(self.requested_output_scope)
-        units = tuple(self.requested_output_units)
-        if len(units) != len(scope) or any(not unit for unit in units):
+        controlled_ids = _canonical_scope(self.controlled_ids)
+        if len(vector) != len(controlled_ids):
             raise ResamplingConstructionError(
-                "Projected output units must cover the requested scope"
+                "Projected candidate must cover the exact controlled-coordinate order"
             )
-        chi_square = _finite(self.chi_square, name="projected chi-square")
-        if chi_square < 0.0:
+        backend_chi_square = (
+            None
+            if self.backend_chi_square is None
+            else _finite(self.backend_chi_square, name="backend diagnostic chi-square")
+        )
+        if backend_chi_square is not None and backend_chi_square < 0.0:
             raise ResamplingConstructionError(
-                "Projected chi-square must be non-negative"
+                "Backend diagnostic chi-square must be non-negative"
             )
         object.__setattr__(self, "candidate_vector", vector)
-        object.__setattr__(self, "requested_output_scope", scope)
-        object.__setattr__(self, "requested_output_units", units)
-        object.__setattr__(self, "chi_square", chi_square)
+        object.__setattr__(self, "controlled_ids", controlled_ids)
+        object.__setattr__(self, "backend_chi_square", backend_chi_square)
+        if self.backend_evaluation_identity is not None:
+            _non_empty_identity(
+                self.backend_evaluation_identity,
+                name="backend evaluation diagnostic identity",
+            )
         object.__setattr__(
             self,
             "identity",
@@ -1288,13 +1344,15 @@ class ProjectedOptimizationSuccess:
                     self.strategy.value,
                     self.component_identities,
                     self.component_outcome_identities,
+                    controlled_ids,
                     self.candidate_identity,
-                    self.materialization_identity,
-                    self.evaluation_identity,
-                    scope,
-                    units,
                     tuple(_float_token(value) for value in vector),
-                    _float_token(chi_square),
+                    (
+                        None
+                        if backend_chi_square is None
+                        else _float_token(backend_chi_square)
+                    ),
+                    self.backend_evaluation_identity,
                 ),
             ),
         )
@@ -1305,17 +1363,18 @@ class ProjectedOptimizationSuccess:
         prepared: ReplicateExecutionPlan,
         *,
         candidate_vector: Sequence[float],
-        chi_square: float,
+        backend_chi_square: float | None,
+        execution_identity: str,
+        backend_evaluation_identity: str | None = None,
     ) -> ProjectedOptimizationSuccess:
-        """Construct exact callback evidence for a prepared native replicate."""
+        """Bind non-authoritative backend evidence to an exact prepared replicate."""
         vector = tuple(float(value) for value in candidate_vector)
-        resolved = prepared.resolve_candidate(vector)
         candidate_identity = _identity(
             "native-resampling-candidate",
             (
                 prepared.identity,
+                prepared.problem.controlled_ids,
                 tuple(_float_token(value) for value in vector),
-                _float_token(float(chi_square)),
             ),
         )
         component_outcomes = tuple(
@@ -1324,34 +1383,6 @@ class ProjectedOptimizationSuccess:
                 (prepared.identity, component_identity, candidate_identity),
             )
             for component_identity in prepared.component_identities
-        )
-        execution_identity = _identity(
-            "native-resampling-execution",
-            (
-                prepared.identity,
-                prepared.invocation_identity,
-                candidate_identity,
-                component_outcomes,
-            ),
-        )
-        evaluation_identity = _identity(
-            "native-resampling-candidate-evaluation",
-            (
-                prepared.evaluation_plan.identity,
-                prepared.parameterization.evaluator_identity,
-                candidate_identity,
-                _items_tokens(resolved),
-            ),
-        )
-        materialization_identity = _identity(
-            "native-resampling-candidate-materialization",
-            (
-                prepared.problem.identity,
-                prepared.invocation_identity,
-                execution_identity,
-                candidate_identity,
-                evaluation_identity,
-            ),
         )
         return cls(
             prepared.identity,
@@ -1372,13 +1403,11 @@ class ProjectedOptimizationSuccess:
             prepared.strategy,
             prepared.component_identities,
             component_outcomes,
+            prepared.problem.controlled_ids,
             candidate_identity,
-            materialization_identity,
-            evaluation_identity,
-            prepared.output_scope,
-            prepared.output_units,
             vector,
-            chi_square,
+            backend_chi_square,
+            backend_evaluation_identity,
         )
 
 
@@ -1441,28 +1470,10 @@ type ProjectedOptimizationResult = (
 )
 
 
-type ReplicateExecutor = Callable[
-    [ReplicateExecutionPlan],
+type CandidateEvidenceTestHook = Callable[
+    [ReplicateExecutionPlan, ProjectedOptimizationResult],
     ProjectedOptimizationResult,
 ]
-
-type ReplicateExecutorFactory = Callable[[ReplicateExecutionPlan], ReplicateExecutor]
-
-
-class _ExecutorOwnershipRegistry:
-    """Operation-local guard against reusing one executor/workspace instance."""
-
-    def __init__(self) -> None:
-        self._lock = Lock()
-        self._executors: list[ReplicateExecutor] = []
-
-    def claim(self, executor: ReplicateExecutor) -> None:
-        with self._lock:
-            if any(existing is executor for existing in self._executors):
-                raise ResamplingConstructionError(
-                    "Executor factory reused one single-owner executor instance"
-                )
-            self._executors.append(executor)
 
 
 _VALIDATED_SUCCESS_CONSTRUCTION_KEY = object()
@@ -1475,14 +1486,23 @@ class ValidatedReplicateSuccess:
     _construction_key: object = field(repr=False, compare=False)
     prepared_replicate_identity: str
     projected_outcome_identity: str
+    evaluation_identity: str
+    materialization_identity: str
     resolved_items: tuple[tuple[str, float], ...]
     chi_square: float
+    backend_chi_square: float | None
+    backend_chi_square_agrees: bool | None
+    fresh_evaluation_count: int
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         if self._construction_key is not _VALIDATED_SUCCESS_CONSTRUCTION_KEY:
             raise ResamplingConstructionError(
                 "Successful samples require resampling-owned validation"
+            )
+        if self.fresh_evaluation_count != 1:
+            raise ResamplingConstructionError(
+                "Successful samples require exactly one fresh validation evaluation"
             )
         object.__setattr__(
             self,
@@ -1492,8 +1512,17 @@ class ValidatedReplicateSuccess:
                 (
                     self.prepared_replicate_identity,
                     self.projected_outcome_identity,
+                    self.evaluation_identity,
+                    self.materialization_identity,
                     _items_tokens(self.resolved_items),
                     _float_token(self.chi_square),
+                    (
+                        None
+                        if self.backend_chi_square is None
+                        else _float_token(self.backend_chi_square)
+                    ),
+                    self.backend_chi_square_agrees,
+                    self.fresh_evaluation_count,
                 ),
             ),
         )
@@ -1741,11 +1770,49 @@ class ResamplingOperation:
         )
 
 
+def _execute_native_candidate(
+    prepared: ReplicateExecutionPlan,
+    engine: EvaluationEngine,
+) -> ProjectedOptimizationResult:
+    """Construct and execute the closed native strategy with replicate-local state."""
+    outcome = execute_direct_trf_candidate(
+        prepared.problem,
+        prepared.invocation,
+        prepared.parameterization,
+        engine,
+    )
+    if (
+        outcome.terminal is DirectTrfCandidateTerminal.SUCCESS
+        and outcome.candidate is not None
+    ):
+        return ProjectedOptimizationSuccess.for_prepared(
+            prepared,
+            candidate_vector=outcome.candidate.vector,
+            backend_chi_square=outcome.candidate.chi_square,
+            execution_identity=outcome.execution.identity,
+            backend_evaluation_identity=outcome.candidate.evaluation_result.identity,
+        )
+    return ProjectedOptimizationFailure(
+        prepared.draw.identity,
+        ReplicateDisposition.FAILED,
+        f"direct_trf_{outcome.terminal.value}",
+        "Replicate-local Direct-TRF did not produce an eligible candidate",
+        optimization_projection_identity=(
+            prepared.request.optimization_projection_identity
+        ),
+        stage=ReplicateStage.EXECUTING,
+        prepared_replicate_identity=prepared.identity,
+        evaluation_plan_identity=prepared.evaluation_plan.identity,
+        problem_identity=prepared.problem.identity,
+        invocation_identity=prepared.invocation.identity,
+        execution_identity=outcome.execution.identity,
+    )
+
+
 def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
     plan: ResamplingPlan,
-    executor_factory: ReplicateExecutorFactory,
-    ownership: _ExecutorOwnershipRegistry,
     request: ReplicateRequest,
+    candidate_test_hook: CandidateEvidenceTestHook | None,
 ) -> ReplicateOutcome:
     draw: ResamplingDraw | None = None
     prepared: ReplicateExecutionPlan | None = None
@@ -1830,16 +1897,17 @@ def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
         )
 
     try:
-        executor = executor_factory(prepared)
-        ownership.claim(executor)
+        optimizer_engine = plan.source_engine.resampled(
+            prepared.evaluation_plan, prepared.profile_bindings
+        )
     except KeyboardInterrupt:
         return failure_outcome(
             ReplicateDisposition.INTERRUPTED,
             ReplicateStage.EXECUTOR_CREATING,
             "executor_creation_interrupted",
-            "Replicate executor creation was interrupted",
+            "Replicate-local optimizer binding was interrupted",
         )
-    except Exception as error:  # noqa: BLE001 - typed executor construction failure
+    except Exception as error:  # noqa: BLE001 - typed local binding failure
         return failure_outcome(
             ReplicateDisposition.FAILED,
             ReplicateStage.EXECUTOR_CREATING,
@@ -1848,7 +1916,10 @@ def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
         )
 
     try:
-        projected = executor(prepared)
+        native_projected = _execute_native_candidate(prepared, optimizer_engine)
+        projected = native_projected
+        if candidate_test_hook is not None:
+            projected = candidate_test_hook(prepared, projected)
     except KeyboardInterrupt:
         return failure_outcome(
             ReplicateDisposition.INTERRUPTED,
@@ -1889,29 +1960,15 @@ def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
             "invalid_projected_outcome",
             "Projected optimization returned an unsupported outcome type",
         )
-
-    try:
-        expected = ProjectedOptimizationSuccess.for_prepared(
-            prepared,
-            candidate_vector=projected.candidate_vector,
-            chi_square=projected.chi_square,
-        )
-    except KeyboardInterrupt:
-        return failure_outcome(
-            ReplicateDisposition.INTERRUPTED,
-            ReplicateStage.VALIDATING,
-            "validation_interrupted",
-            "Fresh candidate validation was interrupted",
-            projected=projected,
-        )
-    except Exception as error:  # noqa: BLE001 - ordinary constraint resolution
+    if not isinstance(native_projected, ProjectedOptimizationSuccess):
         return failure_outcome(
             ReplicateDisposition.FAILED,
             ReplicateStage.VALIDATING,
-            "candidate_resolution_failure",
-            f"{type(error).__name__}: {error}",
-            projected=projected,
+            "ineligible_native_candidate",
+            "The closed native strategy did not produce an eligible candidate",
         )
+
+    expected = native_projected
     lineage_fields = (
         (
             "prepared_replicate",
@@ -1979,22 +2036,13 @@ def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
             expected.component_outcome_identities,
         ),
         ("execution", projected.execution_identity, expected.execution_identity),
+        ("controlled_coordinates", projected.controlled_ids, expected.controlled_ids),
+        ("candidate_vector", projected.candidate_vector, expected.candidate_vector),
         ("candidate", projected.candidate_identity, expected.candidate_identity),
         (
-            "materialization",
-            projected.materialization_identity,
-            expected.materialization_identity,
-        ),
-        ("evaluation", projected.evaluation_identity, expected.evaluation_identity),
-        (
-            "requested_scope",
-            projected.requested_output_scope,
-            expected.requested_output_scope,
-        ),
-        (
-            "requested_units",
-            projected.requested_output_units,
-            expected.requested_output_units,
+            "backend_evaluation",
+            projected.backend_evaluation_identity,
+            expected.backend_evaluation_identity,
         ),
     )
     mismatch = next(
@@ -2010,29 +2058,109 @@ def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
             projected=projected,
         )
     try:
-        resolved_items = prepared.resolve_candidate(projected.candidate_vector)
+        validation_engine = plan.source_engine.resampled(
+            prepared.evaluation_plan, prepared.profile_bindings
+        )
+        validation_evaluator = validation_engine.new_evaluator()
+        lifecycle_frame = prepared.problem.lifecycle_frame(
+            projected.candidate_vector, prepared.parameterization
+        )
+        evaluation_frame = EvaluationFrame.from_lifecycle_frame(
+            prepared.parameterization, lifecycle_frame
+        )
+        evaluated = validation_evaluator.evaluate(evaluation_frame)
     except KeyboardInterrupt:
         return failure_outcome(
             ReplicateDisposition.INTERRUPTED,
             ReplicateStage.VALIDATING,
             "validation_interrupted",
-            "Fresh candidate resolution was interrupted",
+            "Fresh candidate evaluation was interrupted",
             projected=projected,
         )
-    except Exception as error:  # noqa: BLE001 - typed final resolution failure
+    except Exception as error:  # noqa: BLE001 - typed evidence materialization failure
         return failure_outcome(
             ReplicateDisposition.FAILED,
             ReplicateStage.VALIDATING,
-            "candidate_resolution_failure",
+            "fresh_evaluation_failure",
             f"{type(error).__name__}: {error}",
             projected=projected,
         )
+    if isinstance(evaluated, EvaluationFailure):
+        return failure_outcome(
+            ReplicateDisposition.FAILED,
+            ReplicateStage.VALIDATING,
+            "fresh_evaluation_failure",
+            f"{evaluated.category}: {evaluated.message}",
+            projected=projected,
+        )
+    if not isinstance(evaluated, EvaluationResult):
+        return failure_outcome(
+            ReplicateDisposition.FAILED,
+            ReplicateStage.VALIDATING,
+            "invalid_fresh_evaluation",
+            "Fresh evaluator returned an unsupported result type",
+            projected=projected,
+        )
+    try:
+        canonical_evaluation = EvaluationResult.from_record(
+            evaluated.to_record(), prepared.evaluation_plan
+        )
+        resolved_items = tuple(
+            (param_id, canonical_evaluation.resolved_values[param_id])
+            for param_id in prepared.output_scope
+        )
+        ordinary_resolved = prepared.resolve_candidate(projected.candidate_vector)
+        chi_square = canonical_chi_square(canonical_evaluation.residuals)
+        if (
+            canonical_evaluation.evaluator_compatibility_identity
+            != validation_engine.compatibility_identity
+            or canonical_evaluation.plan_identity != prepared.evaluation_plan.identity
+            or resolved_items != ordinary_resolved
+            or tuple(canonical_evaluation.resolved_values) != prepared.output_scope
+            or (
+                expected.backend_evaluation_identity is not None
+                and canonical_evaluation.identity
+                != expected.backend_evaluation_identity
+            )
+        ):
+            raise ResamplingConstructionError(
+                "Fresh evaluation differs from exact complete replicate scope"
+            )
+    except Exception as error:  # noqa: BLE001 - canonical result qualification
+        return failure_outcome(
+            ReplicateDisposition.FAILED,
+            ReplicateStage.VALIDATING,
+            "fresh_materialization_failure",
+            f"{type(error).__name__}: {error}",
+            projected=projected,
+        )
+    materialization_identity = _identity(
+        "native-resampling-fresh-materialization",
+        (
+            prepared.identity,
+            projected.candidate_identity,
+            projected.execution_identity,
+            validation_engine.compatibility_identity,
+            canonical_evaluation.identity,
+            _items_tokens(resolved_items),
+        ),
+    )
+    backend_agrees = (
+        None
+        if projected.backend_chi_square is None
+        else projected.backend_chi_square == chi_square
+    )
     success = ValidatedReplicateSuccess(
         _VALIDATED_SUCCESS_CONSTRUCTION_KEY,
         prepared.identity,
         projected.identity,
+        canonical_evaluation.identity,
+        materialization_identity,
         resolved_items,
-        projected.chi_square,
+        chi_square,
+        projected.backend_chi_square,
+        backend_agrees,
+        1,
     )
     return ReplicateOutcome(
         plan.identity,
@@ -2048,16 +2176,15 @@ def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
 
 def _execute_serial_replicates(
     plan: ResamplingPlan,
-    executor_factory: ReplicateExecutorFactory,
-    ownership: _ExecutorOwnershipRegistry,
     cancellation_probe: Callable[[], bool] | None,
+    candidate_test_hook: CandidateEvidenceTestHook | None,
 ) -> tuple[list[ReplicateOutcome], OperationTerminal]:
     outcomes: list[ReplicateOutcome] = []
     terminal = OperationTerminal.COMPLETED
     for request in plan.replicates:
         if cancellation_probe is not None and cancellation_probe():
             return outcomes, OperationTerminal.CANCELLED
-        outcome = _execute_replicate(plan, executor_factory, ownership, request)
+        outcome = _execute_replicate(plan, request, candidate_test_hook)
         outcomes.append(outcome)
         if outcome.disposition is ReplicateDisposition.CANCELLED:
             return outcomes, OperationTerminal.CANCELLED
@@ -2082,10 +2209,9 @@ def _replicate_terminal(
 
 def _execute_parallel_replicates(
     plan: ResamplingPlan,
-    executor_factory: ReplicateExecutorFactory,
-    ownership: _ExecutorOwnershipRegistry,
     execution: ExecutionSettings,
     cancellation_probe: Callable[[], bool] | None,
+    candidate_test_hook: CandidateEvidenceTestHook | None,
 ) -> tuple[list[ReplicateOutcome], OperationTerminal]:
     worker_count = min(execution.workers, plan.replicate_count)
     outcomes: list[ReplicateOutcome] = []
@@ -2099,9 +2225,8 @@ def _execute_parallel_replicates(
                 pool.submit(
                     _execute_replicate,
                     plan,
-                    executor_factory,
-                    ownership,
                     plan.replicates[next_ordinal],
+                    candidate_test_hook,
                 )
             )
             next_ordinal += 1
@@ -2125,9 +2250,8 @@ def _execute_parallel_replicates(
                         pool.submit(
                             _execute_replicate,
                             plan,
-                            executor_factory,
-                            ownership,
                             plan.replicates[next_ordinal],
+                            candidate_test_hook,
                         )
                     )
                     next_ordinal += 1
@@ -2151,10 +2275,10 @@ def _execute_parallel_replicates(
 def execute_resampling_evidence(
     accepted: AcceptedFitResult,
     plan: ResamplingPlan,
-    executor_factory: ReplicateExecutorFactory,
     *,
     execution: ExecutionSettings | None = None,
     cancellation_probe: Callable[[], bool] | None = None,
+    candidate_test_hook: CandidateEvidenceTestHook | None = None,
 ) -> ResamplingOperation:
     """Execute canonical evidence-only replicates without analysis-state authority."""
     if (
@@ -2172,24 +2296,21 @@ def execute_resampling_evidence(
         plan.parameterization,
     )
     settings = ExecutionSettings() if execution is None else execution
-    ownership = _ExecutorOwnershipRegistry()
     if cancellation_probe is not None and cancellation_probe():
         outcomes: list[ReplicateOutcome] = []
         terminal = OperationTerminal.CANCELLED
     elif settings.workers == 1:
         outcomes, terminal = _execute_serial_replicates(
             plan,
-            executor_factory,
-            ownership,
             cancellation_probe,
+            candidate_test_hook,
         )
     else:
         outcomes, terminal = _execute_parallel_replicates(
             plan,
-            executor_factory,
-            ownership,
             settings,
             cancellation_probe,
+            candidate_test_hook,
         )
     completed_ordinals = {outcome.ordinal for outcome in outcomes}
     unstarted = tuple(
@@ -2395,39 +2516,100 @@ class CorrelationEntry:
             )
 
 
-_SUMMARY_CONSTRUCTION_KEY = object()
-
-
 @dataclass(frozen=True, slots=True)
 class ResamplingSummary:
     """Canonical joint summary reconstructed from one exact evidence artifact."""
 
-    _construction_key: object = field(repr=False, compare=False)
-    evidence_identity: str
-    output_scope: tuple[str, ...]
-    output_units: tuple[str, ...]
-    included_ordinals: tuple[int, ...]
-    unstarted_ordinals: tuple[int, ...]
-    exclusions: tuple[ResamplingExclusion, ...]
-    samples: tuple[SummarySample, ...]
-    distributions: tuple[ParameterDistribution, ...]
-    covariance: tuple[CovarianceEntry, ...]
-    correlations: tuple[CorrelationEntry, ...]
-    policy_identity: str
-    policy_version: str
+    evidence: ResamplingEvidence = field(repr=False, compare=False)
+    policy: ResamplingSummaryPolicy = field(repr=False, compare=False)
+    evidence_identity: str = field(init=False)
+    output_scope: tuple[str, ...] = field(init=False)
+    output_units: tuple[str, ...] = field(init=False)
+    included_ordinals: tuple[int, ...] = field(init=False)
+    unstarted_ordinals: tuple[int, ...] = field(init=False)
+    exclusions: tuple[ResamplingExclusion, ...] = field(init=False)
+    samples: tuple[SummarySample, ...] = field(init=False)
+    distributions: tuple[ParameterDistribution, ...] = field(init=False)
+    covariance: tuple[CovarianceEntry, ...] = field(init=False)
+    correlations: tuple[CorrelationEntry, ...] = field(init=False)
+    policy_identity: str = field(init=False)
+    policy_version: str = field(init=False)
     claims: tuple[ClaimAssessment, ...] = field(init=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        if self._construction_key is not _SUMMARY_CONSTRUCTION_KEY:
+        successful = tuple(
+            outcome for outcome in self.evidence.outcomes if outcome.success is not None
+        )
+        if len(successful) < self.evidence.plan.minimum_successful_count:
             raise ResamplingConstructionError(
-                "Resampling summaries must be constructed from source evidence"
+                "Successful complete-scope coverage is below the declared minimum"
             )
+        samples = tuple(
+            SummarySample(
+                outcome.ordinal,
+                outcome.identity,
+                outcome.success.resolved_items,
+            )
+            for outcome in successful
+            if outcome.success is not None
+        )
+        if any(
+            tuple(param_id for param_id, _value in sample.items)
+            != self.evidence.plan.output_scope
+            for sample in samples
+        ):
+            raise ResamplingConstructionError(
+                "Successful source outcomes do not share the complete scope"
+            )
+        matrix = np.asarray(
+            [[value for _param_id, value in sample.items] for sample in samples],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(matrix)):
+            raise ResamplingConstructionError(
+                "A source sample contains a non-finite complete-scope value"
+            )
+        distributions, covariance, correlations = _build_summary_statistics(
+            matrix,
+            self.evidence.plan.output_scope,
+            self.policy,
+        )
+        unstarted = tuple(
+            outcome.ordinal
+            for outcome in self.evidence.outcomes
+            if outcome.disposition is ReplicateDisposition.NOT_STARTED
+        )
+        exclusions = tuple(
+            ResamplingExclusion(
+                outcome.ordinal,
+                outcome.identity,
+                outcome.disposition,
+                outcome.failure.category if outcome.failure is not None else "unknown",
+            )
+            for outcome in self.evidence.outcomes
+            if outcome.failure is not None
+            and outcome.disposition is not ReplicateDisposition.NOT_STARTED
+        )
+        object.__setattr__(self, "evidence_identity", self.evidence.identity)
+        object.__setattr__(self, "output_scope", self.evidence.plan.output_scope)
+        object.__setattr__(self, "output_units", self.evidence.plan.output_units)
+        object.__setattr__(
+            self, "included_ordinals", tuple(item.ordinal for item in successful)
+        )
+        object.__setattr__(self, "unstarted_ordinals", unstarted)
+        object.__setattr__(self, "exclusions", exclusions)
+        object.__setattr__(self, "samples", samples)
+        object.__setattr__(self, "distributions", distributions)
+        object.__setattr__(self, "covariance", covariance)
+        object.__setattr__(self, "correlations", correlations)
+        object.__setattr__(self, "policy_identity", self.policy.identity)
+        object.__setattr__(self, "policy_version", self.policy.version)
         claims = (
             ClaimAssessment(
                 "COMMON_SCOPE_INCLUSION",
                 ClaimState.SATISFIED,
-                self.policy_identity,
+                self.policy.identity,
                 (
                     f"scope={','.join(self.output_scope)}",
                     f"units={','.join(self.output_units)}",
@@ -2437,13 +2619,13 @@ class ResamplingSummary:
             ClaimAssessment(
                 "MINIMUM_SUCCESSFUL_COVERAGE",
                 ClaimState.SATISFIED,
-                self.policy_identity,
+                self.policy.identity,
                 (f"included={len(self.included_ordinals)}",),
             ),
             ClaimAssessment(
                 "FINITE_EMPIRICAL_SUMMARY",
                 ClaimState.SATISFIED,
-                self.policy_identity,
+                self.policy.identity,
             ),
         )
         object.__setattr__(self, "claims", claims)
@@ -2598,74 +2780,7 @@ class ResamplingSummary:
         policy: ResamplingSummaryPolicy,
     ) -> ResamplingSummary:
         """Compute all summary fields from one common complete successful set."""
-        successful = tuple(
-            outcome for outcome in evidence.outcomes if outcome.success is not None
-        )
-        if len(successful) < evidence.plan.minimum_successful_count:
-            raise ResamplingConstructionError(
-                "Successful complete-scope coverage is below the declared minimum"
-            )
-        samples = tuple(
-            SummarySample(
-                outcome.ordinal,
-                outcome.identity,
-                outcome.success.resolved_items,
-            )
-            for outcome in successful
-            if outcome.success is not None
-        )
-        if any(
-            tuple(param_id for param_id, _value in sample.items)
-            != evidence.plan.output_scope
-            for sample in samples
-        ):
-            raise ResamplingConstructionError(
-                "Successful source outcomes do not share the complete scope"
-            )
-        matrix = np.asarray(
-            [[value for _param_id, value in sample.items] for sample in samples],
-            dtype=np.float64,
-        )
-        if not np.all(np.isfinite(matrix)):
-            raise ResamplingConstructionError(
-                "A source sample contains a non-finite complete-scope value"
-            )
-        distributions, covariance, correlations = _build_summary_statistics(
-            matrix,
-            evidence.plan.output_scope,
-            policy,
-        )
-        unstarted = tuple(
-            outcome.ordinal
-            for outcome in evidence.outcomes
-            if outcome.disposition is ReplicateDisposition.NOT_STARTED
-        )
-        exclusions = tuple(
-            ResamplingExclusion(
-                outcome.ordinal,
-                outcome.identity,
-                outcome.disposition,
-                outcome.failure.category if outcome.failure is not None else "unknown",
-            )
-            for outcome in evidence.outcomes
-            if outcome.failure is not None
-            and outcome.disposition is not ReplicateDisposition.NOT_STARTED
-        )
-        return cls(
-            _SUMMARY_CONSTRUCTION_KEY,
-            evidence.identity,
-            evidence.plan.output_scope,
-            evidence.plan.output_units,
-            tuple(outcome.ordinal for outcome in successful),
-            unstarted,
-            exclusions,
-            samples,
-            distributions,
-            covariance,
-            correlations,
-            policy.identity,
-            policy.version,
-        )
+        return cls(evidence, policy)
 
     def claim(self, name: str) -> ClaimState:
         """Return one exact named claim; unknown claims fail closed."""
@@ -2679,12 +2794,6 @@ class ResamplingSummaryOutcome:
     terminal: SummaryTerminal
     summary: ResamplingSummary | None = None
     failure: SummaryFailure | None = None
-    claimed_evidence_identity: str | None = field(
-        default=None,
-        kw_only=True,
-        repr=False,
-        compare=False,
-    )
     evidence_identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -2702,13 +2811,6 @@ class ResamplingSummaryOutcome:
             if self.failure is not None
             else ""
         )
-        if (
-            self.claimed_evidence_identity is not None
-            and self.claimed_evidence_identity != identity
-        ):
-            raise ResamplingConstructionError(
-                "Summary outcome evidence identity differs from its payload"
-            )
         object.__setattr__(self, "evidence_identity", identity)
 
 

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -14,7 +14,7 @@ import json
 import math
 import warnings
 from collections.abc import Callable, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from enum import StrEnum
 from numbers import Real
@@ -226,12 +226,26 @@ class ReplicateRequest:
     plan_identity: str
     ordinal: int
     structural_identity: str
+    optimization_projection_identity: str
+    component_identities: tuple[str, ...]
     seed: int
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         if self.ordinal < 0:
             raise ResamplingConstructionError("Replicate ordinal must be non-negative")
+        _non_empty_identity(
+            self.optimization_projection_identity,
+            name="optimization projection identity",
+        )
+        if (
+            not self.component_identities
+            or any(not item for item in self.component_identities)
+            or len(set(self.component_identities)) != len(self.component_identities)
+        ):
+            raise ResamplingConstructionError(
+                "Replicate request requires unique projected component identities"
+            )
         _unsigned_seed(self.seed, name="replicate seed")
         object.__setattr__(
             self,
@@ -242,6 +256,8 @@ class ReplicateRequest:
                     self.plan_identity,
                     self.ordinal,
                     self.structural_identity,
+                    self.optimization_projection_identity,
+                    self.component_identities,
                     self.seed,
                 ),
             ),
@@ -257,6 +273,7 @@ class ResamplingPlan:
     scheme: ResamplingScheme
     replicate_count: int
     replicate_structural_identities: tuple[str, ...]
+    replicate_component_identities: tuple[tuple[str, ...], ...]
     root_seed: int
     source_dataset_identity: str
     output_scope: tuple[str, ...]
@@ -279,6 +296,9 @@ class ResamplingPlan:
                 "Minimum successful replicate count cannot exceed the population"
             )
         supplied_structural_identities = tuple(self.replicate_structural_identities)
+        supplied_component_identities = tuple(
+            tuple(items) for items in self.replicate_component_identities
+        )
         if (
             len(supplied_structural_identities) != count
             or any(not item for item in supplied_structural_identities)
@@ -287,7 +307,26 @@ class ResamplingPlan:
             raise ResamplingConstructionError(
                 "Resampling requires one unique structural identity per replicate"
             )
-        structural_identities = tuple(sorted(supplied_structural_identities))
+        if len(supplied_component_identities) != count or any(
+            not items
+            or any(not item for item in items)
+            or len(set(items)) != len(items)
+            for items in supplied_component_identities
+        ):
+            raise ResamplingConstructionError(
+                "Resampling requires complete unique component identities per replicate"
+            )
+        canonical_work_units = tuple(
+            sorted(
+                zip(
+                    supplied_structural_identities,
+                    supplied_component_identities,
+                    strict=True,
+                )
+            )
+        )
+        structural_identities = tuple(item[0] for item in canonical_work_units)
+        component_identities = tuple(item[1] for item in canonical_work_units)
         root_seed = _unsigned_seed(self.root_seed, name="root seed")
         scope = _canonical_scope(self.output_scope)
         for name, value in (
@@ -308,6 +347,7 @@ class ResamplingPlan:
                 self.scheme.value,
                 count,
                 structural_identities,
+                component_identities,
                 root_seed,
                 self.source_dataset_identity,
                 scope,
@@ -319,7 +359,9 @@ class ResamplingPlan:
             ),
         )
         requests: list[ReplicateRequest] = []
-        for ordinal, structural_identity in enumerate(structural_identities):
+        for ordinal, (structural_identity, components) in enumerate(
+            zip(structural_identities, component_identities, strict=True)
+        ):
             seed = _derive_seed(
                 root_seed=root_seed,
                 stage_identity=identity,
@@ -327,7 +369,14 @@ class ResamplingPlan:
                 structural_identity=structural_identity,
             )
             requests.append(
-                ReplicateRequest(identity, ordinal, structural_identity, seed)
+                ReplicateRequest(
+                    identity,
+                    ordinal,
+                    structural_identity,
+                    self.optimization_projection_identity,
+                    components,
+                    seed,
+                )
             )
         seeds = tuple(item.seed for item in requests)
         if len(set(seeds)) != len(seeds):
@@ -339,6 +388,11 @@ class ResamplingPlan:
             self,
             "replicate_structural_identities",
             structural_identities,
+        )
+        object.__setattr__(
+            self,
+            "replicate_component_identities",
+            component_identities,
         )
         object.__setattr__(self, "minimum_successful_count", minimum)
         object.__setattr__(self, "root_seed", root_seed)
@@ -354,6 +408,7 @@ class ResamplingPlan:
         scheme: ResamplingScheme,
         replicate_count: int,
         replicate_structural_identities: Sequence[str],
+        replicate_component_identities: Sequence[Sequence[str]],
         root_seed: int,
         source_dataset_identity: str,
         output_scope: Sequence[str],
@@ -371,6 +426,7 @@ class ResamplingPlan:
             scheme,
             replicate_count,
             tuple(replicate_structural_identities),
+            tuple(tuple(items) for items in replicate_component_identities),
             root_seed,
             source_dataset_identity,
             tuple(output_scope),
@@ -640,11 +696,13 @@ class ProjectedOptimizationSuccess:
     """Complete projected candidate evidence with no acceptance or commit authority."""
 
     transformed_data_identity: str
+    optimization_projection_identity: str
     evaluation_plan_identity: str
     problem_identity: str
     invocation_identity: str
     execution_identity: str
     strategy: OptimizationStrategy
+    component_identities: tuple[str, ...]
     component_outcome_identities: tuple[str, ...]
     resolved_items: tuple[tuple[str, float], ...]
     chi_square: float
@@ -658,17 +716,28 @@ class ProjectedOptimizationSuccess:
     def __post_init__(self) -> None:
         for name, value in (
             ("transformed data identity", self.transformed_data_identity),
+            ("optimization projection identity", self.optimization_projection_identity),
             ("evaluation plan identity", self.evaluation_plan_identity),
             ("problem identity", self.problem_identity),
             ("invocation identity", self.invocation_identity),
             ("execution identity", self.execution_identity),
         ):
             _non_empty_identity(value, name=name)
-        if not self.component_outcome_identities or any(
-            not item for item in self.component_outcome_identities
+        if (
+            not self.component_outcome_identities
+            or any(not item for item in self.component_outcome_identities)
+            or len(self.component_outcome_identities) != len(self.component_identities)
         ):
             raise ResamplingConstructionError(
                 "Projected optimization requires complete component outcomes"
+            )
+        if (
+            not self.component_identities
+            or any(not item for item in self.component_identities)
+            or len(set(self.component_identities)) != len(self.component_identities)
+        ):
+            raise ResamplingConstructionError(
+                "Projected optimization requires unique component identities"
             )
         items = tuple(
             (param_id, _finite(value, name=f"resolved value {param_id!r}"))
@@ -703,11 +772,13 @@ class ProjectedOptimizationSuccess:
                 "native-projected-optimization-success",
                 (
                     self.transformed_data_identity,
+                    self.optimization_projection_identity,
                     self.evaluation_plan_identity,
                     self.problem_identity,
                     self.invocation_identity,
                     self.execution_identity,
                     self.strategy.value,
+                    self.component_identities,
                     self.component_outcome_identities,
                     _items_tokens(items),
                     _float_token(chi_square),
@@ -724,6 +795,7 @@ class ProjectedOptimizationFailure:
     disposition: ReplicateDisposition
     category: str
     message: str
+    optimization_projection_identity: str = field(kw_only=True)
     evaluation_plan_identity: str | None = None
     problem_identity: str | None = None
     execution_identity: str | None = None
@@ -739,6 +811,10 @@ class ProjectedOptimizationFailure:
             raise ResamplingConstructionError(
                 "Projected failure requires data identity, category, and message"
             )
+        _non_empty_identity(
+            self.optimization_projection_identity,
+            name="optimization projection identity",
+        )
         object.__setattr__(
             self,
             "identity",
@@ -749,6 +825,7 @@ class ProjectedOptimizationFailure:
                     self.disposition.value,
                     self.category,
                     self.message,
+                    self.optimization_projection_identity,
                     self.evaluation_plan_identity,
                     self.problem_identity,
                     self.execution_identity,
@@ -1013,6 +1090,7 @@ def _execute_replicate(
             ReplicateDisposition.INTERRUPTED,
             "asynchronous_interruption",
             "Replicate projected optimization was interrupted",
+            optimization_projection_identity=request.optimization_projection_identity,
         )
         return ReplicateOutcome(
             plan.identity,
@@ -1037,6 +1115,7 @@ def _execute_replicate(
             ReplicateDisposition.FAILED,
             "projected_execution_failure",
             f"{type(error).__name__}: {error}",
+            optimization_projection_identity=request.optimization_projection_identity,
         )
         return ReplicateOutcome(
             plan.identity,
@@ -1060,6 +1139,9 @@ def _execute_replicate(
                 projected.problem_identity,
                 projected.execution_identity,
                 projected.component_outcome_identities,
+                optimization_projection_identity=(
+                    request.optimization_projection_identity
+                ),
             )
             return ReplicateOutcome(
                 plan.identity,
@@ -1079,6 +1161,7 @@ def _execute_replicate(
             ReplicateDisposition.FAILED,
             "invalid_projected_outcome",
             "Projected optimization returned an unsupported outcome type",
+            optimization_projection_identity=request.optimization_projection_identity,
         )
         payload = failure
     if payload.transformed_data_identity != draw.identity:
@@ -1087,8 +1170,34 @@ def _execute_replicate(
             ReplicateDisposition.FAILED,
             "transformed_data_lineage_mismatch",
             "Projected optimization used a different transformed-data identity",
+            optimization_projection_identity=request.optimization_projection_identity,
         )
         payload = mismatch
+    if (
+        payload.optimization_projection_identity
+        != request.optimization_projection_identity
+    ):
+        payload = ProjectedOptimizationFailure(
+            draw.identity,
+            ReplicateDisposition.FAILED,
+            "optimization_projection_lineage_mismatch",
+            "Projected optimization used a different declared projection",
+            optimization_projection_identity=request.optimization_projection_identity,
+        )
+    if isinstance(payload, ProjectedOptimizationSuccess) and (
+        payload.component_identities != request.component_identities
+    ):
+        payload = ProjectedOptimizationFailure(
+            draw.identity,
+            ReplicateDisposition.FAILED,
+            "incomplete_component_projection",
+            "Projected optimization did not return every planned component",
+            optimization_projection_identity=request.optimization_projection_identity,
+            evaluation_plan_identity=payload.evaluation_plan_identity,
+            problem_identity=payload.problem_identity,
+            execution_identity=payload.execution_identity,
+            component_outcome_identities=payload.component_outcome_identities,
+        )
     if isinstance(payload, ProjectedOptimizationSuccess):
         return ReplicateOutcome(
             plan.identity,
@@ -1130,37 +1239,57 @@ def _execute_serial_replicates(
     return outcomes, terminal
 
 
+def _replicate_terminal(
+    outcomes: Sequence[ReplicateOutcome],
+) -> OperationTerminal:
+    if any(
+        outcome.disposition is ReplicateDisposition.INTERRUPTED for outcome in outcomes
+    ):
+        return OperationTerminal.INTERRUPTED
+    if any(
+        outcome.disposition is ReplicateDisposition.CANCELLED for outcome in outcomes
+    ):
+        return OperationTerminal.CANCELLED
+    return OperationTerminal.COMPLETED
+
+
 def _execute_parallel_replicates(
     plan: ResamplingPlan,
     population: ResamplingPopulation,
     executor: ReplicateExecutor,
     execution: ExecutionSettings,
+    cancellation_probe: Callable[[], bool] | None,
 ) -> tuple[list[ReplicateOutcome], OperationTerminal]:
     worker_count = min(execution.workers, plan.replicate_count)
-    with (
-        native_thread_environment(execution.native_thread_env(parallel=True)),
-        ThreadPoolExecutor(max_workers=worker_count) as pool,
-    ):
-        outcomes = list(
-            pool.map(
-                lambda request: _execute_replicate(
-                    plan,
-                    population,
-                    executor,
-                    request,
-                ),
-                plan.replicates,
-            )
-        )
-    if any(
-        outcome.disposition is ReplicateDisposition.INTERRUPTED for outcome in outcomes
-    ):
-        return outcomes, OperationTerminal.INTERRUPTED
-    if any(
-        outcome.disposition is ReplicateDisposition.CANCELLED for outcome in outcomes
-    ):
-        return outcomes, OperationTerminal.CANCELLED
-    return outcomes, OperationTerminal.COMPLETED
+    outcomes: list[ReplicateOutcome] = []
+    terminal = OperationTerminal.COMPLETED
+    with native_thread_environment(execution.native_thread_env(parallel=True)):
+        pool = ThreadPoolExecutor(max_workers=worker_count)
+        pending: set[Future[ReplicateOutcome]] = {
+            pool.submit(_execute_replicate, plan, population, executor, request)
+            for request in plan.replicates
+        }
+        try:
+            while pending:
+                done, pending = wait(
+                    pending,
+                    timeout=0.01 if cancellation_probe is not None else None,
+                    return_when=FIRST_COMPLETED,
+                )
+                outcomes.extend(future.result() for future in done)
+                terminal = _replicate_terminal(outcomes)
+                if cancellation_probe is not None and cancellation_probe():
+                    terminal = OperationTerminal.CANCELLED
+                if terminal is not OperationTerminal.COMPLETED:
+                    break
+        except KeyboardInterrupt:
+            terminal = OperationTerminal.INTERRUPTED
+        finally:
+            for future in pending:
+                future.cancel()
+            pool.shutdown(wait=True, cancel_futures=True)
+    outcomes.sort(key=lambda outcome: outcome.ordinal)
+    return outcomes, terminal
 
 
 def execute_resampling_evidence(
@@ -1193,7 +1322,7 @@ def execute_resampling_evidence(
             None,
             tuple(range(plan.replicate_count)),
         )
-    if settings.workers == 1 or cancellation_probe is not None:
+    if settings.workers == 1:
         outcomes, terminal = _execute_serial_replicates(
             plan,
             population,
@@ -1206,6 +1335,7 @@ def execute_resampling_evidence(
             population,
             executor,
             settings,
+            cancellation_probe,
         )
     evidence = (
         ResamplingEvidence(plan, population.identity, tuple(outcomes), terminal)

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -16,7 +16,7 @@ import math
 import warnings
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from numbers import Real
 from typing import Literal, cast
@@ -1476,56 +1476,377 @@ type CandidateEvidenceTestHook = Callable[
 ]
 
 
-_VALIDATED_SUCCESS_CONSTRUCTION_KEY = object()
-
-
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, init=False)
 class ValidatedReplicateSuccess:
-    """Resampling-owned complete sample after exact lineage and resolution checks."""
+    """Canonical complete sample derived from exact fresh materialization sources."""
 
-    _construction_key: object = field(repr=False, compare=False)
-    prepared_replicate_identity: str
-    projected_outcome_identity: str
-    evaluation_identity: str
-    materialization_identity: str
-    resolved_items: tuple[tuple[str, float], ...]
-    chi_square: float
-    backend_chi_square: float | None
-    backend_chi_square_agrees: bool | None
-    fresh_evaluation_count: int
-    identity: str = field(init=False)
+    prepared: ReplicateExecutionPlan = field(init=False, repr=False, compare=False)
+    projected: ProjectedOptimizationSuccess = field(
+        init=False, repr=False, compare=False
+    )
+    evaluation_result: EvaluationResult = field(init=False, repr=False, compare=False)
 
-    def __post_init__(self) -> None:
-        if self._construction_key is not _VALIDATED_SUCCESS_CONSTRUCTION_KEY:
-            raise ResamplingConstructionError(
-                "Successful samples require resampling-owned validation"
+    @classmethod
+    def from_materialization(
+        cls,
+        prepared: ReplicateExecutionPlan,
+        projected: ProjectedOptimizationSuccess,
+        evaluation_result: EvaluationResult,
+    ) -> ValidatedReplicateSuccess:
+        """Construct one success solely from its exact subordinate evidence."""
+        try:
+            rebound_prepared = replace(prepared)
+            canonical_projected = ProjectedOptimizationSuccess.for_prepared(
+                rebound_prepared,
+                candidate_vector=projected.candidate_vector,
+                backend_chi_square=projected.backend_chi_square,
+                execution_identity=projected.execution_identity,
+                backend_evaluation_identity=(projected.backend_evaluation_identity),
             )
-        if self.fresh_evaluation_count != 1:
-            raise ResamplingConstructionError(
-                "Successful samples require exactly one fresh validation evaluation"
+            canonical_evaluation = EvaluationResult.from_record(
+                evaluation_result.to_record(), rebound_prepared.evaluation_plan
             )
-        object.__setattr__(
-            self,
-            "identity",
-            _identity(
-                "native-resampling-validated-success",
+            resolved_items = tuple(
+                (param_id, canonical_evaluation.resolved_values[param_id])
+                for param_id in rebound_prepared.output_scope
+            )
+            if (
+                rebound_prepared.identity != prepared.identity
+                or canonical_projected != projected
+                or canonical_projected.identity != projected.identity
+                or canonical_evaluation.identity != evaluation_result.identity
+                or canonical_evaluation.plan_identity
+                != rebound_prepared.evaluation_plan.identity
+                or canonical_evaluation.parameterization_identity
+                != rebound_prepared.parameterization.evaluator_identity
+                or tuple(canonical_evaluation.resolved_values)
+                != rebound_prepared.output_scope
+                or resolved_items
+                != rebound_prepared.resolve_candidate(projected.candidate_vector)
+                or (
+                    projected.backend_evaluation_identity is not None
+                    and projected.backend_evaluation_identity
+                    != canonical_evaluation.identity
+                )
+            ):
+                raise ResamplingConstructionError(
+                    "Fresh materialization differs from its exact prepared candidate"
+                )
+            canonical_chi_square(canonical_evaluation.residuals)
+        except ResamplingConstructionError:
+            raise
+        except Exception as error:
+            raise ResamplingConstructionError(
+                "Successful replicate has an invalid fresh derivation chain"
+            ) from error
+        success = object.__new__(cls)
+        object.__setattr__(success, "prepared", rebound_prepared)
+        object.__setattr__(success, "projected", canonical_projected)
+        object.__setattr__(success, "evaluation_result", canonical_evaluation)
+        return success
+
+    @property
+    def prepared_replicate_identity(self) -> str:
+        return self.prepared.identity
+
+    @property
+    def projected_outcome_identity(self) -> str:
+        return self.projected.identity
+
+    @property
+    def evaluation_identity(self) -> str:
+        return self.evaluation_result.identity
+
+    @property
+    def output_scope(self) -> tuple[str, ...]:
+        return self.prepared.output_scope
+
+    @property
+    def output_units(self) -> tuple[str, ...]:
+        return self.prepared.output_units
+
+    @property
+    def resolved_items(self) -> tuple[tuple[str, float], ...]:
+        return tuple(
+            (param_id, self.evaluation_result.resolved_values[param_id])
+            for param_id in self.output_scope
+        )
+
+    @property
+    def chi_square(self) -> float:
+        return canonical_chi_square(self.evaluation_result.residuals)
+
+    @property
+    def backend_chi_square(self) -> float | None:
+        return self.projected.backend_chi_square
+
+    @property
+    def backend_chi_square_agrees(self) -> bool | None:
+        return (
+            None
+            if self.backend_chi_square is None
+            else self.backend_chi_square == self.chi_square
+        )
+
+    @property
+    def fresh_evaluation_count(self) -> int:
+        return 1
+
+    @property
+    def materialization_identity(self) -> str:
+        return _identity(
+            "native-resampling-fresh-materialization",
+            (
+                self.prepared.identity,
+                self.projected.candidate_identity,
+                self.projected.execution_identity,
+                self.evaluation_result.evaluator_compatibility_identity,
+                self.evaluation_result.identity,
+                _items_tokens(self.resolved_items),
+            ),
+        )
+
+    @property
+    def claims(self) -> tuple[ClaimAssessment, ...]:
+        return (
+            ClaimAssessment(
+                "FRESH_MATERIALIZATION_INTEGRITY",
+                ClaimState.SATISFIED,
+                self.prepared.identity,
                 (
-                    self.prepared_replicate_identity,
-                    self.projected_outcome_identity,
-                    self.evaluation_identity,
-                    self.materialization_identity,
-                    _items_tokens(self.resolved_items),
-                    _float_token(self.chi_square),
-                    (
-                        None
-                        if self.backend_chi_square is None
-                        else _float_token(self.backend_chi_square)
-                    ),
-                    self.backend_chi_square_agrees,
-                    self.fresh_evaluation_count,
+                    f"evaluation={self.evaluation_identity}",
+                    f"scope={','.join(self.output_scope)}",
                 ),
             ),
         )
+
+    @property
+    def identity(self) -> str:
+        return _identity(
+            "native-resampling-validated-success",
+            (
+                self.prepared_replicate_identity,
+                self.projected_outcome_identity,
+                self.evaluation_identity,
+                self.materialization_identity,
+                _items_tokens(self.resolved_items),
+                _float_token(self.chi_square),
+                (
+                    None
+                    if self.backend_chi_square is None
+                    else _float_token(self.backend_chi_square)
+                ),
+                self.backend_chi_square_agrees,
+                self.fresh_evaluation_count,
+                self.output_scope,
+                self.output_units,
+                tuple(
+                    (
+                        claim.name,
+                        claim.state.value,
+                        claim.policy_identity,
+                        claim.details,
+                    )
+                    for claim in self.claims
+                ),
+            ),
+        )
+
+    @staticmethod
+    def _projected_record(
+        projected: ProjectedOptimizationSuccess,
+    ) -> dict[str, object]:
+        return {
+            "prepared_replicate_identity": projected.prepared_replicate_identity,
+            "accepted_result_identity": projected.accepted_result_identity,
+            "accepted_occurrence_identity": projected.accepted_occurrence_identity,
+            "source_snapshot_occurrence_identity": (
+                projected.source_snapshot_occurrence_identity
+            ),
+            "source_snapshot_revision": projected.source_snapshot_revision,
+            "transformed_data_identity": projected.transformed_data_identity,
+            "optimization_projection_identity": (
+                projected.optimization_projection_identity
+            ),
+            "evaluation_plan_identity": projected.evaluation_plan_identity,
+            "problem_identity": projected.problem_identity,
+            "parameterization_identity": projected.parameterization_identity,
+            "evaluator_parameterization_identity": (
+                projected.evaluator_parameterization_identity
+            ),
+            "constraint_program_identity": projected.constraint_program_identity,
+            "workflow_identity": projected.workflow_identity,
+            "invocation_identity": projected.invocation_identity,
+            "execution_identity": projected.execution_identity,
+            "strategy": projected.strategy.value,
+            "component_identities": list(projected.component_identities),
+            "component_outcome_identities": list(
+                projected.component_outcome_identities
+            ),
+            "controlled_ids": list(projected.controlled_ids),
+            "candidate_identity": projected.candidate_identity,
+            "candidate_vector": [
+                _float_token(value) for value in projected.candidate_vector
+            ],
+            "backend_chi_square": (
+                None
+                if projected.backend_chi_square is None
+                else _float_token(projected.backend_chi_square)
+            ),
+            "backend_evaluation_identity": projected.backend_evaluation_identity,
+            "identity": projected.identity,
+        }
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize sources plus checked readable projections."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "prepared_replicate_identity": self.prepared_replicate_identity,
+            "request_identity": self.prepared.request.identity,
+            "draw_identity": self.prepared.draw.identity,
+            "evaluation_plan_identity": self.prepared.evaluation_plan.identity,
+            "problem_identity": self.prepared.problem.identity,
+            "projected": self._projected_record(self.projected),
+            "evaluation_result": self.evaluation_result.to_record(),
+            "output_scope": list(self.output_scope),
+            "output_units": list(self.output_units),
+            "resolved_items": [
+                [param_id, _float_token(value)]
+                for param_id, value in self.resolved_items
+            ],
+            "chi_square": _float_token(self.chi_square),
+            "backend_chi_square": (
+                None
+                if self.backend_chi_square is None
+                else _float_token(self.backend_chi_square)
+            ),
+            "backend_chi_square_agrees": self.backend_chi_square_agrees,
+            "fresh_evaluation_count": self.fresh_evaluation_count,
+            "materialization_identity": self.materialization_identity,
+            "claims": [
+                {
+                    "name": claim.name,
+                    "state": claim.state.value,
+                    "policy_identity": claim.policy_identity,
+                    "details": list(claim.details),
+                }
+                for claim in self.claims
+            ],
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        plan: ResamplingPlan,
+        request: ReplicateRequest,
+    ) -> ValidatedReplicateSuccess:
+        """Rebuild from exact source context and reject altered checked copies."""
+        try:
+            draw = generate_resampling_draw(plan.dataset, request)
+            prepared = ReplicateExecutionPlan.prepare(plan, request, draw)
+            projected_record = record.get("projected")
+            evaluation_record = record.get("evaluation_result")
+            if not isinstance(projected_record, Mapping) or not isinstance(
+                evaluation_record, Mapping
+            ):
+                raise TypeError("Success source records must be mappings")
+            vector_record = projected_record.get("candidate_vector")
+            if not isinstance(vector_record, list):
+                raise TypeError("Candidate vector must be a list")
+            backend_record = projected_record.get("backend_chi_square")
+            backend_chi_square = (
+                None if backend_record is None else float.fromhex(str(backend_record))
+            )
+            execution_identity = projected_record.get("execution_identity")
+            if not isinstance(execution_identity, str):
+                raise TypeError("Execution identity must be a string")
+            backend_evaluation_identity = projected_record.get(
+                "backend_evaluation_identity"
+            )
+            if backend_evaluation_identity is not None and not isinstance(
+                backend_evaluation_identity, str
+            ):
+                raise TypeError("Backend evaluation identity must be a string")
+            projected = ProjectedOptimizationSuccess.for_prepared(
+                prepared,
+                candidate_vector=tuple(
+                    float.fromhex(str(value)) for value in vector_record
+                ),
+                backend_chi_square=backend_chi_square,
+                execution_identity=execution_identity,
+                backend_evaluation_identity=backend_evaluation_identity,
+            )
+            if projected_record != cls._projected_record(projected):
+                raise ResamplingConstructionError(
+                    "Stored projected candidate differs from exact prepared lineage"
+                )
+            evaluation_result = EvaluationResult.from_record(
+                cast("Mapping[str, object]", evaluation_record),
+                prepared.evaluation_plan,
+            )
+            success = cls.from_materialization(prepared, projected, evaluation_result)
+        except ResamplingConstructionError:
+            raise
+        except Exception as error:
+            raise ResamplingConstructionError(
+                "Malformed validated replicate success record"
+            ) from error
+        if record != success.to_record():
+            raise ResamplingConstructionError(
+                "Stored success differs from its canonical fresh derivation"
+            )
+        return success
+
+    def validate_integrity(
+        self,
+        plan: ResamplingPlan,
+        request: ReplicateRequest,
+    ) -> ValidatedReplicateSuccess:
+        """Reconstruct this success from the exact operation-owned derivation."""
+        try:
+            canonical_draw = generate_resampling_draw(plan.dataset, request)
+            canonical_prepared = ReplicateExecutionPlan.prepare(
+                plan, request, canonical_draw
+            )
+            stored_prepared = replace(self.prepared)
+            if (
+                stored_prepared.identity != self.prepared.identity
+                or stored_prepared.identity != canonical_prepared.identity
+                or self.prepared.request.identity != request.identity
+                or self.prepared.draw.identity != canonical_draw.identity
+            ):
+                raise ResamplingConstructionError(
+                    "Successful replicate belongs to another prepared request or draw"
+                )
+            validation_engine = plan.source_engine.resampled(
+                canonical_prepared.evaluation_plan,
+                canonical_prepared.profile_bindings,
+            )
+            if (
+                self.evaluation_result.evaluator_compatibility_identity
+                != validation_engine.compatibility_identity
+            ):
+                raise ResamplingConstructionError(
+                    "Successful evaluation has foreign evaluator compatibility"
+                )
+            canonical = type(self).from_materialization(
+                canonical_prepared,
+                self.projected,
+                self.evaluation_result,
+            )
+            if self.to_record() != canonical.to_record():
+                raise ResamplingConstructionError(
+                    "Successful replicate differs from its canonical derivation"
+                )
+        except ResamplingConstructionError:
+            raise
+        except Exception as error:
+            raise ResamplingConstructionError(
+                "Successful replicate integrity validation failed"
+            ) from error
+        return canonical
 
 
 @dataclass(frozen=True, slots=True)
@@ -1589,6 +1910,77 @@ class ReplicateOutcome:
             ),
         )
 
+    def validate_integrity(self, plan: ResamplingPlan) -> None:  # noqa: C901
+        """Recursively validate this terminal payload against its exact request."""
+        try:
+            if self.ordinal < 0 or self.ordinal >= plan.replicate_count:
+                raise ResamplingConstructionError(
+                    "Replicate outcome ordinal is outside its exact plan"
+                )
+            request = plan.replicates[self.ordinal]
+            if (
+                self.plan_identity != plan.identity
+                or self.request_identity != request.identity
+                or self.seed != request.seed
+            ):
+                raise ResamplingConstructionError(
+                    "Replicate outcome differs from its exact planned request"
+                )
+            succeeded = self.disposition is ReplicateDisposition.SUCCEEDED
+            if succeeded != (self.success is not None) or succeeded == (
+                self.failure is not None
+            ):
+                raise ResamplingConstructionError(
+                    "Replicate outcome has inconsistent terminal payload"
+                )
+            if self.success is not None:
+                canonical_success = self.success.validate_integrity(plan, request)
+                if (
+                    self.draw_identity != canonical_success.prepared.draw.identity
+                    or self.stage is not ReplicateStage.TERMINAL
+                ):
+                    raise ResamplingConstructionError(
+                        "Successful outcome differs from its generated draw or stage"
+                    )
+                payload_identity = canonical_success.identity
+            elif self.failure is not None:
+                canonical_failure = replace(self.failure)
+                if (
+                    canonical_failure.identity != self.failure.identity
+                    or canonical_failure.transformed_data_identity != self.draw_identity
+                ):
+                    raise ResamplingConstructionError(
+                        "Failed outcome has altered terminal evidence"
+                    )
+                payload_identity = canonical_failure.identity
+            else:
+                raise ResamplingConstructionError(
+                    "Replicate outcome lacks terminal evidence"
+                )
+            expected_identity = _identity(
+                "native-resampling-replicate-outcome",
+                (
+                    self.plan_identity,
+                    self.request_identity,
+                    self.ordinal,
+                    self.seed,
+                    self.draw_identity,
+                    self.stage.value,
+                    self.disposition.value,
+                    payload_identity,
+                ),
+            )
+            if self.identity != expected_identity:
+                raise ResamplingConstructionError(
+                    "Replicate outcome identity differs from its terminal payload"
+                )
+        except ResamplingConstructionError:
+            raise
+        except Exception as error:
+            raise ResamplingConstructionError(
+                "Replicate outcome integrity validation failed"
+            ) from error
+
 
 @dataclass(frozen=True, slots=True)
 class ResamplingEvidence:
@@ -1606,10 +1998,14 @@ class ResamplingEvidence:
     claims: tuple[ClaimAssessment, ...] = field(init=False)
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: C901
         if not self.outcomes:
             raise ResamplingConstructionError(
                 "Resampling evidence requires at least one genuine replicate outcome"
+            )
+        if self.population_identity != self.plan.dataset.identity:
+            raise ResamplingConstructionError(
+                "Resampling evidence belongs to another source population"
             )
         ordinals = tuple(outcome.ordinal for outcome in self.outcomes)
         if ordinals != tuple(sorted(ordinals)) or len(set(ordinals)) != len(ordinals):
@@ -1627,6 +2023,8 @@ class ResamplingEvidence:
             raise ResamplingConstructionError(
                 "Resampling outcomes differ from their planned replicate identities"
             )
+        for outcome in self.outcomes:
+            outcome.validate_integrity(self.plan)
         for outcome in self.outcomes:
             if (
                 outcome.success is not None
@@ -1738,6 +2136,34 @@ class ResamplingEvidence:
     def claim(self, name: str) -> ClaimState:
         """Return one exact named claim; unknown claims fail closed."""
         return _claim_state(self.claims, name)
+
+    def validate_integrity(self) -> None:
+        """Recompute this evidence and recursively reject altered descendants."""
+        try:
+            canonical = type(self)(
+                self.plan,
+                self.population_identity,
+                self.outcomes,
+                self.operation_terminal,
+            )
+            if (
+                self.lifecycle != canonical.lifecycle
+                or self.completed_count != canonical.completed_count
+                or self.successful_count != canonical.successful_count
+                or self.failed_count != canonical.failed_count
+                or self.coverage_satisfied != canonical.coverage_satisfied
+                or self.claims != canonical.claims
+                or self.identity != canonical.identity
+            ):
+                raise ResamplingConstructionError(
+                    "Resampling evidence differs from its recursive derivation"
+                )
+        except ResamplingConstructionError:
+            raise
+        except Exception as error:
+            raise ResamplingConstructionError(
+                "Resampling evidence integrity validation failed"
+            ) from error
 
 
 @dataclass(frozen=True, slots=True)
@@ -2110,7 +2536,7 @@ def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
             for param_id in prepared.output_scope
         )
         ordinary_resolved = prepared.resolve_candidate(projected.candidate_vector)
-        chi_square = canonical_chi_square(canonical_evaluation.residuals)
+        canonical_chi_square(canonical_evaluation.residuals)
         if (
             canonical_evaluation.evaluator_compatibility_identity
             != validation_engine.compatibility_identity
@@ -2134,33 +2560,10 @@ def _execute_replicate(  # noqa: C901 - ordered staged ownership boundary
             f"{type(error).__name__}: {error}",
             projected=projected,
         )
-    materialization_identity = _identity(
-        "native-resampling-fresh-materialization",
-        (
-            prepared.identity,
-            projected.candidate_identity,
-            projected.execution_identity,
-            validation_engine.compatibility_identity,
-            canonical_evaluation.identity,
-            _items_tokens(resolved_items),
-        ),
-    )
-    backend_agrees = (
-        None
-        if projected.backend_chi_square is None
-        else projected.backend_chi_square == chi_square
-    )
-    success = ValidatedReplicateSuccess(
-        _VALIDATED_SUCCESS_CONSTRUCTION_KEY,
-        prepared.identity,
-        projected.identity,
-        canonical_evaluation.identity,
-        materialization_identity,
-        resolved_items,
-        chi_square,
-        projected.backend_chi_square,
-        backend_agrees,
-        1,
+    success = ValidatedReplicateSuccess.from_materialization(
+        prepared,
+        projected,
+        canonical_evaluation,
     )
     return ReplicateOutcome(
         plan.identity,
@@ -2538,6 +2941,7 @@ class ResamplingSummary:
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        self.evidence.validate_integrity()
         successful = tuple(
             outcome for outcome in self.evidence.outcomes if outcome.success is not None
         )
@@ -2900,6 +3304,18 @@ def summarize_resampling_evidence(
 ) -> ResamplingSummaryOutcome:
     """Derive one summary from all and only complete successful scope rows."""
     exact_policy = ResamplingSummaryPolicy() if policy is None else policy
+    try:
+        evidence.validate_integrity()
+    except ResamplingConstructionError as error:
+        failure = SummaryFailure(
+            evidence.identity,
+            "invalid_source_evidence",
+            f"Source evidence failed recursive integrity validation: {error}",
+        )
+        return ResamplingSummaryOutcome(
+            SummaryTerminal.SOURCE_INVALID,
+            failure=failure,
+        )
     if evidence.successful_count < evidence.plan.minimum_successful_count:
         failure = SummaryFailure(
             evidence.identity,

--- a/tests/test_native_resampling.py
+++ b/tests/test_native_resampling.py
@@ -83,6 +83,7 @@ def _population() -> ResamplingPopulation:
         mask=(True, True, True, True, False),
         references=(True, True, False, False, False),
         nucleus_groups=("N1", "N1", "N2", "N3", "N3"),
+        profile_blocks=("P1", "P1", "P1", "P1", "P2"),
     )
 
 
@@ -96,6 +97,10 @@ def _plan(
         accepted,
         scheme=scheme,
         replicate_count=count,
+        replicate_structural_identities=tuple(
+            f"qualification-replicate-{name}"
+            for name in ("alpha", "beta", "gamma", "delta")[:count]
+        ),
         root_seed=0x1234_5678_90AB_CDEF,
         source_dataset_identity="qualification-dataset",
         output_scope=("A", "B"),
@@ -136,10 +141,31 @@ def test_replicate_plan_uses_canonical_ordinals_and_identity_derived_seeds() -> 
     assert len({request.seed for request in plan.replicates}) == 4
     assert plan == _plan(accepted, ResamplingScheme.MONTE_CARLO)
 
+    reordered = ResamplingPlan.for_accepted(
+        accepted,
+        scheme=ResamplingScheme.MONTE_CARLO,
+        replicate_count=4,
+        replicate_structural_identities=tuple(
+            reversed(plan.replicate_structural_identities)
+        ),
+        root_seed=plan.root_seed,
+        source_dataset_identity=plan.source_dataset_identity,
+        output_scope=plan.output_scope,
+        optimization_projection_identity=plan.optimization_projection_identity,
+        minimum_successful_count=plan.minimum_successful_count,
+    )
+    assert reordered == plan
+
     changed = ResamplingPlan.for_accepted(
         accepted,
         scheme=ResamplingScheme.MONTE_CARLO,
         replicate_count=4,
+        replicate_structural_identities=(
+            "qualification-replicate-alpha",
+            "qualification-replicate-beta",
+            "qualification-replicate-gamma",
+            "qualification-replicate-delta",
+        ),
         root_seed=0x1234_5678_90AB_CDEE,
         source_dataset_identity="qualification-dataset",
         output_scope=("A", "B"),
@@ -184,6 +210,18 @@ def test_seeded_generation_preserves_mc_bs_and_bsn_scientific_schemes() -> None:
     assert mc.source_indices == tuple(range(5))
     assert mc.standard_errors == population.standard_errors
     assert mc.observations != population.calculated
+    np.testing.assert_allclose(
+        mc.observations,
+        (
+            10.209847500036986,
+            14.930749036336255,
+            31.904952620387146,
+            39.372147264939954,
+            48.225783000334324,
+        ),
+        rtol=0.0,
+        atol=1.0e-14,
+    )
 
     bootstrap = generate_resampling_draw(
         population,
@@ -199,6 +237,7 @@ def test_seeded_generation_preserves_mc_bs_and_bsn_scientific_schemes() -> None:
     ) == tuple(population.references[target] for target in masked_targets)
     assert bootstrap.source_indices[-1] == 4
     assert bootstrap.observations[-1] == population.observed[-1]
+    assert bootstrap.source_indices == (0, 0, 2, 2, 4)
 
     nucleus = generate_resampling_draw(
         population,
@@ -214,6 +253,35 @@ def test_seeded_generation_preserves_mc_bs_and_bsn_scientific_schemes() -> None:
         if source_group == group
     )
     assert nucleus.source_indices == expected_sources
+    assert nucleus.sampled_nucleus_groups == ("N2", "N1", "N3")
+    assert nucleus.source_indices == (2, 0, 1, 3, 4)
+
+
+def test_bootstrap_resamples_each_profile_reference_pool_independently() -> None:
+    population = ResamplingPopulation(
+        source_dataset_identity="blocked-dataset",
+        observed=(10.0, 11.0, 20.0, 21.0),
+        calculated=(10.0, 11.0, 20.0, 21.0),
+        standard_errors=(1.0, 1.0, 1.0, 1.0),
+        mask=(True, True, True, True),
+        references=(True, False, True, False),
+        nucleus_groups=("N1", "N1", "N2", "N2"),
+        profile_blocks=("P1", "P1", "P2", "P2"),
+    )
+    draw = generate_resampling_draw(
+        population,
+        ResamplingScheme.BOOTSTRAP,
+        seed=404,
+    )
+
+    assert all(
+        population.profile_blocks[target] == population.profile_blocks[source]
+        for target, source in enumerate(draw.source_indices)
+    )
+    assert all(
+        population.references[target] == population.references[source]
+        for target, source in enumerate(draw.source_indices)
+    )
 
 
 def test_resampling_execution_is_evidence_only_scope_complete_and_worker_stable() -> (
@@ -321,6 +389,59 @@ def test_failed_replicates_remain_typed_and_summary_uses_one_common_scope() -> N
         entry.value is None or np.isfinite(entry.value)
         for entry in summary.correlations
     )
+    distributions = {item.parameter_id: item for item in summary.distributions}
+    assert distributions["A"].mean == pytest.approx(2.0, rel=0.0, abs=1.0e-15)
+    assert distributions["A"].standard_deviation == pytest.approx(
+        np.sqrt(2.0), rel=0.0, abs=1.0e-15
+    )
+    assert distributions["A"].median == pytest.approx(2.0)
+    assert distributions["A"].percentile_95_lower == pytest.approx(1.05)
+    assert distributions["A"].percentile_95_upper == pytest.approx(2.95)
+    covariance = {
+        (item.parameter_a, item.parameter_b): item.value for item in summary.covariance
+    }
+    assert covariance[("A", "A")] == pytest.approx(2.0)
+    assert covariance[("A", "B")] == pytest.approx(-2.0)
+    correlations = {
+        (item.parameter_a, item.parameter_b): item.value
+        for item in summary.correlations
+    }
+    assert correlations[("A", "B")] == pytest.approx(-1.0)
+
+
+def test_zero_variance_correlation_is_typed_without_nan() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=2)
+
+    def project(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationSuccess:
+        return ProjectedOptimizationSuccess(
+            transformed_data_identity=draw.identity,
+            evaluation_plan_identity=f"plan-{request.ordinal}",
+            problem_identity=f"problem-{request.ordinal}",
+            invocation_identity=f"invocation-{request.ordinal}",
+            execution_identity=f"execution-{request.ordinal}",
+            strategy=OptimizationStrategy.DIRECT_TRF,
+            component_outcome_identities=(f"component-{request.ordinal}",),
+            resolved_items=(("A", float(request.ordinal)), ("B", 5.0)),
+            chi_square=1.0,
+        )
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        _population(),
+        project,
+    )
+    assert operation.evidence is not None
+    outcome = summarize_resampling_evidence(operation.evidence)
+    assert outcome.summary is not None
+    b_entries = tuple(
+        entry for entry in outcome.summary.correlations if entry.parameter_b == "B"
+    )
+    assert all(entry.value is None for entry in b_entries)
 
 
 def test_partial_evidence_and_summary_publish_only_under_declared_contract() -> None:
@@ -363,10 +484,37 @@ def test_partial_evidence_and_summary_publish_only_under_declared_contract() -> 
     assert summary_outcome.summary is None
     assert summary_outcome.failure is not None
 
+
+def test_valid_partial_summary_records_unstarted_requested_ordinals() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=4)
+    calls = 0
+
+    def project(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationSuccess:
+        nonlocal calls
+        calls += 1
+        return _successful_projection()(request, draw)
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        _population(),
+        project,
+        cancellation_probe=lambda: calls >= 2,
+    )
+    assert operation.evidence is not None
+    outcome = summarize_resampling_evidence(operation.evidence)
+    assert outcome.terminal is SummaryTerminal.COMPLETED
+    assert outcome.summary is not None
+    assert outcome.summary.unstarted_ordinals == (2, 3)
+
     initially_cancelled = execute_resampling_evidence(
         accepted,
         plan,
-        population,
+        _population(),
         project,
         execution=ExecutionSettings(workers=1),
         cancellation_probe=lambda: True,

--- a/tests/test_native_resampling.py
+++ b/tests/test_native_resampling.py
@@ -1,101 +1,233 @@
-"""Behavioral qualification tests for native resampling evidence (#599).
-
-The public seams are deterministic replicate planning and data generation,
-evidence-only projected optimization, and scope-atomic summary derivation.  The
-production lmfit runner remains outside this qualification harness.
-"""
+"""Behavioral qualification tests for native resampling evidence (#599)."""
 
 from __future__ import annotations
 
+import copy
 import dataclasses
+import hashlib
+import json
 from collections.abc import Callable
-from threading import Event
+from threading import Event, Lock, get_ident
+from typing import Any
 
 import numpy as np
 import pytest
 
-from chemex.optimize.direct_trf import AcceptedFitResult
+from chemex.evaluation.native import (
+    EvaluationPlan,
+    EvaluationResult,
+    ProfilePlan,
+    ResolvedEvaluationValues,
+)
+from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
 from chemex.optimize.native_resampling import (
     ClaimState,
+    CorrelationAvailability,
     OptimizationStrategy,
     ProjectedOptimizationFailure,
     ProjectedOptimizationResult,
     ProjectedOptimizationSuccess,
     ReplicateDisposition,
+    ReplicateExecutionPlan,
     ReplicateRequest,
+    ReplicateStage,
     ResamplingConstructionError,
-    ResamplingDraw,
+    ResamplingDatasetManifest,
     ResamplingLifecycle,
     ResamplingPlan,
-    ResamplingPopulation,
     ResamplingScheme,
+    ResamplingSummary,
+    ResamplingSummaryOutcome,
+    ResamplingSummaryPolicy,
     SummaryTerminal,
     execute_resampling_evidence,
     generate_resampling_draw,
     summarize_resampling_evidence,
 )
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    ConstraintProgram,
+    ParameterRole,
+    ScientificFunctionBinder,
+)
+from chemex.parameters.values import AnalysisValuesSnapshot
 from chemex.runtime import ExecutionSettings
 
 
-def _accepted_anchor() -> AcceptedFitResult:
-    """Use the exact authoritative constructor without fabricating fit authority."""
-    from chemex.evaluation.native import EvaluationResult, ResolvedEvaluationValues
+def _evaluation_identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"schema": 1, "kind": kind, "record": record},
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
+
+def _profile_plan(
+    name: str,
+    *,
+    profile_ordinal: int,
+    offset: int,
+    observed: tuple[float, ...],
+    errors: tuple[float, ...],
+    mask: tuple[bool, ...],
+) -> ProfilePlan:
+    source_identity = f"source-{name}"
+    return ProfilePlan(
+        _evaluation_identity(
+            "profile-plan",
+            (source_identity, 0, profile_ordinal, offset),
+        ),
+        source_identity,
+        0,
+        profile_ordinal,
+        offset,
+        (("a", "A"), ("b", "B")),
+        True,
+        observed,
+        errors,
+        mask,
+        f"kernel-{name}",
+        f"kernel-config-{name}",
+        f"spectrometer-{name}",
+        f"positions-{name}",
+        (len(observed),),
+    )
+
+
+def _native_context() -> tuple[
+    AcceptedFitResult,
+    ResamplingDatasetManifest,
+    OptimizationProblem,
+    ActiveParameterization,
+]:
+    binder = ScientificFunctionBinder("qualification", {})
+    program = ConstraintProgram(
+        "parameter-model",
+        "model",
+        "definitions",
+        "configuration",
+        binder.identity,
+        ("A", "B"),
+        ("A", "B"),
+        (),
+        (),
+        (),
+    )
+    parameterization = ActiveParameterization(
+        program,
+        binder,
+        "source-occurrence",
+        4,
+        (("A", ParameterRole.FIT), ("B", ParameterRole.FIT)),
+    )
+    evaluation_plan = EvaluationPlan(
+        parameterization.evaluator_identity,
+        program.fingerprint,
+        (
+            _profile_plan(
+                "P1",
+                profile_ordinal=0,
+                offset=0,
+                observed=(10.0, 20.0, 30.0, 40.0),
+                errors=(1.0, 2.0, 1.5, 0.5),
+                mask=(True, True, True, True),
+            ),
+            _profile_plan(
+                "P2",
+                profile_ordinal=1,
+                offset=4,
+                observed=(50.0,),
+                errors=(2.5,),
+                mask=(False,),
+            ),
+        ),
+        ("A", "B"),
+    )
+    dataset = ResamplingDatasetManifest(
+        evaluation_plan,
+        (11.0, 19.0, 31.0, 39.0, 49.0),
+        (True, True, False, False, False),
+        ("N1", "N1", "N2", "N3", "N3"),
+        (
+            "position=100",
+            "position=200",
+            "position=300",
+            "position=400",
+            "position=500",
+        ),
+    )
+    snapshot = AnalysisValuesSnapshot(
+        "source-occurrence",
+        "model",
+        "definitions",
+        "configuration",
+        4,
+        (("A", 1.0), ("B", 2.0)),
+    )
+    problem = OptimizationProblem(
+        evaluation_plan.identity,
+        parameterization.identity,
+        parameterization.evaluator_identity,
+        program.fingerprint,
+        "configuration",
+        snapshot,
+        (("A", 1.0), ("B", 2.0)),
+        ("A", "B"),
+        (),
+        (1.0, 2.0),
+        (-100.0, -100.0),
+        (100.0, 100.0),
+        ("A", "B"),
+    )
     result = EvaluationResult(
-        plan_identity="accepted-plan",
-        parameterization_identity="accepted-parameterization",
-        evaluator_compatibility_identity="accepted-evaluator",
-        resolved_values=ResolvedEvaluationValues(
-            "accepted-parameterization",
-            "accepted-program",
+        evaluation_plan.identity,
+        parameterization.evaluator_identity,
+        parameterization.evaluator_identity,
+        ResolvedEvaluationValues(
+            parameterization.evaluator_identity,
+            program.fingerprint,
             (("A", 1.0), ("B", 2.0)),
         ),
-        unscaled_calculations=np.array([1.0]),
-        normalized_calculations=np.array([1.0]),
-        residuals=np.array([0.0]),
-        profiles=(),
+        np.array(dataset.calculated),
+        np.array(dataset.calculated),
+        np.array((1.0, -0.5, 2.0 / 3.0, -2.0)),
+        (),
     )
-    return AcceptedFitResult.for_qualification(
+    accepted = AcceptedFitResult.for_qualification(
         occurrence_identity="accepted-occurrence",
-        problem_identity="accepted-problem",
+        problem_identity=problem.identity,
         invocation_identity="accepted-invocation",
         execution_identity="accepted-execution",
         materialization_identity="accepted-materialization",
-        parameterization_identity="accepted-parameterization",
-        evaluator_parameterization_identity="accepted-parameterization",
-        source_occurrence_identity="source-occurrence",
-        source_revision=4,
-        controlled_ids=("A", "B"),
-        vector=(1.0, 2.0),
+        parameterization_identity=parameterization.identity,
+        evaluator_parameterization_identity=parameterization.evaluator_identity,
+        source_occurrence_identity=snapshot.occurrence_identity,
+        source_revision=snapshot.revision,
+        controlled_ids=problem.controlled_ids,
+        vector=problem.start,
         chi_square=0.0,
         evaluation_result=result,
-        commit_scope=("A", "B"),
-        commit_items=(("A", 1.0), ("B", 2.0)),
+        commit_scope=problem.commit_scope,
+        commit_items=problem.independent_items,
         origin_context_identity="accepted-origin",
     )
-
-
-def _population() -> ResamplingPopulation:
-    return ResamplingPopulation(
-        source_dataset_identity="qualification-dataset",
-        observed=(10.0, 20.0, 30.0, 40.0, 50.0),
-        calculated=(11.0, 19.0, 31.0, 39.0, 49.0),
-        standard_errors=(1.0, 2.0, 1.5, 0.5, 2.5),
-        mask=(True, True, True, True, False),
-        references=(True, True, False, False, False),
-        nucleus_groups=("N1", "N1", "N2", "N3", "N3"),
-        profile_blocks=("P1", "P1", "P1", "P1", "P2"),
-    )
+    return accepted, dataset, problem, parameterization
 
 
 def _plan(
-    accepted: AcceptedFitResult,
     scheme: ResamplingScheme,
     *,
     count: int = 4,
-) -> ResamplingPlan:
-    return ResamplingPlan.for_accepted(
+    minimum: int = 2,
+) -> tuple[AcceptedFitResult, ResamplingPlan]:
+    accepted, dataset, problem, parameterization = _native_context()
+    plan = ResamplingPlan.for_accepted(
         accepted,
+        dataset=dataset,
+        source_problem=problem,
+        parameterization=parameterization,
         scheme=scheme,
         replicate_count=count,
         replicate_structural_identities=tuple(
@@ -106,51 +238,75 @@ def _plan(
             (f"component-{ordinal}",) for ordinal in range(count)
         ),
         root_seed=0x1234_5678_90AB_CDEF,
-        source_dataset_identity="qualification-dataset",
         output_scope=("A", "B"),
-        optimization_projection_identity="direct-trf-projection-v1",
-        minimum_successful_count=2,
+        output_units=("arbitrary", "arbitrary"),
+        minimum_successful_count=minimum,
+        strategy=OptimizationStrategy.DIRECT_TRF,
+        strategy_settings=(("objective_request_budget", "80"),),
+    )
+    return accepted, plan
+
+
+def _success(
+    prepared: ReplicateExecutionPlan,
+    *,
+    constant_b: bool = False,
+) -> ProjectedOptimizationSuccess:
+    ordinal = prepared.request.ordinal
+    return ProjectedOptimizationSuccess.for_prepared(
+        prepared,
+        candidate_vector=(float(ordinal + 1), 5.0 if constant_b else 10.0 - ordinal),
+        chi_square=float(ordinal + 1),
     )
 
 
-def _successful_projection(
-    offset: float = 0.0,
-) -> Callable[[ReplicateRequest, ResamplingDraw], ProjectedOptimizationSuccess]:
-    def execute(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationSuccess:
-        ordinal = request.ordinal
-        return ProjectedOptimizationSuccess(
-            transformed_data_identity=draw.identity,
-            optimization_projection_identity=request.optimization_projection_identity,
-            evaluation_plan_identity=f"plan-{ordinal}",
-            problem_identity=f"problem-{ordinal}",
-            invocation_identity=f"invocation-{ordinal}",
-            execution_identity=f"execution-{ordinal}",
-            strategy=OptimizationStrategy.DIRECT_TRF,
-            component_identities=request.component_identities,
-            component_outcome_identities=(f"component-{ordinal}",),
-            resolved_items=(("A", offset + ordinal + 1.0), ("B", 10.0 - ordinal)),
-            chi_square=float(ordinal + 1),
-        )
+def _successful_factory(
+    *, constant_b: bool = False
+) -> Callable[
+    [ReplicateExecutionPlan],
+    Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess],
+]:
+    def factory(
+        _prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        return lambda exact: _success(exact, constant_b=constant_b)
 
-    return execute
+    return factory
+
+
+def _request(
+    dataset: ResamplingDatasetManifest,
+    scheme: ResamplingScheme,
+    seed: int,
+) -> ReplicateRequest:
+    return ReplicateRequest(
+        "generation-plan",
+        dataset.identity,
+        scheme,
+        "chemex-mc-bs-bsn-v1",
+        0,
+        "generation-replicate",
+        "generation-projection",
+        ("generation-component",),
+        seed,
+    )
 
 
 def test_replicate_plan_uses_canonical_ordinals_and_identity_derived_seeds() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO)
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
 
     assert tuple(request.ordinal for request in plan.replicates) == (0, 1, 2, 3)
     assert len({request.identity for request in plan.replicates}) == 4
     assert len({request.seed for request in plan.replicates}) == 4
-    assert plan == _plan(accepted, ResamplingScheme.MONTE_CARLO)
+    assert plan.source_dataset_identity == plan.dataset.identity
 
     reordered = ResamplingPlan.for_accepted(
         accepted,
-        scheme=ResamplingScheme.MONTE_CARLO,
-        replicate_count=4,
+        dataset=plan.dataset,
+        source_problem=plan.source_problem,
+        parameterization=plan.parameterization,
+        scheme=plan.scheme,
+        replicate_count=plan.replicate_count,
         replicate_structural_identities=tuple(
             reversed(plan.replicate_structural_identities)
         ),
@@ -158,70 +314,76 @@ def test_replicate_plan_uses_canonical_ordinals_and_identity_derived_seeds() -> 
             reversed(plan.replicate_component_identities)
         ),
         root_seed=plan.root_seed,
-        source_dataset_identity=plan.source_dataset_identity,
         output_scope=plan.output_scope,
-        optimization_projection_identity=plan.optimization_projection_identity,
+        output_units=plan.output_units,
         minimum_successful_count=plan.minimum_successful_count,
+        strategy=plan.strategy,
+        strategy_settings=plan.strategy_settings,
     )
-    assert reordered == plan
-
-    changed = ResamplingPlan.for_accepted(
-        accepted,
-        scheme=ResamplingScheme.MONTE_CARLO,
-        replicate_count=4,
-        replicate_structural_identities=(
-            "qualification-replicate-alpha",
-            "qualification-replicate-beta",
-            "qualification-replicate-gamma",
-            "qualification-replicate-delta",
-        ),
-        replicate_component_identities=tuple(
-            (f"component-{ordinal}",) for ordinal in range(4)
-        ),
-        root_seed=0x1234_5678_90AB_CDEE,
-        source_dataset_identity="qualification-dataset",
-        output_scope=("A", "B"),
-        optimization_projection_identity="direct-trf-projection-v1",
-        minimum_successful_count=2,
-    )
-    assert tuple(request.seed for request in changed.replicates) != tuple(
-        request.seed for request in plan.replicates
+    assert reordered.identity == plan.identity
+    assert tuple(item.seed for item in reordered.replicates) == tuple(
+        item.seed for item in plan.replicates
     )
 
 
-def test_execution_rejects_a_different_source_dataset_lineage() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO)
-    mismatched = dataclasses.replace(
-        _population(),
-        source_dataset_identity="other-dataset",
+def test_altered_source_calculation_cannot_rebind_the_accepted_native_result() -> None:
+    accepted, dataset, problem, parameterization = _native_context()
+    altered = dataclasses.replace(
+        dataset,
+        calculated=(12.0, *dataset.calculated[1:]),
     )
 
-    with pytest.raises(ResamplingConstructionError, match="source dataset"):
-        execute_resampling_evidence(
+    with pytest.raises(ResamplingConstructionError, match="accepted native lineage"):
+        ResamplingPlan.for_accepted(
             accepted,
-            plan,
-            mismatched,
-            _successful_projection(),
+            dataset=altered,
+            source_problem=problem,
+            parameterization=parameterization,
+            scheme=ResamplingScheme.MONTE_CARLO,
+            replicate_count=1,
+            replicate_structural_identities=("altered-source",),
+            replicate_component_identities=(("component",),),
+            root_seed=7,
+            output_scope=("A", "B"),
+            output_units=("arbitrary", "arbitrary"),
+            minimum_successful_count=1,
         )
 
 
+def test_source_dataset_record_rejects_an_altered_observation_with_stale_identity() -> (
+    None
+):
+    _accepted, dataset, _problem, _parameterization = _native_context()
+    first_profile = dataset.evaluation_plan.profiles[0]
+    changed_plan = dataclasses.replace(
+        dataset.evaluation_plan,
+        profiles=(
+            dataclasses.replace(
+                first_profile,
+                experimental_values=(
+                    first_profile.experimental_values[0] + 0.5,
+                    *first_profile.experimental_values[1:],
+                ),
+            ),
+            *dataset.evaluation_plan.profiles[1:],
+        ),
+    )
+    altered = dataclasses.replace(dataset, evaluation_plan=changed_plan)
+
+    assert altered.identity != dataset.identity
+    record = altered.to_record()
+    record["identity"] = dataset.identity
+    with pytest.raises(ValueError, match="identity"):
+        ResamplingDatasetManifest.from_record(record)
+
+
 def test_seeded_generation_preserves_mc_bs_and_bsn_scientific_schemes() -> None:
-    population = _population()
+    _accepted, dataset, _problem, _parameterization = _native_context()
 
     mc = generate_resampling_draw(
-        population,
-        ResamplingScheme.MONTE_CARLO,
-        seed=101,
+        dataset,
+        _request(dataset, ResamplingScheme.MONTE_CARLO, 101),
     )
-    assert mc == generate_resampling_draw(
-        population,
-        ResamplingScheme.MONTE_CARLO,
-        seed=101,
-    )
-    assert mc.source_indices == tuple(range(5))
-    assert mc.standard_errors == population.standard_errors
-    assert mc.observations != population.calculated
     np.testing.assert_allclose(
         mc.observations,
         (
@@ -234,273 +396,392 @@ def test_seeded_generation_preserves_mc_bs_and_bsn_scientific_schemes() -> None:
         rtol=0.0,
         atol=1.0e-14,
     )
+    assert mc.source_indices == tuple(range(5))
 
     bootstrap = generate_resampling_draw(
-        population,
-        ResamplingScheme.BOOTSTRAP,
-        seed=202,
+        dataset,
+        _request(dataset, ResamplingScheme.BOOTSTRAP, 202),
     )
-    masked_targets = tuple(
-        index for index, value in enumerate(population.mask) if value
-    )
-    assert tuple(
-        population.references[source]
-        for source in bootstrap.source_indices[: len(masked_targets)]
-    ) == tuple(population.references[target] for target in masked_targets)
-    assert bootstrap.source_indices[-1] == 4
-    assert bootstrap.observations[-1] == population.observed[-1]
     assert bootstrap.source_indices == (0, 0, 2, 2, 4)
+    assert all(
+        dataset.profile_blocks[target] == dataset.profile_blocks[source]
+        for target, source in enumerate(bootstrap.source_indices)
+    )
+    assert all(
+        dataset.references[target] == dataset.references[source]
+        for target, source in enumerate(bootstrap.source_indices)
+    )
 
     nucleus = generate_resampling_draw(
-        population,
-        ResamplingScheme.NUCLEUS_BOOTSTRAP,
-        seed=303,
+        dataset,
+        _request(dataset, ResamplingScheme.NUCLEUS_BOOTSTRAP, 303),
     )
-    assert len(nucleus.sampled_nucleus_groups) == 3
-    assert set(nucleus.sampled_nucleus_groups) <= {"N1", "N2", "N3"}
-    expected_sources = tuple(
-        index
-        for group in nucleus.sampled_nucleus_groups
-        for index, source_group in enumerate(population.nucleus_groups)
-        if source_group == group
-    )
-    assert nucleus.source_indices == expected_sources
     assert nucleus.sampled_nucleus_groups == ("N2", "N1", "N3")
     assert nucleus.source_indices == (2, 0, 1, 3, 4)
 
 
-def test_bootstrap_resamples_each_profile_reference_pool_independently() -> None:
-    population = ResamplingPopulation(
-        source_dataset_identity="blocked-dataset",
-        observed=(10.0, 11.0, 20.0, 21.0),
-        calculated=(10.0, 11.0, 20.0, 21.0),
-        standard_errors=(1.0, 1.0, 1.0, 1.0),
-        mask=(True, True, True, True),
-        references=(True, False, True, False),
-        nucleus_groups=("N1", "N1", "N2", "N2"),
-        profile_blocks=("P1", "P1", "P2", "P2"),
-    )
-    draw = generate_resampling_draw(
-        population,
-        ResamplingScheme.BOOTSTRAP,
-        seed=404,
+def test_altered_generated_observation_cannot_retain_or_rebind_draw_identity() -> None:
+    _accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    request = plan.replicates[0]
+    draw = generate_resampling_draw(plan.dataset, request)
+    altered = dataclasses.replace(
+        draw,
+        observations=(draw.observations[0] + 1.0, *draw.observations[1:]),
     )
 
+    assert altered.identity != draw.identity
+    with pytest.raises(ResamplingConstructionError, match="canonical seeded"):
+        ReplicateExecutionPlan.prepare(plan, request, altered)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "foreign_value"),
+    (
+        ("accepted_result_identity", "foreign-accepted-result"),
+        ("accepted_occurrence_identity", "foreign-accepted-occurrence"),
+        ("source_snapshot_occurrence_identity", "foreign-source-snapshot"),
+        ("source_snapshot_revision", 99),
+        ("evaluation_plan_identity", "foreign-evaluation-plan"),
+        ("problem_identity", "foreign-problem"),
+        ("parameterization_identity", "foreign-parameterization"),
+        ("invocation_identity", "foreign-invocation"),
+        ("execution_identity", "foreign-execution"),
+        ("workflow_identity", "foreign-workflow"),
+        ("strategy", OptimizationStrategy.DE_DIRECT_TRF),
+        ("component_identities", ("foreign-component",)),
+        ("component_outcome_identities", ("foreign-component-outcome",)),
+        ("candidate_identity", "foreign-candidate"),
+        ("materialization_identity", "foreign-materialization"),
+        ("evaluation_identity", "foreign-evaluation"),
+        ("prepared_replicate_identity", "foreign-prepared-replicate"),
+        ("requested_output_units", ("foreign-unit", "foreign-unit")),
+    ),
+)
+def test_foreign_native_lineage_never_enters_successful_evidence(
+    field_name: str,
+    foreign_value: object,
+) -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+
+    def factory(
+        _prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        def execute(exact: ReplicateExecutionPlan) -> ProjectedOptimizationSuccess:
+            return dataclasses.replace(
+                _success(exact),
+                **{field_name: foreign_value},
+            )
+
+        return execute
+
+    operation = execute_resampling_evidence(accepted, plan, factory)
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 0
+    assert all(outcome.success is None for outcome in operation.evidence.outcomes)
     assert all(
-        population.profile_blocks[target] == population.profile_blocks[source]
-        for target, source in enumerate(draw.source_indices)
+        outcome.failure is not None
+        and outcome.failure.stage is ReplicateStage.VALIDATING
+        for outcome in operation.evidence.outcomes
     )
+
+
+def test_incomplete_requested_scope_never_enters_successful_evidence() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+
+    def factory(
+        _prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        return lambda exact: dataclasses.replace(
+            _success(exact),
+            requested_output_scope=("A",),
+            requested_output_units=("arbitrary",),
+        )
+
+    operation = execute_resampling_evidence(accepted, plan, factory)
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 0
     assert all(
-        population.references[target] == population.references[source]
-        for target, source in enumerate(draw.source_indices)
+        outcome.failure is not None
+        and outcome.failure.category == "requested_scope_lineage_mismatch"
+        for outcome in operation.evidence.outcomes
     )
 
 
-def test_resampling_execution_is_evidence_only_scope_complete_and_worker_stable() -> (
+def test_foreign_transformed_data_with_correct_values_and_dimensions_fails_closed() -> (
     None
 ):
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO)
-    population = _population()
+    accepted, plan = _plan(ResamplingScheme.BOOTSTRAP, count=2)
 
+    def factory(
+        _prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        return lambda exact: dataclasses.replace(
+            _success(exact),
+            transformed_data_identity="foreign-draw-with-identical-values",
+        )
+
+    operation = execute_resampling_evidence(accepted, plan, factory)
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 0
+    assert all(
+        outcome.failure is not None
+        and outcome.failure.category == "transformed_data_lineage_mismatch"
+        for outcome in operation.evidence.outcomes
+    )
+
+
+def test_candidate_is_freshly_resolved_and_no_fit_or_commit_authority_is_exposed() -> (
+    None
+):
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    before = accepted
+    prepared_problems: list[OptimizationProblem] = []
+
+    def factory(
+        prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        prepared_problems.append(prepared.problem)
+        return lambda exact: _success(exact)
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        factory,
+    )
+
+    assert accepted is before
+    assert operation.evidence is not None
+    assert tuple(
+        outcome.success.resolved_items
+        for outcome in operation.evidence.outcomes
+        if outcome.success is not None
+    ) == ((("A", 1.0), ("B", 10.0)), (("A", 2.0), ("B", 9.0)))
+    assert all(
+        not outcome.success or not hasattr(outcome.success, "accepted_result")
+        for outcome in operation.evidence.outcomes
+    )
+    assert all(
+        not outcome.success or not hasattr(outcome.success, "commit_authority")
+        for outcome in operation.evidence.outcomes
+    )
+    assert all(not problem.acceptance_authority for problem in prepared_problems)
+
+
+def test_out_of_bounds_candidate_fails_fresh_problem_resolution() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+
+    def factory(
+        _prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        return lambda exact: dataclasses.replace(
+            _success(exact),
+            candidate_vector=(101.0, 5.0),
+        )
+
+    operation = execute_resampling_evidence(accepted, plan, factory)
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 0
+    assert all(
+        outcome.failure is not None
+        and outcome.failure.category == "candidate_resolution_failure"
+        and outcome.stage is ReplicateStage.VALIDATING
+        for outcome in operation.evidence.outcomes
+    )
+
+
+class _SingleOwnerExecutor:
+    def __init__(
+        self,
+        prepared: ReplicateExecutionPlan,
+        owners: list[tuple[object, int, int]],
+        owner_lock: Lock,
+        releases: tuple[Event, ...] | None,
+    ) -> None:
+        self.prepared = prepared
+        self.owners = owners
+        self.owner_lock = owner_lock
+        self.releases = releases
+        self.used = False
+
+    def __call__(self, exact: ReplicateExecutionPlan) -> ProjectedOptimizationSuccess:
+        if self.used or exact is not self.prepared:
+            raise RuntimeError("executor/workspace reused across replicates")
+        self.used = True
+        ordinal = exact.request.ordinal
+        if self.releases is not None:
+            if ordinal + 1 < len(self.releases):
+                assert self.releases[ordinal + 1].wait(timeout=1.0)
+            self.releases[ordinal].set()
+        with self.owner_lock:
+            self.owners.append((self, ordinal, get_ident()))
+        return _success(exact)
+
+
+def _isolated_factory(
+    owners: list[tuple[object, int, int]],
+    owner_lock: Lock,
+    releases: tuple[Event, ...] | None = None,
+) -> Callable[[ReplicateExecutionPlan], _SingleOwnerExecutor]:
+    return lambda prepared: _SingleOwnerExecutor(
+        prepared,
+        owners,
+        owner_lock,
+        releases,
+    )
+
+
+def test_serial_and_reordered_multi_worker_execution_use_fresh_single_owners() -> None:
+    accepted, plan = _plan(ResamplingScheme.NUCLEUS_BOOTSTRAP)
+    serial_owners: list[tuple[object, int, int]] = []
+    parallel_owners: list[tuple[object, int, int]] = []
     serial = execute_resampling_evidence(
         accepted,
         plan,
-        population,
-        _successful_projection(),
+        _isolated_factory(serial_owners, Lock()),
         execution=ExecutionSettings(workers=1),
     )
+    releases = tuple(Event() for _ in plan.replicates)
     parallel = execute_resampling_evidence(
         accepted,
         plan,
-        population,
-        _successful_projection(),
-        execution=ExecutionSettings(workers=3),
+        _isolated_factory(parallel_owners, Lock(), releases),
+        execution=ExecutionSettings(workers=4),
     )
 
     assert serial.evidence is not None
     assert parallel.evidence is not None
     assert serial.evidence.identity == parallel.evidence.identity
-    assert tuple(outcome.ordinal for outcome in serial.evidence.outcomes) == (
+    assert len({item[0] for item in serial_owners}) == plan.replicate_count
+    assert len({item[0] for item in parallel_owners}) == plan.replicate_count
+    assert tuple(item[1] for item in parallel_owners) == (3, 2, 1, 0)
+    assert tuple(outcome.ordinal for outcome in parallel.evidence.outcomes) == (
         0,
         1,
         2,
         3,
     )
-    assert all(
-        outcome.disposition is ReplicateDisposition.SUCCEEDED
-        for outcome in serial.evidence.outcomes
+    assert tuple(item.seed for item in serial.evidence.plan.replicates) == tuple(
+        item.seed for item in parallel.evidence.plan.replicates
     )
-    assert all(outcome.success is not None for outcome in serial.evidence.outcomes)
-    assert all(
-        outcome.success.resolved_items == tuple(outcome.success.resolved_items)
-        and tuple(param_id for param_id, _value in outcome.success.resolved_items)
-        == plan.output_scope
-        for outcome in serial.evidence.outcomes
-        if outcome.success is not None
+
+
+def test_one_executor_failure_does_not_corrupt_other_replicate_evidence() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
+
+    def factory(
+        prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        if prepared.request.ordinal == 1:
+            return lambda _exact: (_ for _ in ()).throw(RuntimeError("owner failed"))
+        return lambda exact: _success(exact)
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        factory,
+        execution=ExecutionSettings(workers=3),
     )
-    assert not hasattr(serial.evidence, "accepted_result")
-    assert not hasattr(serial.evidence, "commit_authority")
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 3
+    assert operation.evidence.outcomes[1].failure is not None
+    assert (
+        operation.evidence.outcomes[1].failure.category == "projected_execution_failure"
+    )
 
 
-def test_projection_and_complete_component_lineage_fail_closed() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=2)
+@pytest.mark.parametrize("workers", (1, 3))
+def test_shared_executor_instance_is_rejected_by_single_owner_contract(
+    workers: int,
+) -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
 
-    def wrong_projection(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationSuccess:
-        success = _successful_projection()(request, draw)
-        return dataclasses.replace(
-            success,
-            optimization_projection_identity="different-projection",
+    def shared(exact: ReplicateExecutionPlan) -> ProjectedOptimizationSuccess:
+        return _success(exact)
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        lambda _prepared: shared,
+        execution=ExecutionSettings(workers=workers),
+    )
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 1
+    assert (
+        sum(
+            outcome.failure is not None
+            and outcome.failure.category == "executor_creation_failure"
+            for outcome in operation.evidence.outcomes
         )
-
-    projection_operation = execute_resampling_evidence(
-        accepted,
-        plan,
-        _population(),
-        wrong_projection,
-    )
-    assert projection_operation.evidence is not None
-    assert all(
-        outcome.failure is not None
-        and outcome.failure.category == "optimization_projection_lineage_mismatch"
-        for outcome in projection_operation.evidence.outcomes
-    )
-
-    def missing_component(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationSuccess:
-        success = _successful_projection()(request, draw)
-        return dataclasses.replace(success, component_identities=("other-component",))
-
-    component_operation = execute_resampling_evidence(
-        accepted,
-        plan,
-        _population(),
-        missing_component,
-    )
-    assert component_operation.evidence is not None
-    assert all(
-        outcome.failure is not None
-        and outcome.failure.category == "incomplete_component_projection"
-        for outcome in component_operation.evidence.outcomes
+        == plan.replicate_count - 1
     )
 
 
-def test_multi_worker_cancellation_freezes_completed_partial_evidence() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=4)
-    first_completed = Event()
-    release_remaining = Event()
+def test_partial_evidence_preserves_unstarted_ordinals_and_valid_summary() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
+    calls = 0
 
-    def project(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationSuccess:
-        if request.ordinal == 0:
-            result = _successful_projection()(request, draw)
-            first_completed.set()
-            return result
-        release_remaining.wait(timeout=0.2)
-        return _successful_projection()(request, draw)
+    def factory(
+        _prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        def execute(exact: ReplicateExecutionPlan) -> ProjectedOptimizationSuccess:
+            nonlocal calls
+            calls += 1
+            return _success(exact)
+
+        return execute
 
     operation = execute_resampling_evidence(
         accepted,
         plan,
-        _population(),
-        project,
-        execution=ExecutionSettings(workers=2),
-        cancellation_probe=first_completed.is_set,
+        factory,
+        cancellation_probe=lambda: calls >= 2,
     )
-    release_remaining.set()
 
-    assert operation.terminal.value == "cancelled"
     assert operation.evidence is not None
-    terminal_ordinals = tuple(
-        outcome.ordinal for outcome in operation.evidence.outcomes
-    )
-    assert 0 in terminal_ordinals
-    assert set(terminal_ordinals).isdisjoint(operation.unstarted_ordinals)
-    assert tuple(sorted((*terminal_ordinals, *operation.unstarted_ordinals))) == (
+    assert operation.evidence.completed_count == 2
+    assert operation.evidence.lifecycle is ResamplingLifecycle.CANCELLED
+    assert operation.unstarted_ordinals == (2, 3)
+    assert tuple(outcome.ordinal for outcome in operation.evidence.outcomes) == (
         0,
         1,
         2,
         3,
     )
+    assert all(
+        operation.evidence.outcomes[index].disposition
+        is ReplicateDisposition.NOT_STARTED
+        for index in operation.unstarted_ordinals
+    )
+    summary = summarize_resampling_evidence(operation.evidence)
+    assert summary.terminal is SummaryTerminal.COMPLETED
+    assert summary.summary is not None
+    assert summary.summary.unstarted_ordinals == (2, 3)
 
 
-def test_failed_replicates_remain_typed_and_summary_uses_one_common_scope() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.BOOTSTRAP, count=3)
-    population = _population()
-
-    def project(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationResult:
-        if request.ordinal == 1:
-            return ProjectedOptimizationFailure(
-                transformed_data_identity=draw.identity,
-                optimization_projection_identity=(
-                    request.optimization_projection_identity
-                ),
-                disposition=ReplicateDisposition.FAILED,
-                category="solver_unsuccessful",
-                message="declared local budget exhausted",
-                evaluation_plan_identity="plan-1",
-                problem_identity="problem-1",
-                execution_identity="execution-1",
-            )
-        return _successful_projection()(request, draw)
-
+def test_summary_numerical_references_and_zero_variance_are_canonical() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=3)
     operation = execute_resampling_evidence(
         accepted,
         plan,
-        population,
-        project,
-        execution=ExecutionSettings(workers=2),
+        _successful_factory(constant_b=True),
     )
     assert operation.evidence is not None
-    evidence = operation.evidence
-    assert tuple(outcome.disposition for outcome in evidence.outcomes) == (
-        ReplicateDisposition.SUCCEEDED,
-        ReplicateDisposition.FAILED,
-        ReplicateDisposition.SUCCEEDED,
-    )
-    assert evidence.completed_count == 3
-    assert evidence.successful_count == 2
-    assert evidence.failed_count == 1
-    assert evidence.claim("MINIMUM_SUCCESSFUL_COVERAGE") is ClaimState.SATISFIED
-    assert evidence.claim("COMPLETE_SCOPE_SUCCESS_ROWS") is ClaimState.SATISFIED
-
-    summary_outcome = summarize_resampling_evidence(evidence)
-    assert summary_outcome.terminal is SummaryTerminal.COMPLETED
-    assert summary_outcome.summary is not None
-    summary = summary_outcome.summary
-    assert summary.included_ordinals == (0, 2)
-    assert summary.claim("COMMON_SCOPE_INCLUSION") is ClaimState.SATISFIED
-    assert summary.claim("MINIMUM_SUCCESSFUL_COVERAGE") is ClaimState.SATISFIED
-    assert tuple(item.ordinal for item in summary.exclusions) == (1,)
-    assert all(row.ordinal in summary.included_ordinals for row in summary.samples)
-    assert all(
-        tuple(param_id for param_id, _value in row.items) == plan.output_scope
-        for row in summary.samples
-    )
-    assert all(
-        entry.value is None or np.isfinite(entry.value)
-        for entry in summary.correlations
-    )
+    outcome = summarize_resampling_evidence(operation.evidence)
+    assert outcome.summary is not None
+    summary = outcome.summary
     distributions = {item.parameter_id: item for item in summary.distributions}
+    # Small exact values use stable binary64 reductions; this absolute tolerance is
+    # roughly one ulp here and detects any change of estimator or percentile policy.
     assert distributions["A"].mean == pytest.approx(2.0, rel=0.0, abs=1.0e-15)
     assert distributions["A"].standard_deviation == pytest.approx(
-        np.sqrt(2.0), rel=0.0, abs=1.0e-15
+        1.0, rel=0.0, abs=1.0e-15
     )
-    # These small exact inputs exercise only stable binary64 reductions; one ulp-scale
-    # absolute tolerance avoids asserting on representation noise without hiding drift.
     assert distributions["A"].median == pytest.approx(2.0, rel=0.0, abs=1.0e-15)
     assert distributions["A"].percentile_95_lower == pytest.approx(
         1.05, rel=0.0, abs=1.0e-15
@@ -511,196 +792,234 @@ def test_failed_replicates_remain_typed_and_summary_uses_one_common_scope() -> N
     covariance = {
         (item.parameter_a, item.parameter_b): item.value for item in summary.covariance
     }
-    assert covariance[("A", "A")] == pytest.approx(2.0, rel=0.0, abs=1.0e-15)
-    assert covariance[("A", "B")] == pytest.approx(-2.0, rel=0.0, abs=1.0e-15)
-    correlations = {
-        (item.parameter_a, item.parameter_b): item.value
-        for item in summary.correlations
-    }
-    assert correlations[("A", "B")] == pytest.approx(-1.0, rel=0.0, abs=1.0e-15)
-
-
-def test_zero_variance_correlation_is_typed_without_nan() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=2)
-
-    def project(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationSuccess:
-        return ProjectedOptimizationSuccess(
-            transformed_data_identity=draw.identity,
-            optimization_projection_identity=request.optimization_projection_identity,
-            evaluation_plan_identity=f"plan-{request.ordinal}",
-            problem_identity=f"problem-{request.ordinal}",
-            invocation_identity=f"invocation-{request.ordinal}",
-            execution_identity=f"execution-{request.ordinal}",
-            strategy=OptimizationStrategy.DIRECT_TRF,
-            component_identities=request.component_identities,
-            component_outcome_identities=(f"component-{request.ordinal}",),
-            resolved_items=(("A", float(request.ordinal)), ("B", 5.0)),
-            chi_square=1.0,
-        )
-
-    operation = execute_resampling_evidence(
-        accepted,
-        plan,
-        _population(),
-        project,
-    )
-    assert operation.evidence is not None
-    outcome = summarize_resampling_evidence(operation.evidence)
-    assert outcome.summary is not None
+    assert covariance[("A", "A")] == pytest.approx(1.0, rel=0.0, abs=1.0e-15)
+    assert covariance[("A", "B")] == pytest.approx(0.0, rel=0.0, abs=1.0e-15)
     b_entries = tuple(
-        entry for entry in outcome.summary.correlations if entry.parameter_b == "B"
+        entry
+        for entry in summary.correlations
+        if entry.parameter_a == "B" or entry.parameter_b == "B"
     )
-    assert all(entry.value is None for entry in b_entries)
-
-
-def test_partial_evidence_and_summary_publish_only_under_declared_contract() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.NUCLEUS_BOOTSTRAP, count=4)
-    population = _population()
-
-    calls = 0
-
-    def cancel_after_one() -> bool:
-        return calls >= 1
-
-    def project(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationSuccess:
-        nonlocal calls
-        calls += 1
-        return _successful_projection()(request, draw)
-
-    operation = execute_resampling_evidence(
-        accepted,
-        plan,
-        population,
-        project,
-        execution=ExecutionSettings(workers=1),
-        cancellation_probe=cancel_after_one,
+    assert all(
+        entry.availability is CorrelationAvailability.ZERO_VARIANCE
+        and entry.value is None
+        for entry in b_entries
     )
+
+
+def test_summary_record_rejects_every_independent_tampering_vector() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=3)
+    operation = execute_resampling_evidence(accepted, plan, _successful_factory())
     assert operation.evidence is not None
-    assert operation.evidence.completed_count == 1
-    assert operation.evidence.successful_count == 1
-    assert operation.evidence.lifecycle is ResamplingLifecycle.CANCELLED
-    assert (
-        operation.evidence.claim("MINIMUM_SUCCESSFUL_COVERAGE") is ClaimState.VIOLATED
-    )
-    assert operation.unstarted_ordinals == (1, 2, 3)
-
-    summary_outcome = summarize_resampling_evidence(operation.evidence)
-    assert summary_outcome.terminal is SummaryTerminal.INSUFFICIENT_COVERAGE
-    assert summary_outcome.summary is None
-    assert summary_outcome.failure is not None
-
-
-def test_valid_partial_summary_records_unstarted_requested_ordinals() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=4)
-    calls = 0
-
-    def project(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationSuccess:
-        nonlocal calls
-        calls += 1
-        return _successful_projection()(request, draw)
-
-    operation = execute_resampling_evidence(
-        accepted,
-        plan,
-        _population(),
-        project,
-        cancellation_probe=lambda: calls >= 2,
-    )
-    assert operation.evidence is not None
-    outcome = summarize_resampling_evidence(operation.evidence)
-    assert outcome.terminal is SummaryTerminal.COMPLETED
+    policy = ResamplingSummaryPolicy()
+    outcome = summarize_resampling_evidence(operation.evidence, policy)
     assert outcome.summary is not None
-    assert outcome.summary.unstarted_ordinals == (2, 3)
+    summary = outcome.summary
+    evidence = operation.evidence
 
-    initially_cancelled = execute_resampling_evidence(
-        accepted,
-        plan,
-        _population(),
-        project,
-        execution=ExecutionSettings(workers=1),
-        cancellation_probe=lambda: True,
+    def mutate(path: tuple[object, ...], value: object) -> None:
+        record = copy.deepcopy(summary.to_record())
+        target: Any = record
+        for key in path[:-1]:
+            target = target[key]
+        target[path[-1]] = value
+        with pytest.raises(ResamplingConstructionError, match="canonical"):
+            ResamplingSummary.from_record(record, evidence, policy)
+
+    mutate(("included_ordinals", 0), 2)
+    mutate(("samples", 0, "items", 0, 1), (9.0).hex())
+    mutate(("output_scope", 0), "B")
+    mutate(("output_units", 0), "foreign-unit")
+    mutate(("distributions", 0, "percentile_95_lower"), (0.0).hex())
+    mutate(("covariance", 0, "value"), (99.0).hex())
+    mutate(("correlations", 0, "value"), (0.5).hex())
+    mutate(("correlations", 0, "availability"), "zero_variance")
+    mutate(("evidence_identity",), "foreign-evidence")
+    mutate(("policy_identity",), "foreign-policy")
+    mutate(("claims", 0, "state"), "violated")
+
+    changed_policy = ResamplingSummaryPolicy(percentile_lower=5.0)
+    with pytest.raises(ResamplingConstructionError, match="canonical"):
+        ResamplingSummary.from_record(
+            summary.to_record(),
+            evidence,
+            changed_policy,
+        )
+    with pytest.raises(ResamplingConstructionError, match="evidence identity"):
+        ResamplingSummaryOutcome(
+            SummaryTerminal.COMPLETED,
+            summary=summary,
+            claimed_evidence_identity="foreign-evidence",
+        )
+
+
+def test_summary_constructor_cannot_accept_caller_supplied_arrays_or_claims() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    operation = execute_resampling_evidence(accepted, plan, _successful_factory())
+    assert operation.evidence is not None
+    summary = summarize_resampling_evidence(operation.evidence).summary
+    assert summary is not None
+
+    with pytest.raises(ResamplingConstructionError, match="source evidence"):
+        dataclasses.replace(summary, _construction_key=object())
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_stage", "draw_present"),
+    (
+        (KeyboardInterrupt(), ReplicateStage.GENERATING, False),
+        (RuntimeError("generation failed"), ReplicateStage.GENERATING, False),
+    ),
+)
+def test_pre_draw_generation_terminal_is_typed_and_factory_is_not_created(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+    expected_stage: ReplicateStage,
+    draw_present: bool,
+) -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
+    factory_calls = 0
+
+    def fail_generation(
+        _dataset: ResamplingDatasetManifest,
+        _request: ReplicateRequest,
+    ) -> None:
+        raise failure
+
+    def factory(
+        _prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        nonlocal factory_calls
+        factory_calls += 1
+        return _success
+
+    monkeypatch.setattr(
+        "chemex.optimize.native_resampling.generate_resampling_draw",
+        fail_generation,
     )
-    assert initially_cancelled.evidence is None
-    assert initially_cancelled.unstarted_ordinals == (0, 1, 2, 3)
+    operation = execute_resampling_evidence(accepted, plan, factory)
+
+    assert factory_calls == 0
+    assert operation.evidence is not None
+    first = operation.evidence.outcomes[0]
+    assert first.stage is expected_stage
+    assert (first.draw_identity is not None) is draw_present
+    assert first.disposition is (
+        ReplicateDisposition.INTERRUPTED
+        if isinstance(failure, KeyboardInterrupt)
+        else ReplicateDisposition.FAILED
+    )
+    assert tuple(outcome.ordinal for outcome in operation.evidence.outcomes) == (
+        0,
+        1,
+        2,
+        3,
+    )
+    expected_remaining = (
+        ReplicateDisposition.NOT_STARTED
+        if isinstance(failure, KeyboardInterrupt)
+        else ReplicateDisposition.FAILED
+    )
+    assert all(
+        outcome.disposition is expected_remaining
+        for outcome in operation.evidence.outcomes[1:]
+    )
 
 
-def test_success_payload_rejects_nan_and_non_atomic_scope() -> None:
-    with pytest.raises(ResamplingConstructionError, match="complete output scope"):
-        ProjectedOptimizationSuccess(
-            transformed_data_identity="draw",
-            optimization_projection_identity="projection",
-            evaluation_plan_identity="plan",
-            problem_identity="problem",
-            invocation_identity="invocation",
-            execution_identity="execution",
-            strategy=OptimizationStrategy.DIRECT_TRF,
-            component_identities=("component",),
-            component_outcome_identities=("component",),
-            resolved_items=(("A", 1.0),),
-            chi_square=1.0,
-            expected_output_scope=("A", "B"),
-        )
-    with pytest.raises(ResamplingConstructionError, match="finite"):
-        ProjectedOptimizationSuccess(
-            transformed_data_identity="draw",
-            optimization_projection_identity="projection",
-            evaluation_plan_identity="plan",
-            problem_identity="problem",
-            invocation_identity="invocation",
-            execution_identity="execution",
-            strategy=OptimizationStrategy.DIRECT_TRF,
-            component_identities=("component",),
-            component_outcome_identities=("component",),
-            resolved_items=(("A", np.nan), ("B", 2.0)),
-            chi_square=1.0,
-            expected_output_scope=("A", "B"),
-        )
+def test_interruption_after_draw_before_executor_creation_is_typed() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
+
+    def interrupt_factory(
+        _prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationResult]:
+        raise KeyboardInterrupt
+
+    operation = execute_resampling_evidence(accepted, plan, interrupt_factory)
+
+    assert operation.evidence is not None
+    first = operation.evidence.outcomes[0]
+    assert first.disposition is ReplicateDisposition.INTERRUPTED
+    assert first.stage is ReplicateStage.EXECUTOR_CREATING
+    assert first.draw_identity is not None
+    assert all(
+        outcome.disposition is ReplicateDisposition.NOT_STARTED
+        for outcome in operation.evidence.outcomes[1:]
+    )
 
 
-def test_non_finite_summary_arithmetic_returns_typed_unavailability() -> None:
-    accepted = _accepted_anchor()
-    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=2)
+@pytest.mark.parametrize("workers", (1, 3))
+def test_optimization_interruption_preserves_complete_ordinal_accounting(
+    workers: int,
+) -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
 
-    def project(
-        request: ReplicateRequest,
-        draw: ResamplingDraw,
-    ) -> ProjectedOptimizationSuccess:
-        value = -1.0e308 if request.ordinal == 0 else 1.0e308
-        return ProjectedOptimizationSuccess(
-            transformed_data_identity=draw.identity,
-            optimization_projection_identity=request.optimization_projection_identity,
-            evaluation_plan_identity=f"plan-{request.ordinal}",
-            problem_identity=f"problem-{request.ordinal}",
-            invocation_identity=f"invocation-{request.ordinal}",
-            execution_identity=f"execution-{request.ordinal}",
-            strategy=OptimizationStrategy.DIRECT_TRF,
-            component_identities=request.component_identities,
-            component_outcome_identities=(f"component-{request.ordinal}",),
-            resolved_items=(("A", value), ("B", value)),
-            chi_square=1.0,
-        )
+    def factory(
+        prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationResult]:
+        if prepared.request.ordinal == 0:
+            return lambda _exact: (_ for _ in ()).throw(KeyboardInterrupt())
+        return lambda exact: _success(exact)
 
     operation = execute_resampling_evidence(
         accepted,
         plan,
-        _population(),
-        project,
+        factory,
+        execution=ExecutionSettings(workers=workers),
+    )
+
+    assert operation.evidence is not None
+    assert tuple(outcome.ordinal for outcome in operation.evidence.outcomes) == (
+        0,
+        1,
+        2,
+        3,
+    )
+    interrupted = operation.evidence.outcomes[0]
+    assert interrupted.disposition is ReplicateDisposition.INTERRUPTED
+    assert interrupted.stage is ReplicateStage.EXECUTING
+    assert interrupted.draw_identity is not None
+    assert len(operation.evidence.outcomes) == plan.replicate_count
+
+
+def test_projected_failure_remains_typed_and_summary_uses_common_scope() -> None:
+    accepted, plan = _plan(ResamplingScheme.BOOTSTRAP, count=3)
+
+    def factory(
+        prepared: ReplicateExecutionPlan,
+    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationResult]:
+        if prepared.request.ordinal != 1:
+            return lambda exact: _success(exact)
+
+        def fail(exact: ReplicateExecutionPlan) -> ProjectedOptimizationFailure:
+            return ProjectedOptimizationFailure(
+                exact.draw.identity,
+                ReplicateDisposition.FAILED,
+                "solver_unsuccessful",
+                "declared local budget exhausted",
+                optimization_projection_identity=(
+                    exact.request.optimization_projection_identity
+                ),
+                stage=ReplicateStage.EXECUTING,
+                prepared_replicate_identity=exact.identity,
+                evaluation_plan_identity=exact.evaluation_plan.identity,
+                problem_identity=exact.problem.identity,
+                invocation_identity=exact.invocation_identity,
+            )
+
+        return fail
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        factory,
+        execution=ExecutionSettings(workers=2),
     )
     assert operation.evidence is not None
-    outcome = summarize_resampling_evidence(operation.evidence)
-    assert outcome.terminal is SummaryTerminal.SOURCE_INVALID
-    assert outcome.summary is None
-    assert outcome.failure is not None
-    assert outcome.failure.category == "non_finite_summary_arithmetic"
+    evidence = operation.evidence
+    assert evidence.successful_count == 2
+    assert evidence.failed_count == 1
+    assert evidence.claim("MINIMUM_SUCCESSFUL_COVERAGE") is ClaimState.SATISFIED
+
+    outcome = summarize_resampling_evidence(evidence)
+    assert outcome.summary is not None
+    assert outcome.summary.included_ordinals == (0, 2)
+    assert tuple(item.ordinal for item in outcome.summary.exclusions) == (1,)

--- a/tests/test_native_resampling.py
+++ b/tests/test_native_resampling.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import hashlib
+import json
 from collections.abc import Callable
 from copy import deepcopy
 from threading import Event, Lock
@@ -22,6 +24,7 @@ from chemex.evaluation.native import (
     EvaluationFrame,
     EvaluationPlan,
     EvaluationResult,
+    ResolvedEvaluationValues,
 )
 from chemex.nmr.spectrometer import Spectrometer
 from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
@@ -45,6 +48,7 @@ from chemex.optimize.native_resampling import (
     ResamplingSummaryOutcome,
     ResamplingSummaryPolicy,
     SummaryTerminal,
+    ValidatedReplicateSuccess,
     execute_resampling_evidence,
     generate_resampling_draw,
     summarize_resampling_evidence,
@@ -784,8 +788,10 @@ def test_serial_and_reordered_multi_worker_execution_use_fresh_single_owners(
     assert serial.evidence is not None
     assert parallel.evidence is not None
     assert serial.evidence.identity == parallel.evidence.identity
-    assert serial_engine_count == 2 * plan.replicate_count
-    assert len(engines) == 4 * plan.replicate_count
+    # Each replicate owns optimizer and validation engines; recursive evidence
+    # qualification independently rebinds the immutable compatibility descriptor.
+    assert serial_engine_count == 3 * plan.replicate_count
+    assert len(engines) == 6 * plan.replicate_count
     assert len({id(item) for item in engines}) == len(engines)
     assert serial_evaluator_count >= 2 * plan.replicate_count
     assert len({id(item) for item in evaluators}) == len(evaluators)
@@ -1013,6 +1019,178 @@ def test_summary_constructor_cannot_accept_caller_supplied_arrays_or_claims() ->
     recomputed = dataclasses.replace(summary, policy=changed_policy)
     assert recomputed.policy_identity == changed_policy.identity
     assert recomputed.identity != summary.identity
+
+
+def test_validated_success_cannot_be_retargeted_and_rehashed_into_summary() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    source_values = accepted.evaluation_result.resolved_values.ordered_items()
+    operation = execute_resampling_evidence(accepted, plan)
+    assert operation.evidence is not None
+    outcome = operation.evidence.outcomes[0]
+    assert outcome.success is not None
+
+    for field_name, value in (
+        ("resolved_items", (("A", 999.0), ("B", 999.0))),
+        ("chi_square", 999.0),
+        ("materialization_identity", "forged-materialization"),
+        ("evaluation_identity", "forged-evaluation"),
+        ("output_scope", ("B", "A")),
+        ("output_units", ("wrong", "wrong")),
+        ("claims", ()),
+        ("identity", "forged-success"),
+    ):
+        with pytest.raises(TypeError):
+            dataclasses.replace(outcome.success, **{field_name: value})
+
+    assert accepted.evaluation_result.resolved_values.ordered_items() == source_values
+
+
+def test_summary_revalidates_success_after_post_construction_mutation() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    operation = execute_resampling_evidence(accepted, plan)
+    assert operation.evidence is not None
+    success = operation.evidence.outcomes[0].success
+    assert success is not None
+    altered_snapshot = ResolvedEvaluationValues(
+        success.evaluation_result.resolved_values.parameterization_identity,
+        success.evaluation_result.resolved_values.program_identity,
+        (("A", 999.0), ("B", 999.0)),
+    )
+    object.__setattr__(
+        success,
+        "evaluation_result",
+        dataclasses.replace(
+            success.evaluation_result,
+            resolved_values=altered_snapshot,
+        ),
+    )
+    forged_outcome = dataclasses.replace(
+        operation.evidence.outcomes[0], success=success
+    )
+    with pytest.raises(ResamplingConstructionError):
+        dataclasses.replace(
+            operation.evidence,
+            outcomes=(forged_outcome, *operation.evidence.outcomes[1:]),
+        )
+
+    summary = summarize_resampling_evidence(operation.evidence)
+
+    assert summary.terminal is SummaryTerminal.SOURCE_INVALID
+    assert summary.summary is None
+    assert summary.failure is not None
+    assert summary.failure.category == "invalid_source_evidence"
+
+
+def test_validated_success_record_round_trip_recomputes_every_projection() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    operation = execute_resampling_evidence(accepted, plan)
+    assert operation.evidence is not None
+    success = operation.evidence.outcomes[0].success
+    assert success is not None
+
+    restored = ValidatedReplicateSuccess.from_record(
+        success.to_record(),
+        plan,
+        plan.replicates[0],
+    )
+    restored_outcome = dataclasses.replace(
+        operation.evidence.outcomes[0], success=restored
+    )
+    restored_evidence = dataclasses.replace(
+        operation.evidence,
+        outcomes=(restored_outcome, *operation.evidence.outcomes[1:]),
+    )
+
+    assert restored.to_record() == success.to_record()
+    assert summarize_resampling_evidence(restored_evidence).terminal is (
+        SummaryTerminal.COMPLETED
+    )
+
+
+def test_validated_success_record_rejects_tampered_checked_projections() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    operation = execute_resampling_evidence(accepted, plan)
+    assert operation.evidence is not None
+    success = operation.evidence.outcomes[0].success
+    assert success is not None
+
+    def reject(path: tuple[object, ...], value: object) -> None:
+        record = copy.deepcopy(success.to_record())
+        target: Any = record
+        for key in path[:-1]:
+            target = target[key]
+        target[path[-1]] = value
+        record["identity"] = hashlib.sha256(
+            json.dumps(record, sort_keys=True).encode()
+        ).hexdigest()
+        with pytest.raises(ResamplingConstructionError):
+            ValidatedReplicateSuccess.from_record(
+                record,
+                plan,
+                plan.replicates[0],
+            )
+
+    reject(("resolved_items", 0, 1), (999.0).hex())
+    reject(("chi_square",), (999.0).hex())
+    reject(("materialization_identity",), "forged-materialization")
+    reject(("evaluation_result", "identity"), "forged-evaluation")
+    reject(("output_scope", 0), "B")
+    reject(("output_units", 0), "wrong-unit")
+    reject(("claims", 0, "state"), "violated")
+    reject(("projected", "problem_identity"), "foreign-problem")
+
+
+def test_success_record_rejects_rehashed_altered_complete_resolved_snapshot() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    operation = execute_resampling_evidence(accepted, plan)
+    assert operation.evidence is not None
+    success = operation.evidence.outcomes[0].success
+    assert success is not None
+    altered_snapshot = ResolvedEvaluationValues(
+        success.evaluation_result.resolved_values.parameterization_identity,
+        success.evaluation_result.resolved_values.program_identity,
+        (("A", 999.0), ("B", 999.0)),
+    )
+    altered_evaluation = dataclasses.replace(
+        success.evaluation_result,
+        resolved_values=altered_snapshot,
+    )
+    record = copy.deepcopy(success.to_record())
+    record["evaluation_result"] = altered_evaluation.to_record()
+    record["resolved_items"] = [["A", (999.0).hex()], ["B", (999.0).hex()]]
+    record["identity"] = hashlib.sha256(
+        json.dumps(record, sort_keys=True).encode()
+    ).hexdigest()
+
+    with pytest.raises(ResamplingConstructionError):
+        ValidatedReplicateSuccess.from_record(
+            record,
+            plan,
+            plan.replicates[0],
+        )
+
+
+def test_equivalent_looking_manual_success_without_exact_derivation_fails_closed() -> (
+    None
+):
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    operation = execute_resampling_evidence(accepted, plan)
+    assert operation.evidence is not None
+    first = operation.evidence.outcomes[0]
+    second = operation.evidence.outcomes[1]
+    assert first.success is not None
+    assert second.success is not None
+    manual = object.__new__(ValidatedReplicateSuccess)
+    object.__setattr__(manual, "prepared", first.success.prepared)
+    object.__setattr__(manual, "projected", second.success.projected)
+    object.__setattr__(manual, "evaluation_result", first.success.evaluation_result)
+    forged_outcome = dataclasses.replace(first, success=manual)
+
+    with pytest.raises(ResamplingConstructionError):
+        dataclasses.replace(
+            operation.evidence,
+            outcomes=(forged_outcome, *operation.evidence.outcomes[1:]),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_native_resampling.py
+++ b/tests/test_native_resampling.py
@@ -420,8 +420,17 @@ def test_multi_worker_cancellation_freezes_completed_partial_evidence() -> None:
 
     assert operation.terminal.value == "cancelled"
     assert operation.evidence is not None
-    assert tuple(outcome.ordinal for outcome in operation.evidence.outcomes) == (0,)
-    assert operation.unstarted_ordinals == (1, 2, 3)
+    terminal_ordinals = tuple(
+        outcome.ordinal for outcome in operation.evidence.outcomes
+    )
+    assert 0 in terminal_ordinals
+    assert set(terminal_ordinals).isdisjoint(operation.unstarted_ordinals)
+    assert tuple(sorted((*terminal_ordinals, *operation.unstarted_ordinals))) == (
+        0,
+        1,
+        2,
+        3,
+    )
 
 
 def test_failed_replicates_remain_typed_and_summary_uses_one_common_scope() -> None:

--- a/tests/test_native_resampling.py
+++ b/tests/test_native_resampling.py
@@ -1,0 +1,439 @@
+"""Behavioral qualification tests for native resampling evidence (#599).
+
+The public seams are deterministic replicate planning and data generation,
+evidence-only projected optimization, and scope-atomic summary derivation.  The
+production lmfit runner remains outside this qualification harness.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from chemex.optimize.direct_trf import AcceptedFitResult
+from chemex.optimize.native_resampling import (
+    ClaimState,
+    OptimizationStrategy,
+    ProjectedOptimizationFailure,
+    ProjectedOptimizationResult,
+    ProjectedOptimizationSuccess,
+    ReplicateDisposition,
+    ReplicateRequest,
+    ResamplingConstructionError,
+    ResamplingDraw,
+    ResamplingLifecycle,
+    ResamplingPlan,
+    ResamplingPopulation,
+    ResamplingScheme,
+    SummaryTerminal,
+    execute_resampling_evidence,
+    generate_resampling_draw,
+    summarize_resampling_evidence,
+)
+from chemex.runtime import ExecutionSettings
+
+
+def _accepted_anchor() -> AcceptedFitResult:
+    """Use the exact authoritative constructor without fabricating fit authority."""
+    from chemex.evaluation.native import EvaluationResult, ResolvedEvaluationValues
+
+    result = EvaluationResult(
+        plan_identity="accepted-plan",
+        parameterization_identity="accepted-parameterization",
+        evaluator_compatibility_identity="accepted-evaluator",
+        resolved_values=ResolvedEvaluationValues(
+            "accepted-parameterization",
+            "accepted-program",
+            (("A", 1.0), ("B", 2.0)),
+        ),
+        unscaled_calculations=np.array([1.0]),
+        normalized_calculations=np.array([1.0]),
+        residuals=np.array([0.0]),
+        profiles=(),
+    )
+    return AcceptedFitResult.for_qualification(
+        occurrence_identity="accepted-occurrence",
+        problem_identity="accepted-problem",
+        invocation_identity="accepted-invocation",
+        execution_identity="accepted-execution",
+        materialization_identity="accepted-materialization",
+        parameterization_identity="accepted-parameterization",
+        evaluator_parameterization_identity="accepted-parameterization",
+        source_occurrence_identity="source-occurrence",
+        source_revision=4,
+        controlled_ids=("A", "B"),
+        vector=(1.0, 2.0),
+        chi_square=0.0,
+        evaluation_result=result,
+        commit_scope=("A", "B"),
+        commit_items=(("A", 1.0), ("B", 2.0)),
+        origin_context_identity="accepted-origin",
+    )
+
+
+def _population() -> ResamplingPopulation:
+    return ResamplingPopulation(
+        source_dataset_identity="qualification-dataset",
+        observed=(10.0, 20.0, 30.0, 40.0, 50.0),
+        calculated=(11.0, 19.0, 31.0, 39.0, 49.0),
+        standard_errors=(1.0, 2.0, 1.5, 0.5, 2.5),
+        mask=(True, True, True, True, False),
+        references=(True, True, False, False, False),
+        nucleus_groups=("N1", "N1", "N2", "N3", "N3"),
+    )
+
+
+def _plan(
+    accepted: AcceptedFitResult,
+    scheme: ResamplingScheme,
+    *,
+    count: int = 4,
+) -> ResamplingPlan:
+    return ResamplingPlan.for_accepted(
+        accepted,
+        scheme=scheme,
+        replicate_count=count,
+        root_seed=0x1234_5678_90AB_CDEF,
+        source_dataset_identity="qualification-dataset",
+        output_scope=("A", "B"),
+        optimization_projection_identity="direct-trf-projection-v1",
+        minimum_successful_count=2,
+    )
+
+
+def _successful_projection(
+    offset: float = 0.0,
+) -> Callable[[ReplicateRequest, ResamplingDraw], ProjectedOptimizationSuccess]:
+    def execute(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationSuccess:
+        ordinal = request.ordinal
+        return ProjectedOptimizationSuccess(
+            transformed_data_identity=draw.identity,
+            evaluation_plan_identity=f"plan-{ordinal}",
+            problem_identity=f"problem-{ordinal}",
+            invocation_identity=f"invocation-{ordinal}",
+            execution_identity=f"execution-{ordinal}",
+            strategy=OptimizationStrategy.DIRECT_TRF,
+            component_outcome_identities=(f"component-{ordinal}",),
+            resolved_items=(("A", offset + ordinal + 1.0), ("B", 10.0 - ordinal)),
+            chi_square=float(ordinal + 1),
+        )
+
+    return execute
+
+
+def test_replicate_plan_uses_canonical_ordinals_and_identity_derived_seeds() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO)
+
+    assert tuple(request.ordinal for request in plan.replicates) == (0, 1, 2, 3)
+    assert len({request.identity for request in plan.replicates}) == 4
+    assert len({request.seed for request in plan.replicates}) == 4
+    assert plan == _plan(accepted, ResamplingScheme.MONTE_CARLO)
+
+    changed = ResamplingPlan.for_accepted(
+        accepted,
+        scheme=ResamplingScheme.MONTE_CARLO,
+        replicate_count=4,
+        root_seed=0x1234_5678_90AB_CDEE,
+        source_dataset_identity="qualification-dataset",
+        output_scope=("A", "B"),
+        optimization_projection_identity="direct-trf-projection-v1",
+        minimum_successful_count=2,
+    )
+    assert tuple(request.seed for request in changed.replicates) != tuple(
+        request.seed for request in plan.replicates
+    )
+
+
+def test_execution_rejects_a_different_source_dataset_lineage() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO)
+    mismatched = dataclasses.replace(
+        _population(),
+        source_dataset_identity="other-dataset",
+    )
+
+    with pytest.raises(ResamplingConstructionError, match="source dataset"):
+        execute_resampling_evidence(
+            accepted,
+            plan,
+            mismatched,
+            _successful_projection(),
+        )
+
+
+def test_seeded_generation_preserves_mc_bs_and_bsn_scientific_schemes() -> None:
+    population = _population()
+
+    mc = generate_resampling_draw(
+        population,
+        ResamplingScheme.MONTE_CARLO,
+        seed=101,
+    )
+    assert mc == generate_resampling_draw(
+        population,
+        ResamplingScheme.MONTE_CARLO,
+        seed=101,
+    )
+    assert mc.source_indices == tuple(range(5))
+    assert mc.standard_errors == population.standard_errors
+    assert mc.observations != population.calculated
+
+    bootstrap = generate_resampling_draw(
+        population,
+        ResamplingScheme.BOOTSTRAP,
+        seed=202,
+    )
+    masked_targets = tuple(
+        index for index, value in enumerate(population.mask) if value
+    )
+    assert tuple(
+        population.references[source]
+        for source in bootstrap.source_indices[: len(masked_targets)]
+    ) == tuple(population.references[target] for target in masked_targets)
+    assert bootstrap.source_indices[-1] == 4
+    assert bootstrap.observations[-1] == population.observed[-1]
+
+    nucleus = generate_resampling_draw(
+        population,
+        ResamplingScheme.NUCLEUS_BOOTSTRAP,
+        seed=303,
+    )
+    assert len(nucleus.sampled_nucleus_groups) == 3
+    assert set(nucleus.sampled_nucleus_groups) <= {"N1", "N2", "N3"}
+    expected_sources = tuple(
+        index
+        for group in nucleus.sampled_nucleus_groups
+        for index, source_group in enumerate(population.nucleus_groups)
+        if source_group == group
+    )
+    assert nucleus.source_indices == expected_sources
+
+
+def test_resampling_execution_is_evidence_only_scope_complete_and_worker_stable() -> (
+    None
+):
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO)
+    population = _population()
+
+    serial = execute_resampling_evidence(
+        accepted,
+        plan,
+        population,
+        _successful_projection(),
+        execution=ExecutionSettings(workers=1),
+    )
+    parallel = execute_resampling_evidence(
+        accepted,
+        plan,
+        population,
+        _successful_projection(),
+        execution=ExecutionSettings(workers=3),
+    )
+
+    assert serial.evidence is not None
+    assert parallel.evidence is not None
+    assert serial.evidence.identity == parallel.evidence.identity
+    assert tuple(outcome.ordinal for outcome in serial.evidence.outcomes) == (
+        0,
+        1,
+        2,
+        3,
+    )
+    assert all(
+        outcome.disposition is ReplicateDisposition.SUCCEEDED
+        for outcome in serial.evidence.outcomes
+    )
+    assert all(outcome.success is not None for outcome in serial.evidence.outcomes)
+    assert all(
+        outcome.success.resolved_items == tuple(outcome.success.resolved_items)
+        and tuple(param_id for param_id, _value in outcome.success.resolved_items)
+        == plan.output_scope
+        for outcome in serial.evidence.outcomes
+        if outcome.success is not None
+    )
+    assert not hasattr(serial.evidence, "accepted_result")
+    assert not hasattr(serial.evidence, "commit_authority")
+
+
+def test_failed_replicates_remain_typed_and_summary_uses_one_common_scope() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.BOOTSTRAP, count=3)
+    population = _population()
+
+    def project(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationResult:
+        if request.ordinal == 1:
+            return ProjectedOptimizationFailure(
+                transformed_data_identity=draw.identity,
+                disposition=ReplicateDisposition.FAILED,
+                category="solver_unsuccessful",
+                message="declared local budget exhausted",
+                evaluation_plan_identity="plan-1",
+                problem_identity="problem-1",
+                execution_identity="execution-1",
+            )
+        return _successful_projection()(request, draw)
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        population,
+        project,
+        execution=ExecutionSettings(workers=2),
+    )
+    assert operation.evidence is not None
+    evidence = operation.evidence
+    assert tuple(outcome.disposition for outcome in evidence.outcomes) == (
+        ReplicateDisposition.SUCCEEDED,
+        ReplicateDisposition.FAILED,
+        ReplicateDisposition.SUCCEEDED,
+    )
+    assert evidence.completed_count == 3
+    assert evidence.successful_count == 2
+    assert evidence.failed_count == 1
+    assert evidence.claim("MINIMUM_SUCCESSFUL_COVERAGE") is ClaimState.SATISFIED
+    assert evidence.claim("COMPLETE_SCOPE_SUCCESS_ROWS") is ClaimState.SATISFIED
+
+    summary_outcome = summarize_resampling_evidence(evidence)
+    assert summary_outcome.terminal is SummaryTerminal.COMPLETED
+    assert summary_outcome.summary is not None
+    summary = summary_outcome.summary
+    assert summary.included_ordinals == (0, 2)
+    assert summary.claim("COMMON_SCOPE_INCLUSION") is ClaimState.SATISFIED
+    assert summary.claim("MINIMUM_SUCCESSFUL_COVERAGE") is ClaimState.SATISFIED
+    assert tuple(item.ordinal for item in summary.exclusions) == (1,)
+    assert all(row.ordinal in summary.included_ordinals for row in summary.samples)
+    assert all(
+        tuple(param_id for param_id, _value in row.items) == plan.output_scope
+        for row in summary.samples
+    )
+    assert all(
+        entry.value is None or np.isfinite(entry.value)
+        for entry in summary.correlations
+    )
+
+
+def test_partial_evidence_and_summary_publish_only_under_declared_contract() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.NUCLEUS_BOOTSTRAP, count=4)
+    population = _population()
+
+    calls = 0
+
+    def cancel_after_one() -> bool:
+        return calls >= 1
+
+    def project(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationSuccess:
+        nonlocal calls
+        calls += 1
+        return _successful_projection()(request, draw)
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        population,
+        project,
+        execution=ExecutionSettings(workers=1),
+        cancellation_probe=cancel_after_one,
+    )
+    assert operation.evidence is not None
+    assert operation.evidence.completed_count == 1
+    assert operation.evidence.successful_count == 1
+    assert operation.evidence.lifecycle is ResamplingLifecycle.CANCELLED
+    assert (
+        operation.evidence.claim("MINIMUM_SUCCESSFUL_COVERAGE") is ClaimState.VIOLATED
+    )
+    assert operation.unstarted_ordinals == (1, 2, 3)
+
+    summary_outcome = summarize_resampling_evidence(operation.evidence)
+    assert summary_outcome.terminal is SummaryTerminal.INSUFFICIENT_COVERAGE
+    assert summary_outcome.summary is None
+    assert summary_outcome.failure is not None
+
+    initially_cancelled = execute_resampling_evidence(
+        accepted,
+        plan,
+        population,
+        project,
+        execution=ExecutionSettings(workers=1),
+        cancellation_probe=lambda: True,
+    )
+    assert initially_cancelled.evidence is None
+    assert initially_cancelled.unstarted_ordinals == (0, 1, 2, 3)
+
+
+def test_success_payload_rejects_nan_and_non_atomic_scope() -> None:
+    with pytest.raises(ResamplingConstructionError, match="complete output scope"):
+        ProjectedOptimizationSuccess(
+            transformed_data_identity="draw",
+            evaluation_plan_identity="plan",
+            problem_identity="problem",
+            invocation_identity="invocation",
+            execution_identity="execution",
+            strategy=OptimizationStrategy.DIRECT_TRF,
+            component_outcome_identities=("component",),
+            resolved_items=(("A", 1.0),),
+            chi_square=1.0,
+            expected_output_scope=("A", "B"),
+        )
+    with pytest.raises(ResamplingConstructionError, match="finite"):
+        ProjectedOptimizationSuccess(
+            transformed_data_identity="draw",
+            evaluation_plan_identity="plan",
+            problem_identity="problem",
+            invocation_identity="invocation",
+            execution_identity="execution",
+            strategy=OptimizationStrategy.DIRECT_TRF,
+            component_outcome_identities=("component",),
+            resolved_items=(("A", np.nan), ("B", 2.0)),
+            chi_square=1.0,
+            expected_output_scope=("A", "B"),
+        )
+
+
+def test_non_finite_summary_arithmetic_returns_typed_unavailability() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=2)
+
+    def project(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationSuccess:
+        value = -1.0e308 if request.ordinal == 0 else 1.0e308
+        return ProjectedOptimizationSuccess(
+            transformed_data_identity=draw.identity,
+            evaluation_plan_identity=f"plan-{request.ordinal}",
+            problem_identity=f"problem-{request.ordinal}",
+            invocation_identity=f"invocation-{request.ordinal}",
+            execution_identity=f"execution-{request.ordinal}",
+            strategy=OptimizationStrategy.DIRECT_TRF,
+            component_outcome_identities=(f"component-{request.ordinal}",),
+            resolved_items=(("A", value), ("B", value)),
+            chi_square=1.0,
+        )
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        _population(),
+        project,
+    )
+    assert operation.evidence is not None
+    outcome = summarize_resampling_evidence(operation.evidence)
+    assert outcome.terminal is SummaryTerminal.SOURCE_INVALID
+    assert outcome.summary is None
+    assert outcome.failure is not None
+    assert outcome.failure.category == "non_finite_summary_arithmetic"

--- a/tests/test_native_resampling.py
+++ b/tests/test_native_resampling.py
@@ -4,21 +4,26 @@ from __future__ import annotations
 
 import copy
 import dataclasses
-import hashlib
-import json
 from collections.abc import Callable
-from threading import Event, Lock, get_ident
-from typing import Any
+from copy import deepcopy
+from threading import Event, Lock
+from types import SimpleNamespace
+from typing import Any, cast
 
 import numpy as np
 import pytest
+from pydantic import BaseModel
 
+import chemex.optimize.native_resampling as resampling_module
+from chemex.containers.data import Data
+from chemex.containers.profile import Profile, PulseSequence
 from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFrame,
     EvaluationPlan,
     EvaluationResult,
-    ProfilePlan,
-    ResolvedEvaluationValues,
 )
+from chemex.nmr.spectrometer import Spectrometer
 from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
 from chemex.optimize.native_resampling import (
     ClaimState,
@@ -50,49 +55,63 @@ from chemex.parameters.parameterization import (
     ParameterRole,
     ScientificFunctionBinder,
 )
+from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.printers.data import Printer
 from chemex.runtime import ExecutionSettings
 
 
-def _evaluation_identity(kind: str, record: object) -> str:
-    encoded = json.dumps(
-        {"schema": 1, "kind": kind, "record": record},
-        ensure_ascii=True,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode()
-    return hashlib.sha256(encoded).hexdigest()
+class _KernelSettings(BaseModel):
+    kind: str = "linear-test-kernel"
 
 
-def _profile_plan(
+class _LinearSpectrometer:
+    def __init__(self, name: str) -> None:
+        self.spin_system = SpinSystem.from_name(name)
+        self.values = {"a": 0.0, "b": 0.0}
+
+    def update(self, values: dict[str, float]) -> None:
+        self.values = dict(values)
+
+    def new_native_workspace(self) -> _LinearSpectrometer:
+        return deepcopy(self)
+
+    def native_kernel_descriptor(self) -> dict[str, object]:
+        return {"kind": "linear-test-spectrometer"}
+
+
+class _LinearPulseSequence:
+    settings = _KernelSettings()
+
+    def calculate(self, spectrometer: _LinearSpectrometer, data: Data) -> np.ndarray:
+        return spectrometer.values["a"] + spectrometer.values["b"] * np.asarray(
+            data.metadata, dtype=np.float64
+        )
+
+    def is_reference(self, metadata: np.ndarray) -> np.ndarray:
+        return metadata < 10.0
+
+
+def _profile(
     name: str,
-    *,
-    profile_ordinal: int,
-    offset: int,
     observed: tuple[float, ...],
     errors: tuple[float, ...],
+    metadata: tuple[float, ...],
     mask: tuple[bool, ...],
-) -> ProfilePlan:
-    source_identity = f"source-{name}"
-    return ProfilePlan(
-        _evaluation_identity(
-            "profile-plan",
-            (source_identity, 0, profile_ordinal, offset),
-        ),
-        source_identity,
-        0,
-        profile_ordinal,
-        offset,
-        (("a", "A"), ("b", "B")),
-        True,
-        observed,
-        errors,
-        mask,
-        f"kernel-{name}",
-        f"kernel-config-{name}",
-        f"spectrometer-{name}",
-        f"positions-{name}",
-        (len(observed),),
+) -> Profile:
+    data = Data(
+        exp=np.asarray(observed, dtype=np.float64),
+        err=np.asarray(errors, dtype=np.float64),
+        metadata=np.asarray(metadata, dtype=np.float64),
+    )
+    data.mask = np.asarray(mask, dtype=np.bool_)
+    return Profile(
+        data,
+        cast("Spectrometer", _LinearSpectrometer(name)),
+        cast("PulseSequence", _LinearPulseSequence()),
+        {"a": "A", "b": "B"},
+        cast("Printer", None),
+        is_scaled=False,
     )
 
 
@@ -101,6 +120,7 @@ def _native_context() -> tuple[
     ResamplingDatasetManifest,
     OptimizationProblem,
     ActiveParameterization,
+    EvaluationEngine,
 ]:
     binder = ScientificFunctionBinder("qualification", {})
     program = ConstraintProgram(
@@ -122,32 +142,36 @@ def _native_context() -> tuple[
         4,
         (("A", ParameterRole.FIT), ("B", ParameterRole.FIT)),
     )
-    evaluation_plan = EvaluationPlan(
-        parameterization.evaluator_identity,
-        program.fingerprint,
-        (
-            _profile_plan(
-                "P1",
-                profile_ordinal=0,
-                offset=0,
-                observed=(10.0, 20.0, 30.0, 40.0),
-                errors=(1.0, 2.0, 1.5, 0.5),
-                mask=(True, True, True, True),
-            ),
-            _profile_plan(
-                "P2",
-                profile_ordinal=1,
-                offset=4,
-                observed=(50.0,),
-                errors=(2.5,),
-                mask=(False,),
-            ),
-        ),
-        ("A", "B"),
+    snapshot = AnalysisValuesSnapshot(
+        "source-occurrence",
+        "model",
+        "definitions",
+        "configuration",
+        4,
+        (("A", 1.0), ("B", 2.0)),
     )
+    profiles = (
+        _profile(
+            "1N",
+            (10.0, 20.0, 30.0, 40.0),
+            (1.0, 2.0, 1.5, 0.5),
+            (5.0, 9.0, 15.0, 19.0),
+            (True, True, True, True),
+        ),
+        _profile("2N", (50.0,), (2.5,), (24.0,), (False,)),
+    )
+    experiments = cast("Any", (SimpleNamespace(profiles=profiles),))
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    evaluation_plan = engine.plan
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(snapshot),
+    )
+    result = engine.new_evaluator().evaluate(frame)
+    assert isinstance(result, EvaluationResult)
     dataset = ResamplingDatasetManifest(
         evaluation_plan,
-        (11.0, 19.0, 31.0, 39.0, 49.0),
+        tuple(float(value) for value in result.normalized_calculations),
         (True, True, False, False, False),
         ("N1", "N1", "N2", "N3", "N3"),
         (
@@ -157,14 +181,6 @@ def _native_context() -> tuple[
             "position=400",
             "position=500",
         ),
-    )
-    snapshot = AnalysisValuesSnapshot(
-        "source-occurrence",
-        "model",
-        "definitions",
-        "configuration",
-        4,
-        (("A", 1.0), ("B", 2.0)),
     )
     problem = OptimizationProblem(
         evaluation_plan.identity,
@@ -180,20 +196,6 @@ def _native_context() -> tuple[
         (-100.0, -100.0),
         (100.0, 100.0),
         ("A", "B"),
-    )
-    result = EvaluationResult(
-        evaluation_plan.identity,
-        parameterization.evaluator_identity,
-        parameterization.evaluator_identity,
-        ResolvedEvaluationValues(
-            parameterization.evaluator_identity,
-            program.fingerprint,
-            (("A", 1.0), ("B", 2.0)),
-        ),
-        np.array(dataset.calculated),
-        np.array(dataset.calculated),
-        np.array((1.0, -0.5, 2.0 / 3.0, -2.0)),
-        (),
     )
     accepted = AcceptedFitResult.for_qualification(
         occurrence_identity="accepted-occurrence",
@@ -213,7 +215,7 @@ def _native_context() -> tuple[
         commit_items=problem.independent_items,
         origin_context_identity="accepted-origin",
     )
-    return accepted, dataset, problem, parameterization
+    return accepted, dataset, problem, parameterization, engine
 
 
 def _plan(
@@ -222,12 +224,13 @@ def _plan(
     count: int = 4,
     minimum: int = 2,
 ) -> tuple[AcceptedFitResult, ResamplingPlan]:
-    accepted, dataset, problem, parameterization = _native_context()
+    accepted, dataset, problem, parameterization, engine = _native_context()
     plan = ResamplingPlan.for_accepted(
         accepted,
         dataset=dataset,
         source_problem=problem,
         parameterization=parameterization,
+        source_engine=engine,
         scheme=scheme,
         replicate_count=count,
         replicate_structural_identities=tuple(
@@ -249,29 +252,18 @@ def _plan(
 
 def _success(
     prepared: ReplicateExecutionPlan,
-    *,
-    constant_b: bool = False,
+    projected: ProjectedOptimizationResult,
 ) -> ProjectedOptimizationSuccess:
-    ordinal = prepared.request.ordinal
-    return ProjectedOptimizationSuccess.for_prepared(
-        prepared,
-        candidate_vector=(float(ordinal + 1), 5.0 if constant_b else 10.0 - ordinal),
-        chi_square=float(ordinal + 1),
-    )
+    assert isinstance(projected, ProjectedOptimizationSuccess)
+    assert projected.prepared_replicate_identity == prepared.identity
+    return projected
 
 
-def _successful_factory(
-    *, constant_b: bool = False
-) -> Callable[
-    [ReplicateExecutionPlan],
-    Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess],
+def _successful_factory() -> Callable[
+    [ReplicateExecutionPlan, ProjectedOptimizationResult],
+    ProjectedOptimizationSuccess,
 ]:
-    def factory(
-        _prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
-        return lambda exact: _success(exact, constant_b=constant_b)
-
-    return factory
+    return _success
 
 
 def _request(
@@ -305,6 +297,7 @@ def test_replicate_plan_uses_canonical_ordinals_and_identity_derived_seeds() -> 
         dataset=plan.dataset,
         source_problem=plan.source_problem,
         parameterization=plan.parameterization,
+        source_engine=plan.source_engine,
         scheme=plan.scheme,
         replicate_count=plan.replicate_count,
         replicate_structural_identities=tuple(
@@ -327,7 +320,7 @@ def test_replicate_plan_uses_canonical_ordinals_and_identity_derived_seeds() -> 
 
 
 def test_altered_source_calculation_cannot_rebind_the_accepted_native_result() -> None:
-    accepted, dataset, problem, parameterization = _native_context()
+    accepted, dataset, problem, parameterization, engine = _native_context()
     altered = dataclasses.replace(
         dataset,
         calculated=(12.0, *dataset.calculated[1:]),
@@ -339,6 +332,7 @@ def test_altered_source_calculation_cannot_rebind_the_accepted_native_result() -
             dataset=altered,
             source_problem=problem,
             parameterization=parameterization,
+            source_engine=engine,
             scheme=ResamplingScheme.MONTE_CARLO,
             replicate_count=1,
             replicate_structural_identities=("altered-source",),
@@ -353,7 +347,7 @@ def test_altered_source_calculation_cannot_rebind_the_accepted_native_result() -
 def test_source_dataset_record_rejects_an_altered_observation_with_stale_identity() -> (
     None
 ):
-    _accepted, dataset, _problem, _parameterization = _native_context()
+    _accepted, dataset, _problem, _parameterization, _engine = _native_context()
     first_profile = dataset.evaluation_plan.profiles[0]
     changed_plan = dataclasses.replace(
         dataset.evaluation_plan,
@@ -378,7 +372,7 @@ def test_source_dataset_record_rejects_an_altered_observation_with_stale_identit
 
 
 def test_seeded_generation_preserves_mc_bs_and_bsn_scientific_schemes() -> None:
-    _accepted, dataset, _problem, _parameterization = _native_context()
+    _accepted, dataset, _problem, _parameterization, _engine = _native_context()
 
     mc = generate_resampling_draw(
         dataset,
@@ -451,10 +445,8 @@ def test_altered_generated_observation_cannot_retain_or_rebind_draw_identity() -
         ("component_identities", ("foreign-component",)),
         ("component_outcome_identities", ("foreign-component-outcome",)),
         ("candidate_identity", "foreign-candidate"),
-        ("materialization_identity", "foreign-materialization"),
-        ("evaluation_identity", "foreign-evaluation"),
         ("prepared_replicate_identity", "foreign-prepared-replicate"),
-        ("requested_output_units", ("foreign-unit", "foreign-unit")),
+        ("controlled_ids", ("B", "A")),
     ),
 )
 def test_foreign_native_lineage_never_enters_successful_evidence(
@@ -463,18 +455,14 @@ def test_foreign_native_lineage_never_enters_successful_evidence(
 ) -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
 
-    def factory(
+    def hook(
         _prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
-        def execute(exact: ReplicateExecutionPlan) -> ProjectedOptimizationSuccess:
-            return dataclasses.replace(
-                _success(exact),
-                **{field_name: foreign_value},
-            )
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
+        assert isinstance(projected, ProjectedOptimizationSuccess)
+        return dataclasses.replace(projected, **{field_name: foreign_value})
 
-        return execute
-
-    operation = execute_resampling_evidence(accepted, plan, factory)
+    operation = execute_resampling_evidence(accepted, plan, candidate_test_hook=hook)
 
     assert operation.evidence is not None
     assert operation.evidence.successful_count == 0
@@ -486,25 +474,25 @@ def test_foreign_native_lineage_never_enters_successful_evidence(
     )
 
 
-def test_incomplete_requested_scope_never_enters_successful_evidence() -> None:
+def test_incomplete_or_reordered_controlled_scope_never_enters_successful_evidence() -> (
+    None
+):
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
 
-    def factory(
+    def hook(
         _prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
-        return lambda exact: dataclasses.replace(
-            _success(exact),
-            requested_output_scope=("A",),
-            requested_output_units=("arbitrary",),
-        )
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
+        assert isinstance(projected, ProjectedOptimizationSuccess)
+        return dataclasses.replace(projected, controlled_ids=("B", "A"))
 
-    operation = execute_resampling_evidence(accepted, plan, factory)
+    operation = execute_resampling_evidence(accepted, plan, candidate_test_hook=hook)
 
     assert operation.evidence is not None
     assert operation.evidence.successful_count == 0
     assert all(
         outcome.failure is not None
-        and outcome.failure.category == "requested_scope_lineage_mismatch"
+        and outcome.failure.category == "controlled_coordinates_lineage_mismatch"
         for outcome in operation.evidence.outcomes
     )
 
@@ -514,15 +502,16 @@ def test_foreign_transformed_data_with_correct_values_and_dimensions_fails_close
 ):
     accepted, plan = _plan(ResamplingScheme.BOOTSTRAP, count=2)
 
-    def factory(
+    def hook(
         _prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
-        return lambda exact: dataclasses.replace(
-            _success(exact),
-            transformed_data_identity="foreign-draw-with-identical-values",
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
+        assert isinstance(projected, ProjectedOptimizationSuccess)
+        return dataclasses.replace(
+            projected, transformed_data_identity="foreign-draw-with-identical-values"
         )
 
-    operation = execute_resampling_evidence(accepted, plan, factory)
+    operation = execute_resampling_evidence(accepted, plan, candidate_test_hook=hook)
 
     assert operation.evidence is not None
     assert operation.evidence.successful_count == 0
@@ -540,25 +529,26 @@ def test_candidate_is_freshly_resolved_and_no_fit_or_commit_authority_is_exposed
     before = accepted
     prepared_problems: list[OptimizationProblem] = []
 
-    def factory(
+    def hook(
         prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
         prepared_problems.append(prepared.problem)
-        return lambda exact: _success(exact)
+        return projected
 
     operation = execute_resampling_evidence(
         accepted,
         plan,
-        factory,
+        candidate_test_hook=hook,
     )
 
     assert accepted is before
     assert operation.evidence is not None
-    assert tuple(
-        outcome.success.resolved_items
+    assert operation.evidence.successful_count == 2
+    assert all(
+        outcome.success is not None and outcome.success.fresh_evaluation_count == 1
         for outcome in operation.evidence.outcomes
-        if outcome.success is not None
-    ) == ((("A", 1.0), ("B", 10.0)), (("A", 2.0), ("B", 9.0)))
+    )
     assert all(
         not outcome.success or not hasattr(outcome.success, "accepted_result")
         for outcome in operation.evidence.outcomes
@@ -570,94 +560,236 @@ def test_candidate_is_freshly_resolved_and_no_fit_or_commit_authority_is_exposed
     assert all(not problem.acceptance_authority for problem in prepared_problems)
 
 
-def test_out_of_bounds_candidate_fails_fresh_problem_resolution() -> None:
-    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+def test_backend_chi_square_is_diagnostic_and_fresh_chi_square_is_authoritative() -> (
+    None
+):
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=1, minimum=1)
+    backend_value = 9.87654321e123
 
-    def factory(
+    def corrupt_backend_diagnostic(
         _prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
-        return lambda exact: dataclasses.replace(
-            _success(exact),
-            candidate_vector=(101.0, 5.0),
-        )
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
+        assert isinstance(projected, ProjectedOptimizationSuccess)
+        return dataclasses.replace(projected, backend_chi_square=backend_value)
 
-    operation = execute_resampling_evidence(accepted, plan, factory)
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        candidate_test_hook=corrupt_backend_diagnostic,
+    )
+
+    assert operation.evidence is not None
+    success = operation.evidence.outcomes[0].success
+    assert success is not None
+    assert success.backend_chi_square == backend_value
+    assert success.backend_chi_square_agrees is False
+    assert success.chi_square != backend_value
+    assert np.isfinite(success.chi_square)
+    assert success.fresh_evaluation_count == 1
+
+
+def test_foreign_candidate_lineage_fails_before_fresh_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    original = EvaluationEngine.resampled
+    bound_engines: list[EvaluationEngine] = []
+
+    def record_binding(
+        engine: EvaluationEngine,
+        evaluation_plan: EvaluationPlan,
+        bindings: object,
+    ) -> EvaluationEngine:
+        result = original(engine, evaluation_plan, cast("Any", bindings))
+        bound_engines.append(result)
+        return result
+
+    def foreign_problem(
+        _prepared: ReplicateExecutionPlan,
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
+        assert isinstance(projected, ProjectedOptimizationSuccess)
+        return dataclasses.replace(projected, problem_identity="foreign-problem")
+
+    monkeypatch.setattr(EvaluationEngine, "resampled", record_binding)
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        candidate_test_hook=foreign_problem,
+    )
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 0
+    assert len(bound_engines) == plan.replicate_count
+
+
+def test_fresh_validation_evaluator_failure_is_typed_and_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+    original = EvaluationEngine.resampled
+    binding_count = 0
+
+    def fail_validation_binding(
+        engine: EvaluationEngine,
+        evaluation_plan: EvaluationPlan,
+        bindings: object,
+    ) -> EvaluationEngine:
+        nonlocal binding_count
+        binding_count += 1
+        result = original(engine, evaluation_plan, cast("Any", bindings))
+        if binding_count % 2 == 0:
+
+            def fail_new_evaluator() -> object:
+                raise RuntimeError("fresh validation workspace failed")
+
+            result.new_evaluator = fail_new_evaluator  # type: ignore[method-assign]
+        return result
+
+    monkeypatch.setattr(EvaluationEngine, "resampled", fail_validation_binding)
+    operation = execute_resampling_evidence(accepted, plan)
 
     assert operation.evidence is not None
     assert operation.evidence.successful_count == 0
     assert all(
         outcome.failure is not None
-        and outcome.failure.category == "candidate_resolution_failure"
+        and outcome.failure.category == "fresh_evaluation_failure"
+        for outcome in operation.evidence.outcomes
+    )
+    assert summarize_resampling_evidence(operation.evidence).summary is None
+
+
+def test_each_eligible_candidate_receives_exactly_one_fresh_validation_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=3)
+    original_resampled = EvaluationEngine.resampled
+    original_new_evaluator = EvaluationEngine.new_evaluator
+    binding_count = 0
+    validation_engine_ids: set[int] = set()
+    evaluation_counts: dict[int, int] = {}
+
+    def identify_validation_engine(
+        engine: EvaluationEngine,
+        evaluation_plan: EvaluationPlan,
+        bindings: object,
+    ) -> EvaluationEngine:
+        nonlocal binding_count
+        binding_count += 1
+        result = original_resampled(engine, evaluation_plan, cast("Any", bindings))
+        if binding_count % 2 == 0:
+            validation_engine_ids.add(id(result))
+        return result
+
+    def count_validation_evaluation(engine: EvaluationEngine) -> object:
+        evaluator = original_new_evaluator(engine)
+        if id(engine) in validation_engine_ids:
+            original_evaluate = evaluator.evaluate
+
+            def counted(frame: EvaluationFrame) -> object:
+                evaluation_counts[id(engine)] = evaluation_counts.get(id(engine), 0) + 1
+                return original_evaluate(frame)
+
+            evaluator.evaluate = counted  # type: ignore[method-assign]
+        return evaluator
+
+    monkeypatch.setattr(EvaluationEngine, "resampled", identify_validation_engine)
+    monkeypatch.setattr(EvaluationEngine, "new_evaluator", count_validation_evaluation)
+    operation = execute_resampling_evidence(accepted, plan)
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == plan.replicate_count
+    assert tuple(evaluation_counts.values()) == (1, 1, 1)
+
+
+def test_out_of_bounds_candidate_fails_fresh_problem_resolution() -> None:
+    accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
+
+    def hook(
+        _prepared: ReplicateExecutionPlan,
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
+        assert isinstance(projected, ProjectedOptimizationSuccess)
+        return dataclasses.replace(projected, candidate_vector=(101.0, 5.0))
+
+    operation = execute_resampling_evidence(accepted, plan, candidate_test_hook=hook)
+
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 0
+    assert all(
+        outcome.failure is not None
+        and outcome.failure.category == "candidate_vector_lineage_mismatch"
         and outcome.stage is ReplicateStage.VALIDATING
         for outcome in operation.evidence.outcomes
     )
 
 
-class _SingleOwnerExecutor:
-    def __init__(
-        self,
-        prepared: ReplicateExecutionPlan,
-        owners: list[tuple[object, int, int]],
-        owner_lock: Lock,
-        releases: tuple[Event, ...] | None,
-    ) -> None:
-        self.prepared = prepared
-        self.owners = owners
-        self.owner_lock = owner_lock
-        self.releases = releases
-        self.used = False
-
-    def __call__(self, exact: ReplicateExecutionPlan) -> ProjectedOptimizationSuccess:
-        if self.used or exact is not self.prepared:
-            raise RuntimeError("executor/workspace reused across replicates")
-        self.used = True
-        ordinal = exact.request.ordinal
-        if self.releases is not None:
-            if ordinal + 1 < len(self.releases):
-                assert self.releases[ordinal + 1].wait(timeout=1.0)
-            self.releases[ordinal].set()
-        with self.owner_lock:
-            self.owners.append((self, ordinal, get_ident()))
-        return _success(exact)
-
-
-def _isolated_factory(
-    owners: list[tuple[object, int, int]],
-    owner_lock: Lock,
-    releases: tuple[Event, ...] | None = None,
-) -> Callable[[ReplicateExecutionPlan], _SingleOwnerExecutor]:
-    return lambda prepared: _SingleOwnerExecutor(
-        prepared,
-        owners,
-        owner_lock,
-        releases,
-    )
-
-
-def test_serial_and_reordered_multi_worker_execution_use_fresh_single_owners() -> None:
+def test_serial_and_reordered_multi_worker_execution_use_fresh_single_owners(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     accepted, plan = _plan(ResamplingScheme.NUCLEUS_BOOTSTRAP)
-    serial_owners: list[tuple[object, int, int]] = []
-    parallel_owners: list[tuple[object, int, int]] = []
+    engines: list[EvaluationEngine] = []
+    evaluators: list[object] = []
+    engine_lock = Lock()
+    original_resampled = EvaluationEngine.resampled
+    original_new_evaluator = EvaluationEngine.new_evaluator
+
+    def record_resampled(
+        engine: EvaluationEngine,
+        evaluation_plan: EvaluationPlan,
+        bindings: object,
+    ) -> EvaluationEngine:
+        result = original_resampled(engine, evaluation_plan, cast("Any", bindings))
+        with engine_lock:
+            engines.append(result)
+        return result
+
+    def record_evaluator(engine: EvaluationEngine) -> object:
+        evaluator = original_new_evaluator(engine)
+        with engine_lock:
+            evaluators.append(evaluator)
+        return evaluator
+
+    monkeypatch.setattr(EvaluationEngine, "resampled", record_resampled)
+    monkeypatch.setattr(EvaluationEngine, "new_evaluator", record_evaluator)
     serial = execute_resampling_evidence(
         accepted,
         plan,
-        _isolated_factory(serial_owners, Lock()),
         execution=ExecutionSettings(workers=1),
     )
+    serial_engine_count = len(engines)
+    serial_evaluator_count = len(evaluators)
     releases = tuple(Event() for _ in plan.replicates)
+    completion_order: list[int] = []
+
+    def reverse_completion(
+        prepared: ReplicateExecutionPlan,
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
+        ordinal = prepared.request.ordinal
+        if ordinal + 1 < len(releases):
+            assert releases[ordinal + 1].wait(timeout=5.0)
+        releases[ordinal].set()
+        completion_order.append(ordinal)
+        return projected
+
     parallel = execute_resampling_evidence(
         accepted,
         plan,
-        _isolated_factory(parallel_owners, Lock(), releases),
         execution=ExecutionSettings(workers=4),
+        candidate_test_hook=reverse_completion,
     )
 
     assert serial.evidence is not None
     assert parallel.evidence is not None
     assert serial.evidence.identity == parallel.evidence.identity
-    assert len({item[0] for item in serial_owners}) == plan.replicate_count
-    assert len({item[0] for item in parallel_owners}) == plan.replicate_count
-    assert tuple(item[1] for item in parallel_owners) == (3, 2, 1, 0)
+    assert serial_engine_count == 2 * plan.replicate_count
+    assert len(engines) == 4 * plan.replicate_count
+    assert len({id(item) for item in engines}) == len(engines)
+    assert serial_evaluator_count >= 2 * plan.replicate_count
+    assert len({id(item) for item in evaluators}) == len(evaluators)
+    assert tuple(completion_order) == (3, 2, 1, 0)
     assert tuple(outcome.ordinal for outcome in parallel.evidence.outcomes) == (
         0,
         1,
@@ -672,18 +804,19 @@ def test_serial_and_reordered_multi_worker_execution_use_fresh_single_owners() -
 def test_one_executor_failure_does_not_corrupt_other_replicate_evidence() -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
 
-    def factory(
+    def hook(
         prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
         if prepared.request.ordinal == 1:
-            return lambda _exact: (_ for _ in ()).throw(RuntimeError("owner failed"))
-        return lambda exact: _success(exact)
+            raise RuntimeError("owner failed")
+        return projected
 
     operation = execute_resampling_evidence(
         accepted,
         plan,
-        factory,
         execution=ExecutionSettings(workers=3),
+        candidate_test_hook=hook,
     )
 
     assert operation.evidence is not None
@@ -694,53 +827,38 @@ def test_one_executor_failure_does_not_corrupt_other_replicate_evidence() -> Non
     )
 
 
-@pytest.mark.parametrize("workers", (1, 3))
-def test_shared_executor_instance_is_rejected_by_single_owner_contract(
-    workers: int,
-) -> None:
+def test_fresh_lambdas_wrapping_shared_backend_cannot_enter_authoritative_path() -> (
+    None
+):
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
+    shared_backend = object()
+    wrappers = tuple(lambda: shared_backend for _ in plan.replicates)
 
-    def shared(exact: ReplicateExecutionPlan) -> ProjectedOptimizationSuccess:
-        return _success(exact)
-
-    operation = execute_resampling_evidence(
-        accepted,
-        plan,
-        lambda _prepared: shared,
-        execution=ExecutionSettings(workers=workers),
-    )
-
-    assert operation.evidence is not None
-    assert operation.evidence.successful_count == 1
-    assert (
-        sum(
-            outcome.failure is not None
-            and outcome.failure.category == "executor_creation_failure"
-            for outcome in operation.evidence.outcomes
+    with pytest.raises(TypeError, match="executor_factory"):
+        execute_resampling_evidence(
+            accepted,
+            plan,
+            executor_factory=lambda prepared: wrappers[prepared.request.ordinal],
         )
-        == plan.replicate_count - 1
-    )
 
 
 def test_partial_evidence_preserves_unstarted_ordinals_and_valid_summary() -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
     calls = 0
 
-    def factory(
+    def hook(
         _prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
-        def execute(exact: ReplicateExecutionPlan) -> ProjectedOptimizationSuccess:
-            nonlocal calls
-            calls += 1
-            return _success(exact)
-
-        return execute
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
+        nonlocal calls
+        calls += 1
+        return projected
 
     operation = execute_resampling_evidence(
         accepted,
         plan,
-        factory,
         cancellation_probe=lambda: calls >= 2,
+        candidate_test_hook=hook,
     )
 
     assert operation.evidence is not None
@@ -764,13 +882,25 @@ def test_partial_evidence_preserves_unstarted_ordinals_and_valid_summary() -> No
     assert summary.summary.unstarted_ordinals == (2, 3)
 
 
-def test_summary_numerical_references_and_zero_variance_are_canonical() -> None:
+def test_summary_numerical_references_and_zero_variance_are_canonical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=3)
-    operation = execute_resampling_evidence(
-        accepted,
-        plan,
-        _successful_factory(constant_b=True),
-    )
+
+    def fixed_candidate(
+        prepared: ReplicateExecutionPlan,
+        _engine: EvaluationEngine,
+    ) -> ProjectedOptimizationResult:
+        ordinal = prepared.request.ordinal
+        return ProjectedOptimizationSuccess.for_prepared(
+            prepared,
+            candidate_vector=(float(ordinal + 1), 5.0),
+            backend_chi_square=float(ordinal + 1),
+            execution_identity=f"test-execution-{ordinal}",
+        )
+
+    monkeypatch.setattr(resampling_module, "_execute_native_candidate", fixed_candidate)
+    operation = execute_resampling_evidence(accepted, plan)
     assert operation.evidence is not None
     outcome = summarize_resampling_evidence(operation.evidence)
     assert outcome.summary is not None
@@ -808,7 +938,7 @@ def test_summary_numerical_references_and_zero_variance_are_canonical() -> None:
 
 def test_summary_record_rejects_every_independent_tampering_vector() -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=3)
-    operation = execute_resampling_evidence(accepted, plan, _successful_factory())
+    operation = execute_resampling_evidence(accepted, plan)
     assert operation.evidence is not None
     policy = ResamplingSummaryPolicy()
     outcome = summarize_resampling_evidence(operation.evidence, policy)
@@ -844,23 +974,45 @@ def test_summary_record_rejects_every_independent_tampering_vector() -> None:
             evidence,
             changed_policy,
         )
-    with pytest.raises(ResamplingConstructionError, match="evidence identity"):
+    with pytest.raises(TypeError, match="evidence_identity"):
         ResamplingSummaryOutcome(
             SummaryTerminal.COMPLETED,
             summary=summary,
-            claimed_evidence_identity="foreign-evidence",
+            evidence_identity="foreign-evidence",
         )
 
 
 def test_summary_constructor_cannot_accept_caller_supplied_arrays_or_claims() -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO, count=2)
-    operation = execute_resampling_evidence(accepted, plan, _successful_factory())
+    operation = execute_resampling_evidence(accepted, plan)
     assert operation.evidence is not None
     summary = summarize_resampling_evidence(operation.evidence).summary
     assert summary is not None
 
-    with pytest.raises(ResamplingConstructionError, match="source evidence"):
-        dataclasses.replace(summary, _construction_key=object())
+    with pytest.raises(TypeError, match="init=False"):
+        dataclasses.replace(
+            summary,
+            covariance=(dataclasses.replace(summary.covariance[0], value=999.0),),
+        )
+    for field_name in (
+        "included_ordinals",
+        "samples",
+        "distributions",
+        "correlations",
+        "output_scope",
+        "output_units",
+        "claims",
+    ):
+        with pytest.raises(TypeError, match="init=False"):
+            dataclasses.replace(
+                summary,
+                **{field_name: getattr(summary, field_name)},
+            )
+
+    changed_policy = dataclasses.replace(summary.policy, percentile_lower=5.0)
+    recomputed = dataclasses.replace(summary, policy=changed_policy)
+    assert recomputed.policy_identity == changed_policy.identity
+    assert recomputed.identity != summary.identity
 
 
 @pytest.mark.parametrize(
@@ -870,14 +1022,13 @@ def test_summary_constructor_cannot_accept_caller_supplied_arrays_or_claims() ->
         (RuntimeError("generation failed"), ReplicateStage.GENERATING, False),
     ),
 )
-def test_pre_draw_generation_terminal_is_typed_and_factory_is_not_created(
+def test_pre_draw_generation_terminal_is_typed_and_optimizer_is_not_created(
     monkeypatch: pytest.MonkeyPatch,
     failure: BaseException,
     expected_stage: ReplicateStage,
     draw_present: bool,
 ) -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
-    factory_calls = 0
 
     def fail_generation(
         _dataset: ResamplingDatasetManifest,
@@ -885,20 +1036,12 @@ def test_pre_draw_generation_terminal_is_typed_and_factory_is_not_created(
     ) -> None:
         raise failure
 
-    def factory(
-        _prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationSuccess]:
-        nonlocal factory_calls
-        factory_calls += 1
-        return _success
-
     monkeypatch.setattr(
         "chemex.optimize.native_resampling.generate_resampling_draw",
         fail_generation,
     )
-    operation = execute_resampling_evidence(accepted, plan, factory)
+    operation = execute_resampling_evidence(accepted, plan)
 
-    assert factory_calls == 0
     assert operation.evidence is not None
     first = operation.evidence.outcomes[0]
     assert first.stage is expected_stage
@@ -925,15 +1068,26 @@ def test_pre_draw_generation_terminal_is_typed_and_factory_is_not_created(
     )
 
 
-def test_interruption_after_draw_before_executor_creation_is_typed() -> None:
+def test_interruption_after_draw_before_executor_creation_is_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
+    original = EvaluationEngine.resampled
+    calls = 0
 
-    def interrupt_factory(
-        _prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationResult]:
-        raise KeyboardInterrupt
+    def interrupt_binding(
+        engine: EvaluationEngine,
+        evaluation_plan: EvaluationPlan,
+        bindings: object,
+    ) -> EvaluationEngine:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise KeyboardInterrupt
+        return original(engine, evaluation_plan, cast("Any", bindings))
 
-    operation = execute_resampling_evidence(accepted, plan, interrupt_factory)
+    monkeypatch.setattr(EvaluationEngine, "resampled", interrupt_binding)
+    operation = execute_resampling_evidence(accepted, plan)
 
     assert operation.evidence is not None
     first = operation.evidence.outcomes[0]
@@ -952,18 +1106,19 @@ def test_optimization_interruption_preserves_complete_ordinal_accounting(
 ) -> None:
     accepted, plan = _plan(ResamplingScheme.MONTE_CARLO)
 
-    def factory(
+    def hook(
         prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationResult]:
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
         if prepared.request.ordinal == 0:
-            return lambda _exact: (_ for _ in ()).throw(KeyboardInterrupt())
-        return lambda exact: _success(exact)
+            raise KeyboardInterrupt
+        return projected
 
     operation = execute_resampling_evidence(
         accepted,
         plan,
-        factory,
         execution=ExecutionSettings(workers=workers),
+        candidate_test_hook=hook,
     )
 
     assert operation.evidence is not None
@@ -983,35 +1138,32 @@ def test_optimization_interruption_preserves_complete_ordinal_accounting(
 def test_projected_failure_remains_typed_and_summary_uses_common_scope() -> None:
     accepted, plan = _plan(ResamplingScheme.BOOTSTRAP, count=3)
 
-    def factory(
+    def hook(
         prepared: ReplicateExecutionPlan,
-    ) -> Callable[[ReplicateExecutionPlan], ProjectedOptimizationResult]:
+        projected: ProjectedOptimizationResult,
+    ) -> ProjectedOptimizationResult:
         if prepared.request.ordinal != 1:
-            return lambda exact: _success(exact)
-
-        def fail(exact: ReplicateExecutionPlan) -> ProjectedOptimizationFailure:
-            return ProjectedOptimizationFailure(
-                exact.draw.identity,
-                ReplicateDisposition.FAILED,
-                "solver_unsuccessful",
-                "declared local budget exhausted",
-                optimization_projection_identity=(
-                    exact.request.optimization_projection_identity
-                ),
-                stage=ReplicateStage.EXECUTING,
-                prepared_replicate_identity=exact.identity,
-                evaluation_plan_identity=exact.evaluation_plan.identity,
-                problem_identity=exact.problem.identity,
-                invocation_identity=exact.invocation_identity,
-            )
-
-        return fail
+            return projected
+        return ProjectedOptimizationFailure(
+            prepared.draw.identity,
+            ReplicateDisposition.FAILED,
+            "solver_unsuccessful",
+            "declared local budget exhausted",
+            optimization_projection_identity=(
+                prepared.request.optimization_projection_identity
+            ),
+            stage=ReplicateStage.EXECUTING,
+            prepared_replicate_identity=prepared.identity,
+            evaluation_plan_identity=prepared.evaluation_plan.identity,
+            problem_identity=prepared.problem.identity,
+            invocation_identity=prepared.invocation_identity,
+        )
 
     operation = execute_resampling_evidence(
         accepted,
         plan,
-        factory,
         execution=ExecutionSettings(workers=2),
+        candidate_test_hook=hook,
     )
     assert operation.evidence is not None
     evidence = operation.evidence

--- a/tests/test_native_resampling.py
+++ b/tests/test_native_resampling.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Callable
+from threading import Event
 
 import numpy as np
 import pytest
@@ -101,6 +102,9 @@ def _plan(
             f"qualification-replicate-{name}"
             for name in ("alpha", "beta", "gamma", "delta")[:count]
         ),
+        replicate_component_identities=tuple(
+            (f"component-{ordinal}",) for ordinal in range(count)
+        ),
         root_seed=0x1234_5678_90AB_CDEF,
         source_dataset_identity="qualification-dataset",
         output_scope=("A", "B"),
@@ -119,11 +123,13 @@ def _successful_projection(
         ordinal = request.ordinal
         return ProjectedOptimizationSuccess(
             transformed_data_identity=draw.identity,
+            optimization_projection_identity=request.optimization_projection_identity,
             evaluation_plan_identity=f"plan-{ordinal}",
             problem_identity=f"problem-{ordinal}",
             invocation_identity=f"invocation-{ordinal}",
             execution_identity=f"execution-{ordinal}",
             strategy=OptimizationStrategy.DIRECT_TRF,
+            component_identities=request.component_identities,
             component_outcome_identities=(f"component-{ordinal}",),
             resolved_items=(("A", offset + ordinal + 1.0), ("B", 10.0 - ordinal)),
             chi_square=float(ordinal + 1),
@@ -148,6 +154,9 @@ def test_replicate_plan_uses_canonical_ordinals_and_identity_derived_seeds() -> 
         replicate_structural_identities=tuple(
             reversed(plan.replicate_structural_identities)
         ),
+        replicate_component_identities=tuple(
+            reversed(plan.replicate_component_identities)
+        ),
         root_seed=plan.root_seed,
         source_dataset_identity=plan.source_dataset_identity,
         output_scope=plan.output_scope,
@@ -165,6 +174,9 @@ def test_replicate_plan_uses_canonical_ordinals_and_identity_derived_seeds() -> 
             "qualification-replicate-beta",
             "qualification-replicate-gamma",
             "qualification-replicate-delta",
+        ),
+        replicate_component_identities=tuple(
+            (f"component-{ordinal}",) for ordinal in range(4)
         ),
         root_seed=0x1234_5678_90AB_CDEE,
         source_dataset_identity="qualification-dataset",
@@ -331,6 +343,87 @@ def test_resampling_execution_is_evidence_only_scope_complete_and_worker_stable(
     assert not hasattr(serial.evidence, "commit_authority")
 
 
+def test_projection_and_complete_component_lineage_fail_closed() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=2)
+
+    def wrong_projection(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationSuccess:
+        success = _successful_projection()(request, draw)
+        return dataclasses.replace(
+            success,
+            optimization_projection_identity="different-projection",
+        )
+
+    projection_operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        _population(),
+        wrong_projection,
+    )
+    assert projection_operation.evidence is not None
+    assert all(
+        outcome.failure is not None
+        and outcome.failure.category == "optimization_projection_lineage_mismatch"
+        for outcome in projection_operation.evidence.outcomes
+    )
+
+    def missing_component(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationSuccess:
+        success = _successful_projection()(request, draw)
+        return dataclasses.replace(success, component_identities=("other-component",))
+
+    component_operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        _population(),
+        missing_component,
+    )
+    assert component_operation.evidence is not None
+    assert all(
+        outcome.failure is not None
+        and outcome.failure.category == "incomplete_component_projection"
+        for outcome in component_operation.evidence.outcomes
+    )
+
+
+def test_multi_worker_cancellation_freezes_completed_partial_evidence() -> None:
+    accepted = _accepted_anchor()
+    plan = _plan(accepted, ResamplingScheme.MONTE_CARLO, count=4)
+    first_completed = Event()
+    release_remaining = Event()
+
+    def project(
+        request: ReplicateRequest,
+        draw: ResamplingDraw,
+    ) -> ProjectedOptimizationSuccess:
+        if request.ordinal == 0:
+            result = _successful_projection()(request, draw)
+            first_completed.set()
+            return result
+        release_remaining.wait(timeout=0.2)
+        return _successful_projection()(request, draw)
+
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        _population(),
+        project,
+        execution=ExecutionSettings(workers=2),
+        cancellation_probe=first_completed.is_set,
+    )
+    release_remaining.set()
+
+    assert operation.terminal.value == "cancelled"
+    assert operation.evidence is not None
+    assert tuple(outcome.ordinal for outcome in operation.evidence.outcomes) == (0,)
+    assert operation.unstarted_ordinals == (1, 2, 3)
+
+
 def test_failed_replicates_remain_typed_and_summary_uses_one_common_scope() -> None:
     accepted = _accepted_anchor()
     plan = _plan(accepted, ResamplingScheme.BOOTSTRAP, count=3)
@@ -343,6 +436,9 @@ def test_failed_replicates_remain_typed_and_summary_uses_one_common_scope() -> N
         if request.ordinal == 1:
             return ProjectedOptimizationFailure(
                 transformed_data_identity=draw.identity,
+                optimization_projection_identity=(
+                    request.optimization_projection_identity
+                ),
                 disposition=ReplicateDisposition.FAILED,
                 category="solver_unsuccessful",
                 message="declared local budget exhausted",
@@ -394,19 +490,25 @@ def test_failed_replicates_remain_typed_and_summary_uses_one_common_scope() -> N
     assert distributions["A"].standard_deviation == pytest.approx(
         np.sqrt(2.0), rel=0.0, abs=1.0e-15
     )
-    assert distributions["A"].median == pytest.approx(2.0)
-    assert distributions["A"].percentile_95_lower == pytest.approx(1.05)
-    assert distributions["A"].percentile_95_upper == pytest.approx(2.95)
+    # These small exact inputs exercise only stable binary64 reductions; one ulp-scale
+    # absolute tolerance avoids asserting on representation noise without hiding drift.
+    assert distributions["A"].median == pytest.approx(2.0, rel=0.0, abs=1.0e-15)
+    assert distributions["A"].percentile_95_lower == pytest.approx(
+        1.05, rel=0.0, abs=1.0e-15
+    )
+    assert distributions["A"].percentile_95_upper == pytest.approx(
+        2.95, rel=0.0, abs=1.0e-15
+    )
     covariance = {
         (item.parameter_a, item.parameter_b): item.value for item in summary.covariance
     }
-    assert covariance[("A", "A")] == pytest.approx(2.0)
-    assert covariance[("A", "B")] == pytest.approx(-2.0)
+    assert covariance[("A", "A")] == pytest.approx(2.0, rel=0.0, abs=1.0e-15)
+    assert covariance[("A", "B")] == pytest.approx(-2.0, rel=0.0, abs=1.0e-15)
     correlations = {
         (item.parameter_a, item.parameter_b): item.value
         for item in summary.correlations
     }
-    assert correlations[("A", "B")] == pytest.approx(-1.0)
+    assert correlations[("A", "B")] == pytest.approx(-1.0, rel=0.0, abs=1.0e-15)
 
 
 def test_zero_variance_correlation_is_typed_without_nan() -> None:
@@ -419,11 +521,13 @@ def test_zero_variance_correlation_is_typed_without_nan() -> None:
     ) -> ProjectedOptimizationSuccess:
         return ProjectedOptimizationSuccess(
             transformed_data_identity=draw.identity,
+            optimization_projection_identity=request.optimization_projection_identity,
             evaluation_plan_identity=f"plan-{request.ordinal}",
             problem_identity=f"problem-{request.ordinal}",
             invocation_identity=f"invocation-{request.ordinal}",
             execution_identity=f"execution-{request.ordinal}",
             strategy=OptimizationStrategy.DIRECT_TRF,
+            component_identities=request.component_identities,
             component_outcome_identities=(f"component-{request.ordinal}",),
             resolved_items=(("A", float(request.ordinal)), ("B", 5.0)),
             chi_square=1.0,
@@ -527,11 +631,13 @@ def test_success_payload_rejects_nan_and_non_atomic_scope() -> None:
     with pytest.raises(ResamplingConstructionError, match="complete output scope"):
         ProjectedOptimizationSuccess(
             transformed_data_identity="draw",
+            optimization_projection_identity="projection",
             evaluation_plan_identity="plan",
             problem_identity="problem",
             invocation_identity="invocation",
             execution_identity="execution",
             strategy=OptimizationStrategy.DIRECT_TRF,
+            component_identities=("component",),
             component_outcome_identities=("component",),
             resolved_items=(("A", 1.0),),
             chi_square=1.0,
@@ -540,11 +646,13 @@ def test_success_payload_rejects_nan_and_non_atomic_scope() -> None:
     with pytest.raises(ResamplingConstructionError, match="finite"):
         ProjectedOptimizationSuccess(
             transformed_data_identity="draw",
+            optimization_projection_identity="projection",
             evaluation_plan_identity="plan",
             problem_identity="problem",
             invocation_identity="invocation",
             execution_identity="execution",
             strategy=OptimizationStrategy.DIRECT_TRF,
+            component_identities=("component",),
             component_outcome_identities=("component",),
             resolved_items=(("A", np.nan), ("B", 2.0)),
             chi_square=1.0,
@@ -563,11 +671,13 @@ def test_non_finite_summary_arithmetic_returns_typed_unavailability() -> None:
         value = -1.0e308 if request.ordinal == 0 else 1.0e308
         return ProjectedOptimizationSuccess(
             transformed_data_identity=draw.identity,
+            optimization_projection_identity=request.optimization_projection_identity,
             evaluation_plan_identity=f"plan-{request.ordinal}",
             problem_identity=f"problem-{request.ordinal}",
             invocation_identity=f"invocation-{request.ordinal}",
             execution_identity=f"execution-{request.ordinal}",
             strategy=OptimizationStrategy.DIRECT_TRF,
+            component_identities=request.component_identities,
             component_outcome_identities=(f"component-{request.ordinal}",),
             resolved_items=(("A", value), ("B", value)),
             chi_square=1.0,


### PR DESCRIPTION
Closes #599.

## Summary

Adds isolated native resampling evidence for:

* Monte Carlo resampling;
* per-profile bootstrap;
* nucleus bootstrap.

Replicates use canonical ordinals and SHA-256-derived seeds, execute the projected native optimization path without commit authority, and produce complete typed outcomes suitable for deterministic serial or multi-worker qualification.

## Replicate generation and identity

Each resampling request is bound to the exact accepted occurrence, source dataset, evaluation plan, optimization problem, parameterization, requested scope, and generation policy.

Source and draw identities are content-derived from the complete scientific population, including:

* observations and uncertainties;
* masks and metadata;
* profile ordering;
* nucleus grouping;
* scaling and reference semantics;
* transformed replicate content.

Changing scientific data while retaining an old identity is rejected fail-closed.

## Native execution and validation

Each replicate receives an immutable `ReplicateExecutionPlan` containing its exact:

* transformed `EvaluationPlan`;
* derived `OptimizationProblem`;
* parameterization and snapshot lineage;
* workflow and invocation contract;
* component decomposition where applicable;
* requested scope and units.

The optimizer executor may propose a candidate, but it cannot certify scientific success.

Every eligible candidate is freshly evaluated through a new private native evaluator and workspace. Authoritative χ², complete constraint resolution, and the requested-scope sample are derived only from that fresh evaluation.

Replicates remain evidence-only:

* no `AcceptedFitResult`;
* no `LiveFitCommitAuthority`;
* no mutation of `AnalysisValues`.

## Worker isolation and determinism

Stateful execution resources are constructed independently for every replicate.

Serial and multi-worker execution preserve identical:

* replicate identities and seeds;
* generated draws;
* scientific outcomes;
* canonical evidence ordering;
* summaries.

Worker identity and completion order do not enter scientific identity. Deliberately reversed completion order produces the same published evidence.

## Outcomes and partial evidence

Every requested replicate ordinal receives exactly one typed outcome:

* successful complete sample;
* failed;
* excluded;
* cancelled;
* interrupted;
* not started.

No ordinal disappears.

Cancellation and interruption preserve completed evidence truthfully and represent all unscheduled replicates explicitly as `NOT_STARTED`.

A replicate interrupted before draw creation retains its ordinal, seed, request identity, and stage without manufacturing a draw or optimization result.

## Summaries

Percentiles, covariance, and correlations are derived only from complete, compatible successful samples sharing one exact scope, order, units, source evidence, and summary policy.

The implementation does not use:

* NaN placeholders;
* parameter-specific filtering;
* pairwise deletion;
* incomplete samples.

Zero-variance and insufficient-sample cases use explicit typed semantics.

Summary artifacts are recomputed from their exact source evidence. In-memory reconstruction, `dataclasses.replace()`, post-construction mutation, or serialized tampering cannot forge sample values, covariance, correlations, claims, included ordinals, or evidence identities.

## Qualification coverage

Behavioral and adversarial coverage includes:

* deterministic MC, bootstrap, and nucleus-bootstrap draws;
* nucleus-level atomic grouping;
* altered source/draw data;
* foreign evaluation plans, problems, invocations, executions, candidates, and materializations;
* incomplete requested scopes;
* fresh native candidate materialization;
* arbitrary executor-reported χ²;
* stateful shared-executor attacks;
* reversed multi-worker completion order;
* worker-local failures;
* interruption before and during generation/execution;
* complete ordinal accounting;
* summary reconstruction and serialization tampering;
* seeded numerical references for percentiles, covariance, correlation, and zero variance.

## Scope

This remains an isolated native qualification path.

No changes to:

* production optimizer dispatch;
* CLI or TOML;
* output/reporting;
* central parameter values;
* covariance uncertainty;
* MCMC;
* legacy fitting behavior.

## Validation

Implementation validation included:

* full suite: **805 passed** before the final narrow evidence-integrity repair;
* final focused resampling/evaluation validation: **113 passed**;
* targeted reconstruction/serialization validation: **8 passed**;
* `ty`: passed;
* Ruff lint and format checks: passed;
* `git diff --check`: passed;
* Graphify refreshed.

One existing non-failing `emcee` runtime warning remains.

Independent adversarial review: **MERGE**

* Standards: 0 Blocking/Important findings
* Spec: 0 Blocking/Important findings
