### PR TITLE
Publish native committed results and typed evidence at the step root

### DIFF
--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -18,7 +18,7 @@ from numbers import Real
 from threading import Event, RLock
 from typing import SupportsIndex, cast
 from uuid import uuid4
-from weakref import WeakKeyDictionary
+from weakref import ReferenceType, WeakKeyDictionary, ref
 
 import numpy as np
 from scipy.optimize import least_squares
@@ -1615,6 +1615,7 @@ class _AcceptedOccurrenceWitness(_OpaqueOccurrenceWitness):
 class _OccurrenceWitnessBinding:
     occurrence_identity: str
     artifact_identity: str | None = None
+    artifact_reference: ReferenceType[object] | None = None
 
 
 class _OccurrenceWitnessRegistry[WitnessT]:
@@ -1637,7 +1638,10 @@ class _OccurrenceWitnessRegistry[WitnessT]:
         witness: WitnessT,
         occurrence_identity: str,
         artifact_identity: str,
+        *,
+        artifact_object: object | None = None,
     ) -> bool:
+        artifact_reference = None if artifact_object is None else ref(artifact_object)
         with self._lock:
             binding = self._bindings.get(witness)
             if binding is None or binding.occurrence_identity != occurrence_identity:
@@ -1646,20 +1650,40 @@ class _OccurrenceWitnessRegistry[WitnessT]:
                 self._bindings[witness] = _OccurrenceWitnessBinding(
                     occurrence_identity,
                     artifact_identity,
+                    artifact_reference,
                 )
                 return True
-            return binding.artifact_identity == artifact_identity
+            return (
+                binding.occurrence_identity == occurrence_identity
+                and binding.artifact_identity == artifact_identity
+                and (
+                    binding.artifact_reference is None
+                    if artifact_object is None
+                    else binding.artifact_reference is not None
+                    and binding.artifact_reference() is artifact_object
+                )
+            )
 
     def is_bound(
         self,
         witness: WitnessT,
         occurrence_identity: str,
         artifact_identity: str,
+        *,
+        artifact_object: object | None = None,
     ) -> bool:
         with self._lock:
-            return self._bindings.get(witness) == _OccurrenceWitnessBinding(
-                occurrence_identity,
-                artifact_identity,
+            binding = self._bindings.get(witness)
+            return (
+                binding is not None
+                and binding.occurrence_identity == occurrence_identity
+                and binding.artifact_identity == artifact_identity
+                and (
+                    binding.artifact_reference is None
+                    if artifact_object is None
+                    else binding.artifact_reference is not None
+                    and binding.artifact_reference() is artifact_object
+                )
             )
 
 
@@ -2057,15 +2081,18 @@ def _bind_fit_commit_operation_witness(
     witness: _FitCommitOperationWitness,
     occurrence_identity: str,
     operation_identity: str,
+    *,
+    artifact_object: object,
 ) -> bool:
     return _FIT_COMMIT_OPERATION_WITNESSES.bind(
         witness,
         occurrence_identity,
         operation_identity,
+        artifact_object=artifact_object,
     )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class FitCommitOperation:
     """Frozen occurrence-exact result of one attempted atomic fit commit."""
 
@@ -2075,6 +2102,11 @@ class FitCommitOperation:
     problem_identity: str
     terminal: FitCommitTerminal
     receipt: CommitReceipt | None = None
+    committed_snapshot: AnalysisValuesSnapshot | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     failure: FitCommitFailure | None = None
     _occurrence_witness: _FitCommitOperationWitness | None = field(
         default=None,
@@ -2089,6 +2121,7 @@ class FitCommitOperation:
         if (
             not self.occurrence_identity
             or committed != (self.receipt is not None)
+            or committed != (self.committed_snapshot is not None)
             or committed == (self.failure is not None)
         ):
             raise ValueError("Fit commit operation lacks its exact terminal payload")
@@ -2117,6 +2150,7 @@ class FitCommitOperation:
                 self._occurrence_witness,
                 self.occurrence_identity,
                 identity,
+                artifact_object=self,
             )
 
     def to_record(self) -> dict[str, object]:
@@ -2152,6 +2186,7 @@ def fit_commit_operation_is_authoritative(operation: FitCommitOperation) -> bool
         witness,
         operation.occurrence_identity,
         operation.identity,
+        artifact_object=operation,
     )
 
 
@@ -3631,5 +3666,6 @@ def execute_fit_commit(
         problem.identity,
         FitCommitTerminal.COMMITTED,
         receipt=receipt,
+        committed_snapshot=analysis_values.snapshot(),
         _occurrence_witness=witness,
     )

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -39,7 +39,11 @@ from chemex.parameters.parameterization import (
 from chemex.parameters.sealed import SealedConfiguration
 from chemex.parameters.values import (
     AnalysisValues,
+    AnalysisValuesCommitError,
     AnalysisValuesSnapshot,
+    IncompatibleAnalysisValuesError,
+    InvalidAnalysisValuesCommitError,
+    StaleAnalysisValuesError,
 )
 from chemex.typing import Array
 
@@ -1580,52 +1584,97 @@ class GridSelectionProvenance:
         )
 
 
-class _AcceptedOccurrenceWitness:
-    """Opaque process-local witness for one accepted-result occurrence."""
+class _OpaqueOccurrenceWitness:
+    """Noncopyable, nonserializable base for process-local occurrence witnesses."""
 
     __slots__ = ("__weakref__",)
 
-    def __new__(cls) -> _AcceptedOccurrenceWitness:
-        raise TypeError(
-            "Accepted occurrence witnesses are minted only by Direct TRF or "
-            "the isolated qualification constructor"
-        )
+    def __new__(cls) -> _OpaqueOccurrenceWitness:
+        raise TypeError("Occurrence witnesses are minted only by native execution")
 
-    def __copy__(self) -> _AcceptedOccurrenceWitness:
-        raise TypeError("Accepted occurrence witnesses cannot be copied")
+    def __copy__(self) -> _OpaqueOccurrenceWitness:
+        raise TypeError("Occurrence witnesses cannot be copied")
 
-    def __deepcopy__(self, _memo: object) -> _AcceptedOccurrenceWitness:
-        raise TypeError("Accepted occurrence witnesses cannot be copied")
+    def __deepcopy__(self, _memo: object) -> _OpaqueOccurrenceWitness:
+        raise TypeError("Occurrence witnesses cannot be copied")
 
     def __reduce__(self) -> tuple[object, ...]:
-        raise TypeError("Accepted occurrence witnesses cannot be serialized")
+        raise TypeError("Occurrence witnesses cannot be serialized")
 
     def __reduce_ex__(self, _protocol: SupportsIndex, /) -> tuple[object, ...]:
-        raise TypeError("Accepted occurrence witnesses cannot be serialized")
+        raise TypeError("Occurrence witnesses cannot be serialized")
+
+
+class _AcceptedOccurrenceWitness(_OpaqueOccurrenceWitness):
+    """Opaque process-local witness for one accepted-result occurrence."""
+
+    __slots__ = ()
 
 
 @dataclass(frozen=True, slots=True)
-class _AcceptedOccurrenceBinding:
+class _OccurrenceWitnessBinding:
     occurrence_identity: str
-    accepted_result_identity: str | None = None
+    artifact_identity: str | None = None
 
 
-_ACCEPTED_OCCURRENCE_WITNESSES: WeakKeyDictionary[
-    _AcceptedOccurrenceWitness,
-    _AcceptedOccurrenceBinding,
-] = WeakKeyDictionary()
-_ACCEPTED_OCCURRENCE_WITNESSES_LOCK = RLock()
+class _OccurrenceWitnessRegistry[WitnessT]:
+    """Bind opaque witnesses to one occurrence and one immutable artifact."""
+
+    def __init__(self) -> None:
+        self._bindings: WeakKeyDictionary[WitnessT, _OccurrenceWitnessBinding] = (
+            WeakKeyDictionary()
+        )
+        self._lock = RLock()
+
+    def mint(self, witness_type: type[WitnessT], occurrence_identity: str) -> WitnessT:
+        witness = object.__new__(witness_type)
+        with self._lock:
+            self._bindings[witness] = _OccurrenceWitnessBinding(occurrence_identity)
+        return witness
+
+    def bind(
+        self,
+        witness: WitnessT,
+        occurrence_identity: str,
+        artifact_identity: str,
+    ) -> bool:
+        with self._lock:
+            binding = self._bindings.get(witness)
+            if binding is None or binding.occurrence_identity != occurrence_identity:
+                return False
+            if binding.artifact_identity is None:
+                self._bindings[witness] = _OccurrenceWitnessBinding(
+                    occurrence_identity,
+                    artifact_identity,
+                )
+                return True
+            return binding.artifact_identity == artifact_identity
+
+    def is_bound(
+        self,
+        witness: WitnessT,
+        occurrence_identity: str,
+        artifact_identity: str,
+    ) -> bool:
+        with self._lock:
+            return self._bindings.get(witness) == _OccurrenceWitnessBinding(
+                occurrence_identity,
+                artifact_identity,
+            )
+
+
+_ACCEPTED_OCCURRENCE_WITNESSES = _OccurrenceWitnessRegistry[
+    _AcceptedOccurrenceWitness
+]()
 
 
 def _mint_accepted_occurrence_witness(
     occurrence_identity: str,
 ) -> _AcceptedOccurrenceWitness:
-    witness = object.__new__(_AcceptedOccurrenceWitness)
-    with _ACCEPTED_OCCURRENCE_WITNESSES_LOCK:
-        _ACCEPTED_OCCURRENCE_WITNESSES[witness] = _AcceptedOccurrenceBinding(
-            occurrence_identity
-        )
-    return witness
+    return _ACCEPTED_OCCURRENCE_WITNESSES.mint(
+        _AcceptedOccurrenceWitness,
+        occurrence_identity,
+    )
 
 
 def _bind_accepted_occurrence_witness(
@@ -1633,17 +1682,11 @@ def _bind_accepted_occurrence_witness(
     occurrence_identity: str,
     accepted_result_identity: str,
 ) -> bool:
-    with _ACCEPTED_OCCURRENCE_WITNESSES_LOCK:
-        binding = _ACCEPTED_OCCURRENCE_WITNESSES.get(witness)
-        if binding is None or binding.occurrence_identity != occurrence_identity:
-            return False
-        if binding.accepted_result_identity is None:
-            _ACCEPTED_OCCURRENCE_WITNESSES[witness] = _AcceptedOccurrenceBinding(
-                occurrence_identity,
-                accepted_result_identity,
-            )
-            return True
-        return binding.accepted_result_identity == accepted_result_identity
+    return _ACCEPTED_OCCURRENCE_WITNESSES.bind(
+        witness,
+        occurrence_identity,
+        accepted_result_identity,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1756,9 +1799,8 @@ def accepted_occurrence_is_authoritative(accepted: AcceptedFitResult) -> bool:
     """Report whether this object retains its exact construction occurrence."""
     if accepted.occurrence_witness is None:
         return False
-    with _ACCEPTED_OCCURRENCE_WITNESSES_LOCK:
-        binding = _ACCEPTED_OCCURRENCE_WITNESSES.get(accepted.occurrence_witness)
-    return binding == _AcceptedOccurrenceBinding(
+    return _ACCEPTED_OCCURRENCE_WITNESSES.is_bound(
+        accepted.occurrence_witness,
         accepted.occurrence_identity,
         accepted.identity,
     )
@@ -1956,6 +1998,161 @@ class CommitReceipt:
                 ),
             ),
         )
+
+
+class FitCommitFailureCategory(StrEnum):
+    """Closed failure categories for one attempted fit commit."""
+
+    STALE_REVISION = "stale_revision"
+    INCOMPATIBLE_STATE = "incompatible_state"
+    INVALID_CANDIDATE = "invalid_candidate"
+
+
+@dataclass(frozen=True, slots=True)
+class FitCommitFailure:
+    """Sanitized typed reason that an atomic fit commit did not occur."""
+
+    category: FitCommitFailureCategory
+    message: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.message:
+            raise ValueError("Fit commit failure requires a message")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity("native-fit-commit-failure", (self.category.value, self.message)),
+        )
+
+
+class FitCommitTerminal(StrEnum):
+    """Terminal state of one atomic fit commit operation."""
+
+    COMMITTED = "committed"
+    FAILED = "failed"
+
+
+class _FitCommitOperationWitness(_OpaqueOccurrenceWitness):
+    """Opaque process-local witness for one fit-commit operation occurrence."""
+
+    __slots__ = ()
+
+
+_FIT_COMMIT_OPERATION_WITNESSES = _OccurrenceWitnessRegistry[
+    _FitCommitOperationWitness
+]()
+
+
+def _mint_fit_commit_operation_witness(
+    occurrence_identity: str,
+) -> _FitCommitOperationWitness:
+    return _FIT_COMMIT_OPERATION_WITNESSES.mint(
+        _FitCommitOperationWitness,
+        occurrence_identity,
+    )
+
+
+def _bind_fit_commit_operation_witness(
+    witness: _FitCommitOperationWitness,
+    occurrence_identity: str,
+    operation_identity: str,
+) -> bool:
+    return _FIT_COMMIT_OPERATION_WITNESSES.bind(
+        witness,
+        occurrence_identity,
+        operation_identity,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class FitCommitOperation:
+    """Frozen occurrence-exact result of one attempted atomic fit commit."""
+
+    occurrence_identity: str = field(compare=False)
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
+    problem_identity: str
+    terminal: FitCommitTerminal
+    receipt: CommitReceipt | None = None
+    failure: FitCommitFailure | None = None
+    _occurrence_witness: _FitCommitOperationWitness | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        kw_only=True,
+    )
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        committed = self.terminal is FitCommitTerminal.COMMITTED
+        if (
+            not self.occurrence_identity
+            or committed != (self.receipt is not None)
+            or committed == (self.failure is not None)
+        ):
+            raise ValueError("Fit commit operation lacks its exact terminal payload")
+        if self.receipt is not None and (
+            self.receipt.accepted_result_identity != self.accepted_result_identity
+            or self.receipt.accepted_occurrence_identity
+            != self.accepted_occurrence_identity
+            or self.receipt.problem_identity != self.problem_identity
+        ):
+            raise ValueError("Fit commit receipt belongs to another operation anchor")
+        identity = _identity(
+            "native-fit-commit-operation",
+            (
+                self.occurrence_identity,
+                self.accepted_result_identity,
+                self.accepted_occurrence_identity,
+                self.problem_identity,
+                self.terminal.value,
+                None if self.receipt is None else self.receipt.identity,
+                None if self.failure is None else self.failure.identity,
+            ),
+        )
+        object.__setattr__(self, "identity", identity)
+        if self._occurrence_witness is not None:
+            _bind_fit_commit_operation_witness(
+                self._occurrence_witness,
+                self.occurrence_identity,
+                identity,
+            )
+
+    def to_record(self) -> dict[str, object]:
+        """Return the typed diagnostic representation of this operation."""
+        return {
+            "artifact_type": "native_fit_commit_operation",
+            "schema_version": 1,
+            "identity": self.identity,
+            "occurrence_identity": self.occurrence_identity,
+            "accepted_result_identity": self.accepted_result_identity,
+            "accepted_occurrence_identity": self.accepted_occurrence_identity,
+            "problem_identity": self.problem_identity,
+            "terminal": self.terminal.value,
+            "receipt_identity": None if self.receipt is None else self.receipt.identity,
+            "failure": (
+                None
+                if self.failure is None
+                else {
+                    "identity": self.failure.identity,
+                    "category": self.failure.category.value,
+                    "message": self.failure.message,
+                }
+            ),
+        }
+
+
+def fit_commit_operation_is_authoritative(operation: FitCommitOperation) -> bool:
+    """Return whether execution minted this exact commit-operation occurrence."""
+    witness = operation._occurrence_witness
+    if witness is None:
+        return False
+    return _FIT_COMMIT_OPERATION_WITNESSES.is_bound(
+        witness,
+        operation.occurrence_identity,
+        operation.identity,
+    )
 
 
 class CancellationToken:
@@ -2869,6 +3066,17 @@ def _snapshot_commit_context_identity(snapshot: AnalysisValuesSnapshot) -> str:
     )
 
 
+def committed_values_identity(
+    snapshot: AnalysisValuesSnapshot,
+    scope: tuple[str, ...],
+) -> str:
+    """Return the receipt identity for committed values in an exact scope."""
+    return _identity(
+        "native-committed-values",
+        tuple((param_id, _float_token(snapshot[param_id])) for param_id in scope),
+    )
+
+
 def _mint_fit_commit_authority(
     accepted: AcceptedFitResult,
     problem: OptimizationProblem,
@@ -3362,12 +3570,9 @@ def commit_accepted_fit(
         expected=problem.source_snapshot,
         scope=problem.commit_scope,
     )
-    committed_value_identity = _identity(
-        "native-committed-values",
-        tuple(
-            (param_id, _float_token(committed[param_id]))
-            for param_id in problem.commit_scope
-        ),
+    committed_value_identity = committed_values_identity(
+        committed,
+        problem.commit_scope,
     )
     return CommitReceipt(
         accepted.occurrence_identity,
@@ -3379,4 +3584,52 @@ def commit_accepted_fit(
         committed_value_identity,
         committed.model_identity,
         committed.configuration_identity,
+    )
+
+
+def execute_fit_commit(
+    accepted: AcceptedFitResult,
+    authority: LiveFitCommitAuthority,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    analysis_values: AnalysisValues,
+) -> FitCommitOperation:
+    """Attempt one fit commit and freeze either its receipt or typed failure."""
+    occurrence_identity = uuid4().hex
+    witness = _mint_fit_commit_operation_witness(occurrence_identity)
+    try:
+        receipt = commit_accepted_fit(
+            accepted,
+            authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=analysis_values,
+        )
+    except AnalysisValuesCommitError as error:
+        if isinstance(error, StaleAnalysisValuesError):
+            category = FitCommitFailureCategory.STALE_REVISION
+        elif isinstance(error, IncompatibleAnalysisValuesError):
+            category = FitCommitFailureCategory.INCOMPATIBLE_STATE
+        elif isinstance(error, InvalidAnalysisValuesCommitError):
+            category = FitCommitFailureCategory.INVALID_CANDIDATE
+        else:  # pragma: no cover - closed subclasses above are exhaustive today
+            raise
+        return FitCommitOperation(
+            occurrence_identity,
+            accepted.identity,
+            accepted.occurrence_identity,
+            problem.identity,
+            FitCommitTerminal.FAILED,
+            failure=FitCommitFailure(category, str(error)),
+            _occurrence_witness=witness,
+        )
+    return FitCommitOperation(
+        occurrence_identity,
+        accepted.identity,
+        accepted.occurrence_identity,
+        problem.identity,
+        FitCommitTerminal.COMMITTED,
+        receipt=receipt,
+        _occurrence_witness=witness,
     )

--- a/src/chemex/optimize/native_reporting.py
+++ b/src/chemex/optimize/native_reporting.py
@@ -1,0 +1,587 @@
+"""Atomic step-root publication for native qualification results (#608).
+
+This is an isolated qualification seam.  The production CLI remains on its
+legacy reporting path until the native migration gates promote these artifacts.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+from chemex.evaluation.native import EvaluationPlan, EvaluationResult
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    CommitReceipt,
+    DirectTrfExecution,
+    DirectTrfTerminal,
+    FitCommitOperation,
+    FitCommitTerminal,
+    accepted_occurrence_is_authoritative,
+    canonical_chi_square,
+    committed_values_identity,
+    fit_commit_operation_is_authoritative,
+)
+from chemex.optimize.native_mcmc import (
+    McmcEvidence,
+    PosteriorSampleEvidence,
+    PosteriorSummary,
+)
+from chemex.optimize.native_resampling import (
+    ResamplingEvidence,
+    ResamplingSummaryOutcome,
+)
+from chemex.optimize.uncertainty import UncertaintyEvidence
+from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
+from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.plotters.native_reporting import write_native_plots
+from chemex.printers.native_reporting import (
+    write_components,
+    write_data,
+    write_mcmc,
+    write_parameter_reports,
+    write_partial_mcmc,
+    write_partial_resampling,
+    write_resampling,
+    write_statistics,
+    write_suppressed_outcome,
+    write_uncertainty,
+)
+
+
+class NativePublicationError(ValueError):
+    """Raised before publication when authoritative source artifacts disagree."""
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentDiagnostic:
+    """One explicitly non-authoritative fit-component execution view."""
+
+    identity: str
+    disposition: Literal[
+        "succeeded",
+        "failed",
+        "execution_failure",
+        "cancelled",
+        "interrupted",
+        "not_started",
+    ]
+    controlled_ids: tuple[str, ...]
+    local_chi_square: float | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            not self.identity
+            or not self.controlled_ids
+            or len(set(self.controlled_ids)) != len(self.controlled_ids)
+        ):
+            raise NativePublicationError(
+                "Component diagnostics require an identity and controlled scope"
+            )
+        if self.local_chi_square is not None and (
+            not math.isfinite(self.local_chi_square) or self.local_chi_square < 0.0
+        ):
+            raise NativePublicationError(
+                "Component diagnostic chi-square must be finite and non-negative"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingPublication:
+    """One typed resampling family and its scope-atomic summary outcome."""
+
+    evidence: ResamplingEvidence
+    summary: ResamplingSummaryOutcome
+
+
+@dataclass(frozen=True, slots=True)
+class McmcPublication:
+    """Primary chain topology plus explicitly derived posterior evidence."""
+
+    evidence: McmcEvidence
+    posterior_samples: PosteriorSampleEvidence
+    summary: PosteriorSummary
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedFitPublication:
+    """Exact committed anchor from which ordinary fitted output may be rendered."""
+
+    plan: EvaluationPlan
+    parameterization: ActiveParameterization
+    accepted: AcceptedFitResult
+    commit_receipt: CommitReceipt
+    committed_snapshot: AnalysisValuesSnapshot
+    components: tuple[ComponentDiagnostic, ...] = ()
+    uncertainty: UncertaintyEvidence | None = None
+    resampling: tuple[ResamplingPublication, ...] = ()
+    mcmc: McmcPublication | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationPublication:
+    """Authoritative evaluate-only result with no estimate or commit semantics."""
+
+    plan: EvaluationPlan
+    parameterization: ActiveParameterization
+    evaluation_result: EvaluationResult
+
+
+@dataclass(frozen=True, slots=True)
+class SuppressedPublication:
+    """Failure/uncommitted provenance with only genuine partial evidence."""
+
+    lifecycle: Literal[
+        "failed",
+        "accepted_uncommitted",
+        "cancelled",
+        "interrupted",
+    ]
+    operation: (
+        FitCommitOperation | DirectTrfExecution | ResamplingEvidence | McmcEvidence
+    )
+    accepted_result_identity: str | None = None
+    accepted_occurrence_identity: str | None = None
+    components: tuple[ComponentDiagnostic, ...] = ()
+    partial_resampling: tuple[ResamplingEvidence, ...] = ()
+    partial_mcmc: McmcEvidence | None = None
+
+
+type NativePublication = (
+    CommittedFitPublication | EvaluationPublication | SuppressedPublication
+)
+
+
+def _validate_evaluation_artifacts(
+    plan: EvaluationPlan,
+    parameterization: ActiveParameterization,
+    result: EvaluationResult,
+) -> None:
+    if (
+        result.plan_identity != plan.identity
+        or result.parameterization_identity != parameterization.evaluator_identity
+        or plan.parameterization_identity != parameterization.evaluator_identity
+        or plan.constraint_program_identity != parameterization.program.fingerprint
+    ):
+        raise NativePublicationError(
+            "Evaluation result, parameterization, and plan are incompatible"
+        )
+    try:
+        EvaluationPlan.from_record(plan.to_record())
+        EvaluationResult.from_record(result.to_record(), plan)
+    except (ArithmeticError, TypeError, ValueError) as error:
+        raise NativePublicationError(
+            "Native evaluation artifacts fail structural validation"
+        ) from error
+
+
+def _validate_evaluation_only(publication: EvaluationPublication) -> None:
+    if any(
+        publication.parameterization.role(param_id) is ParameterRole.FIT
+        for param_id in publication.parameterization.independent_ids
+    ):
+        raise NativePublicationError(
+            "Evaluate-only publication cannot contain controlled parameters"
+        )
+    _validate_evaluation_artifacts(
+        publication.plan,
+        publication.parameterization,
+        publication.evaluation_result,
+    )
+
+
+def _validate_suppressed(publication: SuppressedPublication) -> None:
+    has_partial_evidence = bool(
+        publication.partial_resampling or publication.partial_mcmc is not None
+    )
+    if (
+        publication.lifecycle == "accepted_uncommitted"
+        and (
+            not publication.accepted_result_identity
+            or not publication.accepted_occurrence_identity
+        )
+    ) or (
+        has_partial_evidence
+        and (
+            not publication.accepted_result_identity
+            or not publication.accepted_occurrence_identity
+        )
+    ):
+        raise NativePublicationError(
+            "Suppressed publication requires typed lifecycle provenance"
+        )
+    operation = publication.operation
+    commit_failure = (
+        isinstance(operation, FitCommitOperation)
+        and fit_commit_operation_is_authoritative(operation)
+        and operation.terminal is FitCommitTerminal.FAILED
+        and operation.accepted_result_identity == publication.accepted_result_identity
+        and operation.accepted_occurrence_identity
+        == publication.accepted_occurrence_identity
+    )
+    direct_terminal = (
+        operation.terminal if isinstance(operation, DirectTrfExecution) else None
+    )
+    stochastic_terminal = (
+        operation.terminal.value
+        if isinstance(operation, McmcEvidence)
+        else operation.lifecycle.value
+        if isinstance(operation, ResamplingEvidence)
+        else None
+    )
+    provenance_matches = (
+        (publication.lifecycle == "accepted_uncommitted" and commit_failure)
+        or (
+            publication.lifecycle == "failed"
+            and direct_terminal
+            not in (None, DirectTrfTerminal.CONVERGED, DirectTrfTerminal.CANCELLED)
+        )
+        or (
+            publication.lifecycle == "cancelled"
+            and (
+                direct_terminal is DirectTrfTerminal.CANCELLED
+                or stochastic_terminal == "cancelled"
+            )
+        )
+        or (
+            publication.lifecycle == "interrupted"
+            and (
+                direct_terminal is DirectTrfTerminal.INTERRUPTED
+                or stochastic_terminal == "interrupted"
+            )
+        )
+    )
+    if not provenance_matches:
+        raise NativePublicationError(
+            "Suppressed lifecycle and atomic operation provenance disagree"
+        )
+    if publication.lifecycle == "accepted_uncommitted" and has_partial_evidence:
+        raise NativePublicationError(
+            "Accepted-but-uncommitted workflows cannot start downstream evidence"
+        )
+    component_ids = tuple(item.identity for item in publication.components)
+    if len(set(component_ids)) != len(component_ids):
+        raise NativePublicationError(
+            "Suppressed component diagnostics require unique identities"
+        )
+    schemes: set[str] = set()
+    for evidence in publication.partial_resampling:
+        evidence.validate_integrity()
+        scheme = evidence.plan.scheme.value
+        if (
+            evidence.lifecycle.value == "completed"
+            or scheme in schemes
+            or evidence.plan.accepted_result_identity
+            != publication.accepted_result_identity
+            or evidence.plan.accepted_occurrence_identity
+            != publication.accepted_occurrence_identity
+        ):
+            raise NativePublicationError(
+                "Suppressed workflows may retain only genuine partial resampling"
+            )
+        schemes.add(scheme)
+    if publication.partial_mcmc is not None:
+        publication.partial_mcmc.validate_integrity()
+        if (
+            publication.partial_mcmc.lifecycle.value == "completed"
+            or publication.partial_mcmc.accepted_result_identity
+            != publication.accepted_result_identity
+            or publication.partial_mcmc.plan.accepted_occurrence_identity
+            != publication.accepted_occurrence_identity
+        ):
+            raise NativePublicationError(
+                "Suppressed workflows may retain only genuine partial MCMC evidence"
+            )
+
+
+def _validate_committed_fit(publication: CommittedFitPublication) -> None:
+    accepted = publication.accepted
+    receipt = publication.commit_receipt
+    committed = publication.committed_snapshot
+    if not accepted_occurrence_is_authoritative(accepted):
+        raise NativePublicationError(
+            "Committed publication requires an authoritative accepted occurrence"
+        )
+    if (
+        accepted.problem_identity != receipt.problem_identity
+        or accepted.identity != receipt.accepted_result_identity
+        or accepted.occurrence_identity != receipt.accepted_occurrence_identity
+        or accepted.source_revision != receipt.old_revision
+        or receipt.new_revision != receipt.old_revision + 1
+        or accepted.commit_scope != receipt.scope
+        or accepted.evaluator_parameterization_identity
+        != publication.parameterization.evaluator_identity
+        or committed.occurrence_identity != accepted.source_occurrence_identity
+        or committed.revision != receipt.new_revision
+        or committed.model_identity != receipt.model_identity
+        or committed.configuration_identity != receipt.configuration_identity
+        or committed.model_identity
+        != publication.parameterization.program.model_identity
+        or committed.definitions_identity
+        != publication.parameterization.program.definitions_identity
+        or committed.configuration_identity
+        != publication.parameterization.program.configuration_identity
+        or receipt.committed_value_identity
+        != committed_values_identity(committed, receipt.scope)
+    ):
+        raise NativePublicationError(
+            "Commit receipt does not belong to the accepted fit result"
+        )
+    if accepted.parameterization_identity != publication.parameterization.identity:
+        raise NativePublicationError(
+            "Accepted fit, parameterization, and evaluation plan are incompatible"
+        )
+    _validate_evaluation_artifacts(
+        publication.plan,
+        publication.parameterization,
+        accepted.evaluation_result,
+    )
+    if accepted.chi_square != canonical_chi_square(
+        accepted.evaluation_result.residuals
+    ):
+        raise NativePublicationError(
+            "Accepted chi-square differs from the retained residual vector"
+        )
+    expected_commit_items = tuple(
+        (param_id, accepted.evaluation_result.resolved_values[param_id])
+        for param_id in accepted.commit_scope
+    )
+    committed_items = tuple(
+        (param_id, committed[param_id]) for param_id in accepted.commit_scope
+    )
+    if (
+        accepted.commit_items != expected_commit_items
+        or committed_items != accepted.commit_items
+        or accepted.commit_scope
+        != tuple(
+            param_id
+            for param_id, _value in accepted.evaluation_result.resolved_values.ordered_items()
+        )
+    ):
+        raise NativePublicationError(
+            "Committed snapshot is not the accepted aggregate resolved state"
+        )
+    expected_controlled_ids = tuple(
+        param_id
+        for param_id in publication.parameterization.independent_ids
+        if publication.parameterization.role(param_id) is ParameterRole.FIT
+    )
+    if accepted.controlled_ids != expected_controlled_ids:
+        raise NativePublicationError(
+            "Accepted control scope differs from the active FIT coordinates"
+        )
+    component_ids = tuple(item.identity for item in publication.components)
+    component_controls = tuple(
+        param_id for item in publication.components for param_id in item.controlled_ids
+    )
+    if publication.components and (
+        len(set(component_ids)) != len(component_ids)
+        or len(set(component_controls)) != len(component_controls)
+        or set(component_controls) != set(accepted.controlled_ids)
+        or any(item.disposition != "succeeded" for item in publication.components)
+    ):
+        raise NativePublicationError(
+            "Component diagnostics must exactly partition the accepted control scope"
+        )
+    _validate_typed_evidence(publication)
+
+
+def _validate_typed_evidence(publication: CommittedFitPublication) -> None:
+    """Fail closed when any requested evidence has a foreign anchor."""
+    accepted = publication.accepted
+    uncertainty = publication.uncertainty
+    if uncertainty is not None and (
+        uncertainty.accepted_anchor is not accepted
+        or uncertainty.accepted_result_identity != accepted.identity
+        or uncertainty.accepted_occurrence_identity != accepted.occurrence_identity
+        or uncertainty.source_parameterization is not publication.parameterization
+        or uncertainty.source_engine.plan.identity != publication.plan.identity
+    ):
+        raise NativePublicationError(
+            "Uncertainty evidence belongs to another accepted fit occurrence"
+        )
+    schemes: set[str] = set()
+    for item in publication.resampling:
+        item.evidence.validate_integrity()
+        scheme = item.evidence.plan.scheme.value
+        if (
+            scheme in schemes
+            or item.evidence.plan.accepted_result_identity != accepted.identity
+            or item.evidence.plan.accepted_occurrence_identity
+            != accepted.occurrence_identity
+            or item.summary.evidence_identity != item.evidence.identity
+        ):
+            raise NativePublicationError(
+                "Resampling evidence belongs to another accepted fit occurrence"
+            )
+        schemes.add(scheme)
+        if item.summary.summary is not None:
+            item.summary.summary.to_record()
+    mcmc = publication.mcmc
+    if mcmc is not None:
+        mcmc.evidence.validate_integrity()
+        mcmc.posterior_samples.validate_integrity()
+        mcmc.summary.validate_integrity()
+        if (
+            mcmc.evidence.plan.accepted is not accepted
+            or mcmc.evidence.accepted_result_identity != accepted.identity
+            or mcmc.evidence.plan.accepted_occurrence_identity
+            != accepted.occurrence_identity
+            or mcmc.posterior_samples.selection.source_evidence is not mcmc.evidence
+            or mcmc.summary.source is not mcmc.posterior_samples
+        ):
+            raise NativePublicationError(
+                "MCMC evidence belongs to another accepted fit occurrence"
+            )
+
+
+def _suppressed_operation_record(
+    operation: FitCommitOperation
+    | DirectTrfExecution
+    | ResamplingEvidence
+    | McmcEvidence,
+) -> dict[str, object]:
+    if isinstance(operation, FitCommitOperation):
+        return operation.to_record()
+    if isinstance(operation, McmcEvidence):
+        return {"artifact_type": "native_mcmc_evidence", **operation.to_record()}
+    if isinstance(operation, ResamplingEvidence):
+        return {
+            "artifact_type": "native_resampling_operation",
+            "identity": operation.identity,
+            "terminal": operation.lifecycle.value,
+            "lifecycle": operation.lifecycle.value,
+            "accepted_result_identity": operation.plan.accepted_result_identity,
+            "accepted_occurrence_identity": (
+                operation.plan.accepted_occurrence_identity
+            ),
+        }
+    return {
+        "artifact_type": "native_direct_trf_execution",
+        "identity": operation.identity,
+        "occurrence_identity": operation.occurrence_identity,
+        "problem_identity": operation.problem_identity,
+        "invocation_identity": operation.invocation_identity,
+        "terminal": operation.terminal.value,
+        "failure": (
+            None
+            if operation.failure is None
+            else {
+                "identity": operation.failure.identity,
+                "category": operation.failure.category,
+                "message": operation.failure.message,
+            }
+        ),
+    }
+
+
+def _render_suppressed(path: Path, publication: SuppressedPublication) -> None:
+    path.mkdir()
+    diagnostics = path / "Diagnostics"
+    diagnostics.mkdir()
+    write_suppressed_outcome(
+        diagnostics / "outcome.json",
+        lifecycle=publication.lifecycle,
+        operation_record=_suppressed_operation_record(publication.operation),
+        accepted_result_identity=publication.accepted_result_identity,
+        accepted_occurrence_identity=publication.accepted_occurrence_identity,
+        components=publication.components,
+    )
+    if not publication.partial_resampling and publication.partial_mcmc is None:
+        return
+    partial = path / "PartialEvidence"
+    partial.mkdir()
+    if publication.partial_resampling:
+        resampling = partial / "Resampling"
+        resampling.mkdir()
+        for evidence in publication.partial_resampling:
+            family = resampling / evidence.plan.scheme.value.upper()
+            family.mkdir()
+            write_partial_resampling(family / "evidence.json", evidence)
+    if publication.partial_mcmc is not None:
+        mcmc = partial / "MCMC"
+        mcmc.mkdir()
+        write_partial_mcmc(mcmc / "evidence.json", publication.partial_mcmc)
+
+
+def _render_committed_fit(
+    path: Path,
+    publication: CommittedFitPublication,
+) -> None:
+    path.mkdir()
+    write_parameter_reports(
+        path / "Parameters",
+        publication.parameterization,
+        publication.accepted.evaluation_result,
+    )
+    write_data(path / "Data", publication.plan, publication.accepted.evaluation_result)
+    write_native_plots(
+        path / "Plots", publication.plan, publication.accepted.evaluation_result
+    )
+    (path / "Statistics").mkdir()
+    write_statistics(
+        path,
+        publication.plan,
+        publication.accepted.evaluation_result,
+        len(publication.accepted.controlled_ids),
+    )
+    write_uncertainty(path / "Statistics", publication.uncertainty)
+    write_resampling(
+        path / "Statistics",
+        tuple((item.evidence, item.summary) for item in publication.resampling),
+    )
+    mcmc = publication.mcmc
+    write_mcmc(
+        path / "Statistics",
+        None if mcmc is None else mcmc.evidence,
+        None if mcmc is None else mcmc.posterior_samples,
+        None if mcmc is None else mcmc.summary,
+    )
+    write_components(path / "Components", publication.components)
+
+
+def _render_evaluation(path: Path, publication: EvaluationPublication) -> None:
+    path.mkdir()
+    write_parameter_reports(
+        path / "Parameters",
+        publication.parameterization,
+        publication.evaluation_result,
+    )
+    write_data(path / "Data", publication.plan, publication.evaluation_result)
+    write_native_plots(path / "Plots", publication.plan, publication.evaluation_result)
+    (path / "Statistics").mkdir()
+    write_statistics(path, publication.plan, publication.evaluation_result, 0)
+
+
+def publish_native_results(
+    path: Path,
+    publication: NativePublication,
+) -> None:
+    """Validate and atomically publish one native method-step result tree."""
+    if isinstance(publication, CommittedFitPublication):
+        _validate_committed_fit(publication)
+    elif isinstance(publication, EvaluationPublication):
+        _validate_evaluation_only(publication)
+    else:
+        _validate_suppressed(publication)
+    destination = Path(path)
+    if destination.exists():
+        raise FileExistsError(f"Native publication destination exists: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = destination.parent / f".{destination.name}.tmp-{uuid4().hex}"
+    try:
+        if isinstance(publication, CommittedFitPublication):
+            _render_committed_fit(staging, publication)
+        elif isinstance(publication, EvaluationPublication):
+            _render_evaluation(staging, publication)
+        else:
+            _render_suppressed(staging, publication)
+        os.replace(staging, destination)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise

--- a/src/chemex/optimize/native_reporting.py
+++ b/src/chemex/optimize/native_reporting.py
@@ -6,9 +6,12 @@ legacy reporting path until the native migration gates promote these artifacts.
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import math
 import os
 import shutil
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -160,6 +163,76 @@ class SuppressedPublication:
 type NativePublication = (
     CommittedFitPublication | EvaluationPublication | SuppressedPublication
 )
+
+_AT_FDCWD = -100
+_RENAME_NOREPLACE = 1
+_RENAME_EXCL = 4
+
+
+def _atomic_publish_noreplace(staging: Path, destination: Path) -> None:
+    """Atomically rename a staged directory without replacing any destination."""
+    if sys.platform == "win32":
+        try:
+            os.rename(staging, destination)
+        except FileExistsError as error:
+            raise FileExistsError(
+                errno.EEXIST,
+                "Native publication destination exists",
+                destination,
+            ) from error
+        return
+
+    source_bytes = os.fsencode(staging)
+    destination_bytes = os.fsencode(destination)
+    if sys.platform == "linux":
+        function_name = "renameat2"
+        argument_types = (
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        )
+        arguments = (
+            _AT_FDCWD,
+            source_bytes,
+            _AT_FDCWD,
+            destination_bytes,
+            _RENAME_NOREPLACE,
+        )
+    elif sys.platform == "darwin":
+        function_name = "renamex_np"
+        argument_types = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint)
+        arguments = (source_bytes, destination_bytes, _RENAME_EXCL)
+    else:
+        raise OSError(
+            errno.ENOTSUP,
+            "Atomic no-replace directory rename is unavailable on this platform",
+            destination,
+        )
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    try:
+        rename_noreplace = getattr(libc, function_name)
+    except AttributeError as error:
+        raise OSError(
+            errno.ENOSYS,
+            f"{function_name} is unavailable for atomic native publication",
+            destination,
+        ) from error
+    rename_noreplace.argtypes = argument_types
+    rename_noreplace.restype = ctypes.c_int
+    result = rename_noreplace(*arguments)
+    if result == 0:
+        return
+    error_number = ctypes.get_errno()
+    if error_number == errno.EEXIST:
+        raise FileExistsError(
+            errno.EEXIST,
+            "Native publication destination exists",
+            destination,
+        )
+    raise OSError(error_number, os.strerror(error_number), destination)
 
 
 def _validate_evaluation_artifacts(
@@ -621,7 +694,7 @@ def publish_native_results(
             _render_evaluation(staging, publication)
         else:
             _render_suppressed(staging, publication)
-        os.replace(staging, destination)
+        _atomic_publish_noreplace(staging, destination)
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
         raise

--- a/src/chemex/optimize/native_reporting.py
+++ b/src/chemex/optimize/native_reporting.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import math
 import os
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 from uuid import uuid4
@@ -33,12 +33,15 @@ from chemex.optimize.native_mcmc import (
     PosteriorSummary,
 )
 from chemex.optimize.native_resampling import (
+    ClaimState,
     ResamplingEvidence,
+    ResamplingLifecycle,
     ResamplingSummaryOutcome,
+    SummaryTerminal,
 )
 from chemex.optimize.uncertainty import UncertaintyEvidence
 from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
-from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.parameters.values import AnalysisValues, AnalysisValuesSnapshot
 from chemex.plotters.native_reporting import write_native_plots
 from chemex.printers.native_reporting import (
     write_components,
@@ -117,6 +120,8 @@ class CommittedFitPublication:
     accepted: AcceptedFitResult
     commit_receipt: CommitReceipt
     committed_snapshot: AnalysisValuesSnapshot
+    commit_operation: FitCommitOperation
+    analysis_values: AnalysisValues = field(repr=False, compare=False)
     components: tuple[ComponentDiagnostic, ...] = ()
     uncertainty: UncertaintyEvidence | None = None
     resampling: tuple[ResamplingPublication, ...] = ()
@@ -238,8 +243,11 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
         (publication.lifecycle == "accepted_uncommitted" and commit_failure)
         or (
             publication.lifecycle == "failed"
-            and direct_terminal
-            not in (None, DirectTrfTerminal.CONVERGED, DirectTrfTerminal.CANCELLED)
+            and (
+                direct_terminal
+                not in (None, DirectTrfTerminal.CONVERGED, DirectTrfTerminal.CANCELLED)
+                or stochastic_terminal == "partial"
+            )
         )
         or (
             publication.lifecycle == "cancelled"
@@ -303,9 +311,24 @@ def _validate_committed_fit(publication: CommittedFitPublication) -> None:
     accepted = publication.accepted
     receipt = publication.commit_receipt
     committed = publication.committed_snapshot
+    operation = publication.commit_operation
+    current = publication.analysis_values.snapshot()
     if not accepted_occurrence_is_authoritative(accepted):
         raise NativePublicationError(
             "Committed publication requires an authoritative accepted occurrence"
+        )
+    if (
+        not fit_commit_operation_is_authoritative(operation)
+        or operation.terminal is not FitCommitTerminal.COMMITTED
+        or operation.receipt is not receipt
+        or operation.committed_snapshot is not committed
+        or operation.accepted_result_identity != accepted.identity
+        or operation.accepted_occurrence_identity != accepted.occurrence_identity
+        or operation.problem_identity != accepted.problem_identity
+        or current != committed
+    ):
+        raise NativePublicationError(
+            "Committed publication requires the exact successful commit operation"
         )
     if (
         accepted.problem_identity != receipt.problem_identity
@@ -409,19 +432,36 @@ def _validate_typed_evidence(publication: CommittedFitPublication) -> None:
     for item in publication.resampling:
         item.evidence.validate_integrity()
         scheme = item.evidence.plan.scheme.value
+        summary = item.summary.summary
         if (
             scheme in schemes
+            or item.evidence.lifecycle is not ResamplingLifecycle.COMPLETED
+            or item.summary.terminal is not SummaryTerminal.COMPLETED
+            or summary is None
+            or summary.evidence is not item.evidence
             or item.evidence.plan.accepted_result_identity != accepted.identity
             or item.evidence.plan.accepted_occurrence_identity
             != accepted.occurrence_identity
             or item.summary.evidence_identity != item.evidence.identity
         ):
             raise NativePublicationError(
-                "Resampling evidence belongs to another accepted fit occurrence"
+                "Ordinary statistics require exact completed resampling evidence"
             )
+        required_claims = (
+            "STRUCTURAL_INTEGRITY",
+            "INTENDED_POPULATION_TERMINAL",
+            "MINIMUM_SUCCESSFUL_COVERAGE",
+            "COMPLETE_SCOPE_SUCCESS_ROWS",
+        )
+        if any(
+            item.evidence.claim(name) is not ClaimState.SATISFIED
+            for name in required_claims
+        ):
+            raise NativePublicationError(
+                "Ordinary statistics require satisfied resampling validity claims"
+            )
+        summary.validate_integrity()
         schemes.add(scheme)
-        if item.summary.summary is not None:
-            item.summary.summary.to_record()
     mcmc = publication.mcmc
     if mcmc is not None:
         mcmc.evidence.validate_integrity()

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -3190,6 +3190,10 @@ class ResamplingSummary:
         """Return one exact named claim; unknown claims fail closed."""
         return _claim_state(self.claims, name)
 
+    def validate_integrity(self) -> None:
+        """Recompute the canonical summary and reject any altered derived field."""
+        type(self).from_record(self.to_record(), self.evidence, self.policy)
+
 
 @dataclass(frozen=True, slots=True)
 class ResamplingSummaryOutcome:

--- a/src/chemex/plotters/native_reporting.py
+++ b/src/chemex/plotters/native_reporting.py
@@ -1,0 +1,54 @@
+"""Diagnostic plot rendering for native step-root publications."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+
+from chemex.evaluation.native import EvaluationPlan, EvaluationResult
+
+
+def write_native_plots(
+    path: Path,
+    plan: EvaluationPlan,
+    result: EvaluationResult,
+) -> None:
+    """Render one aggregate PDF containing every evaluated profile."""
+    path.mkdir()
+    with PdfPages(path / "profiles.pdf") as pdf:
+        for ordinal, descriptor in enumerate(plan.profiles):
+            start = descriptor.observation_offset
+            stop = start + descriptor.observation_count
+            x = np.arange(descriptor.observation_count)
+            retained = np.asarray(descriptor.mask, dtype=np.bool_)
+            figure, axis = plt.subplots(figsize=(7.5, 5.0))
+            axis.errorbar(
+                x[retained],
+                np.asarray(descriptor.experimental_values)[retained],
+                yerr=np.asarray(descriptor.uncertainties)[retained],
+                fmt="o",
+                label="experimental (retained)",
+            )
+            if np.any(~retained):
+                axis.scatter(
+                    x[~retained],
+                    np.asarray(descriptor.experimental_values)[~retained],
+                    marker="x",
+                    label="experimental (masked)",
+                )
+            axis.plot(
+                x,
+                result.normalized_calculations[start:stop],
+                "-",
+                label="calculated",
+            )
+            axis.set_title(f"Profile {ordinal:04d}")
+            axis.set_xlabel("Observation ordinal")
+            axis.set_ylabel("Intensity")
+            axis.legend()
+            figure.tight_layout()
+            pdf.savefig(figure)
+            plt.close(figure)

--- a/src/chemex/printers/native_reporting.py
+++ b/src/chemex/printers/native_reporting.py
@@ -1,0 +1,551 @@
+"""Typed artifact rendering for native step-root publications."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Protocol
+
+from scipy import stats
+
+from chemex.evaluation.native import EvaluationPlan, EvaluationResult
+from chemex.optimize.direct_trf import canonical_chi_square
+from chemex.optimize.native_mcmc import (
+    McmcEvidence,
+    PosteriorSampleEvidence,
+    PosteriorScalarEstimate,
+    PosteriorSummary,
+)
+from chemex.optimize.native_resampling import (
+    ResamplingEvidence,
+    ResamplingSummaryOutcome,
+)
+from chemex.optimize.uncertainty import UncertaintyEvidence
+from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
+
+
+class ComponentDiagnosticRecord(Protocol):
+    """Fields needed to render a non-authoritative component diagnostic."""
+
+    @property
+    def identity(self) -> str: ...
+
+    @property
+    def disposition(self) -> str: ...
+
+    @property
+    def controlled_ids(self) -> tuple[str, ...]: ...
+
+    @property
+    def local_chi_square(self) -> float | None: ...
+
+
+def _toml_float(value: float) -> str:
+    scalar = float(value)
+    if not math.isfinite(scalar):
+        raise ValueError("Published statistics must be finite")
+    return repr(0.0 if scalar == 0.0 else scalar)
+
+
+def _toml_key(value: str) -> str:
+    return json.dumps(value, ensure_ascii=True)
+
+
+def write_json(path: Path, record: object) -> None:
+    """Write one deterministic, strict JSON artifact."""
+    path.write_text(
+        json.dumps(
+            record,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_parameter_reports(
+    path: Path,
+    parameterization: ActiveParameterization,
+    result: EvaluationResult,
+) -> None:
+    """Separate central parameter values by their authoritative role."""
+    path.mkdir()
+    constraints = {
+        item.target_id: item.expression_text
+        for item in parameterization.program.constraints
+    }
+    by_role: dict[ParameterRole, list[tuple[str, float]]] = {
+        role: [] for role in ParameterRole
+    }
+    for param_id in parameterization.scope_ids:
+        by_role[parameterization.role(param_id)].append(
+            (param_id, result.resolved_values[param_id])
+        )
+    filenames = {
+        ParameterRole.FIT: "fitted.toml",
+        ParameterRole.FIX: "fixed.toml",
+        ParameterRole.DERIVED: "constrained.toml",
+    }
+    for role, items in by_role.items():
+        if not items:
+            continue
+        lines = ["[parameters]"]
+        for param_id, value in items:
+            comment = ""
+            if role is ParameterRole.FIX:
+                comment = " # fixed"
+            elif role is ParameterRole.DERIVED:
+                expression = constraints.get(param_id, "model-derived")
+                comment = f" # constrained: {expression}"
+            lines.append(f"{_toml_key(param_id)} = {_toml_float(value)}{comment}")
+        (path / filenames[role]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_data(
+    path: Path,
+    plan: EvaluationPlan,
+    result: EvaluationResult,
+) -> None:
+    """Write aggregate calculated data and retained residual membership."""
+    path.mkdir()
+    for ordinal, (descriptor, profile) in enumerate(
+        zip(plan.profiles, result.profiles, strict=True)
+    ):
+        start = descriptor.observation_offset
+        retained = set(profile.retained_observation_indices)
+        residual_by_index = dict(
+            zip(
+                profile.retained_observation_indices,
+                result.residuals[
+                    profile.residual_offset : profile.residual_offset
+                    + profile.residual_count
+                ],
+                strict=True,
+            )
+        )
+        lines = [
+            (
+                "index\texperimental\tuncertainty\tretained\t"
+                "calculated_unscaled\tcalculated\tresidual\tnormalization"
+            )
+        ]
+        for index in range(descriptor.observation_count):
+            residual = (
+                _toml_float(float(residual_by_index[index]))
+                if index in retained
+                else ""
+            )
+            lines.append(
+                "\t".join(
+                    (
+                        str(index),
+                        _toml_float(descriptor.experimental_values[index]),
+                        _toml_float(descriptor.uncertainties[index]),
+                        "true" if index in retained else "false",
+                        _toml_float(float(result.unscaled_calculations[start + index])),
+                        _toml_float(
+                            float(result.normalized_calculations[start + index])
+                        ),
+                        residual,
+                        _toml_float(profile.normalization_factor),
+                    )
+                )
+            )
+        (path / f"profile_{ordinal:04d}.tsv").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+
+
+def write_statistics(
+    path: Path,
+    plan: EvaluationPlan,
+    result: EvaluationResult,
+    controlled_count: int,
+) -> None:
+    """Write aggregate statistics from retained residuals and approved dof."""
+    residual_count = len(result.residuals)
+    normalization_count = sum(profile.is_scaled for profile in plan.profiles)
+    parameter_count = controlled_count + normalization_count
+    degrees_of_freedom = residual_count - parameter_count
+    chi_square = canonical_chi_square(result.residuals)
+    reduced_chi_square: float | str = (
+        chi_square / degrees_of_freedom if degrees_of_freedom > 0 else "unavailable"
+    )
+    chi_square_p_value: float | str = (
+        float(stats.chi2.sf(chi_square, degrees_of_freedom))
+        if degrees_of_freedom > 0
+        else "unavailable"
+    )
+    ks_p_value = float(stats.kstest(result.residuals, "norm").pvalue)
+    aic = chi_square + 2.0 * parameter_count
+    bic = chi_square + math.log(residual_count) * parameter_count
+
+    def value(item: int | float | str) -> str:
+        if isinstance(item, str):
+            return _toml_key(item)
+        if isinstance(item, int):
+            return str(item)
+        return _toml_float(item)
+
+    items: tuple[tuple[str, int | float | str], ...] = (
+        ("number of data points", residual_count),
+        ("number of variables", parameter_count),
+        ("retained residual count", residual_count),
+        ("controlled parameter count", controlled_count),
+        ("profiled normalization count", normalization_count),
+        ("nominal residual degrees of freedom", degrees_of_freedom),
+        ("chi-square", chi_square),
+        ("reduced-chi-square", reduced_chi_square),
+        ("chi-squared test", chi_square_p_value),
+        ("Kolmogorov-Smirnov test", ks_p_value),
+        ("Akaike Information Criterion (AIC)", aic),
+        ("Bayesian Information Criterion (BIC)", bic),
+    )
+    lines = [f"{_toml_key(key)} = {value(item)}" for key, item in items]
+    (path / "statistics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def component_diagnostic_records(
+    components: Sequence[ComponentDiagnosticRecord],
+) -> list[dict[str, object]]:
+    """Return the shared non-authoritative component record representation."""
+    return [
+        {
+            "ordinal": ordinal,
+            "identity": item.identity,
+            "disposition": item.disposition,
+            "controlled_ids": list(item.controlled_ids),
+            "local_chi_square": item.local_chi_square,
+        }
+        for ordinal, item in enumerate(components)
+    ]
+
+
+def write_components(
+    path: Path,
+    components: Sequence[ComponentDiagnosticRecord],
+) -> None:
+    """Write optional component execution diagnostics without authority copies."""
+    if not components:
+        return
+    path.mkdir()
+    write_json(
+        path / "index.json",
+        {
+            "schema_version": 1,
+            "authority": "diagnostic_only",
+            "components": component_diagnostic_records(components),
+        },
+    )
+
+
+def write_uncertainty(path: Path, uncertainty: UncertaintyEvidence | None) -> None:
+    """Write covariance and constrained evidence in distinct typed families."""
+    if uncertainty is None:
+        return
+    record = uncertainty.to_record()
+    payload = record.get("payload")
+    if not isinstance(payload, dict):
+        raise TypeError("Uncertainty evidence has no typed payload")
+    common = {
+        "schema_version": record["schema_version"],
+        "accepted_result_identity": uncertainty.accepted_result_identity,
+        "accepted_occurrence_identity": uncertainty.accepted_occurrence_identity,
+        "request_identity": uncertainty.request_identity,
+        "policy_identity": uncertainty.policy_identity,
+        "bundle_identity": uncertainty.identity,
+    }
+    covariance_path = path / "Covariance"
+    covariance_path.mkdir()
+    write_json(
+        covariance_path / "evidence.json",
+        common
+        | {
+            "artifact_type": "native_covariance_evidence",
+            "residual_jacobian": payload.get("residual_jacobian"),
+            "rank_diagnostic": payload.get("rank_diagnostic"),
+            "covariance": payload.get("covariance"),
+            "marginal_standard_errors": payload.get("marginal_errors"),
+            "correlations": payload.get("correlations"),
+            "operations": payload.get("operations"),
+            "failures": payload.get("failures"),
+        },
+    )
+    if uncertainty.requested_output_scope:
+        constrained_path = path / "Constrained"
+        constrained_path.mkdir()
+        write_json(
+            constrained_path / "evidence.json",
+            common
+            | {
+                "artifact_type": "native_constrained_evidence",
+                "requested_output_scope": list(uncertainty.requested_output_scope),
+                "constraint_jacobian": payload.get("constraint_jacobian"),
+                "constrained_propagation": payload.get("constrained_propagation"),
+                "marginal_standard_errors": payload.get("constrained_marginal_errors"),
+                "correlations": payload.get("constrained_correlations"),
+                "operations": payload.get("operations"),
+                "failures": payload.get("failures"),
+            },
+        )
+
+
+def resampling_evidence_record(evidence: ResamplingEvidence) -> dict[str, object]:
+    """Serialize one primary resampling execution artifact."""
+    return {
+        "artifact_type": "native_resampling_evidence",
+        "schema_version": 1,
+        "identity": evidence.identity,
+        "plan_identity": evidence.plan.identity,
+        "accepted_result_identity": evidence.plan.accepted_result_identity,
+        "accepted_occurrence_identity": evidence.plan.accepted_occurrence_identity,
+        "scheme": evidence.plan.scheme.value,
+        "lifecycle": evidence.lifecycle.value,
+        "intended_count": evidence.plan.replicate_count,
+        "completed_count": evidence.completed_count,
+        "successful_count": evidence.successful_count,
+        "failed_count": evidence.failed_count,
+        "coverage_satisfied": evidence.coverage_satisfied,
+        "claims": [
+            {
+                "name": claim.name,
+                "state": claim.state.value,
+                "policy_identity": claim.policy_identity,
+                "details": list(claim.details),
+            }
+            for claim in evidence.claims
+        ],
+        "outcomes": [
+            {
+                "ordinal": outcome.ordinal,
+                "seed": outcome.seed,
+                "stage": outcome.stage.value,
+                "disposition": outcome.disposition.value,
+                "identity": outcome.identity,
+                "draw_identity": outcome.draw_identity,
+                "success": (
+                    None if outcome.success is None else outcome.success.to_record()
+                ),
+                "failure": (
+                    None
+                    if outcome.failure is None
+                    else {
+                        "category": outcome.failure.category,
+                        "message": outcome.failure.message,
+                        "identity": outcome.failure.identity,
+                    }
+                ),
+            }
+            for outcome in evidence.outcomes
+        ],
+    }
+
+
+def write_resampling(
+    path: Path,
+    publications: Sequence[tuple[ResamplingEvidence, ResamplingSummaryOutcome]],
+) -> None:
+    """Write resampling evidence and summaries under scheme-specific families."""
+    if not publications:
+        return
+    root = path / "Resampling"
+    root.mkdir()
+    for evidence, outcome in publications:
+        family = root / evidence.plan.scheme.value.upper()
+        family.mkdir()
+        write_json(family / "evidence.json", resampling_evidence_record(evidence))
+        if outcome.summary is not None:
+            record = outcome.summary.to_record()
+            write_json(
+                family / "summary.json",
+                {
+                    "artifact_type": "native_resampling_summary",
+                    "schema_version": record["schema_version"],
+                    "scheme": evidence.plan.scheme.value,
+                    **record,
+                },
+            )
+        elif outcome.failure is not None:
+            write_json(
+                family / "summary.json",
+                {
+                    "artifact_type": "native_resampling_summary_unavailable",
+                    "schema_version": 1,
+                    "scheme": evidence.plan.scheme.value,
+                    "source_evidence_identity": outcome.failure.source_evidence_identity,
+                    "category": outcome.failure.category,
+                    "message": outcome.failure.message,
+                    "identity": outcome.failure.identity,
+                },
+            )
+
+
+def _posterior_estimate_record(
+    estimate: PosteriorScalarEstimate,
+) -> dict[str, str | None]:
+    return {
+        "status": estimate.status.value,
+        "reason": None if estimate.reason is None else estimate.reason.value,
+        "value": None if estimate.value is None else float(estimate.value).hex(),
+    }
+
+
+def _posterior_sample_record(samples: PosteriorSampleEvidence) -> dict[str, object]:
+    return {
+        "artifact_type": "native_posterior_sample_evidence",
+        "schema_version": 1,
+        "identity": samples.identity,
+        "selection_identity": samples.selection_identity,
+        "output_scope": list(samples.output_scope),
+        "successful_labels": [list(label) for label in samples.successful_labels],
+        "outcomes": [
+            {
+                "state_ordinal": item.state_ordinal,
+                "walker_ordinal": item.walker_ordinal,
+                "disposition": item.disposition.value,
+                "independent_items": [
+                    [param_id, float(value).hex()]
+                    for param_id, value in item.independent_items
+                ],
+                "resolved_items": (
+                    None
+                    if item.resolved_items is None
+                    else [
+                        [param_id, float(value).hex()]
+                        for param_id, value in item.resolved_items
+                    ]
+                ),
+                "failure": (
+                    None
+                    if item.failure is None
+                    else {
+                        "category": item.failure.category,
+                        "message": item.failure.message,
+                    }
+                ),
+                "identity": item.identity,
+            }
+            for item in samples.outcomes
+        ],
+    }
+
+
+def _posterior_summary_record(summary: PosteriorSummary) -> dict[str, object]:
+    return {
+        "artifact_type": "native_posterior_summary",
+        "schema_version": 1,
+        "identity": summary.identity,
+        "source_identity": summary.source_identity,
+        "policy_identity": summary.policy_identity,
+        "included_labels": [list(label) for label in summary.included_labels],
+        "excluded_labels": [list(label) for label in summary.excluded_labels],
+        "parameter_summaries": [
+            {
+                "parameter_id": item.parameter_id,
+                "unit": item.unit.value,
+                "quantiles": [
+                    [float(probability).hex(), float(value).hex()]
+                    for probability, value in item.quantiles
+                ],
+                "credible_interval_name": item.credible_interval_name,
+                "credible_interval": [
+                    float(value).hex() for value in item.credible_interval
+                ],
+                "posterior_standard_deviation": float(
+                    item.posterior_standard_deviation
+                ).hex(),
+                "autocorrelation_time": _posterior_estimate_record(
+                    item.autocorrelation_time
+                ),
+                "effective_sample_size": _posterior_estimate_record(
+                    item.effective_sample_size
+                ),
+                "monte_carlo_standard_error": _posterior_estimate_record(
+                    item.monte_carlo_standard_error
+                ),
+            }
+            for item in summary.parameter_summaries
+        ],
+        "covariance": [
+            {
+                "parameter_a": item.parameter_a,
+                "parameter_b": item.parameter_b,
+                "value": float(item.value).hex(),
+            }
+            for item in summary.covariance
+        ],
+        "correlations": [
+            {
+                "parameter_a": item.parameter_a,
+                "parameter_b": item.parameter_b,
+                "estimate": _posterior_estimate_record(item.estimate),
+            }
+            for item in summary.correlations
+        ],
+        "acceptance_diagnostics": summary.acceptance.to_record(),
+    }
+
+
+def write_mcmc(
+    path: Path,
+    evidence: McmcEvidence | None,
+    posterior_samples: PosteriorSampleEvidence | None,
+    summary: PosteriorSummary | None,
+) -> None:
+    """Write primary MCMC and explicitly derived posterior artifacts."""
+    if evidence is None:
+        return
+    if posterior_samples is None or summary is None:
+        raise ValueError("Completed MCMC publication requires derived evidence")
+    root = path / "MCMC"
+    root.mkdir()
+    write_json(
+        root / "evidence.json",
+        {"artifact_type": "native_mcmc_evidence", **evidence.to_record()},
+    )
+    write_json(
+        root / "posterior-samples.json", _posterior_sample_record(posterior_samples)
+    )
+    write_json(root / "posterior-summary.json", _posterior_summary_record(summary))
+
+
+def write_suppressed_outcome(
+    path: Path,
+    *,
+    lifecycle: str,
+    operation_record: dict[str, object],
+    accepted_result_identity: str | None,
+    accepted_occurrence_identity: str | None,
+    components: Sequence[ComponentDiagnosticRecord],
+) -> None:
+    """Write minimal classified provenance for a suppressed workflow."""
+    write_json(
+        path,
+        {
+            "artifact_type": "native_suppressed_publication",
+            "schema_version": 1,
+            "lifecycle": lifecycle,
+            "operation": operation_record,
+            "accepted_result_identity": accepted_result_identity,
+            "accepted_occurrence_identity": accepted_occurrence_identity,
+            "components": component_diagnostic_records(components),
+        },
+    )
+
+
+def write_partial_resampling(path: Path, evidence: ResamplingEvidence) -> None:
+    """Write genuine partial primary resampling evidence."""
+    write_json(path, resampling_evidence_record(evidence))
+
+
+def write_partial_mcmc(path: Path, evidence: McmcEvidence) -> None:
+    """Write genuine partial primary MCMC evidence."""
+    write_json(
+        path,
+        {"artifact_type": "native_partial_mcmc_evidence", **evidence.to_record()},
+    )

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -1,0 +1,633 @@
+"""Behavioral qualification tests for native step-root reporting (#608).
+
+The seam is the published method-step directory.  Tests deliberately exercise
+real native evaluation, acceptance, and commit artifacts while treating the
+renderer implementation as private.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.parameters import read_defaults
+from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
+from chemex.experiments.builder import build_experiments
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    CancellationToken,
+    CommitReceipt,
+    DirectTrfInvocation,
+    FitCommitOperation,
+    FitCommitTerminal,
+    OptimizationProblem,
+    canonical_chi_square,
+    commit_accepted_fit,
+    committed_values_identity,
+    execute_direct_trf,
+    execute_fit_commit,
+)
+from chemex.optimize.native_mcmc import (
+    ExpertMcmcPolicy,
+    McmcExecutionStage,
+    McmcPlan,
+    derive_posterior_sample_evidence,
+    derive_posterior_summary,
+    derive_retained_sample_view,
+    execute_mcmc_evidence,
+)
+from chemex.optimize.native_reporting import (
+    CommittedFitPublication,
+    ComponentDiagnostic,
+    EvaluationPublication,
+    McmcPublication,
+    ResamplingPublication,
+    SuppressedPublication,
+    publish_native_results,
+)
+from chemex.optimize.native_resampling import (
+    ResamplingDatasetManifest,
+    ResamplingPlan,
+    ResamplingScheme,
+    execute_resampling_evidence,
+    summarize_resampling_evidence,
+)
+from chemex.optimize.uncertainty import (
+    ParameterUnit,
+    ResidualVarianceScaling,
+    UncertaintyPolicy,
+    compile_constraint_linearization_capabilities,
+    derive_uncertainty_evidence,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parent.parent
+EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
+METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+def _committed_fit(
+    method: Method | None = None,
+    *,
+    with_uncertainty: bool = False,
+    with_resampling: bool = False,
+    with_mcmc: bool = False,
+) -> CommittedFitPublication:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    selected_method = read_methods([METHOD])["DEFAULT"] if method is None else method
+    parameterization = session.compile_parameterization(
+        selected_method,
+        experiments.param_ids,
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    if with_resampling or with_mcmc:
+        frame = EvaluationFrame.from_lifecycle_frame(
+            parameterization,
+            problem.lifecycle_frame(problem.start, parameterization),
+        )
+        evaluation = engine.new_evaluator().evaluate(frame)
+        assert isinstance(evaluation, EvaluationResult)
+        accepted = AcceptedFitResult.for_qualification(
+            occurrence_identity="issue-608-evidence-anchor",
+            problem_identity=problem.identity,
+            invocation_identity="issue-608-evidence-invocation",
+            execution_identity="issue-608-evidence-execution",
+            materialization_identity="issue-608-evidence-materialization",
+            parameterization_identity=parameterization.identity,
+            evaluator_parameterization_identity=parameterization.evaluator_identity,
+            source_occurrence_identity=problem.source_snapshot.occurrence_identity,
+            source_revision=problem.source_snapshot.revision,
+            controlled_ids=problem.controlled_ids,
+            vector=problem.start,
+            chi_square=canonical_chi_square(evaluation.residuals),
+            evaluation_result=evaluation,
+            commit_scope=problem.commit_scope,
+            commit_items=evaluation.resolved_values.ordered_items(),
+            origin_context_identity="issue-608-evidence-origin",
+        )
+        committed = session.analysis_values.commit(
+            dict(accepted.commit_items),
+            expected=problem.source_snapshot,
+            scope=problem.commit_scope,
+        )
+        receipt = CommitReceipt(
+            accepted.occurrence_identity,
+            accepted.identity,
+            problem.identity,
+            problem.source_snapshot.revision,
+            committed.revision,
+            problem.commit_scope,
+            committed_values_identity(committed, problem.commit_scope),
+            committed.model_identity,
+            committed.configuration_identity,
+        )
+    else:
+        outcome = execute_direct_trf(
+            problem,
+            DirectTrfInvocation.for_problem(problem, objective_request_budget=80),
+            parameterization,
+            engine,
+        )
+        assert outcome.accepted_result is not None
+        assert outcome.commit_authority is not None
+        accepted = outcome.accepted_result
+        receipt = commit_accepted_fit(
+            accepted,
+            outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+        committed = session.analysis_values.snapshot()
+    uncertainty = None
+    if with_uncertainty:
+        controlled_id = problem.controlled_ids[0]
+        derived_id = "__R1A_B_G2N_H_800_0MHZ"
+        policy = UncertaintyPolicy(
+            calibration_identity="issue-608-reporting-qualification-v1",
+            numerical_compatibility_requirement=(
+                "binary64-scipy-economical-svd-fixed-pairwise-v1"
+            ),
+            coordinate_scales=((controlled_id, 1.0),),
+            coordinate_units=((controlled_id, ParameterUnit.RATE_PER_SECOND),),
+            residual_variance_scaling=(
+                ResidualVarianceScaling.ESTIMATED_COMMON_RESIDUAL_VARIANCE
+            ),
+            relative_step_tolerance=1.0e-4,
+            roundoff_multiplier=64.0,
+            smaller_step_extent=8,
+            larger_step_extent=8,
+            svd_driver="gesdd",
+            rank_absolute_tolerance=0.0,
+            rank_relative_tolerance=1.0e-12,
+            weak_relative_tolerance=1.0e-6,
+            singular_value_cluster_relative_tolerance=1.0e-10,
+            conditioning_limit=1.0e12,
+            correlation_roundoff_multiplier=64.0,
+            affine_feasibility_policy=("canonical-root-affine-halfspace-zeta-gt-3-v1"),
+        )
+        compiled = compile_constraint_linearization_capabilities(
+            parameterization,
+            (controlled_id, derived_id),
+            (),
+        )
+        uncertainty = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=policy,
+            constrained_scope=(controlled_id, derived_id),
+            constrained_units=(
+                (controlled_id, ParameterUnit.RATE_PER_SECOND),
+                (derived_id, ParameterUnit.RATE_PER_SECOND),
+            ),
+            constrained_scales=((controlled_id, 1.0), (derived_id, 1.0)),
+            compiled_constraint_linearization=compiled,
+            resolved_environment_identity="issue-608-local-environment",
+        )
+    resampling: tuple[ResamplingPublication, ...] = ()
+    if with_resampling:
+        observation_count = engine.plan.observation_count
+        dataset = ResamplingDatasetManifest(
+            engine.plan,
+            tuple(
+                float(value)
+                for value in accepted.evaluation_result.normalized_calculations
+            ),
+            tuple(False for _index in range(observation_count)),
+            tuple("G2N" for _index in range(observation_count)),
+            tuple(f"ordinal={index}" for index in range(observation_count)),
+        )
+        plan = ResamplingPlan.for_accepted(
+            accepted,
+            dataset=dataset,
+            source_problem=problem,
+            parameterization=parameterization,
+            source_engine=engine,
+            scheme=ResamplingScheme.MONTE_CARLO,
+            replicate_count=2,
+            replicate_structural_identities=("replicate-alpha", "replicate-beta"),
+            replicate_component_identities=(("component",), ("component",)),
+            root_seed=608,
+            output_scope=parameterization.scope_ids,
+            output_units=tuple("native" for _id in parameterization.scope_ids),
+            minimum_successful_count=2,
+            strategy_settings=(("objective_request_budget", "80"),),
+        )
+        operation = execute_resampling_evidence(accepted, plan)
+        assert operation.evidence is not None
+        summary = summarize_resampling_evidence(operation.evidence)
+        resampling = (ResamplingPublication(operation.evidence, summary),)
+    mcmc = None
+    if with_mcmc:
+        policy = ExpertMcmcPolicy(
+            burn_steps=1,
+            retained_steps=3,
+            walkers=4,
+            expert_provenance="issue-608-reporting-qualification",
+        ).resolve(dimension=len(problem.controlled_ids), root_seed=608)
+        plan = McmcPlan.for_accepted(
+            accepted,
+            source_problem=problem,
+            parameterization=parameterization,
+            source_engine=engine,
+            policy=policy,
+            coordinate_units=tuple(
+                (param_id, ParameterUnit.DIMENSIONLESS)
+                for param_id in problem.controlled_ids
+            ),
+        )
+        operation = execute_mcmc_evidence(accepted, plan)
+        assert operation.evidence is not None
+        retained = derive_retained_sample_view(operation.evidence)
+        posterior = derive_posterior_sample_evidence(retained, plan.coordinate_units)
+        summary = derive_posterior_summary(posterior)
+        mcmc = McmcPublication(operation.evidence, posterior, summary)
+    return CommittedFitPublication(
+        engine.plan,
+        parameterization,
+        accepted,
+        receipt,
+        committed,
+        uncertainty=uncertainty,
+        resampling=resampling,
+        mcmc=mcmc,
+    )
+
+
+def _evaluation_only() -> EvaluationPublication:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values()
+    parameterization = session.compile_parameterization(
+        Method(fix=["R1A_A", "PB", "KEX_AB"]), experiments.param_ids
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+    )
+    result = engine.new_evaluator().evaluate(frame)
+    assert isinstance(result, EvaluationResult)
+    return EvaluationPublication(engine.plan, parameterization, result)
+
+
+def _failed_commit_operation() -> FitCommitOperation:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values()
+    parameterization = session.compile_parameterization(
+        read_methods([METHOD])["DEFAULT"], experiments.param_ids
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    source = session.analysis_values.snapshot()
+    problem = OptimizationProblem.from_native(
+        engine.plan, parameterization, configuration, source
+    )
+    outcome = execute_direct_trf(
+        problem,
+        DirectTrfInvocation.for_problem(problem, objective_request_budget=80),
+        parameterization,
+        engine,
+    )
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    session.analysis_values.commit(
+        {param_id: source[param_id] for param_id in problem.commit_scope},
+        expected=source,
+        scope=problem.commit_scope,
+    )
+    operation = execute_fit_commit(
+        outcome.accepted_result,
+        outcome.commit_authority,
+        problem=problem,
+        parameterization=parameterization,
+        analysis_values=session.analysis_values,
+    )
+    assert operation.terminal is FitCommitTerminal.FAILED
+    return operation
+
+
+def test_committed_native_fit_publishes_only_aggregate_step_root(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "STEP"
+
+    publish_native_results(output, publication)
+
+    assert {path.name for path in output.iterdir()} == {
+        "Data",
+        "Parameters",
+        "Plots",
+        "Statistics",
+        "statistics.toml",
+    }
+    assert (output / "Data" / "profile_0000.tsv").is_file()
+    assert (output / "Plots" / "profiles.pdf").stat().st_size > 0
+    assert not (output / "All").exists()
+    assert not (output / "Groups").exists()
+
+    fitted = (output / "Parameters" / "fitted.toml").read_text()
+    assert publication.accepted.controlled_ids[0] in fitted
+    assert "stderr" not in fitted.lower()
+    assert "error" not in fitted.lower()
+    assert "±" not in fitted
+
+    statistics = tomllib.loads((output / "statistics.toml").read_text())
+    residual_count = len(publication.accepted.evaluation_result.residuals)
+    controlled_count = len(publication.accepted.controlled_ids)
+    normalization_count = sum(
+        profile.is_scaled for profile in publication.plan.profiles
+    )
+    degrees_of_freedom = residual_count - controlled_count - normalization_count
+    assert statistics["retained residual count"] == residual_count
+    assert statistics["controlled parameter count"] == controlled_count
+    assert statistics["profiled normalization count"] == normalization_count
+    assert statistics["nominal residual degrees of freedom"] == degrees_of_freedom
+    assert statistics["chi-square"] == pytest.approx(publication.accepted.chi_square)
+    assert statistics["reduced-chi-square"] == pytest.approx(
+        publication.accepted.chi_square / degrees_of_freedom
+    )
+
+
+def test_many_components_are_diagnostic_views_without_authoritative_copies(
+    tmp_path: Path,
+) -> None:
+    base = _committed_fit(
+        Method(fit=["PB", "R1A_A"], fix=["KEX_AB"]),
+    )
+    publication = CommittedFitPublication(
+        base.plan,
+        base.parameterization,
+        base.accepted,
+        base.commit_receipt,
+        base.committed_snapshot,
+        components=(
+            ComponentDiagnostic(
+                "component-alpha",
+                "succeeded",
+                (base.accepted.controlled_ids[0],),
+                local_chi_square=1.25,
+            ),
+            ComponentDiagnostic(
+                "component-beta",
+                "succeeded",
+                base.accepted.controlled_ids[1:],
+                local_chi_square=2.5,
+            ),
+        ),
+    )
+    output = tmp_path / "STEP"
+
+    publish_native_results(output, publication)
+
+    components = json.loads((output / "Components" / "index.json").read_text())
+    assert [item["ordinal"] for item in components["components"]] == [0, 1]
+    assert [item["identity"] for item in components["components"]] == [
+        "component-alpha",
+        "component-beta",
+    ]
+    assert components["authority"] == "diagnostic_only"
+    assert not list((output / "Components").rglob("Parameters"))
+    assert not list((output / "Components").rglob("Data"))
+    assert not list((output / "Components").rglob("Plots"))
+    assert not list((output / "Components").rglob("Statistics"))
+    assert (output / "Parameters" / "fitted.toml").is_file()
+
+
+def test_committed_publication_rejects_a_receipt_without_its_snapshot_witness(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    forged_receipt = replace(
+        publication.commit_receipt,
+        committed_value_identity="foreign-committed-values",
+    )
+
+    with pytest.raises(ValueError, match="Commit receipt does not belong"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(publication, commit_receipt=forged_receipt),
+        )
+
+
+def test_committed_publication_rejects_unsuccessful_component_diagnostics(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    component = ComponentDiagnostic(
+        "failed-component",
+        "failed",
+        publication.accepted.controlled_ids,
+    )
+
+    with pytest.raises(ValueError, match="exactly partition"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(publication, components=(component,)),
+        )
+
+
+def test_zero_component_evaluation_publishes_no_fitted_estimate(tmp_path: Path) -> None:
+    publication = _evaluation_only()
+    output = tmp_path / "STEP"
+
+    publish_native_results(output, publication)
+
+    assert (output / "Data" / "profile_0000.tsv").is_file()
+    assert (output / "Plots" / "profiles.pdf").is_file()
+    assert (output / "Statistics").is_dir()
+    assert not (output / "Parameters" / "fitted.toml").exists()
+    assert not (output / "Components").exists()
+    statistics = tomllib.loads((output / "statistics.toml").read_text())
+    residual_count = len(publication.evaluation_result.residuals)
+    normalization_count = sum(
+        profile.is_scaled for profile in publication.plan.profiles
+    )
+    assert statistics["controlled parameter count"] == 0
+    assert statistics["nominal residual degrees of freedom"] == (
+        residual_count - normalization_count
+    )
+
+
+def test_covariance_and_constrained_evidence_are_separate_from_central_reports(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit(with_uncertainty=True)
+    output = tmp_path / "STEP"
+
+    publish_native_results(output, publication)
+
+    covariance = json.loads(
+        (output / "Statistics" / "Covariance" / "evidence.json").read_text()
+    )
+    constrained = json.loads(
+        (output / "Statistics" / "Constrained" / "evidence.json").read_text()
+    )
+    assert covariance["artifact_type"] == "native_covariance_evidence"
+    assert constrained["artifact_type"] == "native_constrained_evidence"
+    assert covariance["accepted_result_identity"] == publication.accepted.identity
+    assert constrained["accepted_result_identity"] == publication.accepted.identity
+
+    central_reports = "\n".join(
+        path.read_text() for path in (output / "Parameters").glob("*.toml")
+    ).lower()
+    assert "stderr" not in central_reports
+    assert "standard error" not in central_reports
+    assert "±" not in central_reports
+
+
+def test_resampling_and_posterior_evidence_keep_family_specific_semantics(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit(
+        Method(fit=["PB"], fix=["R1A_A", "KEX_AB"]),
+        with_resampling=True,
+        with_mcmc=True,
+    )
+    output = tmp_path / "STEP"
+
+    publish_native_results(output, publication)
+
+    resampling = json.loads(
+        (output / "Statistics" / "Resampling" / "MC" / "summary.json").read_text()
+    )
+    posterior = json.loads(
+        (output / "Statistics" / "MCMC" / "posterior-summary.json").read_text()
+    )
+    assert resampling["artifact_type"] == "native_resampling_summary"
+    assert resampling["scheme"] == "mc"
+    assert all("standard_deviation" in item for item in resampling["distributions"])
+    assert posterior["artifact_type"] == "native_posterior_summary"
+    assert all(
+        "posterior_standard_deviation" in item
+        for item in posterior["parameter_summaries"]
+    )
+    rendered = json.dumps((resampling, posterior)).lower()
+    assert "stderr" not in rendered
+    assert (output / "Statistics" / "Resampling" / "MC" / "evidence.json").is_file()
+    assert (output / "Statistics" / "MCMC" / "evidence.json").is_file()
+
+
+def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
+    tmp_path: Path,
+) -> None:
+    committed = _committed_fit(
+        Method(fit=["PB"], fix=["R1A_A", "KEX_AB"]),
+        with_mcmc=True,
+    )
+    assert committed.mcmc is not None
+    cancellation = CancellationToken()
+
+    def cancel_after_initialization(
+        stage: McmcExecutionStage,
+        _complete_state_count: int,
+    ) -> None:
+        if stage is McmcExecutionStage.BEFORE_TRANSITION:
+            cancellation.cancel()
+
+    operation = execute_mcmc_evidence(
+        committed.accepted,
+        committed.mcmc.evidence.plan,
+        cancellation=cancellation,
+        checkpoint_observer=cancel_after_initialization,
+    )
+    assert operation.evidence is not None
+    foreign_occurrence = SuppressedPublication(
+        "cancelled",
+        operation.evidence,
+        accepted_result_identity=committed.accepted.identity,
+        accepted_occurrence_identity="foreign-accepted-occurrence",
+        partial_mcmc=operation.evidence,
+    )
+    with pytest.raises(ValueError, match="genuine partial MCMC"):
+        publish_native_results(tmp_path / "FOREIGN", foreign_occurrence)
+
+    failed_commit = _failed_commit_operation()
+    forged_commit = replace(failed_commit, occurrence_identity="forged-occurrence")
+    forged = SuppressedPublication(
+        "accepted_uncommitted",
+        forged_commit,
+        accepted_result_identity=forged_commit.accepted_result_identity,
+        accepted_occurrence_identity=forged_commit.accepted_occurrence_identity,
+    )
+    with pytest.raises(ValueError, match="operation provenance disagree"):
+        publish_native_results(tmp_path / "FORGED", forged)
+
+    invalid = SuppressedPublication(
+        "accepted_uncommitted",
+        failed_commit,
+        accepted_result_identity=failed_commit.accepted_result_identity,
+        accepted_occurrence_identity=failed_commit.accepted_occurrence_identity,
+        partial_mcmc=operation.evidence,
+    )
+    output = tmp_path / "STEP"
+
+    with pytest.raises(ValueError, match="cannot start downstream evidence"):
+        publish_native_results(output, invalid)
+    assert not output.exists()
+
+    publication = SuppressedPublication(
+        "accepted_uncommitted",
+        failed_commit,
+        accepted_result_identity=failed_commit.accepted_result_identity,
+        accepted_occurrence_identity=failed_commit.accepted_occurrence_identity,
+    )
+
+    publish_native_results(output, publication)
+
+    assert {path.name for path in output.iterdir()} == {"Diagnostics"}
+    diagnostics = json.loads((output / "Diagnostics" / "outcome.json").read_text())
+    assert diagnostics["operation"]["identity"] == failed_commit.identity
+    assert diagnostics["operation"]["terminal"] == "failed"
+    assert not (output / "PartialEvidence").exists()
+    for normal_name in (
+        "Parameters",
+        "Data",
+        "Plots",
+        "Statistics",
+        "statistics.toml",
+        "Components",
+    ):
+        assert not (output / normal_name).exists()

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -11,13 +11,16 @@ import json
 import tomllib
 from dataclasses import replace
 from pathlib import Path
+from typing import Literal
 
+import numpy as np
 import pytest
 
 from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
 from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
 from chemex.experiments.builder import build_experiments
+from chemex.optimize import native_reporting
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     CancellationToken,
@@ -27,7 +30,6 @@ from chemex.optimize.direct_trf import (
     FitCommitTerminal,
     OptimizationProblem,
     canonical_chi_square,
-    commit_accepted_fit,
     committed_values_identity,
     execute_direct_trf,
     execute_fit_commit,
@@ -51,9 +53,15 @@ from chemex.optimize.native_reporting import (
     publish_native_results,
 )
 from chemex.optimize.native_resampling import (
+    OperationTerminal,
     ResamplingDatasetManifest,
+    ResamplingEvidence,
+    ResamplingLifecycle,
     ResamplingPlan,
     ResamplingScheme,
+    ResamplingSummaryOutcome,
+    SummaryFailure,
+    SummaryTerminal,
     execute_resampling_evidence,
     summarize_resampling_evidence,
 )
@@ -97,6 +105,25 @@ def _committed_fit(
         experiments.param_ids,
     )
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    if with_resampling or with_mcmc:
+        source = session.analysis_values.snapshot()
+        initial_frame = EvaluationFrame.from_lifecycle_frame(
+            parameterization,
+            parameterization.frame_from_snapshot(source),
+        )
+        initial = engine.new_evaluator().evaluate(initial_frame)
+        assert isinstance(initial, EvaluationResult)
+        offset = 0
+        for experiment in experiments:
+            for profile in experiment.profiles:
+                stop = offset + profile.data.size
+                profile.data.exp = np.asarray(
+                    initial.normalized_calculations[offset:stop],
+                    dtype=np.float64,
+                ).copy()
+                profile.data.mark_dirty()
+                offset = stop
+        engine = EvaluationEngine.from_experiments(experiments, parameterization)
     configuration = session.parameter_factory.sealed_configuration
     assert configuration is not None
     problem = OptimizationProblem.from_native(
@@ -105,65 +132,27 @@ def _committed_fit(
         configuration,
         session.analysis_values.snapshot(),
     )
-    if with_resampling or with_mcmc:
-        frame = EvaluationFrame.from_lifecycle_frame(
-            parameterization,
-            problem.lifecycle_frame(problem.start, parameterization),
-        )
-        evaluation = engine.new_evaluator().evaluate(frame)
-        assert isinstance(evaluation, EvaluationResult)
-        accepted = AcceptedFitResult.for_qualification(
-            occurrence_identity="issue-608-evidence-anchor",
-            problem_identity=problem.identity,
-            invocation_identity="issue-608-evidence-invocation",
-            execution_identity="issue-608-evidence-execution",
-            materialization_identity="issue-608-evidence-materialization",
-            parameterization_identity=parameterization.identity,
-            evaluator_parameterization_identity=parameterization.evaluator_identity,
-            source_occurrence_identity=problem.source_snapshot.occurrence_identity,
-            source_revision=problem.source_snapshot.revision,
-            controlled_ids=problem.controlled_ids,
-            vector=problem.start,
-            chi_square=canonical_chi_square(evaluation.residuals),
-            evaluation_result=evaluation,
-            commit_scope=problem.commit_scope,
-            commit_items=evaluation.resolved_values.ordered_items(),
-            origin_context_identity="issue-608-evidence-origin",
-        )
-        committed = session.analysis_values.commit(
-            dict(accepted.commit_items),
-            expected=problem.source_snapshot,
-            scope=problem.commit_scope,
-        )
-        receipt = CommitReceipt(
-            accepted.occurrence_identity,
-            accepted.identity,
-            problem.identity,
-            problem.source_snapshot.revision,
-            committed.revision,
-            problem.commit_scope,
-            committed_values_identity(committed, problem.commit_scope),
-            committed.model_identity,
-            committed.configuration_identity,
-        )
-    else:
-        outcome = execute_direct_trf(
-            problem,
-            DirectTrfInvocation.for_problem(problem, objective_request_budget=80),
-            parameterization,
-            engine,
-        )
-        assert outcome.accepted_result is not None
-        assert outcome.commit_authority is not None
-        accepted = outcome.accepted_result
-        receipt = commit_accepted_fit(
-            accepted,
-            outcome.commit_authority,
-            problem=problem,
-            parameterization=parameterization,
-            analysis_values=session.analysis_values,
-        )
-        committed = session.analysis_values.snapshot()
+    outcome = execute_direct_trf(
+        problem,
+        DirectTrfInvocation.for_problem(problem, objective_request_budget=80),
+        parameterization,
+        engine,
+    )
+    assert outcome.accepted_result is not None
+    assert outcome.commit_authority is not None
+    accepted = outcome.accepted_result
+    commit_operation = execute_fit_commit(
+        accepted,
+        outcome.commit_authority,
+        problem=problem,
+        parameterization=parameterization,
+        analysis_values=session.analysis_values,
+    )
+    assert commit_operation.terminal is FitCommitTerminal.COMMITTED
+    assert commit_operation.receipt is not None
+    assert commit_operation.committed_snapshot is not None
+    receipt = commit_operation.receipt
+    committed = commit_operation.committed_snapshot
     uncertainty = None
     if with_uncertainty:
         controlled_id = problem.controlled_ids[0]
@@ -275,6 +264,8 @@ def _committed_fit(
         accepted,
         receipt,
         committed,
+        commit_operation,
+        session.analysis_values,
         uncertainty=uncertainty,
         resampling=resampling,
         mcmc=mcmc,
@@ -348,6 +339,100 @@ def _failed_commit_operation() -> FitCommitOperation:
     return operation
 
 
+def _publication_from_direct_commit_and_fabricated_evidence() -> (
+    CommittedFitPublication
+):
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values()
+    parameterization = session.compile_parameterization(
+        read_methods([METHOD])["DEFAULT"], experiments.param_ids
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    source = session.analysis_values.snapshot()
+    problem = OptimizationProblem.from_native(
+        engine.plan, parameterization, configuration, source
+    )
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        problem.lifecycle_frame(problem.start, parameterization),
+    )
+    evaluation = engine.new_evaluator().evaluate(frame)
+    assert isinstance(evaluation, EvaluationResult)
+    accepted = AcceptedFitResult.for_qualification(
+        occurrence_identity="issue-608-direct-commit-attack",
+        problem_identity=problem.identity,
+        invocation_identity="issue-608-fabricated-invocation",
+        execution_identity="issue-608-fabricated-execution",
+        materialization_identity="issue-608-fabricated-materialization",
+        parameterization_identity=parameterization.identity,
+        evaluator_parameterization_identity=parameterization.evaluator_identity,
+        source_occurrence_identity=source.occurrence_identity,
+        source_revision=source.revision,
+        controlled_ids=problem.controlled_ids,
+        vector=problem.start,
+        chi_square=canonical_chi_square(evaluation.residuals),
+        evaluation_result=evaluation,
+        commit_scope=problem.commit_scope,
+        commit_items=evaluation.resolved_values.ordered_items(),
+        origin_context_identity="issue-608-fabricated-origin",
+    )
+    committed = session.analysis_values.commit(
+        dict(accepted.commit_items),
+        expected=source,
+        scope=problem.commit_scope,
+    )
+    receipt = CommitReceipt(
+        accepted.occurrence_identity,
+        accepted.identity,
+        problem.identity,
+        source.revision,
+        committed.revision,
+        problem.commit_scope,
+        committed_values_identity(committed, problem.commit_scope),
+        committed.model_identity,
+        committed.configuration_identity,
+    )
+    fabricated_operation = FitCommitOperation(
+        "fabricated-commit-operation",
+        accepted.identity,
+        accepted.occurrence_identity,
+        problem.identity,
+        FitCommitTerminal.COMMITTED,
+        receipt=receipt,
+        committed_snapshot=committed,
+    )
+    return CommittedFitPublication(
+        engine.plan,
+        parameterization,
+        accepted,
+        receipt,
+        committed,
+        fabricated_operation,
+        session.analysis_values,
+    )
+
+
+def _tree_bytes(path: Path) -> dict[str, bytes]:
+    return {
+        str(item.relative_to(path)): item.read_bytes()
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    }
+
+
+def _staging_residue(parent: Path, destination_name: str) -> tuple[Path, ...]:
+    return tuple(parent.glob(f".{destination_name}.tmp-*"))
+
+
 def test_committed_native_fit_publishes_only_aggregate_step_root(
     tmp_path: Path,
 ) -> None:
@@ -403,6 +488,8 @@ def test_many_components_are_diagnostic_views_without_authoritative_copies(
         base.accepted,
         base.commit_receipt,
         base.committed_snapshot,
+        base.commit_operation,
+        base.analysis_values,
         components=(
             ComponentDiagnostic(
                 "component-alpha",
@@ -440,16 +527,93 @@ def test_committed_publication_rejects_a_receipt_without_its_snapshot_witness(
     tmp_path: Path,
 ) -> None:
     publication = _committed_fit()
-    forged_receipt = replace(
-        publication.commit_receipt,
-        committed_value_identity="foreign-committed-values",
-    )
+    reconstructed_receipt = replace(publication.commit_receipt)
 
-    with pytest.raises(ValueError, match="Commit receipt does not belong"):
+    with pytest.raises(ValueError, match="exact successful commit operation"):
         publish_native_results(
             tmp_path / "STEP",
-            replace(publication, commit_receipt=forged_receipt),
+            replace(publication, commit_receipt=reconstructed_receipt),
         )
+    assert not (tmp_path / "STEP").exists()
+
+
+def test_committed_publication_rejects_a_manually_reconstructed_receipt(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    receipt = publication.commit_receipt
+    reconstructed = CommitReceipt(
+        receipt.accepted_occurrence_identity,
+        receipt.accepted_result_identity,
+        receipt.problem_identity,
+        receipt.old_revision,
+        receipt.new_revision,
+        receipt.scope,
+        receipt.committed_value_identity,
+        receipt.model_identity,
+        receipt.configuration_identity,
+    )
+
+    with pytest.raises(ValueError, match="exact successful commit operation"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(publication, commit_receipt=reconstructed),
+        )
+    assert not (tmp_path / "STEP").exists()
+
+
+def test_direct_analysis_values_commit_cannot_fabricate_publication_authority(
+    tmp_path: Path,
+) -> None:
+    publication = _publication_from_direct_commit_and_fabricated_evidence()
+
+    with pytest.raises(ValueError, match="exact successful commit operation"):
+        publish_native_results(tmp_path / "STEP", publication)
+    assert not (tmp_path / "STEP").exists()
+
+
+def test_committed_publication_rejects_another_occurrence_receipt(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    other = _committed_fit()
+
+    with pytest.raises(ValueError, match="exact successful commit operation"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(publication, commit_receipt=other.commit_receipt),
+        )
+    assert not (tmp_path / "STEP").exists()
+
+
+def test_committed_publication_rejects_a_stale_committed_revision(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    current = publication.analysis_values.snapshot()
+    publication.analysis_values.commit(
+        {param_id: current[param_id] for param_id in publication.commit_receipt.scope},
+        expected=current,
+        scope=publication.commit_receipt.scope,
+    )
+
+    with pytest.raises(ValueError, match="exact successful commit operation"):
+        publish_native_results(tmp_path / "STEP", publication)
+    assert not (tmp_path / "STEP").exists()
+
+
+def test_committed_publication_rejects_a_copied_successful_commit_operation(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    copied_operation = replace(publication.commit_operation)
+
+    with pytest.raises(ValueError, match="exact successful commit operation"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(publication, commit_operation=copied_operation),
+        )
+    assert not (tmp_path / "STEP").exists()
 
 
 def test_committed_publication_rejects_unsuccessful_component_diagnostics(
@@ -521,20 +685,24 @@ def test_covariance_and_constrained_evidence_are_separate_from_central_reports(
 def test_resampling_and_posterior_evidence_keep_family_specific_semantics(
     tmp_path: Path,
 ) -> None:
-    publication = _committed_fit(
+    resampling_publication = _committed_fit(with_resampling=True)
+    mcmc_publication = _committed_fit(
         Method(fit=["PB"], fix=["R1A_A", "KEX_AB"]),
-        with_resampling=True,
         with_mcmc=True,
     )
-    output = tmp_path / "STEP"
+    resampling_output = tmp_path / "RESAMPLING"
+    mcmc_output = tmp_path / "MCMC"
 
-    publish_native_results(output, publication)
+    publish_native_results(resampling_output, resampling_publication)
+    publish_native_results(mcmc_output, mcmc_publication)
 
     resampling = json.loads(
-        (output / "Statistics" / "Resampling" / "MC" / "summary.json").read_text()
+        (
+            resampling_output / "Statistics" / "Resampling" / "MC" / "summary.json"
+        ).read_text()
     )
     posterior = json.loads(
-        (output / "Statistics" / "MCMC" / "posterior-summary.json").read_text()
+        (mcmc_output / "Statistics" / "MCMC" / "posterior-summary.json").read_text()
     )
     assert resampling["artifact_type"] == "native_resampling_summary"
     assert resampling["scheme"] == "mc"
@@ -546,8 +714,230 @@ def test_resampling_and_posterior_evidence_keep_family_specific_semantics(
     )
     rendered = json.dumps((resampling, posterior)).lower()
     assert "stderr" not in rendered
-    assert (output / "Statistics" / "Resampling" / "MC" / "evidence.json").is_file()
-    assert (output / "Statistics" / "MCMC" / "evidence.json").is_file()
+    assert (
+        resampling_output / "Statistics" / "Resampling" / "MC" / "evidence.json"
+    ).is_file()
+    assert (mcmc_output / "Statistics" / "MCMC" / "evidence.json").is_file()
+
+
+@pytest.mark.parametrize(
+    ("terminal", "truncate", "expected_lifecycle"),
+    (
+        (OperationTerminal.COMPLETED, True, ResamplingLifecycle.PARTIAL),
+        (OperationTerminal.CANCELLED, False, ResamplingLifecycle.CANCELLED),
+        (OperationTerminal.INTERRUPTED, False, ResamplingLifecycle.INTERRUPTED),
+    ),
+)
+def test_incomplete_resampling_is_rejected_from_ordinary_statistics(
+    tmp_path: Path,
+    terminal: OperationTerminal,
+    truncate: bool,
+    expected_lifecycle: ResamplingLifecycle,
+) -> None:
+    publication = _committed_fit(with_resampling=True)
+    source = publication.resampling[0].evidence
+    outcomes = source.outcomes[:1] if truncate else source.outcomes
+    incomplete = ResamplingEvidence(
+        source.plan,
+        source.population_identity,
+        outcomes,
+        terminal,
+    )
+    assert incomplete.lifecycle is expected_lifecycle
+    summary = summarize_resampling_evidence(incomplete)
+
+    with pytest.raises(ValueError, match="completed resampling evidence"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(
+                publication,
+                resampling=(ResamplingPublication(incomplete, summary),),
+            ),
+        )
+    assert not (tmp_path / "STEP").exists()
+
+
+def test_failed_resampling_summary_is_rejected_from_ordinary_statistics(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit(with_resampling=True)
+    evidence = publication.resampling[0].evidence
+    failure = SummaryFailure(
+        evidence.identity,
+        "failed_summary",
+        "summary qualification failed",
+    )
+    failed = ResamplingSummaryOutcome(
+        SummaryTerminal.SOURCE_INVALID,
+        failure=failure,
+    )
+
+    with pytest.raises(ValueError, match="completed resampling evidence"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(
+                publication,
+                resampling=(ResamplingPublication(evidence, failed),),
+            ),
+        )
+    assert not (tmp_path / "STEP").exists()
+
+
+@pytest.mark.parametrize(
+    ("terminal", "truncate", "suppressed_lifecycle"),
+    (
+        (OperationTerminal.COMPLETED, True, "failed"),
+        (OperationTerminal.CANCELLED, False, "cancelled"),
+        (OperationTerminal.INTERRUPTED, False, "interrupted"),
+    ),
+)
+def test_incomplete_resampling_is_retained_only_as_partial_evidence(
+    tmp_path: Path,
+    terminal: OperationTerminal,
+    truncate: bool,
+    suppressed_lifecycle: Literal["failed", "cancelled", "interrupted"],
+) -> None:
+    publication = _committed_fit(with_resampling=True)
+    source = publication.resampling[0].evidence
+    outcomes = source.outcomes[:1] if truncate else source.outcomes
+    incomplete = ResamplingEvidence(
+        source.plan,
+        source.population_identity,
+        outcomes,
+        terminal,
+    )
+    suppressed = SuppressedPublication(
+        suppressed_lifecycle,
+        incomplete,
+        accepted_result_identity=publication.accepted.identity,
+        accepted_occurrence_identity=publication.accepted.occurrence_identity,
+        partial_resampling=(incomplete,),
+    )
+
+    publish_native_results(tmp_path / "STEP", suppressed)
+
+    assert (tmp_path / "STEP" / "PartialEvidence" / "Resampling").is_dir()
+    assert not (tmp_path / "STEP" / "Statistics").exists()
+
+
+@pytest.mark.parametrize(
+    "alteration",
+    (
+        "included_ordinals",
+        "covariance",
+        "correlations",
+        "percentile",
+        "claims",
+        "source_identity",
+    ),
+)
+def test_altered_resampling_summary_is_rejected_before_staging(
+    tmp_path: Path,
+    alteration: str,
+) -> None:
+    publication = _committed_fit(with_resampling=True)
+    summary = publication.resampling[0].summary.summary
+    assert summary is not None
+    if alteration == "included_ordinals":
+        object.__setattr__(
+            summary, "included_ordinals", (*summary.included_ordinals, 99)
+        )
+    elif alteration == "covariance":
+        object.__setattr__(summary, "covariance", summary.covariance[:-1])
+    elif alteration == "correlations":
+        object.__setattr__(summary, "correlations", summary.correlations[:-1])
+    elif alteration == "percentile":
+        distribution = summary.distributions[0]
+        object.__setattr__(
+            distribution,
+            "percentile_95_upper",
+            distribution.percentile_95_upper + 1.0,
+        )
+    elif alteration == "claims":
+        object.__setattr__(summary, "claims", summary.claims[:-1])
+    else:
+        object.__setattr__(summary, "evidence_identity", "foreign-evidence")
+
+    with pytest.raises(ValueError, match="differs from canonical source evidence"):
+        publish_native_results(tmp_path / "STEP", publication)
+    assert not (tmp_path / "STEP").exists()
+
+
+def test_round_tripped_resampling_summary_remains_publishable(tmp_path: Path) -> None:
+    publication = _committed_fit(with_resampling=True)
+    item = publication.resampling[0]
+    summary = item.summary.summary
+    assert summary is not None
+    restored = type(summary).from_record(
+        summary.to_record(),
+        item.evidence,
+        summary.policy,
+    )
+    outcome = replace(item.summary, summary=restored)
+
+    publish_native_results(
+        tmp_path / "STEP",
+        replace(
+            publication,
+            resampling=(ResamplingPublication(item.evidence, outcome),),
+        ),
+    )
+
+    assert (tmp_path / "STEP" / "Statistics" / "Resampling").is_dir()
+
+
+def test_existing_destination_collision_preserves_authoritative_tree(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "STEP"
+    (output / "existing").mkdir(parents=True)
+    (output / "existing" / "sentinel.bin").write_bytes(b"authoritative-old-tree")
+    before = _tree_bytes(output)
+
+    with pytest.raises(FileExistsError, match="destination exists"):
+        publish_native_results(output, publication)
+
+    assert _tree_bytes(output) == before
+    assert not _staging_residue(tmp_path, output.name)
+
+
+def test_mid_render_failure_removes_staging_without_publishing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "STEP"
+
+    def fail_statistics(*_args: object, **_kwargs: object) -> None:
+        raise OSError("injected statistics rendering failure")
+
+    monkeypatch.setattr(native_reporting, "write_statistics", fail_statistics)
+
+    with pytest.raises(OSError, match="injected statistics rendering failure"):
+        publish_native_results(output, publication)
+
+    assert not output.exists()
+    assert not _staging_residue(tmp_path, output.name)
+
+
+def test_final_rename_failure_removes_complete_staging_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "STEP"
+
+    def fail_replace(_source: object, _destination: object) -> None:
+        raise OSError("injected atomic rename failure")
+
+    monkeypatch.setattr(native_reporting.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="injected atomic rename failure"):
+        publish_native_results(output, publication)
+
+    assert not output.exists()
+    assert not _staging_residue(tmp_path, output.name)
 
 
 def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -902,6 +902,66 @@ def test_existing_destination_collision_preserves_authoritative_tree(
     assert not _staging_residue(tmp_path, output.name)
 
 
+@pytest.mark.parametrize("destination_kind", ["directory", "file", "symlink"])
+def test_destination_appearing_after_staging_preserves_competing_object(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    destination_kind: Literal["directory", "file", "symlink"],
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "STEP"
+    symlink_target = tmp_path / "competing-target"
+    original_write_components = native_reporting.write_components
+
+    def finish_staging_then_create_destination(
+        path: Path,
+        components: tuple[ComponentDiagnostic, ...],
+    ) -> None:
+        original_write_components(path, components)
+        if destination_kind == "directory":
+            sentinel = output / "competing" / "sentinel.bin"
+            sentinel.parent.mkdir(parents=True)
+            sentinel.write_bytes(b"competing-authoritative-tree")
+        elif destination_kind == "file":
+            output.write_bytes(b"competing-authoritative-file")
+        else:
+            symlink_target.mkdir()
+            (symlink_target / "sentinel.bin").write_bytes(
+                b"competing-authoritative-symlink-target"
+            )
+            output.symlink_to(symlink_target, target_is_directory=True)
+
+    monkeypatch.setattr(
+        native_reporting,
+        "write_components",
+        finish_staging_then_create_destination,
+    )
+
+    with pytest.raises(FileExistsError, match="destination exists"):
+        publish_native_results(output, publication)
+
+    if destination_kind == "directory":
+        assert {str(item.relative_to(output)) for item in output.rglob("*")} == {
+            "competing",
+            "competing/sentinel.bin",
+        }
+        assert _tree_bytes(output) == {
+            "competing/sentinel.bin": b"competing-authoritative-tree"
+        }
+    elif destination_kind == "file":
+        assert output.read_bytes() == b"competing-authoritative-file"
+    else:
+        assert output.is_symlink()
+        assert output.readlink() == symlink_target
+        assert {
+            str(item.relative_to(symlink_target)) for item in symlink_target.rglob("*")
+        } == {"sentinel.bin"}
+        assert _tree_bytes(symlink_target) == {
+            "sentinel.bin": b"competing-authoritative-symlink-target"
+        }
+    assert not _staging_residue(tmp_path, output.name)
+
+
 def test_mid_render_failure_removes_staging_without_publishing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -928,10 +988,10 @@ def test_final_rename_failure_removes_complete_staging_tree(
     publication = _committed_fit()
     output = tmp_path / "STEP"
 
-    def fail_replace(_source: object, _destination: object) -> None:
+    def fail_rename(_source: Path, _destination: Path) -> None:
         raise OSError("injected atomic rename failure")
 
-    monkeypatch.setattr(native_reporting.os, "replace", fail_replace)
+    monkeypatch.setattr(native_reporting, "_atomic_publish_noreplace", fail_rename)
 
     with pytest.raises(OSError, match="injected atomic rename failure"):
         publish_native_results(output, publication)


### PR DESCRIPTION
Closes #608.

## Summary

Adds the native qualification path for atomic, aggregate-authoritative method-step output.

* Publishes one authoritative root for Parameters, Data, Plots, and Statistics.
* Keeps component outputs diagnostic-only.
* Separates committed central parameters from covariance, constrained, resampling, and MCMC evidence.
* Uses corrected retained-residual statistics and degrees of freedom.
* Requires the exact witnessed successful commit before fitted publication.
* Suppresses normal fitted output for failed or uncommitted workflows.
* Publishes output atomically with no-clobber collision handling and rollback on render failure.

No production CLI/TOML behavior is changed yet.

## Validation

* Full suite: green on final HEAD
* Native-reporting tests: 33 passed
* `ty`: passed
* Ruff lint/format: passed
* `git diff --check`: passed
* Independent review: MERGE
* Standards: 0 Blocking/Important findings
* Spec: 0 Blocking/Important findings
