### PR TITLE
Add native MCMC evidence

### DIFF
--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import secrets
 import warnings
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -127,7 +128,16 @@ class McmcDiagnosticReason(StrEnum):
     INVALID_AUTOCORRELATION = "invalid_autocorrelation"
     PARTIAL_CHAIN = "partial_chain"
     BACKEND_TRANSITION_INCONSISTENT = "backend_transition_inconsistent"
+    UNVALIDATED_BACKEND_TRANSITIONS = "unvalidated_backend_transitions"
     UNRELIABLE_AUTOCORRELATION = "unreliable_autocorrelation"
+
+
+class BackendTransitionEvidenceKind(StrEnum):
+    """Authority of one backend transition-mask artifact."""
+
+    OBSERVED_EXECUTION = "observed_execution"
+    HISTORICAL_OBSERVATION = "historical_observation"
+    HYPOTHETICAL = "hypothetical"
 
 
 class McmcTrajectoryClaim(StrEnum):
@@ -217,6 +227,123 @@ def _mcmc_evidence_occurrence_is_authoritative(
     with _MCMC_EVIDENCE_WITNESSES_LOCK:
         binding = _MCMC_EVIDENCE_WITNESSES.get(witness)
     return binding == _McmcEvidenceBinding(kind, identity, id(artifact))
+
+
+class _BackendExecutionObservation:
+    """Opaque process-local owner of masks emitted by one sampler occurrence."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls) -> _BackendExecutionObservation:
+        raise TypeError(
+            "Backend observations are minted only by native sampler execution"
+        )
+
+    def __copy__(self) -> _BackendExecutionObservation:
+        raise TypeError("Backend execution observations cannot be copied")
+
+    def __deepcopy__(self, _memo: object) -> _BackendExecutionObservation:
+        raise TypeError("Backend execution observations cannot be copied")
+
+    def __reduce__(self) -> tuple[object, ...]:
+        raise TypeError("Backend execution observations cannot be serialized")
+
+    def __reduce_ex__(self, _protocol: SupportsIndex, /) -> tuple[object, ...]:
+        raise TypeError("Backend execution observations cannot be serialized")
+
+
+@dataclass(frozen=True, slots=True)
+class _BackendExecutionObservationBinding:
+    plan_identity: str
+    execution_occurrence_identity: str
+    transitions: tuple[tuple[int, str, str, tuple[bool, ...]], ...] = ()
+
+
+_BACKEND_EXECUTION_OBSERVATIONS: WeakKeyDictionary[
+    _BackendExecutionObservation,
+    _BackendExecutionObservationBinding,
+] = WeakKeyDictionary()
+_BACKEND_EXECUTION_OBSERVATIONS_LOCK = RLock()
+
+
+def _mint_backend_execution_observation(
+    plan_identity: str,
+) -> _BackendExecutionObservation:
+    observation = object.__new__(_BackendExecutionObservation)
+    binding = _BackendExecutionObservationBinding(
+        plan_identity,
+        _identity(
+            "native-mcmc-backend-execution-occurrence",
+            (plan_identity, secrets.token_hex(32)),
+        ),
+    )
+    with _BACKEND_EXECUTION_OBSERVATIONS_LOCK:
+        _BACKEND_EXECUTION_OBSERVATIONS[observation] = binding
+    return observation
+
+
+def _record_backend_execution_transition(
+    observation: _BackendExecutionObservation,
+    previous: EnsembleState,
+    following: EnsembleState,
+    mask: Sequence[bool],
+) -> None:
+    exact_mask = tuple(mask)
+    with _BACKEND_EXECUTION_OBSERVATIONS_LOCK:
+        binding = _BACKEND_EXECUTION_OBSERVATIONS.get(observation)
+        if (
+            binding is None
+            or following.ordinal != len(binding.transitions) + 1
+            or previous.ordinal + 1 != following.ordinal
+        ):
+            raise McmcExecutionError(
+                "Backend mask does not belong to the active sampler occurrence"
+            )
+        _BACKEND_EXECUTION_OBSERVATIONS[observation] = (
+            _BackendExecutionObservationBinding(
+                binding.plan_identity,
+                binding.execution_occurrence_identity,
+                (
+                    *binding.transitions,
+                    (
+                        following.ordinal,
+                        previous.identity,
+                        following.identity,
+                        exact_mask,
+                    ),
+                ),
+            )
+        )
+
+
+def _bind_backend_observation_to_raw_capture(
+    observation: _BackendExecutionObservation,
+    raw_capture: RawMcmcCapture,
+) -> _BackendExecutionObservationBinding:
+    with _BACKEND_EXECUTION_OBSERVATIONS_LOCK:
+        binding = _BACKEND_EXECUTION_OBSERVATIONS.get(observation)
+        expected_edges = tuple(
+            (following.ordinal, previous.identity, following.identity)
+            for previous, following in zip(
+                raw_capture.states,
+                raw_capture.states[1:],
+                strict=False,
+            )
+        )
+        observed_edges = (
+            tuple(item[:3] for item in binding.transitions) if binding else ()
+        )
+        if (
+            binding is None
+            or binding.plan_identity != raw_capture.plan_identity
+            or binding.execution_occurrence_identity
+            != raw_capture.backend_execution_occurrence_identity
+            or observed_edges != expected_edges
+        ):
+            raise McmcConstructionError(
+                "Backend masks cannot bind to a foreign execution occurrence"
+            )
+        return binding
 
 
 def _identity(kind: str, record: object) -> str:
@@ -1147,7 +1274,9 @@ class BackendTransitionEvidence:
     """Diagnostic-only backend masks bound to exact scientific raw states."""
 
     source_capture: RawMcmcCapture = field(repr=False, compare=False)
+    kind: BackendTransitionEvidenceKind
     observation_provenance: str
+    execution_occurrence_identity: str | None
     transitions: tuple[RawTransitionEvent, ...]
     _occurrence_witness: _McmcEvidenceWitness | None = field(
         default=None,
@@ -1164,6 +1293,14 @@ class BackendTransitionEvidence:
         if self._occurrence_witness is None or not self.observation_provenance:
             raise McmcConstructionError(
                 "Backend transition evidence requires canonical diagnostic provenance"
+            )
+        observed = self.kind in {
+            BackendTransitionEvidenceKind.OBSERVED_EXECUTION,
+            BackendTransitionEvidenceKind.HISTORICAL_OBSERVATION,
+        }
+        if observed != (self.execution_occurrence_identity is not None):
+            raise McmcConstructionError(
+                "Backend transition authority and execution occurrence disagree"
             )
         self.source_capture.validate_integrity()
         transitions = tuple(self.transitions)
@@ -1224,7 +1361,9 @@ class BackendTransitionEvidence:
             "native-mcmc-backend-transition-evidence",
             (
                 self.source_capture.identity,
+                self.kind.value,
                 self.observation_provenance,
+                self.execution_occurrence_identity,
                 tuple(item.identity for item in self.transitions),
                 tuple(
                     (item.transition_ordinal, item.walker_ordinal, item.category)
@@ -1241,15 +1380,41 @@ class BackendTransitionEvidence:
     def is_structurally_consistent(self) -> bool:
         return not self.consistency_failures
 
+    @property
+    def supports_observed_diagnostics(self) -> bool:
+        return self.kind in {
+            BackendTransitionEvidenceKind.OBSERVED_EXECUTION,
+            BackendTransitionEvidenceKind.HISTORICAL_OBSERVATION,
+        }
+
     def validate_integrity(self) -> None:
+        if not isinstance(self.source_capture, RawMcmcCapture):
+            raise McmcConstructionError(
+                "Backend transition evidence has a foreign source object"
+            )
         self.source_capture.validate_integrity()
-        expected = BackendTransitionEvidence.from_capture(
+        if self.source_capture_identity != self.source_capture.identity:
+            raise McmcConstructionError(
+                "Backend transition source identity differs from its source object"
+            )
+        if self.supports_observed_diagnostics and (
+            self.execution_occurrence_identity
+            != self.source_capture.backend_execution_occurrence_identity
+        ):
+            raise McmcConstructionError(
+                "Backend evidence differs from its source execution occurrence"
+            )
+        expected = BackendTransitionEvidence(
             self.source_capture,
-            tuple(item.accepted for item in self.transitions),
-            observation_provenance=self.observation_provenance,
+            self.kind,
+            self.observation_provenance,
+            self.execution_occurrence_identity,
+            self.transitions,
+            _mint_mcmc_evidence_witness("backend-transition-evidence"),
         )
         if (
-            self._content_identity() != self.identity
+            self.consistency_failures != expected.consistency_failures
+            or self._content_identity() != self.identity
             or expected._content_identity() != self.identity
         ):
             raise McmcConstructionError(
@@ -1273,6 +1438,7 @@ class BackendTransitionEvidence:
         *,
         observation_provenance: str,
     ) -> BackendTransitionEvidence:
+        """Create explicitly hypothetical masks without execution authority."""
         exact_masks = tuple(tuple(mask) for mask in masks)
         states = source_capture.states
         if len(exact_masks) != max(0, len(states) - 1):
@@ -1297,24 +1463,99 @@ class BackendTransitionEvidence:
         )
         return cls(
             source_capture,
+            BackendTransitionEvidenceKind.HYPOTHETICAL,
             observation_provenance,
+            None,
             transitions,
             _mint_mcmc_evidence_witness("backend-transition-evidence"),
         )
 
-    def with_observed_masks(
+    def with_hypothetical_masks(
         self,
         masks: Sequence[Sequence[bool]],
         *,
         observation_provenance: str,
     ) -> BackendTransitionEvidence:
-        """Create a diagnostic-only alternative without changing raw states."""
+        """Create an unvalidated alternative without changing scientific states."""
         self.validate_integrity()
         return self.from_capture(
             self.source_capture,
             masks,
             observation_provenance=observation_provenance,
         )
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize backend evidence without its process-local authority witness."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "kind": self.kind.value,
+            "source_capture_identity": self.source_capture_identity,
+            "observation_provenance": self.observation_provenance,
+            "execution_occurrence_identity": self.execution_occurrence_identity,
+            "masks": [list(item.accepted) for item in self.transitions],
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        *,
+        source: BackendTransitionEvidence,
+    ) -> BackendTransitionEvidence:
+        """Restore historical evidence only against its exact live observed source."""
+        source.validate_integrity()
+        if record.get("execution_occurrence_identity") != (
+            source.execution_occurrence_identity
+        ):
+            raise McmcConstructionError(
+                "Stored backend evidence belongs to a foreign execution occurrence"
+            )
+        if record != source.to_record():
+            raise McmcConstructionError(
+                "Stored backend evidence differs from its exact observed source"
+            )
+        if source.kind is not BackendTransitionEvidenceKind.OBSERVED_EXECUTION:
+            raise McmcConstructionError(
+                "Historical backend evidence requires a live observed source"
+            )
+        return cls(
+            source.source_capture,
+            BackendTransitionEvidenceKind.HISTORICAL_OBSERVATION,
+            source.observation_provenance,
+            source.execution_occurrence_identity,
+            source.transitions,
+            _mint_mcmc_evidence_witness("backend-transition-evidence"),
+        )
+
+
+def _mint_observed_backend_transition_evidence(
+    observation: _BackendExecutionObservation,
+    raw_capture: RawMcmcCapture,
+    *,
+    observation_provenance: str,
+) -> BackendTransitionEvidence:
+    """Mint observed masks solely from the execution-owned occurrence registry."""
+    binding = _bind_backend_observation_to_raw_capture(observation, raw_capture)
+    transitions = tuple(
+        RawTransitionEvent(
+            ordinal,
+            previous_identity,
+            following_identity,
+            mask,
+            raw_capture.walkers,
+            sum(mask),
+        )
+        for ordinal, previous_identity, following_identity, mask in binding.transitions
+    )
+    return BackendTransitionEvidence(
+        raw_capture,
+        BackendTransitionEvidenceKind.OBSERVED_EXECUTION,
+        observation_provenance,
+        binding.execution_occurrence_identity,
+        transitions,
+        _mint_mcmc_evidence_witness("backend-transition-evidence"),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1327,6 +1568,7 @@ class RawMcmcCapture:
     walkers: int
     dimension: int
     total_steps: int
+    backend_execution_occurrence_identity: str = field(repr=False, compare=False)
     terminal: McmcOperationTerminal
     states: tuple[EnsembleState, ...]
     objective_request_count: int
@@ -1347,7 +1589,7 @@ class RawMcmcCapture:
             raise McmcConstructionError(
                 "Raw MCMC capture must contain a contiguous complete-state prefix"
             )
-        if not self.plan_identity:
+        if not self.plan_identity or not self.backend_execution_occurrence_identity:
             raise McmcConstructionError("Raw MCMC capture requires a plan identity")
         if self.objective_request_count < 0 or self.evaluation_request_count < 0:
             raise McmcConstructionError(
@@ -1417,9 +1659,19 @@ def _mint_raw_capture(
     evaluation_request_count: int,
     stage: McmcExecutionStage,
     initialization_outcome: McmcInitializationOutcome,
+    backend_observation: _BackendExecutionObservation,
     failure_category: str | None = None,
 ) -> RawMcmcCapture:
     exact_states = tuple(states)
+    with _BACKEND_EXECUTION_OBSERVATIONS_LOCK:
+        observation_binding = _BACKEND_EXECUTION_OBSERVATIONS.get(backend_observation)
+    if (
+        observation_binding is None
+        or observation_binding.plan_identity != plan.identity
+    ):
+        raise McmcConstructionError(
+            "Raw MCMC capture requires its exact backend execution occurrence"
+        )
     capture = RawMcmcCapture(
         plan.identity,
         plan.policy.identity,
@@ -1427,6 +1679,7 @@ def _mint_raw_capture(
         plan.policy.walkers,
         plan.policy.dimension,
         plan.policy.total_steps,
+        observation_binding.execution_occurrence_identity,
         terminal,
         exact_states,
         objective_request_count,
@@ -1988,6 +2241,14 @@ class McmcOperation:
             raise McmcConstructionError(
                 "Every MCMC operation requires raw and backend diagnostic evidence"
             )
+        if (
+            self.backend_transition_evidence.kind
+            is not BackendTransitionEvidenceKind.OBSERVED_EXECUTION
+            or self.backend_transition_evidence.source_capture is not self.raw_capture
+        ):
+            raise McmcConstructionError(
+                "MCMC operation requires execution-owned backend observations"
+            )
         object.__setattr__(self, "identity", self._content_identity())
         if self._occurrence_witness is None or not _bind_mcmc_evidence_witness(
             self._occurrence_witness,
@@ -2198,6 +2459,11 @@ class AcceptanceDiagnostics:
             reason = McmcDiagnosticReason.NO_TRANSITIONS
             fractions = None
             mean = None
+        elif not self.source.supports_observed_diagnostics:
+            status = McmcDiagnosticStatus.UNAVAILABLE
+            reason = McmcDiagnosticReason.UNVALIDATED_BACKEND_TRANSITIONS
+            fractions = None
+            mean = None
         elif not self.source.is_structurally_consistent:
             status = McmcDiagnosticStatus.UNAVAILABLE
             reason = McmcDiagnosticReason.BACKEND_TRANSITION_INCONSISTENT
@@ -2236,7 +2502,7 @@ class AcceptanceDiagnostics:
         return _identity(
             "native-mcmc-acceptance-diagnostics",
             (
-                self.source.identity,
+                self.source_identity,
                 self.state_ordinals,
                 self.walker_ordinals,
                 self.observed_transition_count,
@@ -2263,10 +2529,26 @@ class AcceptanceDiagnostics:
         )
 
     def validate_integrity(self) -> None:
+        if not isinstance(self.source, BackendTransitionEvidence):
+            raise McmcConstructionError(
+                "Acceptance diagnostics require an exact backend source object"
+            )
         self.source.validate_integrity()
+        if self.source_identity != self.source.identity:
+            raise McmcConstructionError(
+                "Acceptance diagnostic source identity differs from its source object"
+            )
         expected = self.from_backend_evidence(self.source)
         if (
-            self._content_identity() != self.identity
+            self.state_ordinals != expected.state_ordinals
+            or self.walker_ordinals != expected.walker_ordinals
+            or self.observed_transition_count != expected.observed_transition_count
+            or self.accepted_counts != expected.accepted_counts
+            or self.status is not expected.status
+            or self.reason is not expected.reason
+            or self.acceptance_fractions != expected.acceptance_fractions
+            or self.mean_acceptance_fraction != expected.mean_acceptance_fraction
+            or self._content_identity() != self.identity
             or expected._content_identity() != self.identity
         ):
             raise McmcConstructionError("Acceptance diagnostic content mismatch")
@@ -3181,8 +3463,8 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     plan.validate_integrity(accepted)
     signal = CancellationToken() if cancellation is None else cancellation
     log_density = _LogDensityEvaluator(plan)
+    backend_observation = _mint_backend_execution_observation(plan.identity)
     states: list[EnsembleState] = []
-    acceptance_masks: list[tuple[bool, ...]] = []
     stage = McmcExecutionStage.BEFORE_INITIALIZATION
     initialization_outcome = McmcInitializationOutcome.NOT_STARTED
 
@@ -3234,11 +3516,16 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
                 raise McmcExecutionError(
                     "MCMC backend omitted its transition diagnostic mask"
                 )
-            acceptance_masks.append(tuple(bool(value) for value in move.last_accepted))
             state = _ensemble_state(
                 ordinal,
                 sampled.coords,
                 sampled.log_prob,
+            )
+            _record_backend_execution_transition(
+                backend_observation,
+                states[-1],
+                state,
+                tuple(bool(value) for value in move.last_accepted),
             )
             states.append(state)
             if state_observer is not None:
@@ -3257,10 +3544,11 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
             log_density.evaluation_request_count,
             stage,
             initialization_outcome,
+            backend_observation,
         )
-        backend_transition_evidence = BackendTransitionEvidence.from_capture(
+        backend_transition_evidence = _mint_observed_backend_transition_evidence(
+            backend_observation,
             raw_capture,
-            acceptance_masks,
             observation_provenance="emcee-stretch-backend-v1",
         )
         validation = validate_raw_mcmc_capture(
@@ -3307,11 +3595,12 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
         log_density.evaluation_request_count,
         stage,
         initialization_outcome,
+        backend_observation,
         category,
     )
-    backend_transition_evidence = BackendTransitionEvidence.from_capture(
+    backend_transition_evidence = _mint_observed_backend_transition_evidence(
+        backend_observation,
         raw_capture,
-        acceptance_masks,
         observation_provenance="emcee-stretch-backend-v1",
     )
     validation = validate_raw_mcmc_capture(

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -129,6 +129,7 @@ class McmcDiagnosticReason(StrEnum):
     PARTIAL_CHAIN = "partial_chain"
     BACKEND_TRANSITION_INCONSISTENT = "backend_transition_inconsistent"
     UNVALIDATED_BACKEND_TRANSITIONS = "unvalidated_backend_transitions"
+    HISTORICAL_OBSERVATION_UNVERIFIED = "historical_observation_unverified"
     UNRELIABLE_AUTOCORRELATION = "unreliable_autocorrelation"
 
 
@@ -1503,6 +1504,10 @@ class BackendTransitionEvidence:
 
     @property
     def supports_observed_diagnostics(self) -> bool:
+        return self.kind is BackendTransitionEvidenceKind.OBSERVED_EXECUTION
+
+    @property
+    def has_execution_occurrence_lineage(self) -> bool:
         return self.kind in {
             BackendTransitionEvidenceKind.OBSERVED_EXECUTION,
             BackendTransitionEvidenceKind.HISTORICAL_OBSERVATION,
@@ -1518,7 +1523,7 @@ class BackendTransitionEvidence:
             raise McmcConstructionError(
                 "Backend transition source identity differs from its source object"
             )
-        if self.supports_observed_diagnostics and (
+        if self.has_execution_occurrence_lineage and (
             self.execution_occurrence_identity
             != self.source_capture.backend_execution_occurrence_identity
         ):
@@ -2033,7 +2038,7 @@ class McmcEvidence:
         backend.validate_integrity()
         source_capture = backend.source_capture
         if (
-            not backend.supports_observed_diagnostics
+            not backend.has_execution_occurrence_lineage
             or backend.execution_occurrence_identity
             != self.backend_execution_occurrence_identity
             or source_capture.backend_execution_occurrence_identity
@@ -2664,7 +2669,12 @@ class AcceptanceDiagnostics:
             sum(transition.accepted[walker] for transition in transitions)
             for walker in walker_ordinals
         )
-        if denominator == 0:
+        if self.source.kind is BackendTransitionEvidenceKind.HISTORICAL_OBSERVATION:
+            status = McmcDiagnosticStatus.UNAVAILABLE
+            reason = McmcDiagnosticReason.HISTORICAL_OBSERVATION_UNVERIFIED
+            fractions = None
+            mean = None
+        elif denominator == 0:
             status = McmcDiagnosticStatus.UNAVAILABLE
             reason = McmcDiagnosticReason.NO_TRANSITIONS
             fractions = None

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -1,0 +1,1151 @@
+"""Prospective native fixed-topology MCMC evidence qualification (#600).
+
+This module is an isolated qualification seam. Production method parsing,
+workflow orchestration, reporting, and parameter-state mutation do not consume
+these artifacts yet.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import cast
+
+import emcee
+import numpy as np
+
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+)
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    OptimizationProblem,
+    accepted_occurrence_is_authoritative,
+    canonical_chi_square,
+)
+from chemex.optimize.uncertainty import ParameterUnit
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.typing import Array
+
+_SCHEMA_VERSION = 1
+_SEED_POLICY_VERSION = "sha256-structural-u64-v1"
+_RNG_ALGORITHM = "numpy-pcg64-lhs+seedsequence-mt19937-emcee-v1"
+_SAMPLER_VERSION = "chemex-emcee-ensemble-v1"
+_INITIALIZATION_VERSION = "bounded-latin-hypercube-v1"
+_PROPOSAL_VERSION = "emcee-stretch-v1"
+_MAX_U64 = (1 << 64) - 1
+
+
+class McmcConstructionError(ValueError):
+    """Raised when a native MCMC policy or artifact is malformed."""
+
+
+class McmcPolicyKind(StrEnum):
+    """Closed prospective native MCMC policy modes."""
+
+    CALIBRATED = "calibrated"
+    EXPERT = "expert"
+
+
+class InitializationKind(StrEnum):
+    """Closed native ensemble initialization constructions."""
+
+    BOUNDED_LATIN_HYPERCUBE = "bounded_latin_hypercube"
+
+
+class ProposalKind(StrEnum):
+    """Closed native ensemble proposal kernels."""
+
+    STRETCH = "stretch"
+
+
+class McmcEvidenceLifecycle(StrEnum):
+    """Lifecycle of a primary chain artifact containing genuine states."""
+
+    COMPLETED = "completed"
+    PARTIAL = "partial"
+
+
+class McmcOperationTerminal(StrEnum):
+    """Terminal disposition of one native MCMC execution operation."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+class McmcExecutionError(RuntimeError):
+    """Raised internally when native evaluation cannot produce log density."""
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "record": record, "schema_version": _SCHEMA_VERSION},
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _nonempty(value: str, *, name: str) -> str:
+    if not value:
+        raise McmcConstructionError(f"{name} must not be empty")
+    return value
+
+
+def _exact_keys(record: Mapping[str, object], expected: set[str], name: str) -> None:
+    if set(record) != expected:
+        raise McmcConstructionError(f"{name} record has unexpected fields")
+
+
+def _positive_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise McmcConstructionError(f"{name} must be a positive integer")
+    return value
+
+
+def _nonnegative_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise McmcConstructionError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _unsigned_seed(value: object, *, name: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > _MAX_U64
+    ):
+        raise McmcConstructionError(f"{name} must be an unsigned 64-bit seed")
+    return value
+
+
+def _finite_positive(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise McmcConstructionError(f"{name} must be a positive finite scalar")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0.0:
+        raise McmcConstructionError(f"{name} must be a positive finite scalar")
+    return result
+
+
+def _derive_seed(root_seed: int, namespace: str, work_unit: str) -> int:
+    fields = (
+        b"chemex-native-seed",
+        _SEED_POLICY_VERSION.encode("ascii"),
+        root_seed.to_bytes(8, "big"),
+        namespace.encode("ascii"),
+        work_unit.encode("ascii"),
+    )
+    encoded = b"".join(len(item).to_bytes(8, "big") + item for item in fields)
+    return int.from_bytes(hashlib.sha256(encoded).digest()[:8], "big")
+
+
+def build_bounded_latin_hypercube(
+    lower_bounds: Sequence[float],
+    upper_bounds: Sequence[float],
+    *,
+    walkers: int,
+    seed: int,
+) -> tuple[tuple[float, ...], ...]:
+    """Construct one reproducible open-bound Latin-hypercube ensemble."""
+    walker_count = _positive_integer(walkers, name="MCMC walker count")
+    rng_seed = _unsigned_seed(seed, name="MCMC initialization seed")
+    lower = np.asarray(tuple(lower_bounds), dtype=np.float64)
+    upper = np.asarray(tuple(upper_bounds), dtype=np.float64)
+    if (
+        lower.ndim != 1
+        or upper.ndim != 1
+        or lower.shape != upper.shape
+        or lower.size < 1
+        or not np.all(np.isfinite(lower))
+        or not np.all(np.isfinite(upper))
+        or not np.all(lower < upper)
+    ):
+        raise McmcConstructionError(
+            "MCMC initialization requires finite strictly ordered bounds"
+        )
+    rng = np.random.Generator(np.random.PCG64(rng_seed))
+    dimension = int(lower.size)
+    unit = np.empty((walker_count, dimension), dtype=np.float64)
+    epsilon = np.finfo(np.float64).eps
+    for coordinate in range(dimension):
+        jitter = np.clip(rng.random(walker_count), epsilon, 1.0 - epsilon)
+        strata = rng.permutation(walker_count)
+        unit[:, coordinate] = (strata + jitter) / walker_count
+    positions = lower + unit * (upper - lower)
+    if not np.all((positions > lower) & (positions < upper)):
+        raise McmcConstructionError(
+            "Bounded Latin-hypercube construction reached a closed bound"
+        )
+    return tuple(tuple(float(value) for value in row) for row in positions)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedMcmcPolicy:
+    """Complete immutable MCMC topology and work allocation fixed pre-run."""
+
+    kind: McmcPolicyKind
+    policy_version: str
+    dimension: int
+    walkers: int
+    burn_steps: int
+    retained_steps: int
+    root_seed: int
+    qualification_dimension_range: tuple[int, int] | None = None
+    proposal_scale: float = 2.0
+    thin: int = 1
+    initialization: InitializationKind = InitializationKind.BOUNDED_LATIN_HYPERCUBE
+    proposal: ProposalKind = ProposalKind.STRETCH
+    sampler_version: str = _SAMPLER_VERSION
+    initialization_version: str = _INITIALIZATION_VERSION
+    proposal_version: str = _PROPOSAL_VERSION
+    seed_policy_version: str = _SEED_POLICY_VERSION
+    rng_algorithm: str = _RNG_ALGORITHM
+    total_steps: int = field(init=False)
+    objective_request_budget: int = field(init=False)
+    initialization_seed: int = field(init=False)
+    sampler_seed: int = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        dimension = _positive_integer(self.dimension, name="MCMC dimension")
+        walkers = _positive_integer(self.walkers, name="MCMC walker count")
+        burn = _nonnegative_integer(self.burn_steps, name="MCMC burn extent")
+        retained = _positive_integer(
+            self.retained_steps,
+            name="MCMC retained extent",
+        )
+        root_seed = _unsigned_seed(self.root_seed, name="MCMC root seed")
+        qualification_range = self.qualification_dimension_range
+        if qualification_range is not None and (
+            len(qualification_range) != 2
+            or isinstance(qualification_range[0], bool)
+            or isinstance(qualification_range[1], bool)
+            or not all(isinstance(value, int) for value in qualification_range)
+            or qualification_range[0] < 1
+            or qualification_range[0] > qualification_range[1]
+            or not qualification_range[0] <= dimension <= qualification_range[1]
+        ):
+            raise McmcConstructionError("MCMC qualification dimension range is invalid")
+        if self.kind is McmcPolicyKind.CALIBRATED and qualification_range is None:
+            raise McmcConstructionError(
+                "Calibrated MCMC policy requires an explicit qualification stratum"
+            )
+        if self.kind is McmcPolicyKind.EXPERT and qualification_range is not None:
+            raise McmcConstructionError(
+                "Expert MCMC policy cannot inherit calibrated qualification"
+            )
+        proposal_scale = _finite_positive(
+            self.proposal_scale,
+            name="MCMC proposal scale",
+        )
+        if proposal_scale <= 1.0:
+            raise McmcConstructionError("MCMC stretch proposal scale must exceed one")
+        if walkers < max(4, 2 * dimension):
+            raise McmcConstructionError(
+                "MCMC walker count must be at least max(4, 2 * dimension)"
+            )
+        if self.thin != 1:
+            raise McmcConstructionError(
+                "Native MCMC retained evidence has fixed THIN=1"
+            )
+        for value, name in (
+            (self.policy_version, "MCMC policy version"),
+            (self.sampler_version, "MCMC sampler version"),
+            (self.initialization_version, "MCMC initialization version"),
+            (self.proposal_version, "MCMC proposal version"),
+            (self.seed_policy_version, "MCMC seed policy version"),
+            (self.rng_algorithm, "MCMC RNG algorithm"),
+        ):
+            _nonempty(value, name=name)
+        total_steps = burn + retained
+        objective_request_budget = walkers * (1 + total_steps)
+        namespace = _identity(
+            "native-mcmc-seed-namespace",
+            (
+                self.kind.value,
+                self.policy_version,
+                dimension,
+                walkers,
+                burn,
+                retained,
+                qualification_range,
+                self.initialization.value,
+                self.proposal.value,
+                float(proposal_scale).hex(),
+            ),
+        )
+        initialization_seed = _derive_seed(root_seed, namespace, "initialization")
+        sampler_seed = _derive_seed(root_seed, namespace, "sampler")
+        if initialization_seed == sampler_seed:
+            raise McmcConstructionError("MCMC derived seeds collided")
+        identity = _identity(
+            "native-mcmc-resolved-policy",
+            (
+                self.kind.value,
+                self.policy_version,
+                dimension,
+                walkers,
+                burn,
+                retained,
+                qualification_range,
+                self.thin,
+                self.initialization.value,
+                self.initialization_version,
+                self.proposal.value,
+                self.proposal_version,
+                float(proposal_scale).hex(),
+                self.sampler_version,
+                objective_request_budget,
+                root_seed,
+                initialization_seed,
+                sampler_seed,
+                self.seed_policy_version,
+                self.rng_algorithm,
+            ),
+        )
+        object.__setattr__(self, "dimension", dimension)
+        object.__setattr__(self, "walkers", walkers)
+        object.__setattr__(self, "burn_steps", burn)
+        object.__setattr__(self, "retained_steps", retained)
+        object.__setattr__(self, "root_seed", root_seed)
+        object.__setattr__(self, "proposal_scale", proposal_scale)
+        object.__setattr__(self, "total_steps", total_steps)
+        object.__setattr__(
+            self,
+            "objective_request_budget",
+            objective_request_budget,
+        )
+        object.__setattr__(self, "initialization_seed", initialization_seed)
+        object.__setattr__(self, "sampler_seed", sampler_seed)
+        object.__setattr__(self, "identity", identity)
+
+
+@dataclass(frozen=True, slots=True)
+class CalibratedMcmcPolicy:
+    """One versioned qualified topology for a bounded dimension stratum."""
+
+    policy_version: str
+    minimum_dimension: int
+    maximum_dimension: int
+    walkers: int
+    burn_steps: int
+    retained_steps: int
+    proposal_scale: float = 2.0
+
+    def resolve(self, *, dimension: int, root_seed: int) -> ResolvedMcmcPolicy:
+        minimum = _positive_integer(
+            self.minimum_dimension,
+            name="calibrated minimum dimension",
+        )
+        maximum = _positive_integer(
+            self.maximum_dimension,
+            name="calibrated maximum dimension",
+        )
+        if minimum > maximum:
+            raise McmcConstructionError(
+                "Calibrated MCMC dimension stratum is strictly inverted"
+            )
+        if not minimum <= dimension <= maximum:
+            raise McmcConstructionError(
+                "No calibrated MCMC policy covers the requested dimension"
+            )
+        return ResolvedMcmcPolicy(
+            kind=McmcPolicyKind.CALIBRATED,
+            policy_version=_nonempty(
+                self.policy_version,
+                name="MCMC policy version",
+            ),
+            dimension=dimension,
+            walkers=self.walkers,
+            burn_steps=self.burn_steps,
+            retained_steps=self.retained_steps,
+            root_seed=root_seed,
+            qualification_dimension_range=(minimum, maximum),
+            proposal_scale=self.proposal_scale,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ExpertMcmcPolicy:
+    """Prospective topology overrides without inherited adequacy claims."""
+
+    burn_steps: int
+    retained_steps: int
+    walkers: int
+    policy_version: str = field(init=False, default="expert-v1")
+
+    def resolve(self, *, dimension: int, root_seed: int) -> ResolvedMcmcPolicy:
+        return ResolvedMcmcPolicy(
+            kind=McmcPolicyKind.EXPERT,
+            policy_version=_nonempty(
+                self.policy_version,
+                name="MCMC expert policy version",
+            ),
+            dimension=dimension,
+            walkers=self.walkers,
+            burn_steps=self.burn_steps,
+            retained_steps=self.retained_steps,
+            root_seed=root_seed,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class McmcPlan:
+    """One accepted-result MCMC request with all choices frozen pre-run."""
+
+    accepted: AcceptedFitResult = field(repr=False, compare=False)
+    source_problem: OptimizationProblem = field(repr=False, compare=False)
+    parameterization: ActiveParameterization = field(repr=False, compare=False)
+    source_engine: EvaluationEngine = field(repr=False, compare=False)
+    policy: ResolvedMcmcPolicy
+    coordinate_units: tuple[tuple[str, ParameterUnit], ...]
+    accepted_result_identity: str = field(init=False)
+    accepted_occurrence_identity: str = field(init=False)
+    problem_identity: str = field(init=False)
+    coordinate_ids: tuple[str, ...] = field(init=False)
+    lower_bounds: tuple[float, ...] = field(init=False)
+    upper_bounds: tuple[float, ...] = field(init=False)
+    initial_ensemble: tuple[tuple[float, ...], ...] = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        accepted = self.accepted
+        problem = self.source_problem
+        parameterization = self.parameterization
+        engine = self.source_engine
+        if not accepted_occurrence_is_authoritative(accepted):
+            raise McmcConstructionError(
+                "MCMC planning requires an exact authoritative accepted occurrence"
+            )
+        snapshot = problem.source_snapshot
+        if (
+            accepted.problem_identity != problem.identity
+            or accepted.parameterization_identity != parameterization.identity
+            or accepted.evaluator_parameterization_identity
+            != parameterization.evaluator_identity
+            or accepted.source_occurrence_identity != snapshot.occurrence_identity
+            or accepted.source_revision != snapshot.revision
+            or accepted.evaluation_result.plan_identity != engine.plan.identity
+            or accepted.evaluation_result.parameterization_identity
+            != parameterization.evaluator_identity
+            or accepted.controlled_ids != problem.controlled_ids
+            or accepted.commit_scope != problem.commit_scope
+            or accepted.commit_items
+            != accepted.evaluation_result.resolved_values.ordered_items()
+        ):
+            raise McmcConstructionError(
+                "MCMC source does not match the exact accepted native lineage"
+            )
+        if (
+            engine.plan.identity != problem.evaluation_plan_identity
+            or engine.plan.parameterization_identity
+            != problem.evaluator_parameterization_identity
+            or engine.plan.constraint_program_identity
+            != problem.constraint_program_identity
+        ):
+            raise McmcConstructionError(
+                "MCMC evaluator does not match the accepted optimization problem"
+            )
+        coordinate_ids = tuple(problem.controlled_ids)
+        if len(coordinate_ids) != self.policy.dimension:
+            raise McmcConstructionError(
+                "Resolved MCMC policy dimension differs from the accepted problem"
+            )
+        resolved_items = dict(accepted.commit_items)
+        if tuple(resolved_items[param_id] for param_id in coordinate_ids) != (
+            accepted.vector
+        ):
+            raise McmcConstructionError(
+                "MCMC accepted vector differs from its materialized central values"
+            )
+        units = tuple(self.coordinate_units)
+        if tuple(param_id for param_id, _unit in units) != coordinate_ids or any(
+            not isinstance(unit, ParameterUnit) for _param_id, unit in units
+        ):
+            raise McmcConstructionError(
+                "MCMC coordinate units must bind the ordered sampled scope"
+            )
+        if problem.affine_half_spaces or problem.affine_equalities:
+            raise McmcConstructionError(
+                "Native MCMC qualification currently supports box-bounded problems"
+            )
+        lower = tuple(problem.lower_bounds)
+        upper = tuple(problem.upper_bounds)
+        initial = build_bounded_latin_hypercube(
+            lower,
+            upper,
+            walkers=self.policy.walkers,
+            seed=self.policy.initialization_seed,
+        )
+        identity = _identity(
+            "native-mcmc-plan",
+            (
+                accepted.identity,
+                accepted.occurrence_identity,
+                problem.identity,
+                parameterization.identity,
+                engine.plan.identity,
+                self.policy.identity,
+                coordinate_ids,
+                units,
+                tuple(float(value).hex() for value in lower),
+                tuple(float(value).hex() for value in upper),
+                tuple(tuple(float(value).hex() for value in row) for row in initial),
+            ),
+        )
+        object.__setattr__(self, "coordinate_units", units)
+        object.__setattr__(self, "accepted_result_identity", accepted.identity)
+        object.__setattr__(
+            self,
+            "accepted_occurrence_identity",
+            accepted.occurrence_identity,
+        )
+        object.__setattr__(self, "problem_identity", problem.identity)
+        object.__setattr__(self, "coordinate_ids", coordinate_ids)
+        object.__setattr__(self, "lower_bounds", lower)
+        object.__setattr__(self, "upper_bounds", upper)
+        object.__setattr__(self, "initial_ensemble", initial)
+        object.__setattr__(self, "identity", identity)
+
+    @classmethod
+    def for_accepted(
+        cls,
+        accepted: AcceptedFitResult,
+        *,
+        source_problem: OptimizationProblem,
+        parameterization: ActiveParameterization,
+        source_engine: EvaluationEngine,
+        policy: ResolvedMcmcPolicy,
+        coordinate_units: Sequence[tuple[str, ParameterUnit]],
+    ) -> McmcPlan:
+        """Bind a prospective MCMC run to one accepted native occurrence."""
+        return cls(
+            accepted,
+            source_problem,
+            parameterization,
+            source_engine,
+            policy,
+            tuple(coordinate_units),
+        )
+
+
+def _finite_state_scalar(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+        raise McmcConstructionError(f"{name} must be a finite binary64 scalar")
+    result = float(value)
+    if not math.isfinite(result):
+        raise McmcConstructionError(f"{name} must be a finite binary64 scalar")
+    return 0.0 if result == 0.0 else result
+
+
+@dataclass(frozen=True, slots=True)
+class EnsembleState:
+    """One atomically completed full-walker state and its log densities."""
+
+    ordinal: int
+    positions: tuple[tuple[float, ...], ...]
+    log_densities: tuple[float, ...]
+    accepted: tuple[bool, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.ordinal < 0:
+            raise McmcConstructionError("MCMC state ordinal must be non-negative")
+        positions = tuple(
+            tuple(
+                _finite_state_scalar(value, name="MCMC state coordinate")
+                for value in row
+            )
+            for row in self.positions
+        )
+        if (
+            not positions
+            or not positions[0]
+            or any(len(row) != len(positions[0]) for row in positions)
+        ):
+            raise McmcConstructionError(
+                "MCMC state positions must be a non-empty rectangular ensemble"
+            )
+        log_densities = tuple(
+            _finite_state_scalar(value, name="MCMC state log density")
+            for value in self.log_densities
+        )
+        accepted = tuple(self.accepted)
+        if (
+            len(log_densities) != len(positions)
+            or len(accepted) != len(positions)
+            or any(not isinstance(value, bool) for value in accepted)
+        ):
+            raise McmcConstructionError(
+                "MCMC state payload must cover every walker exactly once"
+            )
+        identity = _identity(
+            "native-mcmc-ensemble-state",
+            (
+                self.ordinal,
+                tuple(tuple(float(value).hex() for value in row) for row in positions),
+                tuple(float(value).hex() for value in log_densities),
+                accepted,
+            ),
+        )
+        object.__setattr__(self, "positions", positions)
+        object.__setattr__(self, "log_densities", log_densities)
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(self, "identity", identity)
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize one complete state with exact binary64 tokens."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "ordinal": self.ordinal,
+            "positions": [
+                [float(value).hex() for value in row] for row in self.positions
+            ],
+            "log_densities": [float(value).hex() for value in self.log_densities],
+            "accepted": list(self.accepted),
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> EnsembleState:
+        """Restore and content-validate one complete ensemble state."""
+        _exact_keys(
+            record,
+            {
+                "schema_version",
+                "ordinal",
+                "positions",
+                "log_densities",
+                "accepted",
+                "identity",
+            },
+            "MCMC ensemble-state",
+        )
+        if record.get("schema_version") != _SCHEMA_VERSION:
+            raise McmcConstructionError("Unsupported MCMC ensemble-state schema")
+        ordinal = record.get("ordinal")
+        raw_positions = record.get("positions")
+        raw_log_densities = record.get("log_densities")
+        raw_accepted = record.get("accepted")
+        identity = record.get("identity")
+        if (
+            isinstance(ordinal, bool)
+            or not isinstance(ordinal, int)
+            or not isinstance(raw_positions, list)
+            or not all(isinstance(row, list) for row in raw_positions)
+            or not isinstance(raw_log_densities, list)
+            or not isinstance(raw_accepted, list)
+            or not all(isinstance(value, bool) for value in raw_accepted)
+            or not isinstance(identity, str)
+        ):
+            raise McmcConstructionError("Malformed MCMC ensemble-state record")
+        position_rows = cast("list[list[object]]", raw_positions)
+        accepted_values = cast("list[bool]", raw_accepted)
+        if any(
+            not isinstance(value, str) for row in position_rows for value in row
+        ) or any(not isinstance(value, str) for value in raw_log_densities):
+            raise McmcConstructionError("Malformed MCMC ensemble-state binary64 token")
+        try:
+            positions = tuple(
+                tuple(float.fromhex(cast("str", value)) for value in row)
+                for row in position_rows
+            )
+            log_densities = tuple(
+                float.fromhex(cast("str", value)) for value in raw_log_densities
+            )
+        except ValueError as error:
+            raise McmcConstructionError(
+                "Malformed MCMC ensemble-state binary64 token"
+            ) from error
+        state = cls(
+            ordinal,
+            positions,
+            log_densities,
+            tuple(accepted_values),
+        )
+        if state.identity != identity:
+            raise McmcConstructionError("MCMC ensemble-state identity mismatch")
+        return state
+
+
+@dataclass(frozen=True, slots=True)
+class McmcEvidence:
+    """Primary fixed-topology chain evidence preserving ensemble states."""
+
+    plan: McmcPlan = field(repr=False, compare=False)
+    lifecycle: McmcEvidenceLifecycle
+    terminal: McmcOperationTerminal
+    states: tuple[EnsembleState, ...]
+    objective_request_count: int
+    evaluation_request_count: int
+    failure_category: str | None = None
+    plan_identity: str = field(init=False)
+    accepted_result_identity: str = field(init=False)
+    coordinate_ids: tuple[str, ...] = field(init=False)
+    coordinate_units: tuple[tuple[str, ParameterUnit], ...] = field(init=False)
+    completed_transition_count: int = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        states = tuple(self.states)
+        expected_ordinals = tuple(range(len(states)))
+        if not states or tuple(state.ordinal for state in states) != expected_ordinals:
+            raise McmcConstructionError(
+                "MCMC evidence must preserve a contiguous prefix of complete states"
+            )
+        if states[0].positions != self.plan.initial_ensemble:
+            raise McmcConstructionError(
+                "MCMC evidence initial state differs from its frozen plan"
+            )
+        for state in states:
+            if len(state.positions) != self.plan.policy.walkers or any(
+                len(position) != self.plan.policy.dimension
+                for position in state.positions
+            ):
+                raise McmcConstructionError(
+                    "MCMC evidence state topology differs from its frozen plan"
+                )
+        completed = len(states) - 1
+        if completed > self.plan.policy.total_steps:
+            raise McmcConstructionError("MCMC evidence exceeds its frozen topology")
+        if self.lifecycle is McmcEvidenceLifecycle.COMPLETED:
+            if (
+                self.terminal is not McmcOperationTerminal.COMPLETED
+                or completed != self.plan.policy.total_steps
+                or self.failure_category is not None
+            ):
+                raise McmcConstructionError(
+                    "Completed MCMC evidence must contain the complete frozen chain"
+                )
+        elif self.terminal is McmcOperationTerminal.COMPLETED:
+            raise McmcConstructionError(
+                "Partial MCMC evidence cannot have a completed terminal"
+            )
+        if (
+            self.objective_request_count < len(states[0].positions)
+            or self.objective_request_count > self.plan.policy.objective_request_budget
+            or self.evaluation_request_count < 0
+            or self.evaluation_request_count > self.objective_request_count
+        ):
+            raise McmcConstructionError("MCMC request accounting is inconsistent")
+        identity = _identity(
+            "native-mcmc-primary-evidence",
+            (
+                self.plan.identity,
+                self.plan.accepted_result_identity,
+                self.lifecycle.value,
+                self.terminal.value,
+                tuple(state.identity for state in states),
+                self.objective_request_count,
+                self.evaluation_request_count,
+                self.failure_category,
+            ),
+        )
+        object.__setattr__(self, "states", states)
+        object.__setattr__(self, "plan_identity", self.plan.identity)
+        object.__setattr__(
+            self,
+            "accepted_result_identity",
+            self.plan.accepted_result_identity,
+        )
+        object.__setattr__(self, "coordinate_ids", self.plan.coordinate_ids)
+        object.__setattr__(self, "coordinate_units", self.plan.coordinate_units)
+        object.__setattr__(self, "completed_transition_count", completed)
+        object.__setattr__(self, "identity", identity)
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize primary evidence without live evaluator or sampler objects."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "plan_identity": self.plan_identity,
+            "accepted_result_identity": self.accepted_result_identity,
+            "lifecycle": self.lifecycle.value,
+            "terminal": self.terminal.value,
+            "states": [state.to_record() for state in self.states],
+            "objective_request_count": self.objective_request_count,
+            "evaluation_request_count": self.evaluation_request_count,
+            "failure_category": self.failure_category,
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        *,
+        plan: McmcPlan,
+    ) -> McmcEvidence:
+        """Restore primary evidence against its exact trusted execution plan."""
+        _exact_keys(
+            record,
+            {
+                "schema_version",
+                "plan_identity",
+                "accepted_result_identity",
+                "lifecycle",
+                "terminal",
+                "states",
+                "objective_request_count",
+                "evaluation_request_count",
+                "failure_category",
+                "identity",
+            },
+            "MCMC evidence",
+        )
+        if record.get("schema_version") != _SCHEMA_VERSION:
+            raise McmcConstructionError("Unsupported MCMC evidence schema")
+        if (
+            record.get("plan_identity") != plan.identity
+            or record.get("accepted_result_identity") != plan.accepted_result_identity
+        ):
+            raise McmcConstructionError("MCMC evidence lineage identity mismatch")
+        raw_states = record.get("states")
+        objective_count = record.get("objective_request_count")
+        evaluation_count = record.get("evaluation_request_count")
+        failure_category = record.get("failure_category")
+        identity = record.get("identity")
+        if (
+            not isinstance(raw_states, list)
+            or not all(isinstance(item, Mapping) for item in raw_states)
+            or isinstance(objective_count, bool)
+            or not isinstance(objective_count, int)
+            or isinstance(evaluation_count, bool)
+            or not isinstance(evaluation_count, int)
+            or (failure_category is not None and not isinstance(failure_category, str))
+            or not isinstance(identity, str)
+        ):
+            raise McmcConstructionError("Malformed MCMC evidence record")
+        try:
+            lifecycle = McmcEvidenceLifecycle(record.get("lifecycle"))
+            terminal = McmcOperationTerminal(record.get("terminal"))
+        except (TypeError, ValueError) as error:
+            raise McmcConstructionError(
+                "Malformed MCMC evidence lifecycle or terminal"
+            ) from error
+        evidence = cls(
+            plan,
+            lifecycle,
+            terminal,
+            tuple(
+                EnsembleState.from_record(item)
+                for item in cast("list[Mapping[str, object]]", raw_states)
+            ),
+            objective_count,
+            evaluation_count,
+            failure_category,
+        )
+        if evidence.identity != identity:
+            raise McmcConstructionError("MCMC evidence identity mismatch")
+        return evidence
+
+
+@dataclass(frozen=True, slots=True)
+class McmcOperation:
+    """Frozen terminal record for one attempted MCMC evidence execution."""
+
+    terminal: McmcOperationTerminal
+    evidence: McmcEvidence | None
+    failure_category: str | None = None
+    failure_message: str = ""
+
+    def __post_init__(self) -> None:
+        if self.terminal is McmcOperationTerminal.COMPLETED:
+            if self.evidence is None or self.failure_category is not None:
+                raise McmcConstructionError(
+                    "Completed MCMC operation requires completed evidence"
+                )
+        elif self.failure_category is None:
+            raise McmcConstructionError(
+                "Non-completed MCMC operation requires typed failure evidence"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class RetainedSampleView:
+    """Labeled step-major/walker-minor view derived from primary topology."""
+
+    source_evidence_identity: str
+    coordinate_ids: tuple[str, ...]
+    coordinate_units: tuple[tuple[str, ParameterUnit], ...]
+    selected_state_ordinals: tuple[int, ...]
+    sample_indices: tuple[tuple[int, int], ...]
+    samples: tuple[tuple[float, ...], ...]
+    log_densities: tuple[float, ...]
+    is_complete: bool
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-mcmc-retained-sample-view",
+                (
+                    self.source_evidence_identity,
+                    self.coordinate_ids,
+                    self.coordinate_units,
+                    self.selected_state_ordinals,
+                    self.sample_indices,
+                    tuple(
+                        tuple(float(value).hex() for value in sample)
+                        for sample in self.samples
+                    ),
+                    tuple(float(value).hex() for value in self.log_densities),
+                    self.is_complete,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class McmcDiagnostics:
+    """Acceptance diagnostics derived without altering primary chain evidence."""
+
+    source_evidence_identity: str
+    state_ordinals: tuple[int, ...]
+    walker_ordinals: tuple[int, ...]
+    acceptance_fractions: tuple[float, ...]
+    mean_acceptance_fraction: float
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-mcmc-acceptance-diagnostics",
+                (
+                    self.source_evidence_identity,
+                    self.state_ordinals,
+                    self.walker_ordinals,
+                    tuple(float(value).hex() for value in self.acceptance_fractions),
+                    float(self.mean_acceptance_fraction).hex(),
+                ),
+            ),
+        )
+
+
+class _LogDensityEvaluator:
+    def __init__(self, plan: McmcPlan) -> None:
+        self.plan = plan
+        self.evaluator = plan.source_engine.new_evaluator()
+        self.objective_request_count = 0
+        self.evaluation_request_count = 0
+
+    def __call__(self, vector: Array) -> float:
+        if self.objective_request_count >= self.plan.policy.objective_request_budget:
+            raise McmcExecutionError("MCMC objective-request budget exhausted")
+        self.objective_request_count += 1
+        candidate = np.asarray(vector, dtype=np.float64)
+        if (
+            candidate.shape != (self.plan.policy.dimension,)
+            or not np.all(np.isfinite(candidate))
+            or np.any(candidate < np.asarray(self.plan.lower_bounds))
+            or np.any(candidate > np.asarray(self.plan.upper_bounds))
+        ):
+            return -np.inf
+        try:
+            lifecycle = self.plan.source_problem.lifecycle_frame(
+                candidate,
+                self.plan.parameterization,
+            )
+            frame = EvaluationFrame.from_lifecycle_frame(
+                self.plan.parameterization,
+                lifecycle,
+            )
+        except Exception as error:
+            raise McmcExecutionError(
+                f"MCMC candidate frame failed: {type(error).__name__}: {error}"
+            ) from error
+        outcome = self.evaluator.evaluate(frame)
+        self.evaluation_request_count += 1
+        if isinstance(outcome, EvaluationFailure):
+            if outcome.validity == "INVALID_TRIAL":
+                return -np.inf
+            raise McmcExecutionError(
+                f"MCMC native evaluation failed: {outcome.category}: {outcome.message}"
+            )
+        return -0.5 * canonical_chi_square(outcome.residuals)
+
+
+class _RecordingStretchMove(emcee.moves.StretchMove):
+    """Capture the backend's exact per-transition acceptance mask."""
+
+    def __init__(self, *, scale: float) -> None:
+        super().__init__(a=scale)
+        self.last_accepted: Array | None = None
+
+    def propose(self, model: object, state: object) -> tuple[object, Array]:
+        proposed, accepted = super().propose(model, state)
+        self.last_accepted = np.asarray(accepted, dtype=np.bool_).copy()
+        return proposed, self.last_accepted
+
+
+def _ensemble_state(
+    ordinal: int,
+    positions: Array,
+    log_densities: Array,
+    accepted_mask: Array | None,
+) -> EnsembleState:
+    current = np.asarray(positions, dtype=np.float64)
+    accepted = (
+        tuple(False for _ in current)
+        if accepted_mask is None
+        else tuple(bool(value) for value in accepted_mask)
+    )
+    return EnsembleState(
+        ordinal,
+        tuple(tuple(float(value) for value in row) for row in current),
+        tuple(float(value) for value in np.asarray(log_densities, dtype=np.float64)),
+        accepted,
+    )
+
+
+def _legacy_sampler_random_state(seed: int) -> object:
+    keys = np.random.SeedSequence(seed).generate_state(624, dtype=np.uint32)
+    return ("MT19937", keys, 624, 0, 0.0)
+
+
+def execute_mcmc_evidence(
+    accepted: AcceptedFitResult,
+    plan: McmcPlan,
+    *,
+    state_observer: Callable[[EnsembleState], None] | None = None,
+) -> McmcOperation:
+    """Execute one fixed run while preserving only complete ensemble states."""
+    if accepted.identity != plan.accepted_result_identity:
+        raise McmcConstructionError(
+            "MCMC execution accepted result differs from its frozen plan"
+        )
+    log_density = _LogDensityEvaluator(plan)
+    states: list[EnsembleState] = []
+    try:
+        initial = np.asarray(plan.initial_ensemble, dtype=np.float64)
+        initial_log_density = np.asarray(
+            [log_density(row) for row in initial],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(initial_log_density)):
+            raise McmcExecutionError(
+                "MCMC initial ensemble has unavailable native log density"
+            )
+        states.append(_ensemble_state(0, initial, initial_log_density, None))
+        move = _RecordingStretchMove(scale=plan.policy.proposal_scale)
+        sampler = emcee.EnsembleSampler(
+            plan.policy.walkers,
+            plan.policy.dimension,
+            log_density,
+            moves=move,
+        )
+        sampler.random_state = _legacy_sampler_random_state(plan.policy.sampler_seed)
+        emcee_state = emcee.State(initial, log_prob=initial_log_density)
+        for ordinal, sampled in enumerate(
+            sampler.sample(
+                emcee_state,
+                iterations=plan.policy.total_steps,
+                tune=False,
+                skip_initial_state_check=True,
+                store=False,
+            ),
+            start=1,
+        ):
+            state = _ensemble_state(
+                ordinal,
+                sampled.coords,
+                sampled.log_prob,
+                move.last_accepted,
+            )
+            states.append(state)
+            if state_observer is not None:
+                state_observer(state)
+        if log_density.objective_request_count != plan.policy.objective_request_budget:
+            raise McmcExecutionError(
+                "MCMC backend request count differs from the frozen budget"
+            )
+        evidence = McmcEvidence(
+            plan,
+            McmcEvidenceLifecycle.COMPLETED,
+            McmcOperationTerminal.COMPLETED,
+            tuple(states),
+            log_density.objective_request_count,
+            log_density.evaluation_request_count,
+        )
+        return McmcOperation(McmcOperationTerminal.COMPLETED, evidence)
+    except KeyboardInterrupt as error:
+        terminal = McmcOperationTerminal.INTERRUPTED
+        category = "interrupted"
+        message = str(error)
+    except Exception as error:  # noqa: BLE001 - freeze typed operation failure
+        terminal = McmcOperationTerminal.FAILED
+        category = type(error).__name__
+        message = str(error)
+    evidence = (
+        McmcEvidence(
+            plan,
+            McmcEvidenceLifecycle.PARTIAL,
+            terminal,
+            tuple(states),
+            log_density.objective_request_count,
+            log_density.evaluation_request_count,
+            category,
+        )
+        if states
+        else None
+    )
+    return McmcOperation(terminal, evidence, category, message)
+
+
+def derive_retained_sample_view(evidence: McmcEvidence) -> RetainedSampleView:
+    """Select the prospective retained window without flattening primary evidence."""
+    first = evidence.plan.policy.burn_steps + 1
+    selected = tuple(state for state in evidence.states if state.ordinal >= first)
+    ordinals = tuple(state.ordinal for state in selected)
+    sample_indices = tuple(
+        (state.ordinal, walker)
+        for state in selected
+        for walker in range(evidence.plan.policy.walkers)
+    )
+    samples = tuple(position for state in selected for position in state.positions)
+    log_densities = tuple(value for state in selected for value in state.log_densities)
+    return RetainedSampleView(
+        evidence.identity,
+        evidence.coordinate_ids,
+        evidence.coordinate_units,
+        ordinals,
+        sample_indices,
+        samples,
+        log_densities,
+        len(selected) == evidence.plan.policy.retained_steps,
+    )
+
+
+def derive_mcmc_diagnostics(evidence: McmcEvidence) -> McmcDiagnostics:
+    """Derive acceptance diagnostics from complete transition states only."""
+    transitions = evidence.states[1:]
+    completed = len(transitions)
+    accepted_counts = tuple(
+        sum(state.accepted[walker] for state in transitions)
+        for walker in range(evidence.plan.policy.walkers)
+    )
+    fractions = tuple(
+        count / completed if completed else 0.0 for count in accepted_counts
+    )
+    mean = sum(fractions) / len(fractions)
+    return McmcDiagnostics(
+        evidence.identity,
+        tuple(state.ordinal for state in transitions),
+        tuple(range(evidence.plan.policy.walkers)),
+        fractions,
+        mean,
+    )

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -255,8 +255,17 @@ class _BackendExecutionObservation:
 @dataclass(frozen=True, slots=True)
 class _BackendExecutionObservationBinding:
     plan_identity: str
+    policy_identity: str
+    walkers: int
+    dimension: int
+    backend_implementation_identity: str
     execution_occurrence_identity: str
     transitions: tuple[tuple[int, str, str, tuple[bool, ...]], ...] = ()
+    raw_capture_identity: str | None = None
+    raw_capture_object_identity: int | None = None
+    objective_request_count: int | None = None
+    evaluation_request_count: int | None = None
+    mask_payload_identity: str | None = None
 
 
 _BACKEND_EXECUTION_OBSERVATIONS: WeakKeyDictionary[
@@ -267,14 +276,20 @@ _BACKEND_EXECUTION_OBSERVATIONS_LOCK = RLock()
 
 
 def _mint_backend_execution_observation(
-    plan_identity: str,
+    plan: McmcPlan,
+    *,
+    backend_implementation_identity: str,
 ) -> _BackendExecutionObservation:
     observation = object.__new__(_BackendExecutionObservation)
     binding = _BackendExecutionObservationBinding(
-        plan_identity,
+        plan.identity,
+        plan.policy.identity,
+        plan.policy.walkers,
+        plan.policy.dimension,
+        backend_implementation_identity,
         _identity(
             "native-mcmc-backend-execution-occurrence",
-            (plan_identity, secrets.token_hex(32)),
+            (plan.identity, secrets.token_hex(32)),
         ),
     )
     with _BACKEND_EXECUTION_OBSERVATIONS_LOCK:
@@ -302,6 +317,10 @@ def _record_backend_execution_transition(
         _BACKEND_EXECUTION_OBSERVATIONS[observation] = (
             _BackendExecutionObservationBinding(
                 binding.plan_identity,
+                binding.policy_identity,
+                binding.walkers,
+                binding.dimension,
+                binding.backend_implementation_identity,
                 binding.execution_occurrence_identity,
                 (
                     *binding.transitions,
@@ -333,12 +352,50 @@ def _bind_backend_observation_to_raw_capture(
         observed_edges = (
             tuple(item[:3] for item in binding.transitions) if binding else ()
         )
+        mask_payload_identity = (
+            _identity(
+                "native-mcmc-backend-mask-payload",
+                binding.transitions,
+            )
+            if binding
+            else ""
+        )
         if (
             binding is None
             or binding.plan_identity != raw_capture.plan_identity
+            or binding.policy_identity != raw_capture.policy_identity
+            or binding.walkers != raw_capture.walkers
+            or binding.dimension != raw_capture.dimension
             or binding.execution_occurrence_identity
             != raw_capture.backend_execution_occurrence_identity
             or observed_edges != expected_edges
+        ):
+            raise McmcConstructionError(
+                "Backend masks cannot bind to a foreign execution occurrence"
+            )
+        if binding.raw_capture_identity is None:
+            bound = _BackendExecutionObservationBinding(
+                binding.plan_identity,
+                binding.policy_identity,
+                binding.walkers,
+                binding.dimension,
+                binding.backend_implementation_identity,
+                binding.execution_occurrence_identity,
+                binding.transitions,
+                raw_capture.identity,
+                id(raw_capture),
+                raw_capture.objective_request_count,
+                raw_capture.evaluation_request_count,
+                mask_payload_identity,
+            )
+            _BACKEND_EXECUTION_OBSERVATIONS[observation] = bound
+            return bound
+        if (
+            binding.raw_capture_identity != raw_capture.identity
+            or binding.raw_capture_object_identity != id(raw_capture)
+            or binding.objective_request_count != raw_capture.objective_request_count
+            or binding.evaluation_request_count != raw_capture.evaluation_request_count
+            or binding.mask_payload_identity != mask_payload_identity
         ):
             raise McmcConstructionError(
                 "Backend masks cannot bind to a foreign execution occurrence"
@@ -1269,7 +1326,48 @@ class BackendTransitionConsistencyFailure:
     category: str
 
 
-@dataclass(frozen=True, slots=True)
+def _backend_transition_consistency_failures(
+    source_capture: RawMcmcCapture,
+    transitions: Sequence[RawTransitionEvent],
+) -> tuple[BackendTransitionConsistencyFailure, ...]:
+    states = source_capture.states
+    if len(transitions) != max(0, len(states) - 1):
+        raise McmcConstructionError(
+            "Backend transition evidence must cover every complete state edge"
+        )
+    failures: list[BackendTransitionConsistencyFailure] = []
+    for transition, previous, following in zip(
+        transitions,
+        states[:-1],
+        states[1:],
+        strict=True,
+    ):
+        transition.validate_integrity()
+        if (
+            transition.ordinal != following.ordinal
+            or transition.previous_state_identity != previous.identity
+            or transition.next_state_identity != following.identity
+            or transition.proposal_count != source_capture.walkers
+        ):
+            raise McmcConstructionError(
+                "Backend transition labels differ from their exact state edge"
+            )
+        for walker, accepted in enumerate(transition.accepted):
+            if not accepted and (
+                following.positions[walker] != previous.positions[walker]
+                or following.log_densities[walker] != previous.log_densities[walker]
+            ):
+                failures.append(
+                    BackendTransitionConsistencyFailure(
+                        transition.ordinal,
+                        walker,
+                        "rejected_move_changed_state",
+                    )
+                )
+    return tuple(failures)
+
+
+@dataclass(frozen=True, slots=True, init=False)
 class BackendTransitionEvidence:
     """Diagnostic-only backend masks bound to exact scientific raw states."""
 
@@ -1278,16 +1376,27 @@ class BackendTransitionEvidence:
     observation_provenance: str
     execution_occurrence_identity: str | None
     transitions: tuple[RawTransitionEvent, ...]
+    _live_observation_authority: _BackendExecutionObservation | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     _occurrence_witness: _McmcEvidenceWitness | None = field(
         default=None,
         repr=False,
         compare=False,
     )
     source_capture_identity: str = field(init=False)
+    observed_mask_payload_identity: str = field(init=False)
     consistency_failures: tuple[BackendTransitionConsistencyFailure, ...] = field(
         init=False
     )
     identity: str = field(init=False)
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        raise TypeError(
+            "Backend transition evidence is created only by canonical factories"
+        )
 
     def __post_init__(self) -> None:
         if self._occurrence_witness is None or not self.observation_provenance:
@@ -1302,49 +1411,60 @@ class BackendTransitionEvidence:
             raise McmcConstructionError(
                 "Backend transition authority and execution occurrence disagree"
             )
+        if (self.kind is BackendTransitionEvidenceKind.OBSERVED_EXECUTION) != (
+            self._live_observation_authority is not None
+        ):
+            raise McmcConstructionError(
+                "Live backend evidence requires its exact observation authority"
+            )
         self.source_capture.validate_integrity()
         transitions = tuple(self.transitions)
-        states = self.source_capture.states
-        if len(transitions) != max(0, len(states) - 1):
-            raise McmcConstructionError(
-                "Backend transition evidence must cover every complete state edge"
-            )
-        failures: list[BackendTransitionConsistencyFailure] = []
-        for transition, previous, following in zip(
+        failures = _backend_transition_consistency_failures(
+            self.source_capture,
             transitions,
-            states[:-1],
-            states[1:],
-            strict=True,
-        ):
-            transition.validate_integrity()
-            if (
-                transition.ordinal != following.ordinal
-                or transition.previous_state_identity != previous.identity
-                or transition.next_state_identity != following.identity
-                or transition.proposal_count != self.source_capture.walkers
-            ):
-                raise McmcConstructionError(
-                    "Backend transition labels differ from their exact state edge"
-                )
-            for walker, accepted in enumerate(transition.accepted):
-                if not accepted and (
-                    following.positions[walker] != previous.positions[walker]
-                    or following.log_densities[walker] != previous.log_densities[walker]
-                ):
-                    failures.append(
-                        BackendTransitionConsistencyFailure(
-                            transition.ordinal,
-                            walker,
-                            "rejected_move_changed_state",
-                        )
-                    )
+        )
         object.__setattr__(self, "transitions", transitions)
         object.__setattr__(
             self,
             "source_capture_identity",
             self.source_capture.identity,
         )
-        object.__setattr__(self, "consistency_failures", tuple(failures))
+        object.__setattr__(
+            self,
+            "observed_mask_payload_identity",
+            _identity(
+                "native-mcmc-backend-mask-payload",
+                tuple(
+                    (
+                        item.ordinal,
+                        item.previous_state_identity,
+                        item.next_state_identity,
+                        item.accepted,
+                    )
+                    for item in transitions
+                ),
+            ),
+        )
+        object.__setattr__(self, "consistency_failures", failures)
+        if self.kind is BackendTransitionEvidenceKind.OBSERVED_EXECUTION:
+            authority = cast(
+                "_BackendExecutionObservation",
+                self._live_observation_authority,
+            )
+            binding = _bind_backend_observation_to_raw_capture(
+                authority,
+                self.source_capture,
+            )
+            if (
+                binding.execution_occurrence_identity
+                != self.execution_occurrence_identity
+                or binding.backend_implementation_identity
+                != self.observation_provenance
+                or binding.mask_payload_identity != self.observed_mask_payload_identity
+            ):
+                raise McmcConstructionError(
+                    "Observed backend evidence differs from its authority registry"
+                )
         object.__setattr__(self, "identity", self._content_identity())
         if not _bind_mcmc_evidence_witness(
             self._occurrence_witness,
@@ -1364,6 +1484,7 @@ class BackendTransitionEvidence:
                 self.kind.value,
                 self.observation_provenance,
                 self.execution_occurrence_identity,
+                self.observed_mask_payload_identity,
                 tuple(item.identity for item in self.transitions),
                 tuple(
                     (item.transition_ordinal, item.walker_ordinal, item.category)
@@ -1404,18 +1525,32 @@ class BackendTransitionEvidence:
             raise McmcConstructionError(
                 "Backend evidence differs from its source execution occurrence"
             )
-        expected = BackendTransitionEvidence(
+        if self.kind is BackendTransitionEvidenceKind.OBSERVED_EXECUTION:
+            authority = cast(
+                "_BackendExecutionObservation",
+                self._live_observation_authority,
+            )
+            binding = _bind_backend_observation_to_raw_capture(
+                authority,
+                self.source_capture,
+            )
+            if (
+                binding.execution_occurrence_identity
+                != self.execution_occurrence_identity
+                or binding.backend_implementation_identity
+                != self.observation_provenance
+                or binding.mask_payload_identity != self.observed_mask_payload_identity
+            ):
+                raise McmcConstructionError(
+                    "Observed backend evidence differs from its authority registry"
+                )
+        expected_failures = _backend_transition_consistency_failures(
             self.source_capture,
-            self.kind,
-            self.observation_provenance,
-            self.execution_occurrence_identity,
             self.transitions,
-            _mint_mcmc_evidence_witness("backend-transition-evidence"),
         )
         if (
-            self.consistency_failures != expected.consistency_failures
+            self.consistency_failures != expected_failures
             or self._content_identity() != self.identity
-            or expected._content_identity() != self.identity
         ):
             raise McmcConstructionError(
                 "Backend transition diagnostic content identity mismatch"
@@ -1461,12 +1596,14 @@ class BackendTransitionEvidence:
                 strict=True,
             )
         )
-        return cls(
+        return _initialize_backend_transition_evidence(
+            cls,
             source_capture,
             BackendTransitionEvidenceKind.HYPOTHETICAL,
             observation_provenance,
             None,
             transitions,
+            None,
             _mint_mcmc_evidence_witness("backend-transition-evidence"),
         )
 
@@ -1492,6 +1629,7 @@ class BackendTransitionEvidence:
             "source_capture_identity": self.source_capture_identity,
             "observation_provenance": self.observation_provenance,
             "execution_occurrence_identity": self.execution_occurrence_identity,
+            "observed_mask_payload_identity": self.observed_mask_payload_identity,
             "masks": [list(item.accepted) for item in self.transitions],
             "identity": self.identity,
         }
@@ -1519,12 +1657,14 @@ class BackendTransitionEvidence:
             raise McmcConstructionError(
                 "Historical backend evidence requires a live observed source"
             )
-        return cls(
+        return _initialize_backend_transition_evidence(
+            cls,
             source.source_capture,
             BackendTransitionEvidenceKind.HISTORICAL_OBSERVATION,
             source.observation_provenance,
             source.execution_occurrence_identity,
             source.transitions,
+            None,
             _mint_mcmc_evidence_witness("backend-transition-evidence"),
         )
 
@@ -1532,8 +1672,6 @@ class BackendTransitionEvidence:
 def _mint_observed_backend_transition_evidence(
     observation: _BackendExecutionObservation,
     raw_capture: RawMcmcCapture,
-    *,
-    observation_provenance: str,
 ) -> BackendTransitionEvidence:
     """Mint observed masks solely from the execution-owned occurrence registry."""
     binding = _bind_backend_observation_to_raw_capture(observation, raw_capture)
@@ -1548,14 +1686,46 @@ def _mint_observed_backend_transition_evidence(
         )
         for ordinal, previous_identity, following_identity, mask in binding.transitions
     )
-    return BackendTransitionEvidence(
+    return _initialize_backend_transition_evidence(
+        BackendTransitionEvidence,
         raw_capture,
         BackendTransitionEvidenceKind.OBSERVED_EXECUTION,
-        observation_provenance,
+        binding.backend_implementation_identity,
         binding.execution_occurrence_identity,
         transitions,
+        observation,
         _mint_mcmc_evidence_witness("backend-transition-evidence"),
     )
+
+
+def _initialize_backend_transition_evidence(
+    cls: type[BackendTransitionEvidence],
+    source_capture: RawMcmcCapture,
+    kind: BackendTransitionEvidenceKind,
+    observation_provenance: str,
+    execution_occurrence_identity: str | None,
+    transitions: tuple[RawTransitionEvent, ...],
+    live_observation_authority: _BackendExecutionObservation | None,
+    occurrence_witness: _McmcEvidenceWitness,
+) -> BackendTransitionEvidence:
+    evidence = object.__new__(cls)
+    object.__setattr__(evidence, "source_capture", source_capture)
+    object.__setattr__(evidence, "kind", kind)
+    object.__setattr__(evidence, "observation_provenance", observation_provenance)
+    object.__setattr__(
+        evidence,
+        "execution_occurrence_identity",
+        execution_occurrence_identity,
+    )
+    object.__setattr__(evidence, "transitions", transitions)
+    object.__setattr__(
+        evidence,
+        "_live_observation_authority",
+        live_observation_authority,
+    )
+    object.__setattr__(evidence, "_occurrence_witness", occurrence_witness)
+    evidence.__post_init__()
+    return evidence
 
 
 @dataclass(frozen=True, slots=True)
@@ -1668,6 +1838,9 @@ def _mint_raw_capture(
     if (
         observation_binding is None
         or observation_binding.plan_identity != plan.identity
+        or observation_binding.policy_identity != plan.policy.identity
+        or observation_binding.walkers != plan.policy.walkers
+        or observation_binding.dimension != plan.policy.dimension
     ):
         raise McmcConstructionError(
             "Raw MCMC capture requires its exact backend execution occurrence"
@@ -1704,6 +1877,7 @@ class McmcEvidence:
     evaluation_request_count: int
     failure_category: str | None = None
     raw_capture_identity: str = ""
+    backend_execution_occurrence_identity: str = ""
     backend_transition_evidence: BackendTransitionEvidence | None = field(
         default=None,
         repr=False,
@@ -1727,6 +1901,10 @@ class McmcEvidence:
         if self._occurrence_witness is None:
             raise McmcConstructionError(
                 "Primary MCMC evidence must come from fresh native validation"
+            )
+        if not self.backend_execution_occurrence_identity:
+            raise McmcConstructionError(
+                "Primary MCMC evidence requires its backend execution occurrence"
             )
         states = tuple(self.states)
         expected_ordinals = tuple(range(len(states)))
@@ -1769,6 +1947,8 @@ class McmcEvidence:
             or self.evaluation_request_count > self.objective_request_count
         ):
             raise McmcConstructionError("MCMC request accounting is inconsistent")
+        if self.backend_transition_evidence is not None:
+            self._validate_backend_occurrence()
         identity = _identity(
             "native-mcmc-primary-evidence",
             (
@@ -1815,6 +1995,8 @@ class McmcEvidence:
         self.plan.validate_integrity()
         for state in self.states:
             state.validate_integrity()
+        if self.backend_transition_evidence is not None:
+            self._validate_backend_occurrence()
         expected_identity = _identity(
             "native-mcmc-primary-evidence",
             (
@@ -1843,6 +2025,29 @@ class McmcEvidence:
                 "Primary MCMC evidence is not its validation-owned occurrence"
             )
 
+    def _validate_backend_occurrence(self) -> None:
+        backend = cast(
+            "BackendTransitionEvidence",
+            self.backend_transition_evidence,
+        )
+        backend.validate_integrity()
+        source_capture = backend.source_capture
+        if (
+            not backend.supports_observed_diagnostics
+            or backend.execution_occurrence_identity
+            != self.backend_execution_occurrence_identity
+            or source_capture.backend_execution_occurrence_identity
+            != self.backend_execution_occurrence_identity
+            or source_capture.identity != self.raw_capture_identity
+            or source_capture.plan_identity != self.plan.identity
+            or source_capture.policy_identity != self.plan.policy.identity
+            or source_capture.walkers != self.plan.policy.walkers
+            or source_capture.dimension != self.plan.policy.dimension
+        ):
+            raise McmcConstructionError(
+                "Primary backend diagnostics differ from its exact execution occurrence"
+            )
+
     def to_record(self) -> dict[str, object]:
         """Serialize primary evidence without live evaluator or sampler objects."""
         return {
@@ -1856,6 +2061,9 @@ class McmcEvidence:
             "evaluation_request_count": self.evaluation_request_count,
             "failure_category": self.failure_category,
             "raw_capture_identity": self.raw_capture_identity,
+            "backend_execution_occurrence_identity": (
+                self.backend_execution_occurrence_identity
+            ),
             "identity": self.identity,
         }
 
@@ -1881,6 +2089,7 @@ class McmcEvidence:
                 "evaluation_request_count",
                 "failure_category",
                 "raw_capture_identity",
+                "backend_execution_occurrence_identity",
                 "identity",
             },
             "MCMC evidence",
@@ -1947,6 +2156,7 @@ def _mint_primary_evidence(
         raw_capture.evaluation_request_count,
         raw_capture.failure_category,
         raw_capture.identity,
+        raw_capture.backend_execution_occurrence_identity,
         backend_transition_evidence,
         _mint_mcmc_evidence_witness("primary-evidence"),
     )
@@ -3463,7 +3673,10 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     plan.validate_integrity(accepted)
     signal = CancellationToken() if cancellation is None else cancellation
     log_density = _LogDensityEvaluator(plan)
-    backend_observation = _mint_backend_execution_observation(plan.identity)
+    backend_observation = _mint_backend_execution_observation(
+        plan,
+        backend_implementation_identity="emcee-stretch-backend-v1",
+    )
     states: list[EnsembleState] = []
     stage = McmcExecutionStage.BEFORE_INITIALIZATION
     initialization_outcome = McmcInitializationOutcome.NOT_STARTED
@@ -3546,20 +3759,21 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
             initialization_outcome,
             backend_observation,
         )
-        backend_transition_evidence = _mint_observed_backend_transition_evidence(
-            backend_observation,
-            raw_capture,
-            observation_provenance="emcee-stretch-backend-v1",
-        )
-        validation = validate_raw_mcmc_capture(
-            plan,
-            raw_capture,
-            backend_transition_evidence=backend_transition_evidence,
-        )
+        validation = validate_raw_mcmc_capture(plan, raw_capture)
         if not validation.is_complete or validation.primary_evidence is None:
             raise McmcExecutionError("fresh MCMC validation did not complete")
         checkpoint(McmcExecutionStage.BEFORE_FINAL_ASSEMBLY)
+        backend_transition_evidence = _mint_observed_backend_transition_evidence(
+            backend_observation,
+            raw_capture,
+        )
         evidence = validation.primary_evidence
+        object.__setattr__(
+            evidence,
+            "backend_transition_evidence",
+            backend_transition_evidence,
+        )
+        evidence.validate_integrity()
         return _mint_mcmc_operation(
             McmcOperationTerminal.COMPLETED,
             evidence,
@@ -3601,7 +3815,6 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     backend_transition_evidence = _mint_observed_backend_transition_evidence(
         backend_observation,
         raw_capture,
-        observation_provenance="emcee-stretch-backend-v1",
     )
     validation = validate_raw_mcmc_capture(
         plan,

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -126,6 +126,8 @@ class McmcDiagnosticReason(StrEnum):
     ZERO_VARIANCE = "zero_variance"
     INVALID_AUTOCORRELATION = "invalid_autocorrelation"
     PARTIAL_CHAIN = "partial_chain"
+    BACKEND_TRANSITION_INCONSISTENT = "backend_transition_inconsistent"
+    UNRELIABLE_AUTOCORRELATION = "unreliable_autocorrelation"
 
 
 class McmcTrajectoryClaim(StrEnum):
@@ -955,12 +957,11 @@ def _finite_state_scalar(value: object, *, name: str) -> float:
 
 @dataclass(frozen=True, slots=True)
 class EnsembleState:
-    """One raw atomically completed backend state and its observations."""
+    """One atomically completed state with scientific position/log-density facts."""
 
     ordinal: int
     positions: tuple[tuple[float, ...], ...]
     log_densities: tuple[float, ...]
-    accepted: tuple[bool, ...]
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -985,12 +986,7 @@ class EnsembleState:
             _finite_state_scalar(value, name="MCMC state log density")
             for value in self.log_densities
         )
-        accepted = tuple(self.accepted)
-        if (
-            len(log_densities) != len(positions)
-            or len(accepted) != len(positions)
-            or any(not isinstance(value, bool) for value in accepted)
-        ):
+        if len(log_densities) != len(positions):
             raise McmcConstructionError(
                 "MCMC state payload must cover every walker exactly once"
             )
@@ -1000,12 +996,10 @@ class EnsembleState:
                 self.ordinal,
                 tuple(tuple(float(value).hex() for value in row) for row in positions),
                 tuple(float(value).hex() for value in log_densities),
-                accepted,
             ),
         )
         object.__setattr__(self, "positions", positions)
         object.__setattr__(self, "log_densities", log_densities)
-        object.__setattr__(self, "accepted", accepted)
         object.__setattr__(self, "identity", identity)
 
     def to_record(self) -> dict[str, object]:
@@ -1017,7 +1011,6 @@ class EnsembleState:
                 [float(value).hex() for value in row] for row in self.positions
             ],
             "log_densities": [float(value).hex() for value in self.log_densities],
-            "accepted": list(self.accepted),
             "identity": self.identity,
         }
 
@@ -1026,7 +1019,6 @@ class EnsembleState:
             self.ordinal,
             self.positions,
             self.log_densities,
-            self.accepted,
         )
         if expected.identity != self.identity:
             raise McmcConstructionError("MCMC ensemble-state content identity mismatch")
@@ -1041,7 +1033,6 @@ class EnsembleState:
                 "ordinal",
                 "positions",
                 "log_densities",
-                "accepted",
                 "identity",
             },
             "MCMC ensemble-state",
@@ -1051,7 +1042,6 @@ class EnsembleState:
         ordinal = record.get("ordinal")
         raw_positions = record.get("positions")
         raw_log_densities = record.get("log_densities")
-        raw_accepted = record.get("accepted")
         identity = record.get("identity")
         if (
             isinstance(ordinal, bool)
@@ -1059,13 +1049,10 @@ class EnsembleState:
             or not isinstance(raw_positions, list)
             or not all(isinstance(row, list) for row in raw_positions)
             or not isinstance(raw_log_densities, list)
-            or not isinstance(raw_accepted, list)
-            or not all(isinstance(value, bool) for value in raw_accepted)
             or not isinstance(identity, str)
         ):
             raise McmcConstructionError("Malformed MCMC ensemble-state record")
         position_rows = cast("list[list[object]]", raw_positions)
-        accepted_values = cast("list[bool]", raw_accepted)
         if any(
             not isinstance(value, str) for row in position_rows for value in row
         ) or any(not isinstance(value, str) for value in raw_log_densities):
@@ -1086,7 +1073,6 @@ class EnsembleState:
             ordinal,
             positions,
             log_densities,
-            tuple(accepted_values),
         )
         if state.identity != identity:
             raise McmcConstructionError("MCMC ensemble-state identity mismatch")
@@ -1095,7 +1081,7 @@ class EnsembleState:
 
 @dataclass(frozen=True, slots=True)
 class RawTransitionEvent:
-    """Backend-observed derivation edge between two complete states."""
+    """One non-authoritative backend accept/reject observation."""
 
     ordinal: int
     previous_state_identity: str
@@ -1148,6 +1134,190 @@ class RawTransitionEvent:
 
 
 @dataclass(frozen=True, slots=True)
+class BackendTransitionConsistencyFailure:
+    """Structural inconsistency in a backend-declared rejected move."""
+
+    transition_ordinal: int
+    walker_ordinal: int
+    category: str
+
+
+@dataclass(frozen=True, slots=True)
+class BackendTransitionEvidence:
+    """Diagnostic-only backend masks bound to exact scientific raw states."""
+
+    source_capture: RawMcmcCapture = field(repr=False, compare=False)
+    observation_provenance: str
+    transitions: tuple[RawTransitionEvent, ...]
+    _occurrence_witness: _McmcEvidenceWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    source_capture_identity: str = field(init=False)
+    consistency_failures: tuple[BackendTransitionConsistencyFailure, ...] = field(
+        init=False
+    )
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self._occurrence_witness is None or not self.observation_provenance:
+            raise McmcConstructionError(
+                "Backend transition evidence requires canonical diagnostic provenance"
+            )
+        self.source_capture.validate_integrity()
+        transitions = tuple(self.transitions)
+        states = self.source_capture.states
+        if len(transitions) != max(0, len(states) - 1):
+            raise McmcConstructionError(
+                "Backend transition evidence must cover every complete state edge"
+            )
+        failures: list[BackendTransitionConsistencyFailure] = []
+        for transition, previous, following in zip(
+            transitions,
+            states[:-1],
+            states[1:],
+            strict=True,
+        ):
+            transition.validate_integrity()
+            if (
+                transition.ordinal != following.ordinal
+                or transition.previous_state_identity != previous.identity
+                or transition.next_state_identity != following.identity
+                or transition.proposal_count != self.source_capture.walkers
+            ):
+                raise McmcConstructionError(
+                    "Backend transition labels differ from their exact state edge"
+                )
+            for walker, accepted in enumerate(transition.accepted):
+                if not accepted and (
+                    following.positions[walker] != previous.positions[walker]
+                    or following.log_densities[walker] != previous.log_densities[walker]
+                ):
+                    failures.append(
+                        BackendTransitionConsistencyFailure(
+                            transition.ordinal,
+                            walker,
+                            "rejected_move_changed_state",
+                        )
+                    )
+        object.__setattr__(self, "transitions", transitions)
+        object.__setattr__(
+            self,
+            "source_capture_identity",
+            self.source_capture.identity,
+        )
+        object.__setattr__(self, "consistency_failures", tuple(failures))
+        object.__setattr__(self, "identity", self._content_identity())
+        if not _bind_mcmc_evidence_witness(
+            self._occurrence_witness,
+            self,
+            "backend-transition-evidence",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Backend transition evidence occurrence witness is already bound"
+            )
+
+    def _content_identity(self) -> str:
+        return _identity(
+            "native-mcmc-backend-transition-evidence",
+            (
+                self.source_capture.identity,
+                self.observation_provenance,
+                tuple(item.identity for item in self.transitions),
+                tuple(
+                    (item.transition_ordinal, item.walker_ordinal, item.category)
+                    for item in self.consistency_failures
+                ),
+            ),
+        )
+
+    @property
+    def observed_transition_count(self) -> int:
+        return len(self.transitions)
+
+    @property
+    def is_structurally_consistent(self) -> bool:
+        return not self.consistency_failures
+
+    def validate_integrity(self) -> None:
+        self.source_capture.validate_integrity()
+        expected = BackendTransitionEvidence.from_capture(
+            self.source_capture,
+            tuple(item.accepted for item in self.transitions),
+            observation_provenance=self.observation_provenance,
+        )
+        if (
+            self._content_identity() != self.identity
+            or expected._content_identity() != self.identity
+        ):
+            raise McmcConstructionError(
+                "Backend transition diagnostic content identity mismatch"
+            )
+        if not _mcmc_evidence_occurrence_is_authoritative(
+            self._occurrence_witness,
+            self,
+            "backend-transition-evidence",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Backend transition evidence is not its canonical occurrence"
+            )
+
+    @classmethod
+    def from_capture(
+        cls,
+        source_capture: RawMcmcCapture,
+        masks: Sequence[Sequence[bool]],
+        *,
+        observation_provenance: str,
+    ) -> BackendTransitionEvidence:
+        exact_masks = tuple(tuple(mask) for mask in masks)
+        states = source_capture.states
+        if len(exact_masks) != max(0, len(states) - 1):
+            raise McmcConstructionError(
+                "Backend masks must cover every observed transition"
+            )
+        transitions = tuple(
+            RawTransitionEvent(
+                following.ordinal,
+                previous.identity,
+                following.identity,
+                mask,
+                source_capture.walkers,
+                sum(mask),
+            )
+            for previous, following, mask in zip(
+                states[:-1],
+                states[1:],
+                exact_masks,
+                strict=True,
+            )
+        )
+        return cls(
+            source_capture,
+            observation_provenance,
+            transitions,
+            _mint_mcmc_evidence_witness("backend-transition-evidence"),
+        )
+
+    def with_observed_masks(
+        self,
+        masks: Sequence[Sequence[bool]],
+        *,
+        observation_provenance: str,
+    ) -> BackendTransitionEvidence:
+        """Create a diagnostic-only alternative without changing raw states."""
+        self.validate_integrity()
+        return self.from_capture(
+            self.source_capture,
+            masks,
+            observation_provenance=observation_provenance,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class RawMcmcCapture:
     """Execution-only backend observations with no scientific authority."""
 
@@ -1159,7 +1329,6 @@ class RawMcmcCapture:
     total_steps: int
     terminal: McmcOperationTerminal
     states: tuple[EnsembleState, ...]
-    transitions: tuple[RawTransitionEvent, ...]
     objective_request_count: int
     evaluation_request_count: int
     stage: McmcExecutionStage
@@ -1174,7 +1343,6 @@ class RawMcmcCapture:
 
     def __post_init__(self) -> None:
         states = tuple(self.states)
-        transitions = tuple(self.transitions)
         if tuple(state.ordinal for state in states) != tuple(range(len(states))):
             raise McmcConstructionError(
                 "Raw MCMC capture must contain a contiguous complete-state prefix"
@@ -1189,27 +1357,7 @@ class RawMcmcCapture:
             raise McmcConstructionError(
                 "Raw MCMC capture must come from sampler execution"
             )
-        if len(transitions) != max(0, len(states) - 1):
-            raise McmcConstructionError(
-                "Raw MCMC transitions must cover every complete state edge"
-            )
-        for transition, previous, following in zip(
-            transitions,
-            states[:-1],
-            states[1:],
-            strict=True,
-        ):
-            if (
-                transition.ordinal != following.ordinal
-                or transition.previous_state_identity != previous.identity
-                or transition.next_state_identity != following.identity
-                or transition.accepted != following.accepted
-            ):
-                raise McmcConstructionError(
-                    "Raw MCMC transition does not bind its adjacent states"
-                )
         object.__setattr__(self, "states", states)
-        object.__setattr__(self, "transitions", transitions)
         object.__setattr__(self, "identity", self._content_identity())
         if not _bind_mcmc_evidence_witness(
             self._occurrence_witness,
@@ -1233,7 +1381,6 @@ class RawMcmcCapture:
                 self.total_steps,
                 self.terminal.value,
                 tuple(state.identity for state in self.states),
-                tuple(item.identity for item in self.transitions),
                 self.objective_request_count,
                 self.evaluation_request_count,
                 self.stage.value,
@@ -1249,20 +1396,6 @@ class RawMcmcCapture:
     def validate_integrity(self) -> None:
         for state in self.states:
             state.validate_integrity()
-        for transition in self.transitions:
-            transition.validate_integrity()
-        if len(self.transitions) != max(0, len(self.states) - 1) or any(
-            transition.previous_state_identity != previous.identity
-            or transition.next_state_identity != following.identity
-            or transition.accepted != following.accepted
-            for transition, previous, following in zip(
-                self.transitions,
-                self.states[:-1],
-                self.states[1:],
-                strict=True,
-            )
-        ):
-            raise McmcConstructionError("Raw MCMC transition topology mismatch")
         if self._content_identity() != self.identity:
             raise McmcConstructionError("Raw MCMC capture content identity mismatch")
         if not _mcmc_evidence_occurrence_is_authoritative(
@@ -1287,17 +1420,6 @@ def _mint_raw_capture(
     failure_category: str | None = None,
 ) -> RawMcmcCapture:
     exact_states = tuple(states)
-    transitions = tuple(
-        RawTransitionEvent(
-            following.ordinal,
-            previous.identity,
-            following.identity,
-            following.accepted,
-            plan.policy.walkers,
-            sum(following.accepted),
-        )
-        for previous, following in zip(exact_states, exact_states[1:], strict=False)
-    )
     capture = RawMcmcCapture(
         plan.identity,
         plan.policy.identity,
@@ -1307,7 +1429,6 @@ def _mint_raw_capture(
         plan.policy.total_steps,
         terminal,
         exact_states,
-        transitions,
         objective_request_count,
         evaluation_request_count,
         stage,
@@ -1330,6 +1451,11 @@ class McmcEvidence:
     evaluation_request_count: int
     failure_category: str | None = None
     raw_capture_identity: str = ""
+    backend_transition_evidence: BackendTransitionEvidence | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     _occurrence_witness: _McmcEvidenceWitness | None = field(
         default=None,
         repr=False,
@@ -1557,6 +1683,7 @@ def _mint_primary_evidence(
     raw_capture: RawMcmcCapture,
     lifecycle: McmcEvidenceLifecycle,
     states: Sequence[EnsembleState],
+    backend_transition_evidence: BackendTransitionEvidence | None,
 ) -> McmcEvidence:
     evidence = McmcEvidence(
         plan,
@@ -1567,6 +1694,7 @@ def _mint_primary_evidence(
         raw_capture.evaluation_request_count,
         raw_capture.failure_category,
         raw_capture.identity,
+        backend_transition_evidence,
         _mint_mcmc_evidence_witness("primary-evidence"),
     )
     return evidence
@@ -1677,6 +1805,8 @@ def _fresh_authoritative_log_density(
 def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
     plan: McmcPlan,
     raw_capture: RawMcmcCapture,
+    *,
+    backend_transition_evidence: BackendTransitionEvidence | None = None,
 ) -> McmcChainValidation:
     """Freshly validate raw backend observations before minting evidence."""
     expected_state_count = plan.policy.total_steps + 1
@@ -1710,30 +1840,9 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
     validated: list[EnsembleState] = []
     failures: list[McmcValidationFailure] = []
     for state in raw_capture.states:
-        if state.ordinal > 0:
-            transition = raw_capture.transitions[state.ordinal - 1]
-            previous = raw_capture.states[state.ordinal - 1]
-            for walker, accepted in enumerate(transition.accepted):
-                unchanged = (
-                    state.positions[walker] == previous.positions[walker]
-                    and state.log_densities[walker] == previous.log_densities[walker]
-                )
-                if not accepted and not unchanged:
-                    failures.append(
-                        McmcValidationFailure(
-                            state.ordinal,
-                            walker,
-                            "rejected_transition_changed_state",
-                            "rejected walker did not preserve its prior state exactly",
-                        )
-                    )
-                    break
-            if failures:
-                break
         if (
             len(state.positions) != plan.policy.walkers
             or len(state.log_densities) != plan.policy.walkers
-            or len(state.accepted) != plan.policy.walkers
             or any(
                 len(position) != plan.policy.dimension for position in state.positions
             )
@@ -1794,7 +1903,6 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
                 state.ordinal,
                 state.positions,
                 tuple(authoritative),
-                state.accepted,
             )
         )
     primary: McmcEvidence | None = None
@@ -1809,6 +1917,7 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
             raw_capture,
             McmcEvidenceLifecycle.COMPLETED,
             tuple(validated),
+            backend_transition_evidence,
         )
     elif not failures and validated:
         primary = _mint_primary_evidence(
@@ -1816,6 +1925,7 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
             raw_capture,
             McmcEvidenceLifecycle.PARTIAL,
             tuple(validated),
+            backend_transition_evidence,
         )
     elif not failures and raw_capture.terminal is McmcOperationTerminal.COMPLETED:
         failures.append(
@@ -1845,6 +1955,7 @@ class McmcOperation:
     failure_message: str = ""
     raw_capture: RawMcmcCapture | None = None
     validation: McmcChainValidation | None = None
+    backend_transition_evidence: BackendTransitionEvidence | None = None
     _occurrence_witness: _McmcEvidenceWitness | None = field(
         default=None,
         repr=False,
@@ -1869,9 +1980,13 @@ class McmcOperation:
             raise McmcConstructionError(
                 "Non-completed MCMC operation requires typed failure evidence"
             )
-        if self.raw_capture is None or self.validation is None:
+        if (
+            self.raw_capture is None
+            or self.validation is None
+            or self.backend_transition_evidence is None
+        ):
             raise McmcConstructionError(
-                "Every MCMC operation requires zero-or-more-state raw evidence"
+                "Every MCMC operation requires raw and backend diagnostic evidence"
             )
         object.__setattr__(self, "identity", self._content_identity())
         if self._occurrence_witness is None or not _bind_mcmc_evidence_witness(
@@ -1887,6 +2002,10 @@ class McmcOperation:
     def _content_identity(self) -> str:
         capture = cast("RawMcmcCapture", self.raw_capture)
         validation = cast("McmcChainValidation", self.validation)
+        backend = cast(
+            "BackendTransitionEvidence",
+            self.backend_transition_evidence,
+        )
         return _identity(
             "native-mcmc-operation",
             (
@@ -1896,6 +2015,7 @@ class McmcOperation:
                 self.failure_message,
                 capture.identity,
                 validation.identity,
+                backend.identity,
             ),
         )
 
@@ -1914,8 +2034,21 @@ class McmcOperation:
         capture.validate_integrity()
         validation = cast("McmcChainValidation", self.validation)
         validation.validate_integrity()
+        backend = cast(
+            "BackendTransitionEvidence",
+            self.backend_transition_evidence,
+        )
+        backend.validate_integrity()
+        if backend.source_capture is not capture:
+            raise McmcConstructionError(
+                "Operation backend diagnostics differ from its raw capture"
+            )
         if self.evidence is not None:
             self.evidence.validate_integrity()
+            if self.evidence.backend_transition_evidence is not backend:
+                raise McmcConstructionError(
+                    "Operation backend diagnostics differ from primary attachment"
+                )
         if self._content_identity() != self.identity:
             raise McmcConstructionError("MCMC operation content identity mismatch")
         if not _mcmc_evidence_occurrence_is_authoritative(
@@ -1936,6 +2069,7 @@ def _mint_mcmc_operation(
     failure_message: str,
     raw_capture: RawMcmcCapture,
     validation: McmcChainValidation,
+    backend_transition_evidence: BackendTransitionEvidence,
 ) -> McmcOperation:
     return McmcOperation(
         terminal,
@@ -1944,6 +2078,7 @@ def _mint_mcmc_operation(
         failure_message,
         raw_capture,
         validation,
+        backend_transition_evidence,
         _mint_mcmc_evidence_witness("operation"),
     )
 
@@ -2022,50 +2157,164 @@ class RetainedSampleView:
 
 
 @dataclass(frozen=True, slots=True)
-class McmcDiagnostics:
-    """Acceptance diagnostics derived without altering primary chain evidence."""
+class AcceptanceDiagnostics:
+    """Canonical diagnostics derived from one exact backend mask source."""
 
-    source_evidence_identity: str
-    state_ordinals: tuple[int, ...]
-    walker_ordinals: tuple[int, ...]
-    status: McmcDiagnosticStatus
-    reason: McmcDiagnosticReason | None
-    acceptance_fractions: tuple[float, ...] | None
-    mean_acceptance_fraction: float | None
+    source: BackendTransitionEvidence = field(repr=False, compare=False)
+    _occurrence_witness: _McmcEvidenceWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    source_identity: str = field(init=False)
+    state_ordinals: tuple[int, ...] = field(init=False)
+    walker_ordinals: tuple[int, ...] = field(init=False)
+    observed_transition_count: int = field(init=False)
+    accepted_counts: tuple[int, ...] = field(init=False)
+    status: McmcDiagnosticStatus = field(init=False)
+    reason: McmcDiagnosticReason | None = field(init=False)
+    acceptance_fractions: tuple[float, ...] | None = field(init=False)
+    mean_acceptance_fraction: float | None = field(init=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        available = self.status is McmcDiagnosticStatus.AVAILABLE
         if (
-            available != (self.acceptance_fractions is not None)
-            or available != (self.mean_acceptance_fraction is not None)
-            or available == (self.reason is not None)
+            not isinstance(self.source, BackendTransitionEvidence)
+            or self._occurrence_witness is None
         ):
             raise McmcConstructionError(
-                "MCMC diagnostic availability payload is inconsistent"
+                "Acceptance diagnostics require canonical backend derivation"
             )
+        self.source.validate_integrity()
+        walker_ordinals = tuple(range(self.source.source_capture.walkers))
+        transitions = self.source.transitions
+        denominator = len(transitions)
+        accepted_counts = tuple(
+            sum(transition.accepted[walker] for transition in transitions)
+            for walker in walker_ordinals
+        )
+        if denominator == 0:
+            status = McmcDiagnosticStatus.UNAVAILABLE
+            reason = McmcDiagnosticReason.NO_TRANSITIONS
+            fractions = None
+            mean = None
+        elif not self.source.is_structurally_consistent:
+            status = McmcDiagnosticStatus.UNAVAILABLE
+            reason = McmcDiagnosticReason.BACKEND_TRANSITION_INCONSISTENT
+            fractions = None
+            mean = None
+        else:
+            status = McmcDiagnosticStatus.AVAILABLE
+            reason = None
+            fractions = tuple(count / denominator for count in accepted_counts)
+            mean = sum(fractions) / len(fractions)
+        object.__setattr__(self, "source_identity", self.source.identity)
         object.__setattr__(
             self,
-            "identity",
-            _identity(
-                "native-mcmc-acceptance-diagnostics",
-                (
-                    self.source_evidence_identity,
-                    self.state_ordinals,
-                    self.walker_ordinals,
-                    self.status.value,
-                    None if self.reason is None else self.reason.value,
-                    None
-                    if self.acceptance_fractions is None
-                    else tuple(
-                        float(value).hex() for value in self.acceptance_fractions
-                    ),
-                    None
-                    if self.mean_acceptance_fraction is None
-                    else float(self.mean_acceptance_fraction).hex(),
-                ),
+            "state_ordinals",
+            tuple(item.ordinal for item in transitions),
+        )
+        object.__setattr__(self, "walker_ordinals", walker_ordinals)
+        object.__setattr__(self, "observed_transition_count", denominator)
+        object.__setattr__(self, "accepted_counts", accepted_counts)
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "reason", reason)
+        object.__setattr__(self, "acceptance_fractions", fractions)
+        object.__setattr__(self, "mean_acceptance_fraction", mean)
+        object.__setattr__(self, "identity", self._content_identity())
+        if not _bind_mcmc_evidence_witness(
+            self._occurrence_witness,
+            self,
+            "acceptance-diagnostics",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Acceptance diagnostic occurrence witness is already bound"
+            )
+
+    def _content_identity(self) -> str:
+        return _identity(
+            "native-mcmc-acceptance-diagnostics",
+            (
+                self.source.identity,
+                self.state_ordinals,
+                self.walker_ordinals,
+                self.observed_transition_count,
+                self.accepted_counts,
+                self.status.value,
+                None if self.reason is None else self.reason.value,
+                None
+                if self.acceptance_fractions is None
+                else tuple(float(value).hex() for value in self.acceptance_fractions),
+                None
+                if self.mean_acceptance_fraction is None
+                else float(self.mean_acceptance_fraction).hex(),
             ),
         )
+
+    @classmethod
+    def from_backend_evidence(
+        cls,
+        source: BackendTransitionEvidence,
+    ) -> AcceptanceDiagnostics:
+        return cls(
+            source,
+            _mint_mcmc_evidence_witness("acceptance-diagnostics"),
+        )
+
+    def validate_integrity(self) -> None:
+        self.source.validate_integrity()
+        expected = self.from_backend_evidence(self.source)
+        if (
+            self._content_identity() != self.identity
+            or expected._content_identity() != self.identity
+        ):
+            raise McmcConstructionError("Acceptance diagnostic content mismatch")
+        if not _mcmc_evidence_occurrence_is_authoritative(
+            self._occurrence_witness,
+            self,
+            "acceptance-diagnostics",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Acceptance diagnostics are not their canonical occurrence"
+            )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "source_identity": self.source_identity,
+            "state_ordinals": list(self.state_ordinals),
+            "walker_ordinals": list(self.walker_ordinals),
+            "observed_transition_count": self.observed_transition_count,
+            "accepted_counts": list(self.accepted_counts),
+            "status": self.status.value,
+            "reason": None if self.reason is None else self.reason.value,
+            "acceptance_fractions": None
+            if self.acceptance_fractions is None
+            else [float(value).hex() for value in self.acceptance_fractions],
+            "mean_acceptance_fraction": None
+            if self.mean_acceptance_fraction is None
+            else float(self.mean_acceptance_fraction).hex(),
+            "identity": self.identity,
+        }
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        *,
+        source: BackendTransitionEvidence,
+    ) -> AcceptanceDiagnostics:
+        expected = cls.from_backend_evidence(source)
+        if record != expected.to_record():
+            raise McmcConstructionError(
+                "Stored acceptance diagnostics differ from canonical backend evidence"
+            )
+        return expected
+
+
+McmcDiagnostics = AcceptanceDiagnostics
 
 
 class PosteriorSampleDisposition(StrEnum):
@@ -2307,11 +2556,30 @@ class PosteriorSummaryPolicy:
     quantiles: tuple[float, ...] = (0.025, 0.5, 0.975)
     covariance_delta_degrees_of_freedom: int = 1
     minimum_autocorrelation_steps: int = 16
-    version: str = "mcmc-complete-scope-equal-tailed-v1"
+    minimum_autocorrelation_walkers: int = 2
+    autocorrelation_window_parameter: float = 5.0
+    autocorrelation_adequacy_tolerance: float = 50.0
+    version: str = "mcmc-complete-scope-equal-tailed-v2"
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         quantiles = tuple(float(value) for value in self.quantiles)
+        minimum_steps = _positive_integer(
+            self.minimum_autocorrelation_steps,
+            name="Minimum autocorrelation retained steps",
+        )
+        minimum_walkers = _positive_integer(
+            self.minimum_autocorrelation_walkers,
+            name="Minimum autocorrelation retained walkers",
+        )
+        window_parameter = _finite_positive(
+            self.autocorrelation_window_parameter,
+            name="Autocorrelation window parameter",
+        )
+        adequacy_tolerance = _finite_positive(
+            self.autocorrelation_adequacy_tolerance,
+            name="Autocorrelation adequacy tolerance",
+        )
         if (
             not quantiles
             or any(not math.isfinite(value) for value in quantiles)
@@ -2327,10 +2595,22 @@ class PosteriorSummaryPolicy:
                 abs_tol=1.0e-15,
             )
             or self.covariance_delta_degrees_of_freedom != 1
-            or self.minimum_autocorrelation_steps < 2
+            or minimum_steps < 2
         ):
             raise McmcConstructionError("Posterior summary policy is invalid")
         object.__setattr__(self, "quantiles", quantiles)
+        object.__setattr__(self, "minimum_autocorrelation_steps", minimum_steps)
+        object.__setattr__(self, "minimum_autocorrelation_walkers", minimum_walkers)
+        object.__setattr__(
+            self,
+            "autocorrelation_window_parameter",
+            window_parameter,
+        )
+        object.__setattr__(
+            self,
+            "autocorrelation_adequacy_tolerance",
+            adequacy_tolerance,
+        )
         object.__setattr__(
             self,
             "identity",
@@ -2339,11 +2619,29 @@ class PosteriorSummaryPolicy:
                 (
                     tuple(float(value).hex() for value in quantiles),
                     self.covariance_delta_degrees_of_freedom,
-                    self.minimum_autocorrelation_steps,
+                    minimum_steps,
+                    minimum_walkers,
+                    float(window_parameter).hex(),
+                    float(adequacy_tolerance).hex(),
                     self.version,
                 ),
             ),
         )
+
+    def validate_integrity(self) -> None:
+        expected = PosteriorSummaryPolicy(
+            self.quantiles,
+            self.covariance_delta_degrees_of_freedom,
+            self.minimum_autocorrelation_steps,
+            self.minimum_autocorrelation_walkers,
+            self.autocorrelation_window_parameter,
+            self.autocorrelation_adequacy_tolerance,
+            self.version,
+        )
+        if expected.identity != self.identity:
+            raise McmcConstructionError(
+                "Posterior summary policy content identity mismatch"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -2483,6 +2781,8 @@ class PosteriorSummary:
 
     def validate_integrity(self) -> None:
         self.source.validate_integrity()
+        self.policy.validate_integrity()
+        self.acceptance.validate_integrity()
         expected_acceptance = derive_mcmc_diagnostics(
             self.source.selection.source_evidence
         )
@@ -2566,6 +2866,7 @@ def derive_posterior_summary(  # noqa: C901 - joint typed summary assembly
     if cancellation is not None and cancellation.is_cancelled:
         raise McmcConstructionError("Posterior summary derivation was cancelled")
     exact_policy = PosteriorSummaryPolicy() if policy is None else policy
+    exact_policy.validate_integrity()
     successful = tuple(
         outcome
         for outcome in source.outcomes
@@ -2607,6 +2908,8 @@ def derive_posterior_summary(  # noqa: C901 - joint typed summary assembly
         not source.selection.is_complete
         or not complete_grid
         or step_count < exact_policy.minimum_autocorrelation_steps
+        or len(source.selection.selected_walker_ordinals)
+        < exact_policy.minimum_autocorrelation_walkers
     ):
         reason = (
             McmcDiagnosticReason.PARTIAL_CHAIN
@@ -2626,10 +2929,19 @@ def derive_posterior_summary(  # noqa: C901 - joint typed summary assembly
             with warnings.catch_warnings():
                 warnings.simplefilter("error", RuntimeWarning)
                 tau_values = np.asarray(
-                    emcee.autocorr.integrated_time(chain, quiet=True),
+                    emcee.autocorr.integrated_time(
+                        chain,
+                        c=exact_policy.autocorrelation_window_parameter,
+                        tol=exact_policy.autocorrelation_adequacy_tolerance,
+                        quiet=False,
+                    ),
                     dtype=np.float64,
                 )
+        except emcee.autocorr.AutocorrError as error:
+            tau_values = np.asarray(error.tau, dtype=np.float64)
         except Exception:  # noqa: BLE001 - typed unavailable estimate
+            tau_values = np.full(len(source.output_scope), np.nan)
+        if tau_values.shape != (len(source.output_scope),):
             tau_values = np.full(len(source.output_scope), np.nan)
         autocorrelation_values: list[PosteriorScalarEstimate] = []
         ess_values: list[PosteriorScalarEstimate] = []
@@ -2637,6 +2949,17 @@ def derive_posterior_summary(  # noqa: C901 - joint typed summary assembly
         for index, tau in enumerate(tau_values):
             if not math.isfinite(float(tau)) or tau <= 0.0:
                 unavailable = _unavailable(McmcDiagnosticReason.INVALID_AUTOCORRELATION)
+                autocorrelation_values.append(unavailable)
+                ess_values.append(unavailable)
+                mcse_values.append(unavailable)
+                continue
+            if (
+                exact_policy.autocorrelation_adequacy_tolerance * float(tau)
+                > step_count
+            ):
+                unavailable = _unavailable(
+                    McmcDiagnosticReason.UNRELIABLE_AUTOCORRELATION
+                )
                 autocorrelation_values.append(unavailable)
                 ess_values.append(unavailable)
                 mcse_values.append(unavailable)
@@ -2832,19 +3155,12 @@ def _ensemble_state(
     ordinal: int,
     positions: Array,
     log_densities: Array,
-    accepted_mask: Array | None,
 ) -> EnsembleState:
     current = np.asarray(positions, dtype=np.float64)
-    accepted = (
-        tuple(False for _ in current)
-        if accepted_mask is None
-        else tuple(bool(value) for value in accepted_mask)
-    )
     return EnsembleState(
         ordinal,
         tuple(tuple(float(value) for value in row) for row in current),
         tuple(float(value) for value in np.asarray(log_densities, dtype=np.float64)),
-        accepted,
     )
 
 
@@ -2866,6 +3182,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     signal = CancellationToken() if cancellation is None else cancellation
     log_density = _LogDensityEvaluator(plan)
     states: list[EnsembleState] = []
+    acceptance_masks: list[tuple[bool, ...]] = []
     stage = McmcExecutionStage.BEFORE_INITIALIZATION
     initialization_outcome = McmcInitializationOutcome.NOT_STARTED
 
@@ -2890,7 +3207,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
                 "MCMC initial ensemble has unavailable native log density"
             )
         initialization_outcome = McmcInitializationOutcome.COMPLETED
-        states.append(_ensemble_state(0, initial, initial_log_density, None))
+        states.append(_ensemble_state(0, initial, initial_log_density))
         checkpoint(McmcExecutionStage.AFTER_INITIALIZATION)
         checkpoint(McmcExecutionStage.AFTER_COMPLETE_STATE)
         move = _RecordingStretchMove(scale=plan.policy.proposal_scale)
@@ -2913,11 +3230,15 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
             checkpoint(McmcExecutionStage.BEFORE_TRANSITION)
             checkpoint(McmcExecutionStage.DURING_TRANSITION)
             sampled = next(iterator)
+            if move.last_accepted is None:
+                raise McmcExecutionError(
+                    "MCMC backend omitted its transition diagnostic mask"
+                )
+            acceptance_masks.append(tuple(bool(value) for value in move.last_accepted))
             state = _ensemble_state(
                 ordinal,
                 sampled.coords,
                 sampled.log_prob,
-                move.last_accepted,
             )
             states.append(state)
             if state_observer is not None:
@@ -2937,7 +3258,16 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
             stage,
             initialization_outcome,
         )
-        validation = validate_raw_mcmc_capture(plan, raw_capture)
+        backend_transition_evidence = BackendTransitionEvidence.from_capture(
+            raw_capture,
+            acceptance_masks,
+            observation_provenance="emcee-stretch-backend-v1",
+        )
+        validation = validate_raw_mcmc_capture(
+            plan,
+            raw_capture,
+            backend_transition_evidence=backend_transition_evidence,
+        )
         if not validation.is_complete or validation.primary_evidence is None:
             raise McmcExecutionError("fresh MCMC validation did not complete")
         checkpoint(McmcExecutionStage.BEFORE_FINAL_ASSEMBLY)
@@ -2949,6 +3279,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
             "",
             raw_capture,
             validation,
+            backend_transition_evidence,
         )
     except _McmcCancelled as error:
         terminal = McmcOperationTerminal.CANCELLED
@@ -2978,7 +3309,16 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
         initialization_outcome,
         category,
     )
-    validation = validate_raw_mcmc_capture(plan, raw_capture)
+    backend_transition_evidence = BackendTransitionEvidence.from_capture(
+        raw_capture,
+        acceptance_masks,
+        observation_provenance="emcee-stretch-backend-v1",
+    )
+    validation = validate_raw_mcmc_capture(
+        plan,
+        raw_capture,
+        backend_transition_evidence=backend_transition_evidence,
+    )
     return _mint_mcmc_operation(
         terminal,
         validation.primary_evidence,
@@ -2986,6 +3326,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
         message,
         raw_capture,
         validation,
+        backend_transition_evidence,
     )
 
 
@@ -3030,37 +3371,19 @@ def derive_mcmc_diagnostics(
     *,
     cancellation: CancellationToken | None = None,
 ) -> McmcDiagnostics:
-    """Derive acceptance diagnostics from complete transition states only."""
+    """Derive diagnostic-only acceptance observations from their backend source."""
     evidence.validate_integrity()
     if cancellation is not None and cancellation.is_cancelled:
         raise McmcConstructionError("MCMC diagnostic derivation was cancelled")
-    transitions = evidence.states[1:]
-    completed = len(transitions)
-    accepted_counts = tuple(
-        sum(state.accepted[walker] for state in transitions)
-        for walker in range(evidence.plan.policy.walkers)
-    )
-    if completed == 0:
-        return McmcDiagnostics(
-            evidence.identity,
-            (),
-            tuple(range(evidence.plan.policy.walkers)),
-            McmcDiagnosticStatus.UNAVAILABLE,
-            McmcDiagnosticReason.NO_TRANSITIONS,
-            None,
-            None,
+    source = evidence.backend_transition_evidence
+    if (
+        source is None
+        or source.source_capture_identity != evidence.raw_capture_identity
+    ):
+        raise McmcConstructionError(
+            "Primary evidence has no matching backend transition diagnostic source"
         )
-    fractions = tuple(count / completed for count in accepted_counts)
-    mean = sum(fractions) / len(fractions)
-    return McmcDiagnostics(
-        evidence.identity,
-        tuple(state.ordinal for state in transitions),
-        tuple(range(evidence.plan.policy.walkers)),
-        McmcDiagnosticStatus.AVAILABLE,
-        None,
-        fractions,
-        mean,
-    )
+    return AcceptanceDiagnostics.from_backend_evidence(source)
 
 
 def derive_mcmc_operation_diagnostics(
@@ -3072,15 +3395,11 @@ def derive_mcmc_operation_diagnostics(
     operation.validate_integrity()
     if cancellation is not None and cancellation.is_cancelled:
         raise McmcConstructionError("MCMC diagnostic derivation was cancelled")
+    source = cast("BackendTransitionEvidence", operation.backend_transition_evidence)
     if operation.evidence is not None:
-        return derive_mcmc_diagnostics(operation.evidence)
-    capture = cast("RawMcmcCapture", operation.raw_capture)
-    return McmcDiagnostics(
-        operation.identity,
-        (),
-        tuple(range(capture.walkers)),
-        McmcDiagnosticStatus.UNAVAILABLE,
-        McmcDiagnosticReason.NO_TRANSITIONS,
-        None,
-        None,
-    )
+        evidence_source = operation.evidence.backend_transition_evidence
+        if evidence_source is not source:
+            raise McmcConstructionError(
+                "Operation and primary evidence backend diagnostics differ"
+            )
+    return AcceptanceDiagnostics.from_backend_evidence(source)

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -10,21 +10,26 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import warnings
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import cast
+from threading import RLock
+from typing import SupportsIndex, cast
+from weakref import WeakKeyDictionary
 
 import emcee
 import numpy as np
 
 from chemex.evaluation.native import (
+    BoundEvaluator,
     EvaluationEngine,
     EvaluationFailure,
     EvaluationFrame,
 )
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
+    CancellationToken,
     OptimizationProblem,
     accepted_occurrence_is_authoritative,
     canonical_chi_square,
@@ -50,6 +55,7 @@ class McmcPolicyKind(StrEnum):
     """Closed prospective native MCMC policy modes."""
 
     CALIBRATED = "calibrated"
+    CALIBRATION_CANDIDATE = "calibration_candidate"
     EXPERT = "expert"
 
 
@@ -76,12 +82,139 @@ class McmcOperationTerminal(StrEnum):
     """Terminal disposition of one native MCMC execution operation."""
 
     COMPLETED = "completed"
+    CANCELLED = "cancelled"
     FAILED = "failed"
     INTERRUPTED = "interrupted"
 
 
+class McmcExecutionStage(StrEnum):
+    """Last immutable checkpoint reached by one operation."""
+
+    BEFORE_INITIALIZATION = "before_initialization"
+    INITIALIZING = "initializing"
+    AFTER_INITIALIZATION = "after_initialization"
+    BEFORE_TRANSITION = "before_transition"
+    DURING_TRANSITION = "during_transition"
+    AFTER_COMPLETE_STATE = "after_complete_state"
+    FRESH_VALIDATION = "fresh_validation"
+    BEFORE_FINAL_ASSEMBLY = "before_final_assembly"
+
+
+class McmcInitializationOutcome(StrEnum):
+    """Truthful bounded-initialization disposition."""
+
+    NOT_STARTED = "not_started"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+
+
+class McmcDiagnosticStatus(StrEnum):
+    """Typed availability of an observed or estimated diagnostic."""
+
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+
+
+class McmcDiagnosticReason(StrEnum):
+    """Closed reason for unavailable MCMC diagnostic evidence."""
+
+    NO_TRANSITIONS = "no_transitions"
+    INSUFFICIENT_STATES = "insufficient_states"
+    INSUFFICIENT_RETAINED_WINDOW = "insufficient_retained_window"
+    ZERO_VARIANCE = "zero_variance"
+    INVALID_AUTOCORRELATION = "invalid_autocorrelation"
+    PARTIAL_CHAIN = "partial_chain"
+
+
+class McmcTrajectoryClaim(StrEnum):
+    """Authority level of deterministic trajectory observations."""
+
+    ORDINARY_CAPTURE = "ordinary_capture"
+
+
 class McmcExecutionError(RuntimeError):
     """Raised internally when native evaluation cannot produce log density."""
+
+
+class _McmcCancelled(RuntimeError):
+    pass
+
+
+class _McmcEvidenceWitness:
+    """Opaque process-local witness for one canonical evidence occurrence."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls) -> _McmcEvidenceWitness:
+        raise TypeError(
+            "MCMC evidence witnesses are minted only by canonical factories"
+        )
+
+    def __copy__(self) -> _McmcEvidenceWitness:
+        raise TypeError("MCMC evidence witnesses cannot be copied")
+
+    def __deepcopy__(self, _memo: object) -> _McmcEvidenceWitness:
+        raise TypeError("MCMC evidence witnesses cannot be copied")
+
+    def __reduce__(self) -> tuple[object, ...]:
+        raise TypeError("MCMC evidence witnesses cannot be serialized")
+
+    def __reduce_ex__(self, _protocol: SupportsIndex, /) -> tuple[object, ...]:
+        raise TypeError("MCMC evidence witnesses cannot be serialized")
+
+
+@dataclass(frozen=True, slots=True)
+class _McmcEvidenceBinding:
+    kind: str
+    identity: str | None = None
+    object_identity: int | None = None
+
+
+_MCMC_EVIDENCE_WITNESSES: WeakKeyDictionary[
+    _McmcEvidenceWitness,
+    _McmcEvidenceBinding,
+] = WeakKeyDictionary()
+_MCMC_EVIDENCE_WITNESSES_LOCK = RLock()
+
+
+def _mint_mcmc_evidence_witness(kind: str) -> _McmcEvidenceWitness:
+    witness = object.__new__(_McmcEvidenceWitness)
+    with _MCMC_EVIDENCE_WITNESSES_LOCK:
+        _MCMC_EVIDENCE_WITNESSES[witness] = _McmcEvidenceBinding(kind)
+    return witness
+
+
+def _bind_mcmc_evidence_witness(
+    witness: _McmcEvidenceWitness,
+    artifact: object,
+    kind: str,
+    identity: str,
+) -> bool:
+    with _MCMC_EVIDENCE_WITNESSES_LOCK:
+        binding = _MCMC_EVIDENCE_WITNESSES.get(witness)
+        if binding == _McmcEvidenceBinding(kind):
+            _MCMC_EVIDENCE_WITNESSES[witness] = _McmcEvidenceBinding(
+                kind,
+                identity,
+                id(artifact),
+            )
+            return True
+        return binding == _McmcEvidenceBinding(kind, identity, id(artifact))
+
+
+def _mcmc_evidence_occurrence_is_authoritative(
+    witness: _McmcEvidenceWitness | None,
+    artifact: object,
+    kind: str,
+    identity: str,
+) -> bool:
+    if witness is None:
+        return False
+    with _MCMC_EVIDENCE_WITNESSES_LOCK:
+        binding = _MCMC_EVIDENCE_WITNESSES.get(witness)
+    return binding == _McmcEvidenceBinding(kind, identity, id(artifact))
 
 
 def _identity(kind: str, record: object) -> str:
@@ -201,6 +334,7 @@ class ResolvedMcmcPolicy:
     burn_steps: int
     retained_steps: int
     root_seed: int
+    provenance_identity: str
     qualification_dimension_range: tuple[int, int] | None = None
     proposal_scale: float = 2.0
     thin: int = 1
@@ -215,6 +349,7 @@ class ResolvedMcmcPolicy:
     objective_request_budget: int = field(init=False)
     initialization_seed: int = field(init=False)
     sampler_seed: int = field(init=False)
+    has_calibrated_adequacy: bool = field(init=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -241,6 +376,11 @@ class ResolvedMcmcPolicy:
             raise McmcConstructionError(
                 "Calibrated MCMC policy requires an explicit qualification stratum"
             )
+        if self.kind is McmcPolicyKind.CALIBRATED:
+            raise McmcConstructionError(
+                "No repository-frozen calibration reference is available for "
+                "native MCMC"
+            )
         if self.kind is McmcPolicyKind.EXPERT and qualification_range is not None:
             raise McmcConstructionError(
                 "Expert MCMC policy cannot inherit calibrated qualification"
@@ -261,6 +401,7 @@ class ResolvedMcmcPolicy:
             )
         for value, name in (
             (self.policy_version, "MCMC policy version"),
+            (self.provenance_identity, "MCMC policy provenance identity"),
             (self.sampler_version, "MCMC sampler version"),
             (self.initialization_version, "MCMC initialization version"),
             (self.proposal_version, "MCMC proposal version"),
@@ -275,6 +416,7 @@ class ResolvedMcmcPolicy:
             (
                 self.kind.value,
                 self.policy_version,
+                self.provenance_identity,
                 dimension,
                 walkers,
                 burn,
@@ -294,6 +436,7 @@ class ResolvedMcmcPolicy:
             (
                 self.kind.value,
                 self.policy_version,
+                self.provenance_identity,
                 dimension,
                 walkers,
                 burn,
@@ -328,14 +471,103 @@ class ResolvedMcmcPolicy:
         )
         object.__setattr__(self, "initialization_seed", initialization_seed)
         object.__setattr__(self, "sampler_seed", sampler_seed)
+        object.__setattr__(
+            self,
+            "has_calibrated_adequacy",
+            self.kind is McmcPolicyKind.CALIBRATED,
+        )
         object.__setattr__(self, "identity", identity)
 
 
 @dataclass(frozen=True, slots=True)
-class CalibratedMcmcPolicy:
-    """One versioned qualified topology for a bounded dimension stratum."""
+class McmcCalibrationReference:
+    """Future #604 content reference; it carries no authority by itself."""
 
+    calibration_identity: str
+    baseline_release_identity: str
+    numerical_lane_requirement: str
     policy_version: str
+    minimum_dimension: int
+    maximum_dimension: int
+    walkers: int
+    burn_steps: int
+    retained_steps: int
+    proposal_scale: float = 2.0
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        minimum = _positive_integer(
+            self.minimum_dimension,
+            name="calibration-reference minimum dimension",
+        )
+        maximum = _positive_integer(
+            self.maximum_dimension,
+            name="calibration-reference maximum dimension",
+        )
+        if minimum > maximum:
+            raise McmcConstructionError(
+                "MCMC calibration reference has an inverted dimension stratum"
+            )
+        for value, name in (
+            (self.calibration_identity, "MCMC calibration identity"),
+            (self.baseline_release_identity, "MCMC baseline release identity"),
+            (self.numerical_lane_requirement, "MCMC numerical lane requirement"),
+            (self.policy_version, "MCMC calibrated policy version"),
+        ):
+            _nonempty(value, name=name)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-mcmc-calibration-reference",
+                (
+                    self.calibration_identity,
+                    self.baseline_release_identity,
+                    self.numerical_lane_requirement,
+                    self.policy_version,
+                    minimum,
+                    maximum,
+                    self.walkers,
+                    self.burn_steps,
+                    self.retained_steps,
+                    float(self.proposal_scale).hex(),
+                ),
+            ),
+        )
+
+
+def _repository_frozen_calibration_matches(
+    reference: McmcCalibrationReference,
+    authority: object,
+) -> bool:
+    """#604 will bind exact frozen references; none exist at #600."""
+    _ = reference, authority
+    return False
+
+
+@dataclass(frozen=True, slots=True)
+class CalibratedMcmcPolicy:
+    """Future exact-reference path, deliberately unavailable before #604."""
+
+    reference: McmcCalibrationReference
+    authority: object = field(repr=False, compare=False)
+
+    def resolve(self, *, dimension: int, root_seed: int) -> ResolvedMcmcPolicy:
+        if not _repository_frozen_calibration_matches(
+            self.reference,
+            self.authority,
+        ):
+            raise McmcConstructionError(
+                "MCMC calibration reference has no exact repository-frozen authority"
+            )
+        raise AssertionError("#604 must implement calibrated MCMC policy resolution")
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationCandidateMcmcPolicy:
+    """Executable prospective shape without calibrated adequacy authority."""
+
+    candidate_identity: str
     minimum_dimension: int
     maximum_dimension: int
     walkers: int
@@ -346,31 +578,28 @@ class CalibratedMcmcPolicy:
     def resolve(self, *, dimension: int, root_seed: int) -> ResolvedMcmcPolicy:
         minimum = _positive_integer(
             self.minimum_dimension,
-            name="calibrated minimum dimension",
+            name="candidate minimum dimension",
         )
         maximum = _positive_integer(
             self.maximum_dimension,
-            name="calibrated maximum dimension",
+            name="candidate maximum dimension",
         )
-        if minimum > maximum:
+        if minimum > maximum or not minimum <= dimension <= maximum:
             raise McmcConstructionError(
-                "Calibrated MCMC dimension stratum is strictly inverted"
-            )
-        if not minimum <= dimension <= maximum:
-            raise McmcConstructionError(
-                "No calibrated MCMC policy covers the requested dimension"
+                "MCMC calibration candidate does not cover the requested dimension"
             )
         return ResolvedMcmcPolicy(
-            kind=McmcPolicyKind.CALIBRATED,
+            kind=McmcPolicyKind.CALIBRATION_CANDIDATE,
             policy_version=_nonempty(
-                self.policy_version,
-                name="MCMC policy version",
+                self.candidate_identity,
+                name="MCMC calibration candidate identity",
             ),
             dimension=dimension,
             walkers=self.walkers,
             burn_steps=self.burn_steps,
             retained_steps=self.retained_steps,
             root_seed=root_seed,
+            provenance_identity=self.candidate_identity,
             qualification_dimension_range=(minimum, maximum),
             proposal_scale=self.proposal_scale,
         )
@@ -383,6 +612,7 @@ class ExpertMcmcPolicy:
     burn_steps: int
     retained_steps: int
     walkers: int
+    expert_provenance: str
     policy_version: str = field(init=False, default="expert-v1")
 
     def resolve(self, *, dimension: int, root_seed: int) -> ResolvedMcmcPolicy:
@@ -397,7 +627,126 @@ class ExpertMcmcPolicy:
             burn_steps=self.burn_steps,
             retained_steps=self.retained_steps,
             root_seed=root_seed,
+            provenance_identity=_nonempty(
+                self.expert_provenance,
+                name="MCMC expert provenance",
+            ),
         )
+
+
+@dataclass(frozen=True, slots=True)
+class McmcAcceptedAnchor:
+    """Exact occurrence-owned scientific context for one MCMC request."""
+
+    accepted_semantic_identity: str
+    accepted_occurrence_identity: str
+    accepted_occurrence_witness: object = field(repr=False, compare=False)
+    source_occurrence_identity: str
+    source_revision: int
+    problem_identity: str
+    parameterization_identity: str
+    evaluator_parameterization_identity: str
+    constraint_program_identity: str
+    evaluation_plan_identity: str
+    coordinate_units: tuple[tuple[str, ParameterUnit], ...]
+    held_items: tuple[tuple[str, float], ...]
+    lower_bounds: tuple[float, ...]
+    upper_bounds: tuple[float, ...]
+    affine_feasibility_identity: str
+    accepted_vector: tuple[float, ...]
+    accepted_evaluation_identity: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-mcmc-accepted-anchor",
+                (
+                    self.accepted_semantic_identity,
+                    self.accepted_occurrence_identity,
+                    self.source_occurrence_identity,
+                    self.source_revision,
+                    self.problem_identity,
+                    self.parameterization_identity,
+                    self.evaluator_parameterization_identity,
+                    self.constraint_program_identity,
+                    self.evaluation_plan_identity,
+                    self.coordinate_units,
+                    tuple((key, float(value).hex()) for key, value in self.held_items),
+                    tuple(float(value).hex() for value in self.lower_bounds),
+                    tuple(float(value).hex() for value in self.upper_bounds),
+                    self.affine_feasibility_identity,
+                    tuple(float(value).hex() for value in self.accepted_vector),
+                    self.accepted_evaluation_identity,
+                ),
+            ),
+        )
+
+    def validate(
+        self,
+        accepted: AcceptedFitResult,
+        problem: OptimizationProblem,
+        parameterization: ActiveParameterization,
+        engine: EvaluationEngine,
+    ) -> None:
+        """Reject any live object outside the exact frozen accepted lineage."""
+        expected = (
+            self.accepted_semantic_identity,
+            self.accepted_occurrence_identity,
+            self.source_occurrence_identity,
+            self.source_revision,
+            self.problem_identity,
+            self.parameterization_identity,
+            self.evaluator_parameterization_identity,
+            self.constraint_program_identity,
+            self.evaluation_plan_identity,
+            self.coordinate_units,
+            self.held_items,
+            self.lower_bounds,
+            self.upper_bounds,
+            self.affine_feasibility_identity,
+            self.accepted_vector,
+            self.accepted_evaluation_identity,
+        )
+        actual = (
+            accepted.identity,
+            accepted.occurrence_identity,
+            problem.source_snapshot.occurrence_identity,
+            problem.source_snapshot.revision,
+            problem.identity,
+            parameterization.identity,
+            parameterization.evaluator_identity,
+            parameterization.program.fingerprint,
+            engine.plan.identity,
+            tuple(self.coordinate_units),
+            problem.held_items,
+            problem.lower_bounds,
+            problem.upper_bounds,
+            problem.affine_feasibility_identity,
+            accepted.vector,
+            accepted.evaluation_result.identity,
+        )
+        if (
+            not accepted_occurrence_is_authoritative(accepted)
+            or accepted.occurrence_witness is not self.accepted_occurrence_witness
+            or actual != expected
+            or accepted.problem_identity != problem.identity
+            or accepted.evaluation_result.plan_identity != engine.plan.identity
+            or accepted.evaluation_result.parameterization_identity
+            != parameterization.evaluator_identity
+            or problem.evaluation_plan_identity != engine.plan.identity
+            or problem.parameterization_identity != parameterization.identity
+            or problem.evaluator_parameterization_identity
+            != parameterization.evaluator_identity
+            or problem.constraint_program_identity
+            != parameterization.program.fingerprint
+        ):
+            raise McmcConstructionError(
+                "MCMC accepted occurrence or execution context differs from its "
+                "exact anchor"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -410,8 +759,14 @@ class McmcPlan:
     source_engine: EvaluationEngine = field(repr=False, compare=False)
     policy: ResolvedMcmcPolicy
     coordinate_units: tuple[tuple[str, ParameterUnit], ...]
+    anchor: McmcAcceptedAnchor = field(init=False)
     accepted_result_identity: str = field(init=False)
     accepted_occurrence_identity: str = field(init=False)
+    accepted_occurrence_witness: object = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
     problem_identity: str = field(init=False)
     coordinate_ids: tuple[str, ...] = field(init=False)
     lower_bounds: tuple[float, ...] = field(init=False)
@@ -488,11 +843,29 @@ class McmcPlan:
             walkers=self.policy.walkers,
             seed=self.policy.initialization_seed,
         )
+        anchor = McmcAcceptedAnchor(
+            accepted.identity,
+            accepted.occurrence_identity,
+            accepted.occurrence_witness,
+            snapshot.occurrence_identity,
+            snapshot.revision,
+            problem.identity,
+            parameterization.identity,
+            parameterization.evaluator_identity,
+            parameterization.program.fingerprint,
+            engine.plan.identity,
+            units,
+            problem.held_items,
+            lower,
+            upper,
+            problem.affine_feasibility_identity,
+            accepted.vector,
+            accepted.evaluation_result.identity,
+        )
         identity = _identity(
             "native-mcmc-plan",
             (
-                accepted.identity,
-                accepted.occurrence_identity,
+                anchor.identity,
                 problem.identity,
                 parameterization.identity,
                 engine.plan.identity,
@@ -505,11 +878,17 @@ class McmcPlan:
             ),
         )
         object.__setattr__(self, "coordinate_units", units)
+        object.__setattr__(self, "anchor", anchor)
         object.__setattr__(self, "accepted_result_identity", accepted.identity)
         object.__setattr__(
             self,
             "accepted_occurrence_identity",
             accepted.occurrence_identity,
+        )
+        object.__setattr__(
+            self,
+            "accepted_occurrence_witness",
+            accepted.occurrence_witness,
         )
         object.__setattr__(self, "problem_identity", problem.identity)
         object.__setattr__(self, "coordinate_ids", coordinate_ids)
@@ -517,6 +896,31 @@ class McmcPlan:
         object.__setattr__(self, "upper_bounds", upper)
         object.__setattr__(self, "initial_ensemble", initial)
         object.__setattr__(self, "identity", identity)
+
+    def validate_integrity(self, accepted: AcceptedFitResult | None = None) -> None:
+        """Recursively recheck all live plan objects and its exact anchor."""
+        source = self.accepted if accepted is None else accepted
+        self.anchor.validate(
+            source,
+            self.source_problem,
+            self.parameterization,
+            self.source_engine,
+        )
+        expected = McmcPlan.for_accepted(
+            source,
+            source_problem=self.source_problem,
+            parameterization=self.parameterization,
+            source_engine=self.source_engine,
+            policy=self.policy,
+            coordinate_units=self.coordinate_units,
+        )
+        if (
+            expected.identity != self.identity
+            or expected.anchor.identity != self.anchor.identity
+        ):
+            raise McmcConstructionError(
+                "MCMC plan failed recursive integrity validation"
+            )
 
     @classmethod
     def for_accepted(
@@ -551,7 +955,7 @@ def _finite_state_scalar(value: object, *, name: str) -> float:
 
 @dataclass(frozen=True, slots=True)
 class EnsembleState:
-    """One atomically completed full-walker state and its log densities."""
+    """One raw atomically completed backend state and its observations."""
 
     ordinal: int
     positions: tuple[tuple[float, ...], ...]
@@ -617,6 +1021,16 @@ class EnsembleState:
             "identity": self.identity,
         }
 
+    def validate_integrity(self) -> None:
+        expected = EnsembleState(
+            self.ordinal,
+            self.positions,
+            self.log_densities,
+            self.accepted,
+        )
+        if expected.identity != self.identity:
+            raise McmcConstructionError("MCMC ensemble-state content identity mismatch")
+
     @classmethod
     def from_record(cls, record: Mapping[str, object]) -> EnsembleState:
         """Restore and content-validate one complete ensemble state."""
@@ -680,6 +1094,231 @@ class EnsembleState:
 
 
 @dataclass(frozen=True, slots=True)
+class RawTransitionEvent:
+    """Backend-observed derivation edge between two complete states."""
+
+    ordinal: int
+    previous_state_identity: str
+    next_state_identity: str
+    accepted: tuple[bool, ...]
+    proposal_count: int
+    accepted_count: int
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.ordinal < 1 or self.proposal_count < 0 or self.accepted_count < 0:
+            raise McmcConstructionError("Raw MCMC transition counts are invalid")
+        accepted = tuple(self.accepted)
+        if (
+            any(not isinstance(value, bool) for value in accepted)
+            or self.proposal_count != len(accepted)
+            or self.accepted_count != sum(accepted)
+        ):
+            raise McmcConstructionError(
+                "Raw MCMC transition acceptance accounting is inconsistent"
+            )
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-mcmc-raw-transition",
+                (
+                    self.ordinal,
+                    self.previous_state_identity,
+                    self.next_state_identity,
+                    accepted,
+                    self.proposal_count,
+                    self.accepted_count,
+                ),
+            ),
+        )
+
+    def validate_integrity(self) -> None:
+        expected = RawTransitionEvent(
+            self.ordinal,
+            self.previous_state_identity,
+            self.next_state_identity,
+            self.accepted,
+            self.proposal_count,
+            self.accepted_count,
+        )
+        if expected.identity != self.identity:
+            raise McmcConstructionError("Raw MCMC transition content identity mismatch")
+
+
+@dataclass(frozen=True, slots=True)
+class RawMcmcCapture:
+    """Execution-only backend observations with no scientific authority."""
+
+    plan_identity: str
+    policy_identity: str
+    root_seed: int
+    walkers: int
+    dimension: int
+    total_steps: int
+    terminal: McmcOperationTerminal
+    states: tuple[EnsembleState, ...]
+    transitions: tuple[RawTransitionEvent, ...]
+    objective_request_count: int
+    evaluation_request_count: int
+    stage: McmcExecutionStage
+    initialization_outcome: McmcInitializationOutcome
+    failure_category: str | None = None
+    _occurrence_witness: _McmcEvidenceWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        states = tuple(self.states)
+        transitions = tuple(self.transitions)
+        if tuple(state.ordinal for state in states) != tuple(range(len(states))):
+            raise McmcConstructionError(
+                "Raw MCMC capture must contain a contiguous complete-state prefix"
+            )
+        if not self.plan_identity:
+            raise McmcConstructionError("Raw MCMC capture requires a plan identity")
+        if self.objective_request_count < 0 or self.evaluation_request_count < 0:
+            raise McmcConstructionError(
+                "Raw MCMC capture request counts must be non-negative"
+            )
+        if self._occurrence_witness is None:
+            raise McmcConstructionError(
+                "Raw MCMC capture must come from sampler execution"
+            )
+        if len(transitions) != max(0, len(states) - 1):
+            raise McmcConstructionError(
+                "Raw MCMC transitions must cover every complete state edge"
+            )
+        for transition, previous, following in zip(
+            transitions,
+            states[:-1],
+            states[1:],
+            strict=True,
+        ):
+            if (
+                transition.ordinal != following.ordinal
+                or transition.previous_state_identity != previous.identity
+                or transition.next_state_identity != following.identity
+                or transition.accepted != following.accepted
+            ):
+                raise McmcConstructionError(
+                    "Raw MCMC transition does not bind its adjacent states"
+                )
+        object.__setattr__(self, "states", states)
+        object.__setattr__(self, "transitions", transitions)
+        object.__setattr__(self, "identity", self._content_identity())
+        if not _bind_mcmc_evidence_witness(
+            self._occurrence_witness,
+            self,
+            "raw-capture",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Raw MCMC capture occurrence witness is already bound"
+            )
+
+    def _content_identity(self) -> str:
+        return _identity(
+            "native-mcmc-raw-capture",
+            (
+                self.plan_identity,
+                self.policy_identity,
+                self.root_seed,
+                self.walkers,
+                self.dimension,
+                self.total_steps,
+                self.terminal.value,
+                tuple(state.identity for state in self.states),
+                tuple(item.identity for item in self.transitions),
+                self.objective_request_count,
+                self.evaluation_request_count,
+                self.stage.value,
+                self.initialization_outcome.value,
+                self.failure_category,
+            ),
+        )
+
+    @property
+    def complete_state_count(self) -> int:
+        return len(self.states)
+
+    def validate_integrity(self) -> None:
+        for state in self.states:
+            state.validate_integrity()
+        for transition in self.transitions:
+            transition.validate_integrity()
+        if len(self.transitions) != max(0, len(self.states) - 1) or any(
+            transition.previous_state_identity != previous.identity
+            or transition.next_state_identity != following.identity
+            or transition.accepted != following.accepted
+            for transition, previous, following in zip(
+                self.transitions,
+                self.states[:-1],
+                self.states[1:],
+                strict=True,
+            )
+        ):
+            raise McmcConstructionError("Raw MCMC transition topology mismatch")
+        if self._content_identity() != self.identity:
+            raise McmcConstructionError("Raw MCMC capture content identity mismatch")
+        if not _mcmc_evidence_occurrence_is_authoritative(
+            self._occurrence_witness,
+            self,
+            "raw-capture",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Raw MCMC capture is not the exact execution-owned occurrence"
+            )
+
+
+def _mint_raw_capture(
+    plan: McmcPlan,
+    terminal: McmcOperationTerminal,
+    states: Sequence[EnsembleState],
+    objective_request_count: int,
+    evaluation_request_count: int,
+    stage: McmcExecutionStage,
+    initialization_outcome: McmcInitializationOutcome,
+    failure_category: str | None = None,
+) -> RawMcmcCapture:
+    exact_states = tuple(states)
+    transitions = tuple(
+        RawTransitionEvent(
+            following.ordinal,
+            previous.identity,
+            following.identity,
+            following.accepted,
+            plan.policy.walkers,
+            sum(following.accepted),
+        )
+        for previous, following in zip(exact_states, exact_states[1:], strict=False)
+    )
+    capture = RawMcmcCapture(
+        plan.identity,
+        plan.policy.identity,
+        plan.policy.root_seed,
+        plan.policy.walkers,
+        plan.policy.dimension,
+        plan.policy.total_steps,
+        terminal,
+        exact_states,
+        transitions,
+        objective_request_count,
+        evaluation_request_count,
+        stage,
+        initialization_outcome,
+        failure_category,
+        _mint_mcmc_evidence_witness("raw-capture"),
+    )
+    return capture
+
+
+@dataclass(frozen=True, slots=True)
 class McmcEvidence:
     """Primary fixed-topology chain evidence preserving ensemble states."""
 
@@ -690,14 +1329,26 @@ class McmcEvidence:
     objective_request_count: int
     evaluation_request_count: int
     failure_category: str | None = None
+    raw_capture_identity: str = ""
+    _occurrence_witness: _McmcEvidenceWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     plan_identity: str = field(init=False)
     accepted_result_identity: str = field(init=False)
     coordinate_ids: tuple[str, ...] = field(init=False)
     coordinate_units: tuple[tuple[str, ParameterUnit], ...] = field(init=False)
     completed_transition_count: int = field(init=False)
+    trajectory_claim: McmcTrajectoryClaim = field(init=False)
+    canonical_lane_qualified: bool = field(init=False)
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: C901 - complete evidence invariant
+        if self._occurrence_witness is None:
+            raise McmcConstructionError(
+                "Primary MCMC evidence must come from fresh native validation"
+            )
         states = tuple(self.states)
         expected_ordinals = tuple(range(len(states)))
         if not states or tuple(state.ordinal for state in states) != expected_ordinals:
@@ -750,6 +1401,7 @@ class McmcEvidence:
                 self.objective_request_count,
                 self.evaluation_request_count,
                 self.failure_category,
+                self.raw_capture_identity,
             ),
         )
         object.__setattr__(self, "states", states)
@@ -762,7 +1414,55 @@ class McmcEvidence:
         object.__setattr__(self, "coordinate_ids", self.plan.coordinate_ids)
         object.__setattr__(self, "coordinate_units", self.plan.coordinate_units)
         object.__setattr__(self, "completed_transition_count", completed)
+        object.__setattr__(
+            self,
+            "trajectory_claim",
+            McmcTrajectoryClaim.ORDINARY_CAPTURE,
+        )
+        object.__setattr__(self, "canonical_lane_qualified", False)
         object.__setattr__(self, "identity", identity)
+        if not _bind_mcmc_evidence_witness(
+            self._occurrence_witness,
+            self,
+            "primary-evidence",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Primary MCMC evidence occurrence witness is already bound"
+            )
+
+    def validate_integrity(self) -> None:
+        """Recursively reject reconstructed or altered primary evidence."""
+        self.plan.validate_integrity()
+        for state in self.states:
+            state.validate_integrity()
+        expected_identity = _identity(
+            "native-mcmc-primary-evidence",
+            (
+                self.plan.identity,
+                self.plan.accepted_result_identity,
+                self.lifecycle.value,
+                self.terminal.value,
+                tuple(state.identity for state in self.states),
+                self.objective_request_count,
+                self.evaluation_request_count,
+                self.failure_category,
+                self.raw_capture_identity,
+            ),
+        )
+        if expected_identity != self.identity:
+            raise McmcConstructionError(
+                "Primary MCMC evidence content identity mismatch"
+            )
+        if not _mcmc_evidence_occurrence_is_authoritative(
+            self._occurrence_witness,
+            self,
+            "primary-evidence",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Primary MCMC evidence is not its validation-owned occurrence"
+            )
 
     def to_record(self) -> dict[str, object]:
         """Serialize primary evidence without live evaluator or sampler objects."""
@@ -776,6 +1476,7 @@ class McmcEvidence:
             "objective_request_count": self.objective_request_count,
             "evaluation_request_count": self.evaluation_request_count,
             "failure_category": self.failure_category,
+            "raw_capture_identity": self.raw_capture_identity,
             "identity": self.identity,
         }
 
@@ -785,6 +1486,7 @@ class McmcEvidence:
         record: Mapping[str, object],
         *,
         plan: McmcPlan,
+        raw_capture: RawMcmcCapture | None = None,
     ) -> McmcEvidence:
         """Restore primary evidence against its exact trusted execution plan."""
         _exact_keys(
@@ -799,6 +1501,7 @@ class McmcEvidence:
                 "objective_request_count",
                 "evaluation_request_count",
                 "failure_category",
+                "raw_capture_identity",
                 "identity",
             },
             "MCMC evidence",
@@ -833,21 +1536,303 @@ class McmcEvidence:
             raise McmcConstructionError(
                 "Malformed MCMC evidence lifecycle or terminal"
             ) from error
-        evidence = cls(
-            plan,
-            lifecycle,
-            terminal,
-            tuple(
-                EnsembleState.from_record(item)
-                for item in cast("list[Mapping[str, object]]", raw_states)
+        _ = lifecycle, terminal, raw_states, objective_count, evaluation_count
+        _ = failure_category, identity
+        if raw_capture is None:
+            raise McmcConstructionError(
+                "Primary MCMC evidence reconstruction requires its raw capture and "
+                "fresh validation"
+            )
+        validation = validate_raw_mcmc_capture(plan, raw_capture)
+        expected = validation.primary_evidence
+        if expected is None or record != expected.to_record():
+            raise McmcConstructionError(
+                "Stored MCMC evidence identity differs from fresh canonical validation"
+            )
+        return expected
+
+
+def _mint_primary_evidence(
+    plan: McmcPlan,
+    raw_capture: RawMcmcCapture,
+    lifecycle: McmcEvidenceLifecycle,
+    states: Sequence[EnsembleState],
+) -> McmcEvidence:
+    evidence = McmcEvidence(
+        plan,
+        lifecycle,
+        raw_capture.terminal,
+        tuple(states),
+        raw_capture.objective_request_count,
+        raw_capture.evaluation_request_count,
+        raw_capture.failure_category,
+        raw_capture.identity,
+        _mint_mcmc_evidence_witness("primary-evidence"),
+    )
+    return evidence
+
+
+@dataclass(frozen=True, slots=True)
+class McmcValidationFailure:
+    """One typed fresh-validation failure for a state/walker observation."""
+
+    state_ordinal: int
+    walker_ordinal: int
+    category: str
+    message: str
+    backend_log_density: float | None = None
+    authoritative_log_density: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class McmcChainValidation:
+    """Fresh-workspace validation and any qualified primary-chain result."""
+
+    raw_capture_identity: str
+    validated_states: tuple[EnsembleState, ...]
+    failures: tuple[McmcValidationFailure, ...]
+    expected_state_count: int
+    primary_evidence: McmcEvidence | None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "identity", self._content_identity())
+
+    def _content_identity(self) -> str:
+        return _identity(
+            "native-mcmc-chain-validation",
+            (
+                self.raw_capture_identity,
+                tuple(state.identity for state in self.validated_states),
+                tuple(
+                    (
+                        item.state_ordinal,
+                        item.walker_ordinal,
+                        item.category,
+                        item.message,
+                        None
+                        if item.backend_log_density is None
+                        else float(item.backend_log_density).hex(),
+                        None
+                        if item.authoritative_log_density is None
+                        else float(item.authoritative_log_density).hex(),
+                    )
+                    for item in self.failures
+                ),
+                self.expected_state_count,
+                None
+                if self.primary_evidence is None
+                else self.primary_evidence.identity,
             ),
-            objective_count,
-            evaluation_count,
-            failure_category,
         )
-        if evidence.identity != identity:
-            raise McmcConstructionError("MCMC evidence identity mismatch")
-        return evidence
+
+    def validate_integrity(self) -> None:
+        for state in self.validated_states:
+            state.validate_integrity()
+        if self.primary_evidence is not None:
+            self.primary_evidence.validate_integrity()
+        if self._content_identity() != self.identity:
+            raise McmcConstructionError("MCMC chain validation content mismatch")
+
+    @property
+    def complete_state_count(self) -> int:
+        return len(self.validated_states)
+
+    @property
+    def is_complete(self) -> bool:
+        return (
+            not self.failures
+            and self.complete_state_count == self.expected_state_count
+            and self.primary_evidence is not None
+        )
+
+
+def _fresh_authoritative_log_density(
+    plan: McmcPlan,
+    evaluator: BoundEvaluator,
+    position: tuple[float, ...],
+) -> float:
+    """Re-derive one stored state through a validation-only evaluator."""
+    candidate = np.asarray(position, dtype=np.float64)
+    if (
+        candidate.shape != (plan.policy.dimension,)
+        or not np.all(np.isfinite(candidate))
+        or np.any(candidate <= np.asarray(plan.lower_bounds))
+        or np.any(candidate >= np.asarray(plan.upper_bounds))
+    ):
+        raise McmcExecutionError("stored MCMC state is outside its frozen bounds")
+    lifecycle = plan.source_problem.lifecycle_frame(
+        candidate,
+        plan.parameterization,
+    )
+    frame = EvaluationFrame.from_lifecycle_frame(plan.parameterization, lifecycle)
+    outcome = evaluator.evaluate(frame)
+    if isinstance(outcome, EvaluationFailure):
+        raise McmcExecutionError(
+            f"fresh MCMC validation failed: {outcome.category}: {outcome.message}"
+        )
+    return -0.5 * canonical_chi_square(outcome.residuals)
+
+
+def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
+    plan: McmcPlan,
+    raw_capture: RawMcmcCapture,
+) -> McmcChainValidation:
+    """Freshly validate raw backend observations before minting evidence."""
+    expected_state_count = plan.policy.total_steps + 1
+    try:
+        plan.validate_integrity()
+        raw_capture.validate_integrity()
+    except McmcConstructionError as error:
+        return McmcChainValidation(
+            raw_capture.identity,
+            (),
+            (McmcValidationFailure(0, 0, "source_integrity_failure", str(error)),),
+            expected_state_count,
+            None,
+        )
+    if raw_capture.plan_identity != plan.identity:
+        return McmcChainValidation(
+            raw_capture.identity,
+            (),
+            (
+                McmcValidationFailure(
+                    0,
+                    0,
+                    "plan_identity_mismatch",
+                    "raw MCMC capture is not bound to the supplied frozen plan",
+                ),
+            ),
+            expected_state_count,
+            None,
+        )
+    evaluator = plan.source_engine.new_evaluator()
+    validated: list[EnsembleState] = []
+    failures: list[McmcValidationFailure] = []
+    for state in raw_capture.states:
+        if state.ordinal > 0:
+            transition = raw_capture.transitions[state.ordinal - 1]
+            previous = raw_capture.states[state.ordinal - 1]
+            for walker, accepted in enumerate(transition.accepted):
+                unchanged = (
+                    state.positions[walker] == previous.positions[walker]
+                    and state.log_densities[walker] == previous.log_densities[walker]
+                )
+                if not accepted and not unchanged:
+                    failures.append(
+                        McmcValidationFailure(
+                            state.ordinal,
+                            walker,
+                            "rejected_transition_changed_state",
+                            "rejected walker did not preserve its prior state exactly",
+                        )
+                    )
+                    break
+            if failures:
+                break
+        if (
+            len(state.positions) != plan.policy.walkers
+            or len(state.log_densities) != plan.policy.walkers
+            or len(state.accepted) != plan.policy.walkers
+            or any(
+                len(position) != plan.policy.dimension for position in state.positions
+            )
+        ):
+            failures.append(
+                McmcValidationFailure(
+                    state.ordinal,
+                    0,
+                    "state_topology_mismatch",
+                    "raw MCMC state differs from the frozen walker topology",
+                )
+            )
+            break
+        if state.ordinal == 0 and state.positions != plan.initial_ensemble:
+            failures.append(
+                McmcValidationFailure(
+                    0,
+                    0,
+                    "initial_ensemble_mismatch",
+                    "raw MCMC initial state differs from its frozen construction",
+                )
+            )
+            break
+        authoritative: list[float] = []
+        for walker, (position, backend) in enumerate(
+            zip(state.positions, state.log_densities, strict=True)
+        ):
+            try:
+                value = _fresh_authoritative_log_density(plan, evaluator, position)
+            except Exception as error:  # noqa: BLE001 - typed validation evidence
+                failures.append(
+                    McmcValidationFailure(
+                        state.ordinal,
+                        walker,
+                        "fresh_native_evaluation_failed",
+                        f"{type(error).__name__}: {error}",
+                        backend,
+                    )
+                )
+                break
+            authoritative.append(value)
+            if backend != value:
+                failures.append(
+                    McmcValidationFailure(
+                        state.ordinal,
+                        walker,
+                        "backend_log_density_mismatch",
+                        "backend log density differs from fresh native evaluation",
+                        backend,
+                        value,
+                    )
+                )
+                break
+        if failures:
+            break
+        validated.append(
+            EnsembleState(
+                state.ordinal,
+                state.positions,
+                tuple(authoritative),
+                state.accepted,
+            )
+        )
+    primary: McmcEvidence | None = None
+    complete = (
+        raw_capture.terminal is McmcOperationTerminal.COMPLETED
+        and not failures
+        and len(validated) == expected_state_count
+    )
+    if complete:
+        primary = _mint_primary_evidence(
+            plan,
+            raw_capture,
+            McmcEvidenceLifecycle.COMPLETED,
+            tuple(validated),
+        )
+    elif not failures and validated:
+        primary = _mint_primary_evidence(
+            plan,
+            raw_capture,
+            McmcEvidenceLifecycle.PARTIAL,
+            tuple(validated),
+        )
+    elif not failures and raw_capture.terminal is McmcOperationTerminal.COMPLETED:
+        failures.append(
+            McmcValidationFailure(
+                len(validated),
+                0,
+                "incomplete_completed_capture",
+                "completed raw MCMC capture does not contain its frozen topology",
+            )
+        )
+    return McmcChainValidation(
+        raw_capture.identity,
+        tuple(validated),
+        tuple(failures),
+        expected_state_count,
+        primary,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -858,10 +1843,25 @@ class McmcOperation:
     evidence: McmcEvidence | None
     failure_category: str | None = None
     failure_message: str = ""
+    raw_capture: RawMcmcCapture | None = None
+    validation: McmcChainValidation | None = None
+    _occurrence_witness: _McmcEvidenceWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         if self.terminal is McmcOperationTerminal.COMPLETED:
-            if self.evidence is None or self.failure_category is not None:
+            if (
+                self.evidence is None
+                or self.raw_capture is None
+                or self.validation is None
+                or not self.validation.is_complete
+                or self.validation.primary_evidence is not self.evidence
+                or self.failure_category is not None
+            ):
                 raise McmcConstructionError(
                     "Completed MCMC operation requires completed evidence"
                 )
@@ -869,6 +1869,83 @@ class McmcOperation:
             raise McmcConstructionError(
                 "Non-completed MCMC operation requires typed failure evidence"
             )
+        if self.raw_capture is None or self.validation is None:
+            raise McmcConstructionError(
+                "Every MCMC operation requires zero-or-more-state raw evidence"
+            )
+        object.__setattr__(self, "identity", self._content_identity())
+        if self._occurrence_witness is None or not _bind_mcmc_evidence_witness(
+            self._occurrence_witness,
+            self,
+            "operation",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "MCMC operation must come from one canonical execution occurrence"
+            )
+
+    def _content_identity(self) -> str:
+        capture = cast("RawMcmcCapture", self.raw_capture)
+        validation = cast("McmcChainValidation", self.validation)
+        return _identity(
+            "native-mcmc-operation",
+            (
+                self.terminal.value,
+                None if self.evidence is None else self.evidence.identity,
+                self.failure_category,
+                self.failure_message,
+                capture.identity,
+                validation.identity,
+            ),
+        )
+
+    @property
+    def complete_state_count(self) -> int:
+        capture = cast("RawMcmcCapture", self.raw_capture)
+        return capture.complete_state_count
+
+    @property
+    def stage(self) -> McmcExecutionStage:
+        capture = cast("RawMcmcCapture", self.raw_capture)
+        return capture.stage
+
+    def validate_integrity(self) -> None:
+        capture = cast("RawMcmcCapture", self.raw_capture)
+        capture.validate_integrity()
+        validation = cast("McmcChainValidation", self.validation)
+        validation.validate_integrity()
+        if self.evidence is not None:
+            self.evidence.validate_integrity()
+        if self._content_identity() != self.identity:
+            raise McmcConstructionError("MCMC operation content identity mismatch")
+        if not _mcmc_evidence_occurrence_is_authoritative(
+            self._occurrence_witness,
+            self,
+            "operation",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "MCMC operation occurrence is not authoritative"
+            )
+
+
+def _mint_mcmc_operation(
+    terminal: McmcOperationTerminal,
+    evidence: McmcEvidence | None,
+    failure_category: str | None,
+    failure_message: str,
+    raw_capture: RawMcmcCapture,
+    validation: McmcChainValidation,
+) -> McmcOperation:
+    return McmcOperation(
+        terminal,
+        evidence,
+        failure_category,
+        failure_message,
+        raw_capture,
+        validation,
+        _mint_mcmc_evidence_witness("operation"),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -876,36 +1953,72 @@ class RetainedSampleView:
     """Labeled step-major/walker-minor view derived from primary topology."""
 
     source_evidence_identity: str
+    policy_identity: str
     coordinate_ids: tuple[str, ...]
     coordinate_units: tuple[tuple[str, ParameterUnit], ...]
     selected_state_ordinals: tuple[int, ...]
+    selected_walker_ordinals: tuple[int, ...]
     sample_indices: tuple[tuple[int, int], ...]
     samples: tuple[tuple[float, ...], ...]
     log_densities: tuple[float, ...]
     is_complete: bool
+    source_evidence: McmcEvidence = field(repr=False, compare=False)
+    _occurrence_witness: _McmcEvidenceWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        object.__setattr__(
+        if self._occurrence_witness is None:
+            raise McmcConstructionError(
+                "Retained MCMC selection must be derived from primary evidence"
+            )
+        object.__setattr__(self, "identity", self._content_identity())
+        if not _bind_mcmc_evidence_witness(
+            self._occurrence_witness,
             self,
-            "identity",
-            _identity(
-                "native-mcmc-retained-sample-view",
-                (
-                    self.source_evidence_identity,
-                    self.coordinate_ids,
-                    self.coordinate_units,
-                    self.selected_state_ordinals,
-                    self.sample_indices,
-                    tuple(
-                        tuple(float(value).hex() for value in sample)
-                        for sample in self.samples
-                    ),
-                    tuple(float(value).hex() for value in self.log_densities),
-                    self.is_complete,
+            "retained-selection",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Retained MCMC selection occurrence witness is already bound"
+            )
+
+    def _content_identity(self) -> str:
+        return _identity(
+            "native-mcmc-retained-sample-view",
+            (
+                self.source_evidence_identity,
+                self.policy_identity,
+                self.coordinate_ids,
+                self.coordinate_units,
+                self.selected_state_ordinals,
+                self.selected_walker_ordinals,
+                self.sample_indices,
+                tuple(
+                    tuple(float(value).hex() for value in sample)
+                    for sample in self.samples
                 ),
+                tuple(float(value).hex() for value in self.log_densities),
+                self.is_complete,
             ),
         )
+
+    def validate_integrity(self) -> None:
+        self.source_evidence.validate_integrity()
+        if self._content_identity() != self.identity:
+            raise McmcConstructionError("Retained MCMC selection content mismatch")
+        if not _mcmc_evidence_occurrence_is_authoritative(
+            self._occurrence_witness,
+            self,
+            "retained-selection",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Retained MCMC selection is not its canonical derived occurrence"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -915,11 +2028,22 @@ class McmcDiagnostics:
     source_evidence_identity: str
     state_ordinals: tuple[int, ...]
     walker_ordinals: tuple[int, ...]
-    acceptance_fractions: tuple[float, ...]
-    mean_acceptance_fraction: float
+    status: McmcDiagnosticStatus
+    reason: McmcDiagnosticReason | None
+    acceptance_fractions: tuple[float, ...] | None
+    mean_acceptance_fraction: float | None
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        available = self.status is McmcDiagnosticStatus.AVAILABLE
+        if (
+            available != (self.acceptance_fractions is not None)
+            or available != (self.mean_acceptance_fraction is not None)
+            or available == (self.reason is not None)
+        ):
+            raise McmcConstructionError(
+                "MCMC diagnostic availability payload is inconsistent"
+            )
         object.__setattr__(
             self,
             "identity",
@@ -929,11 +2053,723 @@ class McmcDiagnostics:
                     self.source_evidence_identity,
                     self.state_ordinals,
                     self.walker_ordinals,
-                    tuple(float(value).hex() for value in self.acceptance_fractions),
-                    float(self.mean_acceptance_fraction).hex(),
+                    self.status.value,
+                    None if self.reason is None else self.reason.value,
+                    None
+                    if self.acceptance_fractions is None
+                    else tuple(
+                        float(value).hex() for value in self.acceptance_fractions
+                    ),
+                    None
+                    if self.mean_acceptance_fraction is None
+                    else float(self.mean_acceptance_fraction).hex(),
                 ),
             ),
         )
+
+
+class PosteriorSampleDisposition(StrEnum):
+    """Scope-atomic outcome for one retained state/walker label."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorSampleFailure:
+    """Typed exclusion of one entire requested posterior row."""
+
+    category: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorSampleOutcome:
+    """One labeled complete-scope success or typed whole-row failure."""
+
+    state_ordinal: int
+    walker_ordinal: int
+    disposition: PosteriorSampleDisposition
+    independent_items: tuple[tuple[str, float], ...]
+    resolved_items: tuple[tuple[str, float], ...] | None
+    failure: PosteriorSampleFailure | None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        success = self.disposition is PosteriorSampleDisposition.SUCCESS
+        if success != (self.resolved_items is not None) or success == (
+            self.failure is not None
+        ):
+            raise McmcConstructionError(
+                "Posterior sample must contain exactly its scope-atomic payload"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-mcmc-posterior-sample-outcome",
+                (
+                    self.state_ordinal,
+                    self.walker_ordinal,
+                    self.disposition.value,
+                    tuple(
+                        (key, float(value).hex())
+                        for key, value in self.independent_items
+                    ),
+                    None
+                    if self.resolved_items is None
+                    else tuple(
+                        (key, float(value).hex()) for key, value in self.resolved_items
+                    ),
+                    None
+                    if self.failure is None
+                    else (self.failure.category, self.failure.message),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorSampleEvidence:
+    """All retained labels resolved atomically to one requested output scope."""
+
+    selection: RetainedSampleView = field(repr=False, compare=False)
+    output_units: tuple[tuple[str, ParameterUnit], ...]
+    outcomes: tuple[PosteriorSampleOutcome, ...]
+    _occurrence_witness: _McmcEvidenceWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    selection_identity: str = field(init=False)
+    output_scope: tuple[str, ...] = field(init=False)
+    successful_labels: tuple[tuple[int, int], ...] = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self._occurrence_witness is None:
+            raise McmcConstructionError(
+                "Posterior sample evidence must come from canonical resolution"
+            )
+        units = tuple(self.output_units)
+        scope = tuple(param_id for param_id, _unit in units)
+        if (
+            not scope
+            or len(set(scope)) != len(scope)
+            or any(not isinstance(unit, ParameterUnit) for _id, unit in units)
+            or tuple(
+                (outcome.state_ordinal, outcome.walker_ordinal)
+                for outcome in self.outcomes
+            )
+            != self.selection.sample_indices
+        ):
+            raise McmcConstructionError(
+                "Posterior evidence does not exactly cover its retained labels"
+            )
+        for outcome, sample in zip(
+            self.outcomes,
+            self.selection.samples,
+            strict=True,
+        ):
+            if (
+                tuple(key for key, _value in outcome.independent_items)
+                != self.selection.coordinate_ids
+                or tuple(value for _key, value in outcome.independent_items) != sample
+                or (
+                    outcome.resolved_items is not None
+                    and tuple(key for key, _value in outcome.resolved_items) != scope
+                )
+            ):
+                raise McmcConstructionError(
+                    "Posterior outcome differs from its exact labeled complete scope"
+                )
+        successful = tuple(
+            (item.state_ordinal, item.walker_ordinal)
+            for item in self.outcomes
+            if item.disposition is PosteriorSampleDisposition.SUCCESS
+        )
+        object.__setattr__(self, "output_units", units)
+        object.__setattr__(self, "selection_identity", self.selection.identity)
+        object.__setattr__(self, "output_scope", scope)
+        object.__setattr__(self, "successful_labels", successful)
+        object.__setattr__(self, "identity", self._content_identity())
+        if not _bind_mcmc_evidence_witness(
+            self._occurrence_witness,
+            self,
+            "posterior-sample-evidence",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Posterior sample evidence occurrence witness is already bound"
+            )
+
+    def _content_identity(self) -> str:
+        return _identity(
+            "native-mcmc-posterior-sample-evidence",
+            (
+                self.selection.identity,
+                self.output_units,
+                tuple(item.identity for item in self.outcomes),
+            ),
+        )
+
+    def validate_integrity(self) -> None:
+        self.selection.validate_integrity()
+        for outcome in self.outcomes:
+            expected = PosteriorSampleOutcome(
+                outcome.state_ordinal,
+                outcome.walker_ordinal,
+                outcome.disposition,
+                outcome.independent_items,
+                outcome.resolved_items,
+                outcome.failure,
+            )
+            if expected.identity != outcome.identity:
+                raise McmcConstructionError(
+                    "Posterior sample outcome content identity mismatch"
+                )
+        if self._content_identity() != self.identity:
+            raise McmcConstructionError("Posterior sample evidence content mismatch")
+        if not _mcmc_evidence_occurrence_is_authoritative(
+            self._occurrence_witness,
+            self,
+            "posterior-sample-evidence",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Posterior sample evidence is not its canonical resolved occurrence"
+            )
+
+
+def derive_posterior_sample_evidence(
+    selection: RetainedSampleView,
+    output_units: Sequence[tuple[str, ParameterUnit]],
+    *,
+    cancellation: CancellationToken | None = None,
+) -> PosteriorSampleEvidence:
+    """Resolve held and constrained values for every retained labeled sample."""
+    selection.validate_integrity()
+    if cancellation is not None and cancellation.is_cancelled:
+        raise McmcConstructionError("Posterior sample derivation was cancelled")
+    plan = selection.source_evidence.plan
+    units = tuple(output_units)
+    scope = tuple(param_id for param_id, _unit in units)
+    if not scope or any(
+        param_id not in plan.parameterization.scope_ids for param_id in scope
+    ):
+        raise McmcConstructionError(
+            "Posterior output scope must be an ordered subset of the active scope"
+        )
+    outcomes: list[PosteriorSampleOutcome] = []
+    for label, sample in zip(selection.sample_indices, selection.samples, strict=True):
+        if cancellation is not None and cancellation.is_cancelled:
+            raise McmcConstructionError("Posterior sample derivation was cancelled")
+        independent_items = tuple(zip(plan.coordinate_ids, sample, strict=True))
+        try:
+            frame = plan.source_problem.lifecycle_frame(sample, plan.parameterization)
+            resolved = plan.parameterization.resolve(frame)
+            resolved_items = tuple(
+                (param_id, float(resolved[param_id])) for param_id in scope
+            )
+            if any(not math.isfinite(value) for _key, value in resolved_items):
+                raise ValueError("resolved posterior value is non-finite")
+            outcome = PosteriorSampleOutcome(
+                label[0],
+                label[1],
+                PosteriorSampleDisposition.SUCCESS,
+                independent_items,
+                resolved_items,
+                None,
+            )
+        except Exception as error:  # noqa: BLE001 - typed whole-sample evidence
+            outcome = PosteriorSampleOutcome(
+                label[0],
+                label[1],
+                PosteriorSampleDisposition.FAILED,
+                independent_items,
+                None,
+                PosteriorSampleFailure(type(error).__name__, str(error)),
+            )
+        outcomes.append(outcome)
+    evidence = PosteriorSampleEvidence(
+        selection,
+        units,
+        tuple(outcomes),
+        _mint_mcmc_evidence_witness("posterior-sample-evidence"),
+    )
+    return evidence
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorSummaryPolicy:
+    """Explicit equal-tailed complete-case summary convention."""
+
+    quantiles: tuple[float, ...] = (0.025, 0.5, 0.975)
+    covariance_delta_degrees_of_freedom: int = 1
+    minimum_autocorrelation_steps: int = 16
+    version: str = "mcmc-complete-scope-equal-tailed-v1"
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        quantiles = tuple(float(value) for value in self.quantiles)
+        if (
+            not quantiles
+            or any(not math.isfinite(value) for value in quantiles)
+            or tuple(sorted(set(quantiles))) != quantiles
+            or quantiles[0] < 0.0
+            or quantiles[-1] > 1.0
+            or len(quantiles) != 3
+            or quantiles[1] != 0.5
+            or not math.isclose(
+                quantiles[0],
+                1.0 - quantiles[2],
+                rel_tol=0.0,
+                abs_tol=1.0e-15,
+            )
+            or self.covariance_delta_degrees_of_freedom != 1
+            or self.minimum_autocorrelation_steps < 2
+        ):
+            raise McmcConstructionError("Posterior summary policy is invalid")
+        object.__setattr__(self, "quantiles", quantiles)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-mcmc-posterior-summary-policy",
+                (
+                    tuple(float(value).hex() for value in quantiles),
+                    self.covariance_delta_degrees_of_freedom,
+                    self.minimum_autocorrelation_steps,
+                    self.version,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorScalarEstimate:
+    """One available estimate or explicit typed unavailability."""
+
+    status: McmcDiagnosticStatus
+    reason: McmcDiagnosticReason | None
+    value: float | None
+
+    def __post_init__(self) -> None:
+        available = self.status is McmcDiagnosticStatus.AVAILABLE
+        if available != (self.value is not None) or available == (
+            self.reason is not None
+        ):
+            raise McmcConstructionError(
+                "Posterior estimate availability payload is inconsistent"
+            )
+        if self.value is not None and not math.isfinite(self.value):
+            raise McmcConstructionError("Posterior estimate must be finite")
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorParameterSummary:
+    parameter_id: str
+    unit: ParameterUnit
+    quantiles: tuple[tuple[float, float], ...]
+    credible_interval_name: str
+    credible_interval: tuple[float, float]
+    posterior_standard_deviation: float
+    autocorrelation_time: PosteriorScalarEstimate
+    effective_sample_size: PosteriorScalarEstimate
+    monte_carlo_standard_error: PosteriorScalarEstimate
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorMatrixEntry:
+    parameter_a: str
+    parameter_b: str
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorCorrelationEntry:
+    parameter_a: str
+    parameter_b: str
+    estimate: PosteriorScalarEstimate
+
+
+def _posterior_estimate_record(item: PosteriorScalarEstimate) -> object:
+    return (
+        item.status.value,
+        None if item.reason is None else item.reason.value,
+        None if item.value is None else float(item.value).hex(),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorSummary:
+    """Complete-case posterior summary over one exact successful sample set."""
+
+    source: PosteriorSampleEvidence = field(repr=False, compare=False)
+    policy: PosteriorSummaryPolicy = field(repr=False, compare=False)
+    included_labels: tuple[tuple[int, int], ...]
+    excluded_labels: tuple[tuple[int, int], ...]
+    parameter_summaries: tuple[PosteriorParameterSummary, ...]
+    covariance: tuple[PosteriorMatrixEntry, ...]
+    correlations: tuple[PosteriorCorrelationEntry, ...]
+    acceptance: McmcDiagnostics
+    _occurrence_witness: _McmcEvidenceWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    source_identity: str = field(init=False)
+    policy_identity: str = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self._occurrence_witness is None:
+            raise McmcConstructionError(
+                "Posterior summary must come from canonical complete-case derivation"
+            )
+        object.__setattr__(self, "source_identity", self.source.identity)
+        object.__setattr__(self, "policy_identity", self.policy.identity)
+        object.__setattr__(self, "identity", self._content_identity())
+        if not _bind_mcmc_evidence_witness(
+            self._occurrence_witness,
+            self,
+            "posterior-summary",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Posterior summary occurrence witness is already bound"
+            )
+
+    def _content_identity(self) -> str:
+        return _identity(
+            "native-mcmc-posterior-summary",
+            (
+                self.source.identity,
+                self.policy.identity,
+                self.included_labels,
+                self.excluded_labels,
+                tuple(
+                    (
+                        item.parameter_id,
+                        item.unit.value,
+                        tuple(
+                            (float(probability).hex(), float(value).hex())
+                            for probability, value in item.quantiles
+                        ),
+                        item.credible_interval_name,
+                        tuple(float(value).hex() for value in item.credible_interval),
+                        float(item.posterior_standard_deviation).hex(),
+                        _posterior_estimate_record(item.autocorrelation_time),
+                        _posterior_estimate_record(item.effective_sample_size),
+                        _posterior_estimate_record(item.monte_carlo_standard_error),
+                    )
+                    for item in self.parameter_summaries
+                ),
+                tuple(
+                    (item.parameter_a, item.parameter_b, float(item.value).hex())
+                    for item in self.covariance
+                ),
+                tuple(
+                    (
+                        item.parameter_a,
+                        item.parameter_b,
+                        _posterior_estimate_record(item.estimate),
+                    )
+                    for item in self.correlations
+                ),
+                self.acceptance.identity,
+            ),
+        )
+
+    def validate_integrity(self) -> None:
+        self.source.validate_integrity()
+        expected_acceptance = derive_mcmc_diagnostics(
+            self.source.selection.source_evidence
+        )
+        if (
+            expected_acceptance != self.acceptance
+            or self._content_identity() != self.identity
+        ):
+            raise McmcConstructionError("Posterior summary content mismatch")
+        if not _mcmc_evidence_occurrence_is_authoritative(
+            self._occurrence_witness,
+            self,
+            "posterior-summary",
+            self.identity,
+        ):
+            raise McmcConstructionError(
+                "Posterior summary is not its canonical derived occurrence"
+            )
+
+
+class PosteriorSummaryTerminal(StrEnum):
+    """Closed result of one posterior summary request."""
+
+    COMPLETED = "completed"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorSummaryFailure:
+    """Typed reason no complete posterior summary was available."""
+
+    source_identity: str
+    category: str
+    message: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.source_identity or not self.category or not self.message:
+            raise McmcConstructionError(
+                "Posterior summary failure requires source, category, and message"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-mcmc-posterior-summary-failure",
+                (self.source_identity, self.category, self.message),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorSummaryOutcome:
+    """Exactly one canonical summary or typed unavailability."""
+
+    terminal: PosteriorSummaryTerminal
+    summary: PosteriorSummary | None = None
+    failure: PosteriorSummaryFailure | None = None
+
+    def __post_init__(self) -> None:
+        completed = self.terminal is PosteriorSummaryTerminal.COMPLETED
+        if completed != (self.summary is not None) or completed == (
+            self.failure is not None
+        ):
+            raise McmcConstructionError(
+                "Posterior summary outcome has an inconsistent terminal payload"
+            )
+
+
+def _unavailable(reason: McmcDiagnosticReason) -> PosteriorScalarEstimate:
+    return PosteriorScalarEstimate(McmcDiagnosticStatus.UNAVAILABLE, reason, None)
+
+
+def derive_posterior_summary(  # noqa: C901 - joint typed summary assembly
+    source: PosteriorSampleEvidence,
+    policy: PosteriorSummaryPolicy | None = None,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> PosteriorSummary:
+    """Summarize only the exact common complete successful posterior rows."""
+    source.validate_integrity()
+    if cancellation is not None and cancellation.is_cancelled:
+        raise McmcConstructionError("Posterior summary derivation was cancelled")
+    exact_policy = PosteriorSummaryPolicy() if policy is None else policy
+    successful = tuple(
+        outcome
+        for outcome in source.outcomes
+        if outcome.disposition is PosteriorSampleDisposition.SUCCESS
+    )
+    if len(successful) < 2:
+        raise McmcConstructionError(
+            "Posterior summary requires at least two complete successful samples"
+        )
+    matrix = np.asarray(
+        [
+            [
+                value
+                for _key, value in cast(
+                    "tuple[tuple[str, float], ...]", item.resolved_items
+                )
+            ]
+            for item in successful
+        ],
+        dtype=np.float64,
+    )
+    if not np.all(np.isfinite(matrix)):
+        raise McmcConstructionError("Posterior complete-case matrix is non-finite")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        with np.errstate(over="raise", invalid="raise", divide="raise"):
+            covariance_matrix = np.cov(matrix, rowvar=False, ddof=1)
+    covariance_matrix = np.atleast_2d(covariance_matrix)
+    if not np.all(np.isfinite(covariance_matrix)):
+        raise McmcConstructionError("Posterior covariance is unavailable")
+    variances = np.diag(covariance_matrix)
+    labels = tuple((item.state_ordinal, item.walker_ordinal) for item in successful)
+    complete_grid = len(successful) == len(source.outcomes)
+    step_count = len(source.selection.selected_state_ordinals)
+    autocorrelation: tuple[PosteriorScalarEstimate, ...]
+    ess: tuple[PosteriorScalarEstimate, ...]
+    mcse: tuple[PosteriorScalarEstimate, ...]
+    if (
+        not source.selection.is_complete
+        or not complete_grid
+        or step_count < exact_policy.minimum_autocorrelation_steps
+    ):
+        reason = (
+            McmcDiagnosticReason.PARTIAL_CHAIN
+            if not source.selection.is_complete
+            else McmcDiagnosticReason.INSUFFICIENT_RETAINED_WINDOW
+        )
+        autocorrelation = tuple(_unavailable(reason) for _ in source.output_scope)
+        ess = tuple(_unavailable(reason) for _ in source.output_scope)
+        mcse = tuple(_unavailable(reason) for _ in source.output_scope)
+    else:
+        chain = matrix.reshape(
+            step_count,
+            len(source.selection.selected_walker_ordinals),
+            len(source.output_scope),
+        )
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", RuntimeWarning)
+                tau_values = np.asarray(
+                    emcee.autocorr.integrated_time(chain, quiet=True),
+                    dtype=np.float64,
+                )
+        except Exception:  # noqa: BLE001 - typed unavailable estimate
+            tau_values = np.full(len(source.output_scope), np.nan)
+        autocorrelation_values: list[PosteriorScalarEstimate] = []
+        ess_values: list[PosteriorScalarEstimate] = []
+        mcse_values: list[PosteriorScalarEstimate] = []
+        for index, tau in enumerate(tau_values):
+            if not math.isfinite(float(tau)) or tau <= 0.0:
+                unavailable = _unavailable(McmcDiagnosticReason.INVALID_AUTOCORRELATION)
+                autocorrelation_values.append(unavailable)
+                ess_values.append(unavailable)
+                mcse_values.append(unavailable)
+                continue
+            effective = float(matrix.shape[0] / tau)
+            standard_deviation = math.sqrt(float(variances[index]))
+            autocorrelation_values.append(
+                PosteriorScalarEstimate(
+                    McmcDiagnosticStatus.AVAILABLE,
+                    None,
+                    float(tau),
+                )
+            )
+            ess_values.append(
+                PosteriorScalarEstimate(
+                    McmcDiagnosticStatus.AVAILABLE,
+                    None,
+                    effective,
+                )
+            )
+            mcse_values.append(
+                PosteriorScalarEstimate(
+                    McmcDiagnosticStatus.AVAILABLE,
+                    None,
+                    standard_deviation / math.sqrt(effective),
+                )
+            )
+        autocorrelation = tuple(autocorrelation_values)
+        ess = tuple(ess_values)
+        mcse = tuple(mcse_values)
+    summaries: list[PosteriorParameterSummary] = []
+    for index, (param_id, unit) in enumerate(source.output_units):
+        values = matrix[:, index]
+        quantile_values = np.quantile(values, exact_policy.quantiles, method="linear")
+        quantiles = tuple(
+            (probability, float(value))
+            for probability, value in zip(
+                exact_policy.quantiles,
+                quantile_values,
+                strict=True,
+            )
+        )
+        summaries.append(
+            PosteriorParameterSummary(
+                param_id,
+                unit,
+                quantiles,
+                f"equal_tailed_{100.0 * (quantiles[-1][0] - quantiles[0][0]):g}_percent",
+                (quantiles[0][1], quantiles[-1][1]),
+                float(np.std(values, ddof=1)),
+                autocorrelation[index],
+                ess[index],
+                mcse[index],
+            )
+        )
+    covariance = tuple(
+        PosteriorMatrixEntry(param_a, param_b, float(covariance_matrix[row, column]))
+        for row, param_a in enumerate(source.output_scope)
+        for column, param_b in enumerate(source.output_scope)
+    )
+    correlations: list[PosteriorCorrelationEntry] = []
+    for row, param_a in enumerate(source.output_scope):
+        for column, param_b in enumerate(source.output_scope):
+            denominator = math.sqrt(float(variances[row])) * math.sqrt(
+                float(variances[column])
+            )
+            estimate = (
+                _unavailable(McmcDiagnosticReason.ZERO_VARIANCE)
+                if denominator == 0.0
+                else PosteriorScalarEstimate(
+                    McmcDiagnosticStatus.AVAILABLE,
+                    None,
+                    float(covariance_matrix[row, column] / denominator),
+                )
+            )
+            correlations.append(PosteriorCorrelationEntry(param_a, param_b, estimate))
+    summary = PosteriorSummary(
+        source,
+        exact_policy,
+        labels,
+        tuple(
+            (item.state_ordinal, item.walker_ordinal)
+            for item in source.outcomes
+            if item.disposition is PosteriorSampleDisposition.FAILED
+        ),
+        tuple(summaries),
+        covariance,
+        tuple(correlations),
+        derive_mcmc_diagnostics(source.selection.source_evidence),
+        _mint_mcmc_evidence_witness("posterior-summary"),
+    )
+    return summary
+
+
+def summarize_posterior_evidence(
+    source: PosteriorSampleEvidence,
+    policy: PosteriorSummaryPolicy | None = None,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> PosteriorSummaryOutcome:
+    """Return a summary or durable typed unavailability without fabrication."""
+    try:
+        summary = derive_posterior_summary(
+            source,
+            policy,
+            cancellation=cancellation,
+        )
+    except McmcConstructionError as error:
+        message = str(error)
+        category = (
+            "insufficient_complete_samples"
+            if "at least two" in message
+            else "cancelled"
+            if "cancelled" in message
+            else "invalid_source_or_summary"
+        )
+        return PosteriorSummaryOutcome(
+            PosteriorSummaryTerminal.UNAVAILABLE,
+            failure=PosteriorSummaryFailure(source.identity, category, message),
+        )
+    except (FloatingPointError, OverflowError, RuntimeWarning, ValueError) as error:
+        return PosteriorSummaryOutcome(
+            PosteriorSummaryTerminal.UNAVAILABLE,
+            failure=PosteriorSummaryFailure(
+                source.identity,
+                "numerical_summary_unavailable",
+                f"{type(error).__name__}: {error}",
+            ),
+        )
+    return PosteriorSummaryOutcome(
+        PosteriorSummaryTerminal.COMPLETED,
+        summary=summary,
+    )
 
 
 class _LogDensityEvaluator:
@@ -951,8 +2787,8 @@ class _LogDensityEvaluator:
         if (
             candidate.shape != (self.plan.policy.dimension,)
             or not np.all(np.isfinite(candidate))
-            or np.any(candidate < np.asarray(self.plan.lower_bounds))
-            or np.any(candidate > np.asarray(self.plan.upper_bounds))
+            or np.any(candidate <= np.asarray(self.plan.lower_bounds))
+            or np.any(candidate >= np.asarray(self.plan.upper_bounds))
         ):
             return -np.inf
         try:
@@ -1017,30 +2853,46 @@ def _legacy_sampler_random_state(seed: int) -> object:
     return ("MT19937", keys, 624, 0, 0.0)
 
 
-def execute_mcmc_evidence(
+def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     accepted: AcceptedFitResult,
     plan: McmcPlan,
     *,
     state_observer: Callable[[EnsembleState], None] | None = None,
+    cancellation: CancellationToken | None = None,
+    checkpoint_observer: Callable[[McmcExecutionStage, int], None] | None = None,
 ) -> McmcOperation:
     """Execute one fixed run while preserving only complete ensemble states."""
-    if accepted.identity != plan.accepted_result_identity:
-        raise McmcConstructionError(
-            "MCMC execution accepted result differs from its frozen plan"
-        )
+    plan.validate_integrity(accepted)
+    signal = CancellationToken() if cancellation is None else cancellation
     log_density = _LogDensityEvaluator(plan)
     states: list[EnsembleState] = []
+    stage = McmcExecutionStage.BEFORE_INITIALIZATION
+    initialization_outcome = McmcInitializationOutcome.NOT_STARTED
+
+    def checkpoint(next_stage: McmcExecutionStage) -> None:
+        nonlocal stage
+        stage = next_stage
+        if checkpoint_observer is not None:
+            checkpoint_observer(stage, len(states))
+        if signal.is_cancelled:
+            raise _McmcCancelled(f"MCMC cancelled at {stage.value}")
+
     try:
+        checkpoint(McmcExecutionStage.BEFORE_INITIALIZATION)
         initial = np.asarray(plan.initial_ensemble, dtype=np.float64)
-        initial_log_density = np.asarray(
-            [log_density(row) for row in initial],
-            dtype=np.float64,
-        )
+        initial_values: list[float] = []
+        for row in initial:
+            checkpoint(McmcExecutionStage.INITIALIZING)
+            initial_values.append(log_density(row))
+        initial_log_density = np.asarray(initial_values, dtype=np.float64)
         if not np.all(np.isfinite(initial_log_density)):
             raise McmcExecutionError(
                 "MCMC initial ensemble has unavailable native log density"
             )
+        initialization_outcome = McmcInitializationOutcome.COMPLETED
         states.append(_ensemble_state(0, initial, initial_log_density, None))
+        checkpoint(McmcExecutionStage.AFTER_INITIALIZATION)
+        checkpoint(McmcExecutionStage.AFTER_COMPLETE_STATE)
         move = _RecordingStretchMove(scale=plan.policy.proposal_scale)
         sampler = emcee.EnsembleSampler(
             plan.policy.walkers,
@@ -1050,16 +2902,17 @@ def execute_mcmc_evidence(
         )
         sampler.random_state = _legacy_sampler_random_state(plan.policy.sampler_seed)
         emcee_state = emcee.State(initial, log_prob=initial_log_density)
-        for ordinal, sampled in enumerate(
-            sampler.sample(
-                emcee_state,
-                iterations=plan.policy.total_steps,
-                tune=False,
-                skip_initial_state_check=True,
-                store=False,
-            ),
-            start=1,
-        ):
+        iterator = sampler.sample(
+            emcee_state,
+            iterations=plan.policy.total_steps,
+            tune=False,
+            skip_initial_state_check=True,
+            store=False,
+        )
+        for ordinal in range(1, plan.policy.total_steps + 1):
+            checkpoint(McmcExecutionStage.BEFORE_TRANSITION)
+            checkpoint(McmcExecutionStage.DURING_TRANSITION)
+            sampled = next(iterator)
             state = _ensemble_state(
                 ordinal,
                 sampled.coords,
@@ -1069,45 +2922,82 @@ def execute_mcmc_evidence(
             states.append(state)
             if state_observer is not None:
                 state_observer(state)
+            checkpoint(McmcExecutionStage.AFTER_COMPLETE_STATE)
         if log_density.objective_request_count != plan.policy.objective_request_budget:
             raise McmcExecutionError(
                 "MCMC backend request count differs from the frozen budget"
             )
-        evidence = McmcEvidence(
+        checkpoint(McmcExecutionStage.FRESH_VALIDATION)
+        raw_capture = _mint_raw_capture(
             plan,
-            McmcEvidenceLifecycle.COMPLETED,
             McmcOperationTerminal.COMPLETED,
             tuple(states),
             log_density.objective_request_count,
             log_density.evaluation_request_count,
+            stage,
+            initialization_outcome,
         )
-        return McmcOperation(McmcOperationTerminal.COMPLETED, evidence)
+        validation = validate_raw_mcmc_capture(plan, raw_capture)
+        if not validation.is_complete or validation.primary_evidence is None:
+            raise McmcExecutionError("fresh MCMC validation did not complete")
+        checkpoint(McmcExecutionStage.BEFORE_FINAL_ASSEMBLY)
+        evidence = validation.primary_evidence
+        return _mint_mcmc_operation(
+            McmcOperationTerminal.COMPLETED,
+            evidence,
+            None,
+            "",
+            raw_capture,
+            validation,
+        )
+    except _McmcCancelled as error:
+        terminal = McmcOperationTerminal.CANCELLED
+        category = "cancelled"
+        message = str(error)
+        if initialization_outcome is McmcInitializationOutcome.NOT_STARTED:
+            initialization_outcome = McmcInitializationOutcome.CANCELLED
     except KeyboardInterrupt as error:
         terminal = McmcOperationTerminal.INTERRUPTED
         category = "interrupted"
         message = str(error)
+        if initialization_outcome is McmcInitializationOutcome.NOT_STARTED:
+            initialization_outcome = McmcInitializationOutcome.INTERRUPTED
     except Exception as error:  # noqa: BLE001 - freeze typed operation failure
         terminal = McmcOperationTerminal.FAILED
         category = type(error).__name__
         message = str(error)
-    evidence = (
-        McmcEvidence(
-            plan,
-            McmcEvidenceLifecycle.PARTIAL,
-            terminal,
-            tuple(states),
-            log_density.objective_request_count,
-            log_density.evaluation_request_count,
-            category,
-        )
-        if states
-        else None
+        if initialization_outcome is McmcInitializationOutcome.NOT_STARTED:
+            initialization_outcome = McmcInitializationOutcome.FAILED
+    raw_capture = _mint_raw_capture(
+        plan,
+        terminal,
+        tuple(states),
+        log_density.objective_request_count,
+        log_density.evaluation_request_count,
+        stage,
+        initialization_outcome,
+        category,
     )
-    return McmcOperation(terminal, evidence, category, message)
+    validation = validate_raw_mcmc_capture(plan, raw_capture)
+    return _mint_mcmc_operation(
+        terminal,
+        validation.primary_evidence,
+        category,
+        message,
+        raw_capture,
+        validation,
+    )
 
 
-def derive_retained_sample_view(evidence: McmcEvidence) -> RetainedSampleView:
+def derive_retained_sample_view(
+    evidence: McmcEvidence,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> RetainedSampleView:
     """Select the prospective retained window without flattening primary evidence."""
+    evidence.validate_integrity()
+    if cancellation is not None and cancellation.is_cancelled:
+        raise McmcConstructionError("Retained MCMC selection was cancelled")
     first = evidence.plan.policy.burn_steps + 1
     selected = tuple(state for state in evidence.states if state.ordinal >= first)
     ordinals = tuple(state.ordinal for state in selected)
@@ -1118,34 +3008,79 @@ def derive_retained_sample_view(evidence: McmcEvidence) -> RetainedSampleView:
     )
     samples = tuple(position for state in selected for position in state.positions)
     log_densities = tuple(value for state in selected for value in state.log_densities)
-    return RetainedSampleView(
+    retained = RetainedSampleView(
         evidence.identity,
+        evidence.plan.policy.identity,
         evidence.coordinate_ids,
         evidence.coordinate_units,
         ordinals,
+        tuple(range(evidence.plan.policy.walkers)),
         sample_indices,
         samples,
         log_densities,
         len(selected) == evidence.plan.policy.retained_steps,
+        evidence,
+        _mint_mcmc_evidence_witness("retained-selection"),
     )
+    return retained
 
 
-def derive_mcmc_diagnostics(evidence: McmcEvidence) -> McmcDiagnostics:
+def derive_mcmc_diagnostics(
+    evidence: McmcEvidence,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> McmcDiagnostics:
     """Derive acceptance diagnostics from complete transition states only."""
+    evidence.validate_integrity()
+    if cancellation is not None and cancellation.is_cancelled:
+        raise McmcConstructionError("MCMC diagnostic derivation was cancelled")
     transitions = evidence.states[1:]
     completed = len(transitions)
     accepted_counts = tuple(
         sum(state.accepted[walker] for state in transitions)
         for walker in range(evidence.plan.policy.walkers)
     )
-    fractions = tuple(
-        count / completed if completed else 0.0 for count in accepted_counts
-    )
+    if completed == 0:
+        return McmcDiagnostics(
+            evidence.identity,
+            (),
+            tuple(range(evidence.plan.policy.walkers)),
+            McmcDiagnosticStatus.UNAVAILABLE,
+            McmcDiagnosticReason.NO_TRANSITIONS,
+            None,
+            None,
+        )
+    fractions = tuple(count / completed for count in accepted_counts)
     mean = sum(fractions) / len(fractions)
     return McmcDiagnostics(
         evidence.identity,
         tuple(state.ordinal for state in transitions),
         tuple(range(evidence.plan.policy.walkers)),
+        McmcDiagnosticStatus.AVAILABLE,
+        None,
         fractions,
         mean,
+    )
+
+
+def derive_mcmc_operation_diagnostics(
+    operation: McmcOperation,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> McmcDiagnostics:
+    """Derive truthful diagnostics even when no primary state exists."""
+    operation.validate_integrity()
+    if cancellation is not None and cancellation.is_cancelled:
+        raise McmcConstructionError("MCMC diagnostic derivation was cancelled")
+    if operation.evidence is not None:
+        return derive_mcmc_diagnostics(operation.evidence)
+    capture = cast("RawMcmcCapture", operation.raw_capture)
+    return McmcDiagnostics(
+        operation.identity,
+        (),
+        tuple(range(capture.walkers)),
+        McmcDiagnosticStatus.UNAVAILABLE,
+        McmcDiagnosticReason.NO_TRANSITIONS,
+        None,
+        None,
     )

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -574,6 +574,18 @@ def test_complete_chain_is_primary_and_flat_samples_are_derived_views() -> None:
     assert diagnostics.mean_acceptance_fraction is not None
     assert len(diagnostics.acceptance_fractions) == plan.policy.walkers
     assert 0.0 <= diagnostics.mean_acceptance_fraction <= 1.0
+    assert diagnostics.accepted_counts == (0, 5, 2, 4, 3, 2, 4, 5)
+    assert diagnostics.acceptance_fractions == (
+        0.0,
+        1.0,
+        0.4,
+        0.8,
+        0.6,
+        0.4,
+        0.8,
+        1.0,
+    )
+    assert diagnostics.mean_acceptance_fraction == 0.625
 
 
 def test_interruption_preserves_only_a_contiguous_complete_state_prefix() -> None:
@@ -964,10 +976,83 @@ def test_acceptance_diagnostics_reject_replacement_and_serialized_tampering() ->
 
     canonical = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(source)
     record = canonical.to_record()
-    record["acceptance_fractions"] = [float("nan").hex()]
-    record["mean_acceptance_fraction"] = (-4.0).hex()
-    with pytest.raises(McmcConstructionError, match="canonical backend evidence"):
-        native_mcmc.AcceptanceDiagnostics.from_record(record, source=source)
+    for field_name, forged_value in (
+        ("source_identity", "forged"),
+        ("walker_ordinals", list(reversed(canonical.walker_ordinals))),
+        ("observed_transition_count", 999),
+        ("accepted_counts", [5] * plan.policy.walkers),
+        ("acceptance_fractions", [float("nan").hex()]),
+        ("mean_acceptance_fraction", (-4.0).hex()),
+        ("status", McmcDiagnosticStatus.UNAVAILABLE.value),
+        ("identity", "recomputed-outer-hash"),
+    ):
+        tampered = dict(record)
+        tampered[field_name] = forged_value
+        with pytest.raises(McmcConstructionError, match="canonical backend evidence"):
+            native_mcmc.AcceptanceDiagnostics.from_record(tampered, source=source)
+
+
+def test_acceptance_diagnostics_reject_forged_source_lineage() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    source = operation.backend_transition_evidence
+    assert source is not None
+    diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(source)
+
+    object.__setattr__(diagnostic, "source_identity", "forged")
+
+    with pytest.raises(McmcConstructionError, match="source identity"):
+        diagnostic.validate_integrity()
+
+
+@pytest.mark.parametrize(
+    ("field_name", "forged_value"),
+    (
+        ("state_ordinals", (5, 4, 3, 2, 1)),
+        ("walker_ordinals", (7, 6, 5, 4, 3, 2, 1, 0)),
+        ("observed_transition_count", 999),
+        ("accepted_counts", (5,) * 8),
+        ("acceptance_fractions", (1.0,) * 8),
+        ("mean_acceptance_fraction", 1.0),
+        ("status", McmcDiagnosticStatus.UNAVAILABLE),
+    ),
+)
+def test_acceptance_diagnostics_reject_recursive_field_mutation(
+    field_name: str,
+    forged_value: object,
+) -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    source = operation.backend_transition_evidence
+    assert source is not None
+    diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(source)
+
+    object.__setattr__(diagnostic, field_name, forged_value)
+    object.__setattr__(diagnostic, "identity", diagnostic._content_identity())
+
+    with pytest.raises(McmcConstructionError, match="content"):
+        diagnostic.validate_integrity()
+
+
+def test_acceptance_diagnostics_reject_replaced_source_object() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    source = operation.backend_transition_evidence
+    assert source is not None
+    diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(source)
+    hypothetical = source.with_hypothetical_masks(
+        tuple(
+            (True,) * plan.policy.walkers
+            for _transition in range(plan.policy.total_steps)
+        ),
+        observation_provenance="emcee-stretch-backend-v1",
+    )
+
+    object.__setattr__(diagnostic, "source", hypothetical)
+    object.__setattr__(diagnostic, "identity", diagnostic._content_identity())
+
+    with pytest.raises(McmcConstructionError, match="source identity"):
+        diagnostic.validate_integrity()
 
 
 @pytest.mark.parametrize(
@@ -994,7 +1079,7 @@ def test_backend_mask_variants_do_not_change_primary_scientific_evidence(
         )
         for transition in range(plan.policy.total_steps)
     )
-    variant = backend.with_observed_masks(
+    variant = backend.with_hypothetical_masks(
         masks,
         observation_provenance=backend.observation_provenance,
     )
@@ -1014,6 +1099,16 @@ def test_backend_mask_variants_do_not_change_primary_scientific_evidence(
     variant_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
         variant
     )
+    assert backend.kind is native_mcmc.BackendTransitionEvidenceKind.OBSERVED_EXECUTION
+    assert variant.kind is native_mcmc.BackendTransitionEvidenceKind.HYPOTHETICAL
+    assert original_diagnostic.status is McmcDiagnosticStatus.AVAILABLE
+    assert variant_diagnostic.status is McmcDiagnosticStatus.UNAVAILABLE
+    assert (
+        variant_diagnostic.reason
+        is McmcDiagnosticReason.UNVALIDATED_BACKEND_TRANSITIONS
+    )
+    assert variant_diagnostic.acceptance_fractions is None
+    assert variant_diagnostic.mean_acceptance_fraction is None
     assert variant_diagnostic.source_identity != original_diagnostic.source_identity
     assert variant_diagnostic.identity != original_diagnostic.identity
 
@@ -1038,6 +1133,72 @@ def test_backend_mask_variants_do_not_change_primary_scientific_evidence(
     assert variant_summary.parameter_summaries == original_summary.parameter_summaries
     assert variant_summary.covariance == original_summary.covariance
     assert variant_summary.correlations == original_summary.correlations
+
+
+def test_observed_backend_evidence_is_bound_to_its_execution_occurrence() -> None:
+    accepted, plan = _plan_context()
+    first = execute_mcmc_evidence(accepted, plan)
+    second = execute_mcmc_evidence(accepted, plan)
+    first_source = first.backend_transition_evidence
+    second_source = second.backend_transition_evidence
+    assert first_source is not None
+    assert second_source is not None
+    assert first_source.execution_occurrence_identity != (
+        second_source.execution_occurrence_identity
+    )
+
+    record = first_source.to_record()
+    with pytest.raises(McmcConstructionError, match="execution occurrence"):
+        native_mcmc.BackendTransitionEvidence.from_record(
+            record,
+            source=second_source,
+        )
+
+    restored = native_mcmc.BackendTransitionEvidence.from_record(
+        record,
+        source=first_source,
+    )
+    assert (
+        restored.kind
+        is native_mcmc.BackendTransitionEvidenceKind.HISTORICAL_OBSERVATION
+    )
+    restored_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
+        restored
+    )
+    assert restored_diagnostic.status is McmcDiagnosticStatus.AVAILABLE
+    assert restored_diagnostic.acceptance_fractions == (
+        native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
+            first_source
+        ).acceptance_fractions
+    )
+
+    assert second.raw_capture is not None
+    foreign_masks = tuple(item.accepted for item in first_source.transitions)
+    foreign = native_mcmc.BackendTransitionEvidence.from_capture(
+        second.raw_capture,
+        foreign_masks,
+        observation_provenance="emcee-stretch-backend-v1",
+    )
+    foreign_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
+        foreign
+    )
+    assert foreign.kind is native_mcmc.BackendTransitionEvidenceKind.HYPOTHETICAL
+    assert foreign_diagnostic.status is McmcDiagnosticStatus.UNAVAILABLE
+    assert foreign_diagnostic.acceptance_fractions is None
+
+    for field_name, forged_value in (
+        ("source_capture_identity", "forged"),
+        ("execution_occurrence_identity", "forged"),
+        ("masks", [[True] * plan.policy.walkers] * plan.policy.total_steps),
+        ("identity", "forged"),
+    ):
+        tampered = dict(record)
+        tampered[field_name] = forged_value
+        with pytest.raises(McmcConstructionError):
+            native_mcmc.BackendTransitionEvidence.from_record(
+                tampered,
+                source=first_source,
+            )
 
 
 def test_short_chain_autocorrelation_and_dependents_are_unreliable() -> None:

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -938,6 +938,23 @@ def test_zero_transition_acceptance_is_typed_unavailable() -> None:
     assert diagnostics.acceptance_fractions is None
     assert diagnostics.mean_acceptance_fraction is None
 
+    source = operation.backend_transition_evidence
+    assert source is not None
+    historical = native_mcmc.BackendTransitionEvidence.from_record(
+        source.to_record(),
+        source=source,
+    )
+    historical_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
+        historical
+    )
+    assert historical_diagnostic.status is McmcDiagnosticStatus.UNAVAILABLE
+    assert (
+        historical_diagnostic.reason
+        is McmcDiagnosticReason.HISTORICAL_OBSERVATION_UNVERIFIED
+    )
+    assert historical_diagnostic.acceptance_fractions is None
+    assert historical_diagnostic.mean_acceptance_fraction is None
+
 
 @pytest.mark.parametrize(
     ("fractions", "mean"),
@@ -1172,12 +1189,17 @@ def test_observed_backend_evidence_is_bound_to_its_execution_occurrence() -> Non
     restored_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
         restored
     )
-    assert restored_diagnostic.status is McmcDiagnosticStatus.AVAILABLE
-    assert restored_diagnostic.acceptance_fractions == (
-        native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
-            first_source
-        ).acceptance_fractions
+    assert restored.transitions == first_source.transitions
+    assert restored.observed_mask_payload_identity == (
+        first_source.observed_mask_payload_identity
     )
+    assert restored_diagnostic.status is McmcDiagnosticStatus.UNAVAILABLE
+    assert (
+        restored_diagnostic.reason
+        is McmcDiagnosticReason.HISTORICAL_OBSERVATION_UNVERIFIED
+    )
+    assert restored_diagnostic.acceptance_fractions is None
+    assert restored_diagnostic.mean_acceptance_fraction is None
 
     assert second.raw_capture is not None
     foreign_masks = tuple(item.accepted for item in first_source.transitions)
@@ -1207,6 +1229,42 @@ def test_observed_backend_evidence_is_bound_to_its_execution_occurrence() -> Non
                 tampered,
                 source=first_source,
             )
+
+
+def test_fabricated_historical_masks_cannot_authorize_acceptance_diagnostics() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    source = operation.backend_transition_evidence
+    assert source is not None
+    all_true = source.with_hypothetical_masks(
+        tuple(
+            (True,) * plan.policy.walkers
+            for _transition in range(plan.policy.total_steps)
+        ),
+        observation_provenance=source.observation_provenance,
+    )
+
+    fabricated_history = native_mcmc._initialize_backend_transition_evidence(
+        native_mcmc.BackendTransitionEvidence,
+        source.source_capture,
+        native_mcmc.BackendTransitionEvidenceKind.HISTORICAL_OBSERVATION,
+        source.observation_provenance,
+        source.execution_occurrence_identity,
+        all_true.transitions,
+        None,
+        native_mcmc._mint_mcmc_evidence_witness("backend-transition-evidence"),
+    )
+    diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
+        fabricated_history
+    )
+
+    assert all(
+        all(transition.accepted) for transition in fabricated_history.transitions
+    )
+    assert diagnostic.status is McmcDiagnosticStatus.UNAVAILABLE
+    assert diagnostic.reason is McmcDiagnosticReason.HISTORICAL_OBSERVATION_UNVERIFIED
+    assert diagnostic.acceptance_fractions is None
+    assert diagnostic.mean_acceptance_fraction is None
 
 
 def test_direct_constructor_cannot_forge_observed_backend_evidence() -> None:

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
+import pickle
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, cast
@@ -1087,12 +1089,17 @@ def test_backend_mask_variants_do_not_change_primary_scientific_evidence(
     validation = validate_raw_mcmc_capture(
         plan,
         operation.raw_capture,
-        backend_transition_evidence=variant,
     )
 
     assert validation.primary_evidence is not None
     assert validation.primary_evidence.identity == operation.evidence.identity
     assert validation.primary_evidence.states == operation.evidence.states
+    object.__setattr__(
+        validation.primary_evidence,
+        "backend_transition_evidence",
+        backend,
+    )
+    validation.primary_evidence.validate_integrity()
     original_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
         backend
     )
@@ -1189,6 +1196,7 @@ def test_observed_backend_evidence_is_bound_to_its_execution_occurrence() -> Non
     for field_name, forged_value in (
         ("source_capture_identity", "forged"),
         ("execution_occurrence_identity", "forged"),
+        ("observed_mask_payload_identity", "forged"),
         ("masks", [[True] * plan.policy.walkers] * plan.policy.total_steps),
         ("identity", "forged"),
     ):
@@ -1199,6 +1207,142 @@ def test_observed_backend_evidence_is_bound_to_its_execution_occurrence() -> Non
                 tampered,
                 source=first_source,
             )
+
+
+def test_direct_constructor_cannot_forge_observed_backend_evidence() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    source = operation.backend_transition_evidence
+    assert source is not None
+    all_true = source.with_hypothetical_masks(
+        tuple(
+            (True,) * plan.policy.walkers
+            for _transition in range(plan.policy.total_steps)
+        ),
+        observation_provenance=source.observation_provenance,
+    )
+
+    with pytest.raises(TypeError, match="canonical factories"):
+        native_mcmc.BackendTransitionEvidence(
+            source.source_capture,
+            native_mcmc.BackendTransitionEvidenceKind.OBSERVED_EXECUTION,
+            source.observation_provenance,
+            source.execution_occurrence_identity,
+            all_true.transitions,
+            native_mcmc._mint_mcmc_evidence_witness("backend-transition-evidence"),
+        )
+    with pytest.raises(McmcConstructionError, match="authority registry"):
+        native_mcmc._initialize_backend_transition_evidence(
+            native_mcmc.BackendTransitionEvidence,
+            source.source_capture,
+            native_mcmc.BackendTransitionEvidenceKind.OBSERVED_EXECUTION,
+            source.observation_provenance,
+            source.execution_occurrence_identity,
+            all_true.transitions,
+            source._live_observation_authority,
+            native_mcmc._mint_mcmc_evidence_witness("backend-transition-evidence"),
+        )
+
+    hypothetical_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
+        all_true
+    )
+    assert all_true.kind is native_mcmc.BackendTransitionEvidenceKind.HYPOTHETICAL
+    assert hypothetical_diagnostic.status is McmcDiagnosticStatus.UNAVAILABLE
+    assert hypothetical_diagnostic.acceptance_fractions is None
+
+
+def test_primary_rejects_deterministic_replay_backend_substitution() -> None:
+    accepted, plan = _plan_context()
+    replay_a = execute_mcmc_evidence(accepted, plan)
+    replay_b = execute_mcmc_evidence(accepted, plan)
+    evidence_a = replay_a.evidence
+    evidence_b = replay_b.evidence
+    backend_a = replay_a.backend_transition_evidence
+    backend_b = replay_b.backend_transition_evidence
+    assert evidence_a is not None
+    assert evidence_b is not None
+    assert backend_a is not None
+    assert backend_b is not None
+    assert evidence_a.identity == evidence_b.identity
+    assert replay_a.raw_capture is not None
+    assert replay_b.raw_capture is not None
+    assert replay_a.raw_capture.identity == replay_b.raw_capture.identity
+    assert backend_a.execution_occurrence_identity != (
+        backend_b.execution_occurrence_identity
+    )
+
+    object.__setattr__(evidence_a, "backend_transition_evidence", backend_b)
+
+    with pytest.raises(McmcConstructionError, match="execution occurrence"):
+        evidence_a.validate_integrity()
+    with pytest.raises(McmcConstructionError, match="execution occurrence"):
+        derive_mcmc_diagnostics(evidence_a)
+
+
+def test_backend_observation_authority_is_exact_nontransferable_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accepted, plan = _plan_context()
+    original_factory = cast(
+        "Any",
+        native_mcmc._mint_observed_backend_transition_evidence,
+    )
+    captured: list[Any] = []
+
+    def capture_authority(
+        authority: Any,
+        raw_capture: Any,
+    ) -> Any:
+        captured.append(authority)
+        return original_factory(authority, raw_capture)
+
+    monkeypatch.setattr(
+        native_mcmc,
+        "_mint_observed_backend_transition_evidence",
+        capture_authority,
+    )
+    replay_a = execute_mcmc_evidence(accepted, plan)
+    replay_b = execute_mcmc_evidence(accepted, plan)
+    assert replay_a.raw_capture is not None
+    assert replay_b.raw_capture is not None
+    authority_a, authority_b = captured
+
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.copy(authority_a)
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.deepcopy(authority_a)
+    with pytest.raises(TypeError, match="cannot be serialized"):
+        pickle.dumps(authority_a)
+    with pytest.raises(McmcConstructionError, match="foreign execution occurrence"):
+        original_factory(authority_b, replay_a.raw_capture)
+    with pytest.raises(McmcConstructionError, match="foreign execution occurrence"):
+        original_factory(authority_a, replay_b.raw_capture)
+
+    raw_a = replay_a.raw_capture
+    copied_raw_a = native_mcmc.RawMcmcCapture(
+        raw_a.plan_identity,
+        raw_a.policy_identity,
+        raw_a.root_seed,
+        raw_a.walkers,
+        raw_a.dimension,
+        raw_a.total_steps,
+        raw_a.backend_execution_occurrence_identity,
+        raw_a.terminal,
+        raw_a.states,
+        raw_a.objective_request_count,
+        raw_a.evaluation_request_count,
+        raw_a.stage,
+        raw_a.initialization_outcome,
+        raw_a.failure_category,
+        native_mcmc._mint_mcmc_evidence_witness("raw-capture"),
+    )
+    assert copied_raw_a.identity == raw_a.identity
+    with pytest.raises(McmcConstructionError, match="foreign execution occurrence"):
+        original_factory(authority_a, copied_raw_a)
+
+    absent = object.__new__(native_mcmc._BackendExecutionObservation)
+    with pytest.raises(McmcConstructionError, match="foreign execution occurrence"):
+        original_factory(absent, replay_a.raw_capture)
 
 
 def test_short_chain_autocorrelation_and_dependents_are_unreliable() -> None:

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -49,6 +49,7 @@ from chemex.optimize.native_mcmc import (
     derive_posterior_summary,
     derive_retained_sample_view,
     execute_mcmc_evidence,
+    validate_raw_mcmc_capture,
 )
 from chemex.optimize.uncertainty import ParameterUnit
 from chemex.parameters.parameterization import (
@@ -565,7 +566,8 @@ def test_complete_chain_is_primary_and_flat_samples_are_derived_views() -> None:
     assert retained.is_complete
 
     diagnostics = derive_mcmc_diagnostics(evidence)
-    assert diagnostics.source_evidence_identity == evidence.identity
+    assert operation.backend_transition_evidence is not None
+    assert diagnostics.source_identity == operation.backend_transition_evidence.identity
     assert diagnostics.state_ordinals == (1, 2, 3, 4, 5)
     assert diagnostics.walker_ordinals == tuple(range(plan.policy.walkers))
     assert diagnostics.acceptance_fractions is not None
@@ -693,7 +695,7 @@ def test_fresh_validation_rejects_tampered_backend_log_density() -> None:
         first,
         log_densities=(first.log_densities[0] + 1.0, *first.log_densities[1:]),
     )
-    with pytest.raises(McmcConstructionError, match="transition"):
+    with pytest.raises(McmcConstructionError, match="capture"):
         dataclasses.replace(
             operation.raw_capture,
             states=(tampered_first, *operation.raw_capture.states[1:]),
@@ -710,16 +712,14 @@ def test_fresh_validator_rejects_backend_originated_log_density_mismatch(
         ordinal: int,
         positions: Array,
         log_densities: Array,
-        accepted_mask: Array | None,
     ) -> EnsembleState:
-        state = original(ordinal, positions, log_densities, accepted_mask)
+        state = original(ordinal, positions, log_densities)
         if ordinal != 0:
             return state
         return EnsembleState(
             state.ordinal,
             state.positions,
             (state.log_densities[0] + 1.0, *state.log_densities[1:]),
-            state.accepted,
         )
 
     monkeypatch.setattr(native_mcmc, "_ensemble_state", wrong_backend_density)
@@ -919,8 +919,242 @@ def test_zero_transition_acceptance_is_typed_unavailable() -> None:
 
     assert diagnostics.status is McmcDiagnosticStatus.UNAVAILABLE
     assert diagnostics.reason is McmcDiagnosticReason.NO_TRANSITIONS
+    assert diagnostics.observed_transition_count == 0
+    assert diagnostics.accepted_counts == (0,) * plan.policy.walkers
     assert diagnostics.acceptance_fractions is None
     assert diagnostics.mean_acceptance_fraction is None
+
+
+@pytest.mark.parametrize(
+    ("fractions", "mean"),
+    (((2.5,), -4.0), ((float("nan"),), float("nan"))),
+)
+def test_acceptance_diagnostics_reject_caller_supplied_values(
+    fractions: tuple[float, ...],
+    mean: float,
+) -> None:
+    constructor = cast("Any", native_mcmc.McmcDiagnostics)
+
+    with pytest.raises(TypeError):
+        constructor(
+            "forged-source",
+            (1,),
+            (0,),
+            McmcDiagnosticStatus.AVAILABLE,
+            None,
+            fractions,
+            mean,
+        )
+
+
+def test_acceptance_diagnostics_reject_replacement_and_serialized_tampering() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    source = operation.backend_transition_evidence
+    assert source is not None
+    diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(source)
+    replace = cast("Any", dataclasses.replace)
+
+    with pytest.raises(TypeError, match="init=False"):
+        replace(diagnostic, acceptance_fractions=(2.5,))
+
+    object.__setattr__(diagnostic, "mean_acceptance_fraction", -4.0)
+    with pytest.raises(McmcConstructionError, match="content"):
+        diagnostic.validate_integrity()
+
+    canonical = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(source)
+    record = canonical.to_record()
+    record["acceptance_fractions"] = [float("nan").hex()]
+    record["mean_acceptance_fraction"] = (-4.0).hex()
+    with pytest.raises(McmcConstructionError, match="canonical backend evidence"):
+        native_mcmc.AcceptanceDiagnostics.from_record(record, source=source)
+
+
+@pytest.mark.parametrize(
+    "mask_kind",
+    ("all_true", "all_false", "alternating"),
+)
+def test_backend_mask_variants_do_not_change_primary_scientific_evidence(
+    mask_kind: str,
+) -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.raw_capture is not None
+    assert operation.evidence is not None
+    backend = operation.backend_transition_evidence
+    assert backend is not None
+    masks = tuple(
+        tuple(
+            True
+            if mask_kind == "all_true"
+            else False
+            if mask_kind == "all_false"
+            else (transition + walker) % 2 == 0
+            for walker in range(plan.policy.walkers)
+        )
+        for transition in range(plan.policy.total_steps)
+    )
+    variant = backend.with_observed_masks(
+        masks,
+        observation_provenance=backend.observation_provenance,
+    )
+
+    validation = validate_raw_mcmc_capture(
+        plan,
+        operation.raw_capture,
+        backend_transition_evidence=variant,
+    )
+
+    assert validation.primary_evidence is not None
+    assert validation.primary_evidence.identity == operation.evidence.identity
+    assert validation.primary_evidence.states == operation.evidence.states
+    original_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
+        backend
+    )
+    variant_diagnostic = native_mcmc.AcceptanceDiagnostics.from_backend_evidence(
+        variant
+    )
+    assert variant_diagnostic.source_identity != original_diagnostic.source_identity
+    assert variant_diagnostic.identity != original_diagnostic.identity
+
+    original_selection = derive_retained_sample_view(operation.evidence)
+    variant_selection = derive_retained_sample_view(validation.primary_evidence)
+    assert variant_selection.samples == original_selection.samples
+    assert variant_selection.log_densities == original_selection.log_densities
+    output_units = (
+        ("A", ParameterUnit.DIMENSIONLESS),
+        ("B", ParameterUnit.DIMENSIONLESS),
+    )
+    original_posterior = derive_posterior_sample_evidence(
+        original_selection,
+        output_units,
+    )
+    variant_posterior = derive_posterior_sample_evidence(
+        variant_selection, output_units
+    )
+    assert variant_posterior.outcomes == original_posterior.outcomes
+    original_summary = derive_posterior_summary(original_posterior)
+    variant_summary = derive_posterior_summary(variant_posterior)
+    assert variant_summary.parameter_summaries == original_summary.parameter_summaries
+    assert variant_summary.covariance == original_summary.covariance
+    assert variant_summary.correlations == original_summary.correlations
+
+
+def test_short_chain_autocorrelation_and_dependents_are_unreliable() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    retained_steps = 16
+    policy = ExpertMcmcPolicy(
+        burn_steps=0,
+        retained_steps=retained_steps,
+        walkers=8,
+        expert_provenance="short-autocorrelation-qualification",
+    ).resolve(dimension=2, root_seed=1234)
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=policy,
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.evidence is not None
+    selection = derive_retained_sample_view(operation.evidence)
+    posterior = derive_posterior_sample_evidence(selection, plan.coordinate_units)
+    summary_policy = native_mcmc.PosteriorSummaryPolicy()
+    changed_window_policy = dataclasses.replace(
+        summary_policy,
+        autocorrelation_window_parameter=4.0,
+    )
+    changed_tolerance_policy = dataclasses.replace(
+        summary_policy,
+        autocorrelation_adequacy_tolerance=25.0,
+    )
+    assert changed_window_policy.identity != summary_policy.identity
+    assert changed_tolerance_policy.identity != summary_policy.identity
+    summary = derive_posterior_summary(posterior, summary_policy)
+
+    assert summary.policy_identity == summary_policy.identity
+    for item in summary.parameter_summaries:
+        for estimate in (
+            item.autocorrelation_time,
+            item.effective_sample_size,
+            item.monte_carlo_standard_error,
+        ):
+            assert estimate.status is McmcDiagnosticStatus.UNAVAILABLE
+            assert estimate.reason is McmcDiagnosticReason.UNRELIABLE_AUTOCORRELATION
+            assert estimate.value is None
+
+
+def test_long_chain_autocorrelation_and_dependents_are_reliable() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    retained_steps = 2048
+    walkers = 8
+    policy = ExpertMcmcPolicy(
+        burn_steps=256,
+        retained_steps=retained_steps,
+        walkers=walkers,
+        expert_provenance="long-autocorrelation-qualification",
+    ).resolve(dimension=2, root_seed=5678)
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=policy,
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.evidence is not None
+    selection = derive_retained_sample_view(operation.evidence)
+    posterior = derive_posterior_sample_evidence(selection, plan.coordinate_units)
+    summary_policy = native_mcmc.PosteriorSummaryPolicy()
+    summary = derive_posterior_summary(posterior, summary_policy)
+
+    assert summary.source_identity == posterior.identity
+    assert summary.policy_identity == summary_policy.identity
+    assert summary.included_labels == selection.sample_indices
+    sample_count = retained_steps * walkers
+    for item in summary.parameter_summaries:
+        tau = item.autocorrelation_time
+        effective = item.effective_sample_size
+        mcse = item.monte_carlo_standard_error
+        assert tau.status is McmcDiagnosticStatus.AVAILABLE
+        assert tau.reason is None
+        assert tau.value is not None
+        assert retained_steps >= (
+            summary_policy.autocorrelation_adequacy_tolerance * tau.value
+        )
+        assert effective.status is McmcDiagnosticStatus.AVAILABLE
+        assert effective.value == pytest.approx(sample_count / tau.value)
+        assert mcse.status is McmcDiagnosticStatus.AVAILABLE
+        assert mcse.value == pytest.approx(
+            item.posterior_standard_deviation / np.sqrt(effective.value)
+        )
+
+
+def test_recomputed_outer_hash_cannot_repair_altered_child_diagnostics() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.evidence is not None
+    selection = derive_retained_sample_view(operation.evidence)
+    posterior = derive_posterior_sample_evidence(selection, plan.coordinate_units)
+    summary = derive_posterior_summary(posterior)
+
+    object.__setattr__(summary.acceptance, "mean_acceptance_fraction", -4.0)
+    object.__setattr__(
+        summary.acceptance, "identity", summary.acceptance._content_identity()
+    )
+    object.__setattr__(summary, "identity", summary._content_identity())
+
+    with pytest.raises(McmcConstructionError, match="Acceptance diagnostic"):
+        summary.validate_integrity()
 
 
 def test_complete_scope_posterior_outcomes_and_summary_are_canonical() -> None:

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -1,0 +1,489 @@
+"""Behavioral qualification tests for native fixed-topology MCMC evidence (#600)."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from pydantic import BaseModel
+
+from chemex.containers.data import Data
+from chemex.containers.profile import Profile, PulseSequence
+from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
+from chemex.nmr.spectrometer import Spectrometer
+from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
+from chemex.optimize.native_mcmc import (
+    CalibratedMcmcPolicy,
+    EnsembleState,
+    ExpertMcmcPolicy,
+    InitializationKind,
+    McmcConstructionError,
+    McmcEvidence,
+    McmcEvidenceLifecycle,
+    McmcOperationTerminal,
+    McmcPlan,
+    McmcPolicyKind,
+    ProposalKind,
+    ResolvedMcmcPolicy,
+    build_bounded_latin_hypercube,
+    derive_mcmc_diagnostics,
+    derive_retained_sample_view,
+    execute_mcmc_evidence,
+)
+from chemex.optimize.uncertainty import ParameterUnit
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    ConstraintProgram,
+    ParameterRole,
+    ScientificFunctionBinder,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.printers.data import Printer
+from chemex.typing import Array
+
+
+class _KernelSettings(BaseModel):
+    kind: str = "linear-test-kernel"
+
+
+class _LinearSpectrometer:
+    def __init__(self) -> None:
+        self.spin_system = SpinSystem.from_name("1N")
+        self.values = {"a": 0.0, "b": 0.0}
+
+    def update(self, values: dict[str, float]) -> None:
+        self.values = dict(values)
+
+    def new_native_workspace(self) -> _LinearSpectrometer:
+        return deepcopy(self)
+
+    def native_kernel_descriptor(self) -> dict[str, object]:
+        return {"kind": "linear-test-spectrometer"}
+
+
+class _LinearPulseSequence:
+    settings = _KernelSettings()
+
+    def calculate(self, spectrometer: _LinearSpectrometer, data: Data) -> Array:
+        return spectrometer.values["a"] + spectrometer.values["b"] * np.asarray(
+            data.metadata,
+            dtype=np.float64,
+        )
+
+    def is_reference(self, metadata: Array) -> Array:
+        return metadata < 0.0
+
+
+def _native_context() -> tuple[
+    AcceptedFitResult,
+    OptimizationProblem,
+    ActiveParameterization,
+    EvaluationEngine,
+]:
+    binder = ScientificFunctionBinder("qualification", {})
+    program = ConstraintProgram(
+        "parameter-model",
+        "model",
+        "definitions",
+        "configuration",
+        binder.identity,
+        ("A", "B"),
+        ("A", "B"),
+        (),
+        (),
+        (),
+    )
+    parameterization = ActiveParameterization(
+        program,
+        binder,
+        "source-occurrence",
+        4,
+        (("A", ParameterRole.FIT), ("B", ParameterRole.FIT)),
+    )
+    snapshot = AnalysisValuesSnapshot(
+        "source-occurrence",
+        "model",
+        "definitions",
+        "configuration",
+        4,
+        (("A", 0.5), ("B", 1.5)),
+    )
+    data = Data(
+        exp=np.asarray((1.0, 3.0, 5.0), dtype=np.float64),
+        err=np.ones(3, dtype=np.float64),
+        metadata=np.asarray((0.0, 1.0, 2.0), dtype=np.float64),
+    )
+    profile = Profile(
+        data,
+        cast("Spectrometer", _LinearSpectrometer()),
+        cast("PulseSequence", _LinearPulseSequence()),
+        {"a": "A", "b": "B"},
+        cast("Printer", None),
+        is_scaled=False,
+    )
+    experiments = cast("Any", (SimpleNamespace(profiles=(profile,)),))
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    problem = OptimizationProblem(
+        engine.plan.identity,
+        parameterization.identity,
+        parameterization.evaluator_identity,
+        program.fingerprint,
+        "configuration",
+        snapshot,
+        (("A", 0.5), ("B", 1.5)),
+        ("A", "B"),
+        (),
+        (0.5, 1.5),
+        (0.0, 1.0),
+        (2.0, 3.0),
+        ("A", "B"),
+    )
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        problem.lifecycle_frame((1.0, 2.0), parameterization),
+    )
+    result = engine.new_evaluator().evaluate(frame)
+    assert isinstance(result, EvaluationResult)
+    accepted = AcceptedFitResult.for_qualification(
+        occurrence_identity="accepted-occurrence",
+        problem_identity=problem.identity,
+        invocation_identity="accepted-invocation",
+        execution_identity="accepted-execution",
+        materialization_identity="accepted-materialization",
+        parameterization_identity=parameterization.identity,
+        evaluator_parameterization_identity=parameterization.evaluator_identity,
+        source_occurrence_identity=snapshot.occurrence_identity,
+        source_revision=snapshot.revision,
+        controlled_ids=problem.controlled_ids,
+        vector=(1.0, 2.0),
+        chi_square=0.0,
+        evaluation_result=result,
+        commit_scope=problem.commit_scope,
+        commit_items=result.resolved_values.ordered_items(),
+        origin_context_identity="accepted-origin",
+    )
+    return accepted, problem, parameterization, engine
+
+
+def _resolved_policy() -> ResolvedMcmcPolicy:
+    return ExpertMcmcPolicy(
+        burn_steps=2,
+        retained_steps=3,
+        walkers=8,
+    ).resolve(dimension=2, root_seed=1234)
+
+
+def test_calibrated_policy_resolves_the_complete_prospective_run() -> None:
+    policy = CalibratedMcmcPolicy(
+        policy_version="bounded-analytic-v1",
+        minimum_dimension=1,
+        maximum_dimension=3,
+        walkers=12,
+        burn_steps=20,
+        retained_steps=40,
+    )
+
+    resolved = policy.resolve(dimension=2, root_seed=0x1234_5678_90AB_CDEF)
+
+    assert resolved.kind is McmcPolicyKind.CALIBRATED
+    assert resolved.policy_version == "bounded-analytic-v1"
+    assert resolved.qualification_dimension_range == (1, 3)
+    assert resolved.dimension == 2
+    assert resolved.walkers == 12
+    assert resolved.burn_steps == 20
+    assert resolved.retained_steps == 40
+    assert resolved.total_steps == 60
+    assert resolved.thin == 1
+    assert resolved.initialization is InitializationKind.BOUNDED_LATIN_HYPERCUBE
+    assert resolved.proposal is ProposalKind.STRETCH
+    assert resolved.proposal_scale == 2.0
+    assert resolved.objective_request_budget == 12 * 61
+    assert resolved.root_seed == 0x1234_5678_90AB_CDEF
+    assert resolved.initialization_seed != resolved.sampler_seed
+    assert resolved.identity
+
+
+def test_expert_policy_only_overrides_predeclared_topology() -> None:
+    policy = ExpertMcmcPolicy(
+        burn_steps=7,
+        retained_steps=13,
+        walkers=8,
+    )
+
+    resolved = policy.resolve(dimension=2, root_seed=99)
+
+    assert resolved.kind is McmcPolicyKind.EXPERT
+    assert resolved.policy_version == "expert-v1"
+    assert resolved.qualification_dimension_range is None
+    assert resolved.burn_steps == 7
+    assert resolved.retained_steps == 13
+    assert resolved.walkers == 8
+    assert resolved.initialization is InitializationKind.BOUNDED_LATIN_HYPERCUBE
+    assert resolved.proposal is ProposalKind.STRETCH
+    assert resolved.thin == 1
+    assert resolved.objective_request_budget == 8 * 21
+
+
+def test_calibrated_policy_fails_closed_outside_its_qualified_stratum() -> None:
+    policy = CalibratedMcmcPolicy(
+        policy_version="bounded-analytic-v1",
+        minimum_dimension=1,
+        maximum_dimension=2,
+        walkers=8,
+        burn_steps=10,
+        retained_steps=20,
+    )
+
+    with pytest.raises(McmcConstructionError, match="No calibrated MCMC policy"):
+        policy.resolve(dimension=3, root_seed=1)
+
+
+def test_initial_ensemble_is_a_seeded_bounded_latin_hypercube() -> None:
+    lower = (-2.0, 10.0)
+    upper = (2.0, 22.0)
+
+    first = build_bounded_latin_hypercube(
+        lower,
+        upper,
+        walkers=8,
+        seed=0xCAFE,
+    )
+    second = build_bounded_latin_hypercube(
+        lower,
+        upper,
+        walkers=8,
+        seed=0xCAFE,
+    )
+    positions = np.asarray(first)
+
+    assert first == second
+    assert positions.shape == (8, 2)
+    assert np.all(positions > np.asarray(lower))
+    assert np.all(positions < np.asarray(upper))
+    strata = np.floor(
+        (positions - np.asarray(lower)) / (np.asarray(upper) - np.asarray(lower)) * 8
+    ).astype(int)
+    for dimension in range(2):
+        assert sorted(strata[:, dimension]) == list(range(8))
+
+
+@pytest.mark.parametrize(
+    ("lower", "upper"),
+    (
+        ((-np.inf,), (1.0,)),
+        ((0.0,), (np.inf,)),
+        ((1.0,), (1.0,)),
+        ((2.0,), (1.0,)),
+    ),
+)
+def test_initial_ensemble_rejects_nonfinite_or_empty_bounds(
+    lower: tuple[float, ...],
+    upper: tuple[float, ...],
+) -> None:
+    with pytest.raises(McmcConstructionError, match="finite strictly ordered bounds"):
+        build_bounded_latin_hypercube(lower, upper, walkers=4, seed=1)
+
+
+def test_plan_binds_initial_ensemble_to_exact_accepted_native_lineage() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=_resolved_policy(),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+
+    assert plan.accepted_result_identity == accepted.identity
+    assert accepted.vector != problem.start
+    assert plan.problem_identity == problem.identity
+    assert plan.coordinate_ids == ("A", "B")
+    assert plan.lower_bounds == (0.0, 1.0)
+    assert plan.upper_bounds == (2.0, 3.0)
+    assert len(plan.initial_ensemble) == plan.policy.walkers
+    assert all(
+        lower < value < upper
+        for row in plan.initial_ensemble
+        for value, lower, upper in zip(
+            row,
+            plan.lower_bounds,
+            plan.upper_bounds,
+            strict=True,
+        )
+    )
+    assert plan.identity
+
+
+def test_complete_chain_is_primary_and_flat_samples_are_derived_views() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=_resolved_policy(),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    source_vector = accepted.vector
+    source_items = tuple(problem.source_snapshot.items())
+
+    operation = execute_mcmc_evidence(accepted, plan)
+    replay = execute_mcmc_evidence(accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    evidence = operation.evidence
+    assert replay.evidence is not None
+    assert replay.evidence.identity == evidence.identity
+    assert evidence.lifecycle is McmcEvidenceLifecycle.COMPLETED
+    assert evidence.plan_identity == plan.identity
+    assert evidence.accepted_result_identity == accepted.identity
+    assert evidence.completed_transition_count == plan.policy.total_steps
+    assert tuple(state.ordinal for state in evidence.states) == tuple(
+        range(plan.policy.total_steps + 1)
+    )
+    assert evidence.states[0].positions == plan.initial_ensemble
+    assert all(len(state.positions) == plan.policy.walkers for state in evidence.states)
+    assert all(
+        len(position) == plan.policy.dimension
+        for state in evidence.states
+        for position in state.positions
+    )
+    assert all(
+        len(state.log_densities) == plan.policy.walkers for state in evidence.states
+    )
+    assert evidence.objective_request_count == plan.policy.objective_request_budget
+    assert accepted.vector == source_vector
+    assert tuple(problem.source_snapshot.items()) == source_items
+
+    initial = np.asarray(evidence.states[0].positions)
+    metadata = np.asarray((0.0, 1.0, 2.0))
+    observed = np.asarray((1.0, 3.0, 5.0))
+    expected_initial_log_density = -0.5 * np.sum(
+        (initial[:, 0, np.newaxis] + initial[:, 1, np.newaxis] * metadata - observed)
+        ** 2,
+        axis=1,
+    )
+    # These small, well-conditioned binary64 calculations use only affine
+    # arithmetic and a three-term sum. 1e-14 is roughly 45 machine eps at unit
+    # scale: enough for operation-order differences while still detecting a
+    # changed seeded trajectory or log-density convention.
+    np.testing.assert_allclose(
+        evidence.states[0].log_densities,
+        expected_initial_log_density,
+        rtol=0.0,
+        atol=1.0e-14,
+    )
+    np.testing.assert_allclose(
+        evidence.states[-1].positions,
+        (
+            (0.22193955880807614, 1.2886666343140305),
+            (0.9121794119730182, 2.2579167141311447),
+            (1.8830633726465182, 1.5610464161494841),
+            (1.383428732177615, 1.1821818901130026),
+            (1.1957090816652476, 1.6603544159276828),
+            (1.2211689734419329, 2.26568078108725),
+            (1.1292648992933922, 1.9097405704768293),
+            (0.029980653967193294, 2.8508821421336843),
+        ),
+        rtol=0.0,
+        atol=1.0e-14,
+    )
+
+    retained = derive_retained_sample_view(evidence)
+    assert retained.source_evidence_identity == evidence.identity
+    assert retained.coordinate_ids == plan.coordinate_ids
+    assert retained.selected_state_ordinals == (3, 4, 5)
+    assert retained.sample_indices[0] == (3, 0)
+    assert retained.sample_indices[-1] == (5, 7)
+    assert len(retained.samples) == plan.policy.walkers * plan.policy.retained_steps
+    assert len(retained.log_densities) == len(retained.samples)
+    assert retained.is_complete
+
+    diagnostics = derive_mcmc_diagnostics(evidence)
+    assert diagnostics.source_evidence_identity == evidence.identity
+    assert diagnostics.state_ordinals == (1, 2, 3, 4, 5)
+    assert diagnostics.walker_ordinals == tuple(range(plan.policy.walkers))
+    assert len(diagnostics.acceptance_fractions) == plan.policy.walkers
+    assert 0.0 <= diagnostics.mean_acceptance_fraction <= 1.0
+
+
+def test_interruption_preserves_only_a_contiguous_complete_state_prefix() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=_resolved_policy(),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+
+    def interrupt_after_second_transition(state: EnsembleState) -> None:
+        if state.ordinal == 2:
+            raise KeyboardInterrupt
+
+    operation = execute_mcmc_evidence(
+        accepted,
+        plan,
+        state_observer=interrupt_after_second_transition,
+    )
+
+    assert operation.terminal is McmcOperationTerminal.INTERRUPTED
+    assert operation.failure_category == "interrupted"
+    assert operation.evidence is not None
+    evidence = operation.evidence
+    assert evidence.lifecycle is McmcEvidenceLifecycle.PARTIAL
+    assert tuple(state.ordinal for state in evidence.states) == (0, 1, 2)
+    assert evidence.completed_transition_count == 2
+    assert evidence.objective_request_count == plan.policy.walkers * 3
+    retained = derive_retained_sample_view(evidence)
+    assert retained.selected_state_ordinals == ()
+    assert not retained.is_complete
+
+
+def test_primary_chain_evidence_round_trips_and_rejects_tampering() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=_resolved_policy(),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.evidence is not None
+    evidence = operation.evidence
+
+    record = evidence.to_record()
+    restored = McmcEvidence.from_record(record, plan=plan)
+
+    assert restored.identity == evidence.identity
+    assert restored.states == evidence.states
+    assert restored.objective_request_count == evidence.objective_request_count
+
+    tampered = deepcopy(record)
+    states = cast("list[dict[str, object]]", tampered["states"])
+    positions = cast("list[list[str]]", states[1]["positions"])
+    positions[0][0] = float(float.fromhex(positions[0][0]) + 0.1).hex()
+    with pytest.raises(McmcConstructionError, match="identity"):
+        McmcEvidence.from_record(tampered, plan=plan)

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, cast
@@ -10,26 +11,42 @@ import numpy as np
 import pytest
 from pydantic import BaseModel
 
+import chemex.optimize.native_mcmc as native_mcmc
 from chemex.containers.data import Data
 from chemex.containers.profile import Profile, PulseSequence
 from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
 from chemex.nmr.spectrometer import Spectrometer
-from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    CancellationToken,
+    OptimizationProblem,
+)
 from chemex.optimize.native_mcmc import (
     CalibratedMcmcPolicy,
+    CalibrationCandidateMcmcPolicy,
     EnsembleState,
     ExpertMcmcPolicy,
     InitializationKind,
+    McmcCalibrationReference,
     McmcConstructionError,
+    McmcDiagnosticReason,
+    McmcDiagnosticStatus,
     McmcEvidence,
     McmcEvidenceLifecycle,
+    McmcExecutionStage,
+    McmcInitializationOutcome,
     McmcOperationTerminal,
     McmcPlan,
     McmcPolicyKind,
+    McmcTrajectoryClaim,
+    PosteriorSampleDisposition,
     ProposalKind,
     ResolvedMcmcPolicy,
     build_bounded_latin_hypercube,
     derive_mcmc_diagnostics,
+    derive_mcmc_operation_diagnostics,
+    derive_posterior_sample_evidence,
+    derive_posterior_summary,
     derive_retained_sample_view,
     execute_mcmc_evidence,
 )
@@ -78,7 +95,9 @@ class _LinearPulseSequence:
         return metadata < 0.0
 
 
-def _native_context() -> tuple[
+def _native_context(
+    *, fit_b: bool = True
+) -> tuple[
     AcceptedFitResult,
     OptimizationProblem,
     ActiveParameterization,
@@ -102,7 +121,10 @@ def _native_context() -> tuple[
         binder,
         "source-occurrence",
         4,
-        (("A", ParameterRole.FIT), ("B", ParameterRole.FIT)),
+        (
+            ("A", ParameterRole.FIT),
+            ("B", ParameterRole.FIT if fit_b else ParameterRole.FIX),
+        ),
     )
     snapshot = AnalysisValuesSnapshot(
         "source-occurrence",
@@ -127,6 +149,12 @@ def _native_context() -> tuple[
     )
     experiments = cast("Any", (SimpleNamespace(profiles=(profile,)),))
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    controlled_ids = ("A", "B") if fit_b else ("A",)
+    held_items = () if fit_b else (("B", 1.5),)
+    start = (0.5, 1.5) if fit_b else (0.5,)
+    lower = (0.0, 1.0) if fit_b else (0.0,)
+    upper = (2.0, 3.0) if fit_b else (2.0,)
+    accepted_vector = (1.0, 2.0) if fit_b else (1.0,)
     problem = OptimizationProblem(
         engine.plan.identity,
         parameterization.identity,
@@ -135,16 +163,16 @@ def _native_context() -> tuple[
         "configuration",
         snapshot,
         (("A", 0.5), ("B", 1.5)),
-        ("A", "B"),
-        (),
-        (0.5, 1.5),
-        (0.0, 1.0),
-        (2.0, 3.0),
+        controlled_ids,
+        held_items,
+        start,
+        lower,
+        upper,
         ("A", "B"),
     )
     frame = EvaluationFrame.from_lifecycle_frame(
         parameterization,
-        problem.lifecycle_frame((1.0, 2.0), parameterization),
+        problem.lifecycle_frame(accepted_vector, parameterization),
     )
     result = engine.new_evaluator().evaluate(frame)
     assert isinstance(result, EvaluationResult)
@@ -159,8 +187,8 @@ def _native_context() -> tuple[
         source_occurrence_identity=snapshot.occurrence_identity,
         source_revision=snapshot.revision,
         controlled_ids=problem.controlled_ids,
-        vector=(1.0, 2.0),
-        chi_square=0.0,
+        vector=accepted_vector,
+        chi_square=float(np.sum(result.residuals**2)),
         evaluation_result=result,
         commit_scope=problem.commit_scope,
         commit_items=result.resolved_values.ordered_items(),
@@ -174,11 +202,55 @@ def _resolved_policy() -> ResolvedMcmcPolicy:
         burn_steps=2,
         retained_steps=3,
         walkers=8,
+        expert_provenance="qualification-test-expert",
     ).resolve(dimension=2, root_seed=1234)
 
 
-def test_calibrated_policy_resolves_the_complete_prospective_run() -> None:
-    policy = CalibratedMcmcPolicy(
+def _same_semantics_foreign_occurrence(
+    accepted: AcceptedFitResult,
+) -> AcceptedFitResult:
+    return AcceptedFitResult.for_qualification(
+        occurrence_identity="foreign-accepted-occurrence",
+        problem_identity=accepted.problem_identity,
+        invocation_identity=accepted.invocation_identity,
+        execution_identity=accepted.execution_identity,
+        materialization_identity=accepted.materialization_identity,
+        parameterization_identity=accepted.parameterization_identity,
+        evaluator_parameterization_identity=(
+            accepted.evaluator_parameterization_identity
+        ),
+        source_occurrence_identity=accepted.source_occurrence_identity,
+        source_revision=accepted.source_revision,
+        controlled_ids=accepted.controlled_ids,
+        vector=accepted.vector,
+        chi_square=accepted.chi_square,
+        evaluation_result=accepted.evaluation_result,
+        commit_scope=accepted.commit_scope,
+        commit_items=accepted.commit_items,
+        origin_context_identity=accepted.origin_context_identity,
+    )
+
+
+def test_arbitrary_settings_cannot_mint_calibrated_authority() -> None:
+    with pytest.raises(McmcConstructionError, match="repository-frozen calibration"):
+        ResolvedMcmcPolicy(
+            kind=McmcPolicyKind.CALIBRATED,
+            policy_version="caller-labelled-calibrated",
+            dimension=2,
+            walkers=12,
+            burn_steps=20,
+            retained_steps=40,
+            root_seed=1234,
+            provenance_identity="caller-labelled-settings",
+            qualification_dimension_range=(1, 3),
+        )
+
+
+def test_foreign_calibration_reference_cannot_authorize_policy() -> None:
+    reference = McmcCalibrationReference(
+        calibration_identity="future-calibration-release",
+        baseline_release_identity="future-baseline-release",
+        numerical_lane_requirement="canonical-python-3.13-x86-64",
         policy_version="bounded-analytic-v1",
         minimum_dimension=1,
         maximum_dimension=3,
@@ -186,11 +258,26 @@ def test_calibrated_policy_resolves_the_complete_prospective_run() -> None:
         burn_steps=20,
         retained_steps=40,
     )
+    policy = CalibratedMcmcPolicy(reference, authority=object())
 
-    resolved = policy.resolve(dimension=2, root_seed=0x1234_5678_90AB_CDEF)
+    with pytest.raises(McmcConstructionError, match="calibration reference"):
+        policy.resolve(dimension=2, root_seed=0x1234_5678_90AB_CDEF)
 
-    assert resolved.kind is McmcPolicyKind.CALIBRATED
-    assert resolved.policy_version == "bounded-analytic-v1"
+
+def test_provisional_calibration_candidate_is_explicitly_unqualified() -> None:
+    policy = CalibrationCandidateMcmcPolicy(
+        candidate_identity="candidate-bounded-analytic-v1",
+        minimum_dimension=1,
+        maximum_dimension=3,
+        walkers=12,
+        burn_steps=20,
+        retained_steps=40,
+    )
+
+    resolved = policy.resolve(dimension=2, root_seed=1234)
+
+    assert resolved.kind is McmcPolicyKind.CALIBRATION_CANDIDATE
+    assert not resolved.has_calibrated_adequacy
     assert resolved.qualification_dimension_range == (1, 3)
     assert resolved.dimension == 2
     assert resolved.walkers == 12
@@ -202,7 +289,7 @@ def test_calibrated_policy_resolves_the_complete_prospective_run() -> None:
     assert resolved.proposal is ProposalKind.STRETCH
     assert resolved.proposal_scale == 2.0
     assert resolved.objective_request_budget == 12 * 61
-    assert resolved.root_seed == 0x1234_5678_90AB_CDEF
+    assert resolved.root_seed == 1234
     assert resolved.initialization_seed != resolved.sampler_seed
     assert resolved.identity
 
@@ -212,12 +299,15 @@ def test_expert_policy_only_overrides_predeclared_topology() -> None:
         burn_steps=7,
         retained_steps=13,
         walkers=8,
+        expert_provenance="user-declared-expert-settings",
     )
 
     resolved = policy.resolve(dimension=2, root_seed=99)
 
     assert resolved.kind is McmcPolicyKind.EXPERT
     assert resolved.policy_version == "expert-v1"
+    assert resolved.provenance_identity == "user-declared-expert-settings"
+    assert not resolved.has_calibrated_adequacy
     assert resolved.qualification_dimension_range is None
     assert resolved.burn_steps == 7
     assert resolved.retained_steps == 13
@@ -228,9 +318,9 @@ def test_expert_policy_only_overrides_predeclared_topology() -> None:
     assert resolved.objective_request_budget == 8 * 21
 
 
-def test_calibrated_policy_fails_closed_outside_its_qualified_stratum() -> None:
-    policy = CalibratedMcmcPolicy(
-        policy_version="bounded-analytic-v1",
+def test_calibration_candidate_fails_closed_outside_its_declared_stratum() -> None:
+    policy = CalibrationCandidateMcmcPolicy(
+        candidate_identity="bounded-analytic-candidate-v1",
         minimum_dimension=1,
         maximum_dimension=2,
         walkers=8,
@@ -238,7 +328,7 @@ def test_calibrated_policy_fails_closed_outside_its_qualified_stratum() -> None:
         retained_steps=20,
     )
 
-    with pytest.raises(McmcConstructionError, match="No calibrated MCMC policy"):
+    with pytest.raises(McmcConstructionError, match="does not cover"):
         policy.resolve(dimension=3, root_seed=1)
 
 
@@ -288,6 +378,26 @@ def test_initial_ensemble_rejects_nonfinite_or_empty_bounds(
         build_bounded_latin_hypercube(lower, upper, walkers=4, seed=1)
 
 
+@pytest.mark.parametrize("seed", (True, -1, 1 << 64, 1.5, np.nan))
+def test_initial_ensemble_rejects_noncanonical_seed(seed: object) -> None:
+    with pytest.raises(McmcConstructionError, match="unsigned 64-bit seed"):
+        build_bounded_latin_hypercube((0.0,), (1.0,), walkers=4, seed=cast("int", seed))
+
+
+def test_initial_ensemble_rejects_transposed_or_unrepresentably_narrow_bounds() -> None:
+    with pytest.raises(McmcConstructionError, match="finite strictly ordered bounds"):
+        build_bounded_latin_hypercube(
+            cast("tuple[float, ...]", ((0.0, 1.0),)),
+            cast("tuple[float, ...]", ((2.0, 3.0),)),
+            walkers=4,
+            seed=1,
+        )
+    lower = 1.0
+    upper = float(np.nextafter(lower, np.inf))
+    with pytest.raises(McmcConstructionError, match="closed bound"):
+        build_bounded_latin_hypercube((lower,), (upper,), walkers=4, seed=1)
+
+
 def test_plan_binds_initial_ensemble_to_exact_accepted_native_lineage() -> None:
     accepted, problem, parameterization, engine = _native_context()
 
@@ -304,6 +414,18 @@ def test_plan_binds_initial_ensemble_to_exact_accepted_native_lineage() -> None:
     )
 
     assert plan.accepted_result_identity == accepted.identity
+    assert plan.anchor.accepted_occurrence_identity == accepted.occurrence_identity
+    assert (
+        plan.anchor.source_occurrence_identity
+        == problem.source_snapshot.occurrence_identity
+    )
+    assert plan.anchor.source_revision == problem.source_snapshot.revision
+    assert plan.anchor.evaluation_plan_identity == engine.plan.identity
+    assert plan.anchor.parameterization_identity == parameterization.identity
+    assert plan.anchor.held_items == problem.held_items
+    assert (
+        plan.anchor.affine_feasibility_identity == problem.affine_feasibility_identity
+    )
     assert accepted.vector != problem.start
     assert plan.problem_identity == problem.identity
     assert plan.coordinate_ids == ("A", "B")
@@ -321,6 +443,45 @@ def test_plan_binds_initial_ensemble_to_exact_accepted_native_lineage() -> None:
         )
     )
     assert plan.identity
+
+
+def test_plan_rejects_foreign_problem_parameterization_and_coordinate_order() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    policy = _resolved_policy()
+    units = (
+        ("A", ParameterUnit.DIMENSIONLESS),
+        ("B", ParameterUnit.DIMENSIONLESS),
+    )
+    foreign_problem = dataclasses.replace(problem, start=(0.75, 1.5))
+    foreign_parameterization = dataclasses.replace(parameterization, source_revision=5)
+
+    with pytest.raises(McmcConstructionError, match="exact accepted native lineage"):
+        McmcPlan.for_accepted(
+            accepted,
+            source_problem=foreign_problem,
+            parameterization=parameterization,
+            source_engine=engine,
+            policy=policy,
+            coordinate_units=units,
+        )
+    with pytest.raises(McmcConstructionError, match="exact accepted native lineage"):
+        McmcPlan.for_accepted(
+            accepted,
+            source_problem=problem,
+            parameterization=foreign_parameterization,
+            source_engine=engine,
+            policy=policy,
+            coordinate_units=units,
+        )
+    with pytest.raises(McmcConstructionError, match="coordinate units"):
+        McmcPlan.for_accepted(
+            accepted,
+            source_problem=problem,
+            parameterization=parameterization,
+            source_engine=engine,
+            policy=policy,
+            coordinate_units=tuple(reversed(units)),
+        )
 
 
 def test_complete_chain_is_primary_and_flat_samples_are_derived_views() -> None:
@@ -386,21 +547,12 @@ def test_complete_chain_is_primary_and_flat_samples_are_derived_views() -> None:
         rtol=0.0,
         atol=1.0e-14,
     )
-    np.testing.assert_allclose(
-        evidence.states[-1].positions,
-        (
-            (0.22193955880807614, 1.2886666343140305),
-            (0.9121794119730182, 2.2579167141311447),
-            (1.8830633726465182, 1.5610464161494841),
-            (1.383428732177615, 1.1821818901130026),
-            (1.1957090816652476, 1.6603544159276828),
-            (1.2211689734419329, 2.26568078108725),
-            (1.1292648992933922, 1.9097405704768293),
-            (0.029980653967193294, 2.8508821421336843),
-        ),
-        rtol=0.0,
-        atol=1.0e-14,
-    )
+    # A local seeded replay is ordinary capture evidence only. It is not a
+    # canonical trajectory claim without the #588 live-lane authority and an
+    # independently frozen reference.
+    assert replay.evidence.states == evidence.states
+    assert evidence.trajectory_claim is McmcTrajectoryClaim.ORDINARY_CAPTURE
+    assert not evidence.canonical_lane_qualified
 
     retained = derive_retained_sample_view(evidence)
     assert retained.source_evidence_identity == evidence.identity
@@ -416,6 +568,8 @@ def test_complete_chain_is_primary_and_flat_samples_are_derived_views() -> None:
     assert diagnostics.source_evidence_identity == evidence.identity
     assert diagnostics.state_ordinals == (1, 2, 3, 4, 5)
     assert diagnostics.walker_ordinals == tuple(range(plan.policy.walkers))
+    assert diagnostics.acceptance_fractions is not None
+    assert diagnostics.mean_acceptance_fraction is not None
     assert len(diagnostics.acceptance_fractions) == plan.policy.walkers
     assert 0.0 <= diagnostics.mean_acceptance_fraction <= 1.0
 
@@ -475,7 +629,12 @@ def test_primary_chain_evidence_round_trips_and_rejects_tampering() -> None:
     evidence = operation.evidence
 
     record = evidence.to_record()
-    restored = McmcEvidence.from_record(record, plan=plan)
+    assert operation.raw_capture is not None
+    restored = McmcEvidence.from_record(
+        record,
+        plan=plan,
+        raw_capture=operation.raw_capture,
+    )
 
     assert restored.identity == evidence.identity
     assert restored.states == evidence.states
@@ -486,4 +645,411 @@ def test_primary_chain_evidence_round_trips_and_rejects_tampering() -> None:
     positions = cast("list[list[str]]", states[1]["positions"])
     positions[0][0] = float(float.fromhex(positions[0][0]) + 0.1).hex()
     with pytest.raises(McmcConstructionError, match="identity"):
-        McmcEvidence.from_record(tampered, plan=plan)
+        McmcEvidence.from_record(
+            tampered,
+            plan=plan,
+            raw_capture=operation.raw_capture,
+        )
+
+
+def test_execution_rejects_same_semantics_from_foreign_accepted_occurrence() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=_resolved_policy(),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    foreign = _same_semantics_foreign_occurrence(accepted)
+    assert foreign.identity == accepted.identity
+    assert foreign.occurrence_identity != accepted.occurrence_identity
+
+    with pytest.raises(McmcConstructionError, match="accepted occurrence"):
+        execute_mcmc_evidence(foreign, plan)
+
+
+def test_fresh_validation_rejects_tampered_backend_log_density() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=_resolved_policy(),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.raw_capture is not None
+    first = operation.raw_capture.states[0]
+    tampered_first = dataclasses.replace(
+        first,
+        log_densities=(first.log_densities[0] + 1.0, *first.log_densities[1:]),
+    )
+    with pytest.raises(McmcConstructionError, match="transition"):
+        dataclasses.replace(
+            operation.raw_capture,
+            states=(tampered_first, *operation.raw_capture.states[1:]),
+        )
+
+
+def test_fresh_validator_rejects_backend_originated_log_density_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accepted, plan = _plan_context()
+    original = native_mcmc._ensemble_state
+
+    def wrong_backend_density(
+        ordinal: int,
+        positions: Array,
+        log_densities: Array,
+        accepted_mask: Array | None,
+    ) -> EnsembleState:
+        state = original(ordinal, positions, log_densities, accepted_mask)
+        if ordinal != 0:
+            return state
+        return EnsembleState(
+            state.ordinal,
+            state.positions,
+            (state.log_densities[0] + 1.0, *state.log_densities[1:]),
+            state.accepted,
+        )
+
+    monkeypatch.setattr(native_mcmc, "_ensemble_state", wrong_backend_density)
+
+    operation = execute_mcmc_evidence(accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.FAILED
+    assert operation.evidence is None
+    assert operation.validation is not None
+    assert operation.validation.failures[0].category == "backend_log_density_mismatch"
+
+
+def _plan_context() -> tuple[AcceptedFitResult, McmcPlan]:
+    accepted, problem, parameterization, engine = _native_context()
+    return accepted, McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=_resolved_policy(),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+
+
+def test_cancellation_before_initialization_freezes_zero_state_operation() -> None:
+    accepted, plan = _plan_context()
+    cancellation = CancellationToken()
+    cancellation.cancel()
+
+    operation = execute_mcmc_evidence(
+        accepted,
+        plan,
+        cancellation=cancellation,
+    )
+
+    assert operation.terminal is McmcOperationTerminal.CANCELLED
+    assert operation.complete_state_count == 0
+    assert operation.stage is McmcExecutionStage.BEFORE_INITIALIZATION
+    assert operation.evidence is None
+    assert operation.raw_capture is not None
+    assert operation.raw_capture.policy_identity == plan.policy.identity
+    assert operation.raw_capture.root_seed == plan.policy.root_seed
+    assert (
+        operation.raw_capture.initialization_outcome
+        is McmcInitializationOutcome.CANCELLED
+    )
+    diagnostics = derive_mcmc_operation_diagnostics(operation)
+    assert diagnostics.status is McmcDiagnosticStatus.UNAVAILABLE
+    assert diagnostics.reason is McmcDiagnosticReason.NO_TRANSITIONS
+
+
+@pytest.mark.parametrize(
+    ("target_stage", "terminal", "category"),
+    (
+        (
+            McmcExecutionStage.INITIALIZING,
+            McmcOperationTerminal.INTERRUPTED,
+            "interrupted",
+        ),
+        (
+            McmcExecutionStage.BEFORE_TRANSITION,
+            McmcOperationTerminal.CANCELLED,
+            "cancelled",
+        ),
+        (
+            McmcExecutionStage.DURING_TRANSITION,
+            McmcOperationTerminal.INTERRUPTED,
+            "interrupted",
+        ),
+    ),
+)
+def test_zero_or_initial_state_terminal_checkpoints_are_truthful(
+    target_stage: McmcExecutionStage,
+    terminal: McmcOperationTerminal,
+    category: str,
+) -> None:
+    accepted, plan = _plan_context()
+    cancellation = CancellationToken()
+
+    def stop(stage: McmcExecutionStage, _count: int) -> None:
+        if stage is not target_stage:
+            return
+        if terminal is McmcOperationTerminal.CANCELLED:
+            cancellation.cancel()
+        else:
+            raise KeyboardInterrupt
+
+    operation = execute_mcmc_evidence(
+        accepted,
+        plan,
+        cancellation=cancellation,
+        checkpoint_observer=stop,
+    )
+
+    assert operation.terminal is terminal
+    assert operation.failure_category == category
+    assert operation.stage is target_stage
+    expected_count = 0 if target_stage is McmcExecutionStage.INITIALIZING else 1
+    assert operation.complete_state_count == expected_count
+
+
+def test_initialization_failure_and_later_failure_preserve_only_complete_prefix() -> (
+    None
+):
+    accepted, plan = _plan_context()
+
+    def fail_initialization(stage: McmcExecutionStage, _count: int) -> None:
+        if stage is McmcExecutionStage.INITIALIZING:
+            raise RuntimeError("initialization failure")
+
+    initial_failure = execute_mcmc_evidence(
+        accepted,
+        plan,
+        checkpoint_observer=fail_initialization,
+    )
+    assert initial_failure.terminal is McmcOperationTerminal.FAILED
+    assert initial_failure.complete_state_count == 0
+    assert initial_failure.evidence is None
+    assert initial_failure.raw_capture is not None
+    assert (
+        initial_failure.raw_capture.initialization_outcome
+        is McmcInitializationOutcome.FAILED
+    )
+
+    def fail_after_two_transitions(stage: McmcExecutionStage, count: int) -> None:
+        if stage is McmcExecutionStage.AFTER_COMPLETE_STATE and count == 3:
+            raise RuntimeError("later failure")
+
+    later_failure = execute_mcmc_evidence(
+        accepted,
+        plan,
+        checkpoint_observer=fail_after_two_transitions,
+    )
+    assert later_failure.terminal is McmcOperationTerminal.FAILED
+    assert later_failure.complete_state_count == 3
+    assert later_failure.evidence is not None
+    assert tuple(state.ordinal for state in later_failure.evidence.states) == (0, 1, 2)
+
+
+def test_cancellation_after_complete_state_and_before_final_assembly() -> None:
+    accepted, plan = _plan_context()
+    cancellation = CancellationToken()
+
+    def cancel_after_one_transition(stage: McmcExecutionStage, count: int) -> None:
+        if stage is McmcExecutionStage.AFTER_COMPLETE_STATE and count == 2:
+            cancellation.cancel()
+
+    partial = execute_mcmc_evidence(
+        accepted,
+        plan,
+        cancellation=cancellation,
+        checkpoint_observer=cancel_after_one_transition,
+    )
+    assert partial.terminal is McmcOperationTerminal.CANCELLED
+    assert partial.complete_state_count == 2
+    assert partial.evidence is not None
+    assert tuple(state.ordinal for state in partial.evidence.states) == (0, 1)
+
+    final_cancellation = CancellationToken()
+
+    def cancel_final(stage: McmcExecutionStage, _count: int) -> None:
+        if stage is McmcExecutionStage.BEFORE_FINAL_ASSEMBLY:
+            final_cancellation.cancel()
+
+    final = execute_mcmc_evidence(
+        accepted,
+        plan,
+        cancellation=final_cancellation,
+        checkpoint_observer=cancel_final,
+    )
+    assert final.terminal is McmcOperationTerminal.CANCELLED
+    assert final.complete_state_count == plan.policy.total_steps + 1
+    assert final.evidence is not None
+    assert final.evidence.lifecycle is McmcEvidenceLifecycle.PARTIAL
+
+
+def test_zero_transition_acceptance_is_typed_unavailable() -> None:
+    accepted, plan = _plan_context()
+    cancellation = CancellationToken()
+
+    def cancel_before_transition(stage: McmcExecutionStage, _count: int) -> None:
+        if stage is McmcExecutionStage.BEFORE_TRANSITION:
+            cancellation.cancel()
+
+    operation = execute_mcmc_evidence(
+        accepted,
+        plan,
+        cancellation=cancellation,
+        checkpoint_observer=cancel_before_transition,
+    )
+    assert operation.evidence is not None
+
+    diagnostics = derive_mcmc_diagnostics(operation.evidence)
+
+    assert diagnostics.status is McmcDiagnosticStatus.UNAVAILABLE
+    assert diagnostics.reason is McmcDiagnosticReason.NO_TRANSITIONS
+    assert diagnostics.acceptance_fractions is None
+    assert diagnostics.mean_acceptance_fraction is None
+
+
+def test_complete_scope_posterior_outcomes_and_summary_are_canonical() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.evidence is not None
+    selection = derive_retained_sample_view(operation.evidence)
+
+    posterior = derive_posterior_sample_evidence(
+        selection,
+        (
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    summary = derive_posterior_summary(posterior)
+
+    assert (
+        tuple((item.state_ordinal, item.walker_ordinal) for item in posterior.outcomes)
+        == selection.sample_indices
+    )
+    assert all(
+        item.disposition is PosteriorSampleDisposition.SUCCESS
+        and item.resolved_items is not None
+        and tuple(key for key, _value in item.resolved_items) == ("A", "B")
+        for item in posterior.outcomes
+    )
+    assert summary.included_labels == selection.sample_indices
+    assert not summary.excluded_labels
+    assert len(summary.parameter_summaries) == 2
+    assert all(
+        item.credible_interval_name == "equal_tailed_95_percent"
+        and item.posterior_standard_deviation >= 0.0
+        and item.autocorrelation_time.status is McmcDiagnosticStatus.UNAVAILABLE
+        for item in summary.parameter_summaries
+    )
+    assert len(summary.covariance) == 4
+    assert len(summary.correlations) == 4
+
+    with pytest.raises(McmcConstructionError, match="witness"):
+        dataclasses.replace(summary, included_labels=())
+
+
+def test_posterior_samples_combine_exact_held_values_before_scope_projection() -> None:
+    accepted, problem, parameterization, engine = _native_context(fit_b=False)
+    policy = ExpertMcmcPolicy(
+        burn_steps=1,
+        retained_steps=2,
+        walkers=4,
+        expert_provenance="held-value-qualification",
+    ).resolve(dimension=1, root_seed=9876)
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=policy,
+        coordinate_units=(("A", ParameterUnit.DIMENSIONLESS),),
+    )
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.evidence is not None
+    selection = derive_retained_sample_view(operation.evidence)
+
+    posterior = derive_posterior_sample_evidence(
+        selection,
+        (
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+
+    assert all(
+        outcome.resolved_items is not None and dict(outcome.resolved_items)["B"] == 1.5
+        for outcome in posterior.outcomes
+    )
+
+
+def test_primary_tampering_cannot_reach_any_derived_posterior_artifact() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.evidence is not None
+    evidence = operation.evidence
+    with pytest.raises(McmcConstructionError, match="contiguous"):
+        dataclasses.replace(
+            evidence,
+            states=(evidence.states[0], *reversed(evidence.states[1:])),
+        )
+
+
+def test_all_operation_and_posterior_paths_preserve_source_values_bitwise() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=_resolved_policy(),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    before = problem.source_snapshot.to_json()
+    completed = execute_mcmc_evidence(accepted, plan)
+    cancellation = CancellationToken()
+    cancellation.cancel()
+    cancelled = execute_mcmc_evidence(accepted, plan, cancellation=cancellation)
+
+    def interrupt(stage: McmcExecutionStage, _count: int) -> None:
+        if stage is McmcExecutionStage.INITIALIZING:
+            raise KeyboardInterrupt
+
+    interrupted = execute_mcmc_evidence(
+        accepted,
+        plan,
+        checkpoint_observer=interrupt,
+    )
+    assert completed.evidence is not None
+    selection = derive_retained_sample_view(completed.evidence)
+    posterior = derive_posterior_sample_evidence(
+        selection,
+        (
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    derive_posterior_summary(posterior)
+
+    assert cancelled.terminal is McmcOperationTerminal.CANCELLED
+    assert interrupted.terminal is McmcOperationTerminal.INTERRUPTED
+    assert problem.source_snapshot.to_json() == before
+    assert accepted.vector == (1.0, 2.0)


### PR DESCRIPTION
# Add native MCMC evidence

Closes #600.

## Summary

Adds an isolated native MCMC evidence path with prospective fixed-topology policies, deterministic bounded initialization, complete ensemble-state preservation, typed partial evidence, and non-mutating posterior summaries.

The implementation supports:

* explicit expert and provisional/calibration-candidate policies;
* bounded Latin-hypercube initialization;
* explicit deterministic seeds and fixed budgets;
* complete ensemble states and authoritative log densities;
* contiguous partial-prefix preservation;
* labeled retained selections;
* complete-scope posterior sample outcomes;
* typed diagnostics and posterior summaries.

MCMC evidence remains separate from central parameter estimates and cannot mutate committed `AnalysisValues`.

## Policy and initialization

Each MCMC plan resolves its complete topology before execution, including:

* sampled coordinate scope and units;
* finite strictly ordered bounds;
* walker count;
* burn and retained windows;
* thinning and walker selection;
* proposal settings;
* initialization policy;
* budgets;
* root seed;
* numerical compatibility requirements.

Initialization uses deterministic bounded Latin-hypercube construction in canonical external-coordinate order.

Arbitrary settings cannot claim calibrated scientific authority. Expert and provisional policies remain explicitly distinct from future calibrated policies, whose qualified constants and supported strata are left to #604.

## Exact accepted-point ownership

Every MCMC occurrence is bound to the exact accepted fit occurrence, snapshot/revision, optimization problem, parameterization, evaluation plan, held values, feasibility context, and sampled-coordinate ordering.

Semantically equivalent accepted results from another occurrence cannot be substituted.

## Primary chain evidence

Sampler output is treated as execution capture rather than self-certifying scientific truth.

Complete walker positions are freshly validated through the exact native scientific problem using isolated evaluator/workspace state. Authoritative log densities are derived from the declared prior and freshly evaluated likelihood rather than trusted from arbitrary backend arrays.

Primary evidence preserves:

* complete ensemble-state topology;
* state and walker labels;
* complete positions;
* authoritative log densities;
* exact source policy/request identities;
* lifecycle and partial-prefix provenance.

Reconstruction, `dataclasses.replace()`, post-construction mutation, and serialized tampering cannot make inconsistent chain evidence valid.

## Partial evidence and interruption

Cancellation, interruption, and failure preserve truthful immutable operation evidence.

Only a contiguous prefix of complete ensemble states may enter primary evidence. An incomplete transition never manufactures a complete state using placeholders or NaNs.

Zero-state operations retain typed provenance rather than returning no evidence.

## Backend acceptance diagnostics

Backend acceptance masks are diagnostic evidence only; they do not determine primary chain scientific validity.

Actual live emcee execution owns `OBSERVED_EXECUTION` transition evidence through an execution-specific opaque authority boundary.

Arbitrary caller-supplied masks cannot claim live backend observation.

After serialization/deserialization, acceptance-mask evidence becomes `HISTORICAL_OBSERVATION`: the payload remains available as historical evidence, but it cannot recreate live observation authority or produce currently verified acceptance fractions.

Zero-transition and unverified historical cases produce typed unavailable diagnostics rather than fabricated `0.0` values.

## Retained samples and posterior evidence

Burn-in, thinning, state selection, and walker selection are represented as separate labeled immutable views over the primary chain.

Derived posterior samples preserve exact state/walker labels.

For requested joint output scopes, sampled independent coordinates are combined with exact held values and resolved through the ordinary constraint program for every selected state.

A sample is included only when the complete requested scope resolves successfully.

No:

* parameter-wise NaN filtering;
* pairwise deletion;
* hidden sample-specific denominators.

## Diagnostics and summaries

Posterior diagnostics and summaries are separate derived evidence artifacts tied to their exact source chain and retained selection.

They include typed handling for:

* acceptance fractions;
* integrated autocorrelation;
* effective sample size;
* Monte Carlo standard error;
* posterior covariance and correlation;
* quantiles and credible intervals;
* posterior standard deviation.

Short chains that do not satisfy the declared autocorrelation reliability criterion yield `UNRELIABLE_AUTOCORRELATION`; dependent ESS and MCSE remain unavailable.

A sufficiently long chain produces available autocorrelation, ESS, and MCSE derived from the same exact retained selection.

Posterior dispersion is not exposed as generic `stderr`.

## Numerical qualification

Qualification includes:

* independent analytic log-density verification;
* deterministic bounded initialization;
* seeded trajectory checks;
* state/log-density reconstruction attacks;
* exact accepted-occurrence substitution attacks;
* cancellation and partial-prefix cases;
* zero-state evidence;
* historical/live backend-observation separation;
* posterior complete-scope resolution;
* unreliable and reliable autocorrelation cases.

## Scope

This remains an isolated native qualification API.

No changes to:

* production MCMC dispatch;
* CLI or TOML;
* output/reporting;
* parameter identifiers;
* legacy MCMC behavior;
* covariance or resampling evidence;
* committed central parameter values.

No MCMC artifact receives `AcceptedFitResult`, commit authority, or implicit posterior-median promotion semantics.

## Validation

Final independent adversarial review: **MERGE**

* Standards: 0 Blocking/Important findings
* Spec: 0 Blocking/Important findings

Final focused validation:

* native MCMC tests: **58 passed**
* `ty`: passed
* Ruff lint and format checks: passed
* `git diff --check`: passed

Earlier full-suite validation during implementation reached **824 passed**, with one existing non-failing `emcee` autocorrelation warning.

Graphify was refreshed during implementation.
