### PR TITLE
Publish native product-facing run, restart, manifest, and output provenance

### DIFF
--- a/src/chemex/atomic.py
+++ b/src/chemex/atomic.py
@@ -1,0 +1,79 @@
+"""Small filesystem primitives for atomic product publication."""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import sys
+from pathlib import Path
+
+_AT_FDCWD = -100
+_RENAME_NOREPLACE = 1
+_RENAME_EXCL = 4
+
+
+def publish_directory_noreplace(staging: Path, destination: Path) -> None:
+    """Atomically rename a staged directory without replacing a destination."""
+    if sys.platform == "win32":
+        try:
+            os.rename(staging, destination)
+        except FileExistsError as error:
+            raise FileExistsError(
+                errno.EEXIST,
+                "Publication destination exists",
+                destination,
+            ) from error
+        return
+
+    source_bytes = os.fsencode(staging)
+    destination_bytes = os.fsencode(destination)
+    if sys.platform == "linux":
+        function_name = "renameat2"
+        argument_types = (
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        )
+        arguments = (
+            _AT_FDCWD,
+            source_bytes,
+            _AT_FDCWD,
+            destination_bytes,
+            _RENAME_NOREPLACE,
+        )
+    elif sys.platform == "darwin":
+        function_name = "renamex_np"
+        argument_types = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint)
+        arguments = (source_bytes, destination_bytes, _RENAME_EXCL)
+    else:
+        raise OSError(
+            errno.ENOTSUP,
+            "Atomic no-replace directory rename is unavailable on this platform",
+            destination,
+        )
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    try:
+        rename_noreplace = getattr(libc, function_name)
+    except AttributeError as error:
+        raise OSError(
+            errno.ENOSYS,
+            f"{function_name} is unavailable for atomic publication",
+            destination,
+        ) from error
+    rename_noreplace.argtypes = argument_types
+    rename_noreplace.restype = ctypes.c_int
+    result = rename_noreplace(*arguments)
+    if result == 0:
+        return
+    error_number = ctypes.get_errno()
+    if error_number == errno.EEXIST:
+        raise FileExistsError(
+            errno.EEXIST,
+            "Publication destination exists",
+            destination,
+        )
+    raise OSError(error_number, os.strerror(error_number), destination)

--- a/src/chemex/native_provenance.py
+++ b/src/chemex/native_provenance.py
@@ -19,7 +19,8 @@ import numpy as np
 from chemex import __version__
 from chemex.configuration.conditions import Conditions
 from chemex.configuration.methods import Method
-from chemex.evaluation.native import EvaluationPlan
+from chemex.evaluation.native import EvaluationPlan, EvaluationResult
+from chemex.optimize.direct_trf import DirectTrfExecution, DirectTrfInvocation
 from chemex.parameters.name import ParamName
 from chemex.parameters.parameterization import (
     ActiveParameterization,
@@ -878,12 +879,11 @@ class WorkflowProvenance:
         parameterization: ActiveParameterization,
         plan: EvaluationPlan,
         method: Method,
-        workflow_type: str,
-        grouping_topology: tuple[tuple[str, tuple[str, ...]], ...],
+        invocation: DirectTrfInvocation | None,
+        native_execution: DirectTrfExecution | EvaluationResult,
         policies: tuple[PolicyRecord, ...],
         budgets: tuple[BudgetRecord, ...],
         seeds: tuple[SeedRecord, ...],
-        execution: ExecutionSettings,
         environment: ProvenanceEnvironment,
         baseline_references: tuple[BaselineReference, ...],
     ) -> WorkflowProvenance:
@@ -895,6 +895,14 @@ class WorkflowProvenance:
             raise NativeProvenanceError(
                 "Workflow provenance requires the executed plan and parameterization"
             )
+        workflow_type, grouping_topology, execution_settings = (
+            cls._derive_live_execution_facts(
+                parameterization,
+                plan,
+                invocation,
+                native_execution,
+            )
+        )
         return cls(
             _WORKFLOW_PROVENANCE_KEY,
             _normalized_method_semantics(method),
@@ -910,10 +918,46 @@ class WorkflowProvenance:
             policies,
             budgets,
             seeds,
-            execution,
+            execution_settings,
             environment,
             baseline_references,
         )
+
+    @staticmethod
+    def _derive_live_execution_facts(
+        parameterization: ActiveParameterization,
+        plan: EvaluationPlan,
+        invocation: DirectTrfInvocation | None,
+        native_execution: DirectTrfExecution | EvaluationResult,
+    ) -> tuple[
+        str,
+        tuple[tuple[str, tuple[str, ...]], ...],
+        ExecutionSettings,
+    ]:
+        """Extract publication facts from the exact native occurrence artifacts."""
+        grouping = (("aggregate", parameterization.independent_ids),)
+        if isinstance(native_execution, DirectTrfExecution):
+            if (
+                invocation is None
+                or native_execution.problem_identity != invocation.problem_identity
+                or native_execution.invocation_identity != invocation.identity
+            ):
+                raise NativeProvenanceError(
+                    "Direct TRF provenance requires its exact invocation and execution"
+                )
+            return "direct_trf", grouping, invocation.execution_settings
+        if (
+            invocation is not None
+            or native_execution.plan_identity != plan.identity
+            or native_execution.parameterization_identity
+            != parameterization.evaluator_identity
+        ):
+            raise NativeProvenanceError(
+                "Evaluation provenance requires its exact evaluation result"
+            )
+        # Evaluation-only has no worker dispatcher or optimizer invocation. These are
+        # therefore implementation facts, not publication-time configuration claims.
+        return "evaluation_only", grouping, ExecutionSettings()
 
     @property
     def normalized_method_sha256(self) -> str:
@@ -924,8 +968,18 @@ class WorkflowProvenance:
         parameterization: ActiveParameterization,
         plan: EvaluationPlan,
         method: Method,
+        invocation: DirectTrfInvocation | None,
+        native_execution: DirectTrfExecution | EvaluationResult,
     ) -> None:
         """Re-derive and validate every execution-owned method/selection field."""
+        workflow_type, grouping_topology, execution_settings = (
+            self._derive_live_execution_facts(
+                parameterization,
+                plan,
+                invocation,
+                native_execution,
+            )
+        )
         if (
             self.parameterization_identity != parameterization.identity
             or self.evaluation_plan_identity != plan.identity
@@ -936,9 +990,13 @@ class WorkflowProvenance:
                 tuple(profile.identity for profile in plan.profiles),
                 (),
             )
+            or self.workflow_type != workflow_type
+            or self.grouping_topology != grouping_topology
+            or self.execution != execution_settings
         ):
             raise NativeProvenanceError(
-                "Workflow method and selection differ from executed artifacts"
+                "Workflow method, selection, or execution provenance differs from "
+                "executed artifacts"
             )
 
     @classmethod

--- a/src/chemex/native_provenance.py
+++ b/src/chemex/native_provenance.py
@@ -1,0 +1,674 @@
+"""Typed product-facing provenance for native ChemEx occurrences."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import platform
+import tomllib
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+
+from chemex import __version__
+from chemex.configuration.conditions import Conditions
+from chemex.evaluation.native import EvaluationPlan
+from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    SealedParameterModel,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.runtime import ExecutionSettings
+
+
+class NativeProvenanceError(ValueError):
+    """Raised when product-facing provenance is incomplete or ambiguous."""
+
+
+type StepLifecycle = Literal[
+    "committed",
+    "successful_no_state_change",
+    "failed",
+    "accepted_uncommitted",
+    "cancelled",
+    "interrupted",
+]
+type StepAuthority = Literal["committed_fit", "evaluation_only", "diagnostic_only"]
+type ArtifactRole = Literal[
+    "committed_restart_state",
+    "report_only_fitted_values",
+    "diagnostic_provenance",
+    "partial_evidence",
+    "product_output",
+]
+_BASELINE_REFERENCE_KEY = object()
+_WORKFLOW_PROVENANCE_KEY = object()
+
+
+def _require_text(value: str, field_name: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise NativeProvenanceError(f"{field_name} cannot be empty")
+    return text
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "schema_version": 1, "record": record},
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _toml_key(value: str) -> str:
+    return json.dumps(value, ensure_ascii=True)
+
+
+def _parameter_float(value: float) -> str:
+    scalar = float(value)
+    if math.isnan(scalar):
+        raise NativeProvenanceError("Independent parameter state cannot contain NaN")
+    return repr(0.0 if scalar == 0.0 else scalar)
+
+
+def _normalized_executed_method(
+    parameterization: ActiveParameterization,
+    plan: EvaluationPlan,
+) -> str:
+    """Serialize the realized method semantics, not caller-authored selectors."""
+    lines = [
+        "FORMAT_VERSION = 2",
+        "",
+        "[RESOLVED]",
+        f"MODEL = {_toml_key(parameterization.binder.model_name)}",
+        f"PARAMETERIZATION_IDENTITY = {_toml_key(parameterization.identity)}",
+        f"CONSTRAINT_PROGRAM_IDENTITY = {_toml_key(parameterization.program.fingerprint)}",
+        f"EVALUATION_PLAN_IDENTITY = {_toml_key(plan.identity)}",
+        "",
+    ]
+    for param_id in parameterization.scope_ids:
+        lines.extend(
+            (
+                "[[RESOLVED.PARAMETERS]]",
+                f"ID = {_toml_key(param_id)}",
+                f"ROLE = {_toml_key(parameterization.role(param_id).value)}",
+                "",
+            )
+        )
+    for constraint in parameterization.program.constraints:
+        lines.extend(
+            (
+                "[[RESOLVED.CONSTRAINTS]]",
+                f"TARGET = {_toml_key(constraint.target_id)}",
+                f"EXPRESSION = {_toml_key(constraint.expression_text)}",
+                f"SOURCE = {_toml_key(constraint.source)}",
+                f"DEPENDENCIES = {json.dumps(list(constraint.dependencies))}",
+                "",
+            )
+        )
+    return "\n".join(lines)
+
+
+def serialize_independent_parameters(
+    parameter_model: SealedParameterModel,
+    independent_ids: tuple[str, ...],
+    snapshot: AnalysisValuesSnapshot,
+    *,
+    state_kind: Literal["starting", "committed"],
+) -> str:
+    """Render complete independent values and bounds in ChemEx input form."""
+    if (
+        snapshot.model_identity != parameter_model.model_identity
+        or snapshot.definitions_identity != parameter_model.definitions.identity
+        or snapshot.configuration_identity != parameter_model.configuration.identity
+    ):
+        raise NativeProvenanceError(
+            "Independent parameter snapshot differs from the sealed parameter model"
+        )
+    if len(set(independent_ids)) != len(independent_ids) or any(
+        param_id not in parameter_model.configuration for param_id in independent_ids
+    ):
+        raise NativeProvenanceError(
+            "Independent parameter scope must be unique and completely configured"
+        )
+    sections: dict[str, list[tuple[str, float, float, float]]] = {}
+    for param_id in independent_ids:
+        definition = parameter_model.definitions[param_id]
+        name = ParamName(
+            definition.name,
+            SpinSystem.from_name(definition.spin_system_name),
+            Conditions.model_construct(None, **dict(definition.condition_entries)),
+        )
+        config = parameter_model.configuration[param_id]
+        if name.spin_system:
+            section = name.section
+            key = str(name.spin_system)
+        else:
+            section = "GLOBAL"
+            key = name.section_res
+        sections.setdefault(section, []).append(
+            (key, snapshot[param_id], config.lower_bound, config.upper_bound)
+        )
+    if state_kind == "starting":
+        heading = (
+            "# Complete starting independent parameter state used by this invocation.",
+            "# This is provenance for the original start, not a committed restart.",
+        )
+    else:
+        heading = (
+            "# Complete committed independent parameter state.",
+            "# This file is intended to start a new ChemEx invocation.",
+            "# Report-only fitted values are published separately in fitted.toml.",
+        )
+    lines = [*heading, "# Each array is [value, minimum, maximum].", ""]
+    for section, items in sections.items():
+        lines.append(f"[{_toml_key(section)}]")
+        lines.extend(
+            f"{_toml_key(key)} = [{_parameter_float(value)}, "
+            f"{_parameter_float(lower)}, {_parameter_float(upper)}]"
+            for key, value, lower, upper in items
+        )
+        lines.append("")
+    return "\n".join(lines)
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileSelectionRecord:
+    """Model and profile selection applied to one native workflow."""
+
+    model_name: str
+    include: tuple[str, ...]
+    exclude: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "model_name", _require_text(self.model_name, "model"))
+        for field_name in ("include", "exclude"):
+            values = tuple(
+                _require_text(item, field_name) for item in getattr(self, field_name)
+            )
+            if len(set(values)) != len(values):
+                raise NativeProvenanceError(
+                    f"Profile {field_name} selection contains duplicates"
+                )
+            object.__setattr__(self, field_name, values)
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "model": self.model_name,
+            "include": list(self.include),
+            "exclude": list(self.exclude),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyRecord:
+    """Named immutable policy identity used by a workflow."""
+
+    name: str
+    identity: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _require_text(self.name, "policy name"))
+        object.__setattr__(
+            self, "identity", _require_text(self.identity, "policy identity")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetRecord:
+    """Resolved non-fungible budget and its authoritative usage."""
+
+    name: str
+    limit: int
+    used: int | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _require_text(self.name, "budget name"))
+        if (
+            isinstance(self.limit, bool)
+            or self.limit < 1
+            or isinstance(self.used, bool)
+            or (self.used is not None and (self.used < 0 or self.used > self.limit))
+        ):
+            raise NativeProvenanceError(
+                "Budget limits must be positive and known usage within the limit"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class SeedRecord:
+    """Resolved unsigned seed and the derivation policy that owns it."""
+
+    name: str
+    value: int
+    policy_identity: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _require_text(self.name, "seed name"))
+        object.__setattr__(
+            self,
+            "policy_identity",
+            _require_text(self.policy_identity, "seed policy identity"),
+        )
+        if isinstance(self.value, bool) or not 0 <= self.value < 2**64:
+            raise NativeProvenanceError("Seeds must be unsigned 64-bit integers")
+
+
+@dataclass(frozen=True, slots=True)
+class BaselineReference:
+    """Reference to baseline provenance without transferring its authority."""
+
+    _construction_key: object = field(repr=False, compare=False)
+    kind: Literal["occurrence", "bundle", "manifest"]
+    identity: str
+
+    def __post_init__(self) -> None:
+        if self._construction_key is not _BASELINE_REFERENCE_KEY:
+            raise NativeProvenanceError(
+                "Baseline references must come from validated baseline records"
+            )
+        if self.kind not in ("occurrence", "bundle", "manifest"):
+            raise NativeProvenanceError("Unsupported baseline reference kind")
+        object.__setattr__(
+            self,
+            "identity",
+            _require_text(self.identity, "baseline reference identity"),
+        )
+
+    @classmethod
+    def from_occurrence(cls, occurrence: object) -> BaselineReference:
+        """Reference an occurrence only after canonical record revalidation."""
+        from chemex.baselines import Occurrence
+
+        if not isinstance(occurrence, Occurrence):
+            raise TypeError("Baseline occurrence reference requires Occurrence")
+        canonical = Occurrence.from_record(occurrence.to_record())
+        return cls(_BASELINE_REFERENCE_KEY, "occurrence", canonical.identity)
+
+    @classmethod
+    def from_result_bundle(cls, bundle: object) -> BaselineReference:
+        """Reference a result bundle only after canonical record revalidation."""
+        from chemex.baselines import ResultBundle
+
+        if not isinstance(bundle, ResultBundle):
+            raise TypeError("Baseline bundle reference requires ResultBundle")
+        canonical = ResultBundle.from_record(bundle.to_record())
+        return cls(_BASELINE_REFERENCE_KEY, "bundle", canonical.identity)
+
+    @classmethod
+    def from_result_manifest(cls, bundle: object) -> BaselineReference:
+        """Reference a result manifest only after canonical bundle revalidation."""
+        from chemex.baselines import ResultBundle
+
+        if not isinstance(bundle, ResultBundle):
+            raise TypeError("Baseline manifest reference requires ResultBundle")
+        canonical = ResultBundle.from_record(bundle.to_record())
+        return cls(_BASELINE_REFERENCE_KEY, "manifest", canonical.manifest_identity)
+
+
+@dataclass(frozen=True, slots=True)
+class ProvenanceEnvironment:
+    """Resolved software and numerical-library environment."""
+
+    chemex_version: str
+    python_version: str
+    python_implementation: str
+    platform: str
+    numpy_version: str
+    scipy_version: str
+    emcee_version: str
+    numerical_libraries: tuple[tuple[str, str, str], ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        names = (
+            "chemex_version",
+            "python_version",
+            "python_implementation",
+            "platform",
+            "numpy_version",
+            "scipy_version",
+            "emcee_version",
+        )
+        for name in names:
+            object.__setattr__(self, name, _require_text(getattr(self, name), name))
+        libraries = tuple(
+            tuple(_require_text(value, "numerical library field") for value in item)
+            for item in self.numerical_libraries
+        )
+        if any(len(item) != 3 for item in libraries):
+            raise NativeProvenanceError(
+                "Numerical libraries require kind, name, and version"
+            )
+        if len({item[0] for item in libraries}) != len(libraries):
+            raise NativeProvenanceError("Numerical library kinds must be unique")
+        object.__setattr__(self, "numerical_libraries", libraries)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-provenance-environment",
+                tuple(getattr(self, name) for name in names) + (libraries,),
+            ),
+        )
+
+    @classmethod
+    def from_current_process(cls) -> ProvenanceEnvironment:
+        """Capture the local product and numerical runtime without lmfit fields."""
+
+        def package_version(name: str) -> str:
+            try:
+                return version(name)
+            except PackageNotFoundError:
+                return "unavailable"
+
+        build_dependencies = getattr(np.__config__, "CONFIG", {}).get(
+            "Build Dependencies", {}
+        )
+        libraries = tuple(
+            (
+                kind,
+                str(details.get("name", "unknown")),
+                str(details.get("version", "unknown")),
+            )
+            for kind, details in sorted(build_dependencies.items())
+            if isinstance(details, dict) and details.get("found", False)
+        )
+        return cls(
+            chemex_version=__version__,
+            python_version=platform.python_version(),
+            python_implementation=platform.python_implementation(),
+            platform=platform.platform(),
+            numpy_version=package_version("numpy"),
+            scipy_version=package_version("scipy"),
+            emcee_version=package_version("emcee"),
+            numerical_libraries=libraries,
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "identity": self.identity,
+            "chemex_version": self.chemex_version,
+            "python_version": self.python_version,
+            "python_implementation": self.python_implementation,
+            "platform": self.platform,
+            "numpy_version": self.numpy_version,
+            "scipy_version": self.scipy_version,
+            "emcee_version": self.emcee_version,
+            "numerical_libraries": [
+                {"kind": kind, "name": name, "version": library_version}
+                for kind, name, library_version in self.numerical_libraries
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowProvenance:
+    """Complete static and resolved provenance for one native method workflow."""
+
+    _construction_key: object = field(repr=False, compare=False)
+    normalized_method_text: str
+    selection: ProfileSelectionRecord
+    parameterization_identity: str
+    evaluation_plan_identity: str
+    policies: tuple[PolicyRecord, ...]
+    budgets: tuple[BudgetRecord, ...]
+    seeds: tuple[SeedRecord, ...]
+    execution: ExecutionSettings
+    environment: ProvenanceEnvironment
+    baseline_references: tuple[BaselineReference, ...] = ()
+    workflow_identity: str = field(init=False)
+    method_identity: str = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self._construction_key is not _WORKFLOW_PROVENANCE_KEY:
+            raise NativeProvenanceError(
+                "Workflow provenance must be canonically constructed"
+            )
+        method_text = self.normalized_method_text
+        if not method_text.strip():
+            raise NativeProvenanceError("Normalized method text cannot be empty")
+        try:
+            method = tomllib.loads(method_text)
+        except tomllib.TOMLDecodeError as error:
+            raise NativeProvenanceError(
+                "Normalized method text must be TOML"
+            ) from error
+        format_version = next(
+            (value for key, value in method.items() if key.lower() == "format_version"),
+            None,
+        )
+        if format_version != 2:
+            raise NativeProvenanceError(
+                "Normalized native method must declare FORMAT_VERSION = 2"
+            )
+        for name, records in (
+            ("policy", self.policies),
+            ("budget", self.budgets),
+            ("seed", self.seeds),
+        ):
+            record_names = tuple(item.name for item in records)
+            if len(set(record_names)) != len(record_names):
+                raise NativeProvenanceError(f"{name.title()} names must be unique")
+        baseline_keys = tuple(
+            (item.kind, item.identity) for item in self.baseline_references
+        )
+        if len(set(baseline_keys)) != len(baseline_keys):
+            raise NativeProvenanceError("Baseline references must be unique")
+        method_identity = _identity(
+            "normalized-method-v2",
+            self.normalized_method_sha256,
+        )
+        workflow_identity = _identity(
+            "native-method-step-workflow",
+            {
+                "method_identity": method_identity,
+                "parameterization_identity": self.parameterization_identity,
+                "evaluation_plan_identity": self.evaluation_plan_identity,
+                "selection": self.selection.to_record(),
+                "policies": [(item.name, item.identity) for item in self.policies],
+                "budgets": [
+                    (item.name, item.limit, item.used) for item in self.budgets
+                ],
+                "seeds": [
+                    (item.name, item.value, item.policy_identity) for item in self.seeds
+                ],
+                "execution": (
+                    self.execution.workers,
+                    self.execution.native_threads,
+                ),
+            },
+        )
+        object.__setattr__(self, "method_identity", method_identity)
+        object.__setattr__(self, "workflow_identity", workflow_identity)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-workflow-provenance",
+                {
+                    "workflow_identity": self.workflow_identity,
+                    "method_identity": self.method_identity,
+                    "normalized_method_sha256": self.normalized_method_sha256,
+                    "parameterization_identity": self.parameterization_identity,
+                    "evaluation_plan_identity": self.evaluation_plan_identity,
+                    "selection": self.selection.to_record(),
+                    "policies": [(item.name, item.identity) for item in self.policies],
+                    "budgets": [
+                        (item.name, item.limit, item.used) for item in self.budgets
+                    ],
+                    "seeds": [
+                        (item.name, item.value, item.policy_identity)
+                        for item in self.seeds
+                    ],
+                    "execution": (
+                        self.execution.workers,
+                        self.execution.native_threads,
+                    ),
+                    "environment_identity": self.environment.identity,
+                    "baseline_references": baseline_keys,
+                },
+            ),
+        )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        parameterization: ActiveParameterization,
+        plan: EvaluationPlan,
+        policies: tuple[PolicyRecord, ...],
+        budgets: tuple[BudgetRecord, ...],
+        seeds: tuple[SeedRecord, ...],
+        execution: ExecutionSettings,
+        environment: ProvenanceEnvironment,
+        baseline_references: tuple[BaselineReference, ...] = (),
+    ) -> WorkflowProvenance:
+        """Derive canonical method, selection, and workflow from executed inputs."""
+        if (
+            plan.parameterization_identity != parameterization.evaluator_identity
+            or plan.constraint_program_identity != parameterization.program.fingerprint
+        ):
+            raise NativeProvenanceError(
+                "Workflow provenance requires the executed plan and parameterization"
+            )
+        return cls(
+            _WORKFLOW_PROVENANCE_KEY,
+            _normalized_executed_method(parameterization, plan),
+            ProfileSelectionRecord(
+                parameterization.binder.model_name,
+                tuple(profile.identity for profile in plan.profiles),
+                (),
+            ),
+            parameterization.identity,
+            plan.identity,
+            policies,
+            budgets,
+            seeds,
+            execution,
+            environment,
+            baseline_references,
+        )
+
+    @property
+    def normalized_method_sha256(self) -> str:
+        return hashlib.sha256(self.normalized_method_text.encode()).hexdigest()
+
+    def validate_execution_context(
+        self,
+        parameterization: ActiveParameterization,
+        plan: EvaluationPlan,
+    ) -> None:
+        """Re-derive and validate every execution-owned method/selection field."""
+        if (
+            self.parameterization_identity != parameterization.identity
+            or self.evaluation_plan_identity != plan.identity
+            or self.normalized_method_text
+            != _normalized_executed_method(parameterization, plan)
+            or self.selection
+            != ProfileSelectionRecord(
+                parameterization.binder.model_name,
+                tuple(profile.identity for profile in plan.profiles),
+                (),
+            )
+        ):
+            raise NativeProvenanceError(
+                "Workflow method and selection differ from executed artifacts"
+            )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "identity": self.workflow_identity,
+            "provenance_identity": self.identity,
+            "method": {
+                "identity": self.method_identity,
+                "normalized_sha256": self.normalized_method_sha256,
+                "parameterization_identity": self.parameterization_identity,
+                "evaluation_plan_identity": self.evaluation_plan_identity,
+            },
+            "selection": self.selection.to_record(),
+            "policies": [
+                {"name": item.name, "identity": item.identity} for item in self.policies
+            ],
+            "budgets": [
+                {"name": item.name, "limit": item.limit, "used": item.used}
+                for item in self.budgets
+            ],
+            "seeds": [
+                {
+                    "name": item.name,
+                    "value": item.value,
+                    "policy_identity": item.policy_identity,
+                }
+                for item in self.seeds
+            ],
+            "execution": {
+                "workers": self.execution.workers,
+                "native_threads": self.execution.native_threads,
+            },
+            "environment": self.environment.to_record(),
+            "baseline_references": [
+                {"kind": item.kind, "identity": item.identity}
+                for item in self.baseline_references
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactReference:
+    """Content-addressed product artifact linked by a step manifest."""
+
+    path: str
+    role: ArtifactRole
+    sha256: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _require_text(self.path, "artifact path"))
+        object.__setattr__(self, "role", _require_text(self.role, "artifact role"))
+        digest = self.sha256.lower()
+        if len(digest) != 64 or any(
+            character not in "0123456789abcdef" for character in digest
+        ):
+            raise NativeProvenanceError(
+                "Artifact SHA-256 must be lowercase hexadecimal"
+            )
+        object.__setattr__(self, "sha256", digest)
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedStepReference:
+    """Verified link from invocation provenance to one atomic step publication."""
+
+    path: Path
+    lifecycle: StepLifecycle
+    authority: StepAuthority
+    manifest_identity: str
+    manifest_sha256: str
+    provenance: WorkflowProvenance
+    independent_ids: tuple[str, ...]
+    artifacts: tuple[ArtifactReference, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", Path(self.path).resolve())
+        for field_name in (
+            "lifecycle",
+            "authority",
+            "manifest_identity",
+            "manifest_sha256",
+        ):
+            object.__setattr__(
+                self, field_name, _require_text(getattr(self, field_name), field_name)
+            )
+        if len(self.manifest_sha256) != 64:
+            raise NativeProvenanceError("Step manifest SHA-256 is malformed")
+        if len(set(self.independent_ids)) != len(self.independent_ids):
+            raise NativeProvenanceError("Published independent scope has duplicates")

--- a/src/chemex/native_provenance.py
+++ b/src/chemex/native_provenance.py
@@ -10,12 +10,15 @@ import tomllib
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Literal
+from threading import RLock
+from typing import Literal, cast
+from weakref import ReferenceType, WeakKeyDictionary, ref
 
 import numpy as np
 
 from chemex import __version__
 from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Method
 from chemex.evaluation.native import EvaluationPlan
 from chemex.parameters.name import ParamName
 from chemex.parameters.parameterization import (
@@ -49,6 +52,7 @@ type ArtifactRole = Literal[
 ]
 _BASELINE_REFERENCE_KEY = object()
 _WORKFLOW_PROVENANCE_KEY = object()
+_PUBLISHED_STEP_KEY = object()
 
 
 def _require_text(value: str, field_name: str) -> str:
@@ -56,6 +60,18 @@ def _require_text(value: str, field_name: str) -> str:
     if not text:
         raise NativeProvenanceError(f"{field_name} cannot be empty")
     return text
+
+
+def _record_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise NativeProvenanceError(f"{field_name} must be an integer")
+    return value
+
+
+def _record_strings(value: object, field_name: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise NativeProvenanceError(f"{field_name} must be a string list")
+    return tuple(cast(list[str], value))
 
 
 def _identity(kind: str, record: object) -> str:
@@ -66,6 +82,212 @@ def _identity(kind: str, record: object) -> str:
         sort_keys=True,
     ).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def native_step_manifest_identity(record: dict[str, object]) -> str:
+    """Compute the durable step identity over every canonical child field."""
+    payload = dict(record)
+    payload.pop("manifest_identity", None)
+    return _identity("native-step-manifest-v2", payload)
+
+
+def validate_native_step_manifest_bytes(  # noqa: C901 - closed durable schema
+    content: bytes,
+) -> dict[str, object]:
+    """Recursively validate one durable lifecycle-aware native step manifest."""
+    try:
+        record = tomllib.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise NativeProvenanceError(
+            "Native step manifest is not canonical TOML"
+        ) from error
+    allowed = {
+        "schema_version",
+        "manifest_identity",
+        "lifecycle",
+        "authority",
+        "publication_occurrence_identity",
+        "starting_state_kind",
+        "starting_occurrence_identity",
+        "starting_revision",
+        "accepted_result_identity",
+        "accepted_occurrence_identity",
+        "commit_receipt_identity",
+        "commit_operation_identity",
+        "commit_occurrence_identity",
+        "committed_occurrence_identity",
+        "committed_revision",
+        "problem_identity",
+        "parameterization_identity",
+        "restart_record_identity",
+        "operation_identity",
+        "workflow",
+        "method",
+        "selection",
+        "execution",
+        "environment",
+        "policies",
+        "budgets",
+        "seeds",
+        "baseline_references",
+        "components",
+        "evidence",
+        "artifacts",
+    }
+    if set(record) - allowed or record.get("schema_version") != 1:
+        raise NativeProvenanceError("Native step manifest has unsupported fields")
+    lifecycle = record.get("lifecycle")
+    authority = record.get("authority")
+    common = {
+        "schema_version",
+        "manifest_identity",
+        "lifecycle",
+        "authority",
+        "publication_occurrence_identity",
+        "workflow",
+        "method",
+        "selection",
+        "execution",
+        "environment",
+        "artifacts",
+    }
+    optional = {
+        "policies",
+        "budgets",
+        "seeds",
+        "baseline_references",
+        "components",
+        "evidence",
+    }
+    committed = {
+        "starting_state_kind",
+        "starting_occurrence_identity",
+        "starting_revision",
+        "accepted_result_identity",
+        "accepted_occurrence_identity",
+        "commit_receipt_identity",
+        "commit_operation_identity",
+        "commit_occurrence_identity",
+        "committed_occurrence_identity",
+        "committed_revision",
+        "problem_identity",
+        "parameterization_identity",
+        "restart_record_identity",
+    }
+    if lifecycle == "committed":
+        if authority != "committed_fit" or not common | committed <= set(record):
+            raise NativeProvenanceError("Committed manifest lacks lifecycle authority")
+        forbidden = {"operation_identity"}
+    elif lifecycle == "successful_no_state_change":
+        if authority != "evaluation_only" or not common <= set(record):
+            raise NativeProvenanceError("Evaluation manifest lacks lifecycle authority")
+        forbidden = committed | {"operation_identity"}
+    elif lifecycle in {"failed", "accepted_uncommitted", "cancelled", "interrupted"}:
+        if authority != "diagnostic_only" or not common | {"operation_identity"} <= set(
+            record
+        ):
+            raise NativeProvenanceError("Suppressed manifest lacks lifecycle authority")
+        forbidden = committed - {
+            "accepted_result_identity",
+            "accepted_occurrence_identity",
+        }
+    else:
+        raise NativeProvenanceError("Native step manifest lifecycle is invalid")
+    if forbidden & set(record) or set(record) - (
+        common | optional | committed | {"operation_identity"}
+    ):
+        raise NativeProvenanceError("Native step manifest mixes lifecycle fields")
+    artifacts = record.get("artifacts")
+    if not isinstance(artifacts, dict) or not artifacts:
+        raise NativeProvenanceError("Native step manifest requires artifacts")
+    roles: list[str] = []
+    for path, artifact in artifacts.items():
+        if (
+            not isinstance(path, str)
+            or Path(path).is_absolute()
+            or ".." in Path(path).parts
+            or not isinstance(artifact, dict)
+            or set(artifact) != {"role", "sha256"}
+        ):
+            raise NativeProvenanceError("Native step manifest has malformed artifacts")
+        ArtifactReference(path, artifact.get("role"), artifact.get("sha256"))  # type: ignore[arg-type]
+        roles.append(str(artifact.get("role")))
+    restart_count = roles.count("committed_restart_state")
+    fitted_count = roles.count("report_only_fitted_values")
+    if lifecycle == "committed":
+        restart_paths = {
+            path
+            for path, artifact in artifacts.items()
+            if isinstance(artifact, dict)
+            and artifact.get("role") == "committed_restart_state"
+        }
+        if (
+            restart_paths
+            != {
+                "Parameters/restart.toml",
+                "Parameters/restart-provenance.json",
+            }
+            or fitted_count > 1
+        ):
+            raise NativeProvenanceError(
+                "Committed manifest lacks exact restart linkage"
+            )
+    elif restart_count or fitted_count:
+        raise NativeProvenanceError(
+            "Non-committed manifest claims fitted/restart authority"
+        )
+    components = record.get("components", [])
+    if not isinstance(components, list) or any(
+        not isinstance(item, dict)
+        or set(item)
+        != {"identity", "disposition", "controlled_ids", "location", "authority"}
+        or item.get("disposition")
+        not in {
+            "succeeded",
+            "failed",
+            "execution_failure",
+            "cancelled",
+            "interrupted",
+            "not_started",
+        }
+        or item.get("location") != "Components/index.json"
+        or item.get("authority") != "diagnostic_only"
+        or item.get("location") not in artifacts
+        or not isinstance(artifacts.get(item.get("location")), dict)
+        or cast(dict[str, object], artifacts[item["location"]]).get("role")
+        != "diagnostic_provenance"
+        for item in components
+    ):
+        raise NativeProvenanceError("Native step components are malformed")
+    component_records = cast(list[dict[str, object]], components)
+    component_controls = tuple(
+        _record_strings(item["controlled_ids"], "component controls")
+        for item in component_records
+    )
+    if len({str(item["identity"]) for item in component_records}) != len(
+        component_records
+    ) or any(
+        not controls or len(set(controls)) != len(controls)
+        for controls in component_controls
+    ):
+        raise NativeProvenanceError("Native step component identities are invalid")
+    evidence = record.get("evidence", [])
+    if not isinstance(evidence, list) or any(
+        not isinstance(item, dict)
+        or set(item) != {"family", "identity", "validity", "location"}
+        or item.get("location") not in artifacts
+        for item in evidence
+    ):
+        raise NativeProvenanceError("Native step evidence is malformed")
+    evidence_records = cast(list[dict[str, object]], evidence)
+    if len({str(item["family"]) for item in evidence_records}) != len(evidence_records):
+        raise NativeProvenanceError("Native step evidence families must be unique")
+    WorkflowProvenance.from_manifest_record(record)
+    if record.get("manifest_identity") != native_step_manifest_identity(record):
+        raise NativeProvenanceError(
+            "Native step manifest identity does not match children"
+        )
+    return record
 
 
 def _toml_key(value: str) -> str:
@@ -79,42 +301,61 @@ def _parameter_float(value: float) -> str:
     return repr(0.0 if scalar == 0.0 else scalar)
 
 
-def _normalized_executed_method(
-    parameterization: ActiveParameterization,
-    plan: EvaluationPlan,
-) -> str:
-    """Serialize the realized method semantics, not caller-authored selectors."""
-    lines = [
-        "FORMAT_VERSION = 2",
-        "",
-        "[RESOLVED]",
-        f"MODEL = {_toml_key(parameterization.binder.model_name)}",
-        f"PARAMETERIZATION_IDENTITY = {_toml_key(parameterization.identity)}",
-        f"CONSTRAINT_PROGRAM_IDENTITY = {_toml_key(parameterization.program.fingerprint)}",
-        f"EVALUATION_PLAN_IDENTITY = {_toml_key(plan.identity)}",
-        "",
-    ]
-    for param_id in parameterization.scope_ids:
-        lines.extend(
-            (
-                "[[RESOLVED.PARAMETERS]]",
-                f"ID = {_toml_key(param_id)}",
-                f"ROLE = {_toml_key(parameterization.role(param_id).value)}",
-                "",
-            )
+def _normalized_method_semantics(method: Method) -> str:
+    """Serialize only canonical method semantics; execution facts live elsewhere."""
+    payload = method.model_dump(
+        mode="json",
+        exclude={"include", "exclude"},
+        exclude_none=True,
+    )
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return "\n".join(
+        (
+            "FORMAT_VERSION = 2",
+            "",
+            "[METHOD]",
+            f"CANONICAL_JSON = {_toml_key(canonical)}",
+            "",
         )
-    for constraint in parameterization.program.constraints:
-        lines.extend(
-            (
-                "[[RESOLVED.CONSTRAINTS]]",
-                f"TARGET = {_toml_key(constraint.target_id)}",
-                f"EXPRESSION = {_toml_key(constraint.expression_text)}",
-                f"SOURCE = {_toml_key(constraint.source)}",
-                f"DEPENDENCIES = {json.dumps(list(constraint.dependencies))}",
-                "",
-            )
-        )
-    return "\n".join(lines)
+    )
+
+
+def _validate_normalized_method_semantics(text: str) -> Method:
+    """Require the exact canonical schema-v2 normalized method representation."""
+    try:
+        record = tomllib.loads(text)
+        if set(record) != {"FORMAT_VERSION", "METHOD"} or record["FORMAT_VERSION"] != 2:
+            raise TypeError
+        method_record = record["METHOD"]
+        if not isinstance(method_record, dict) or set(method_record) != {
+            "CANONICAL_JSON"
+        }:
+            raise TypeError
+        canonical_json = method_record["CANONICAL_JSON"]
+        if not isinstance(canonical_json, str):
+            raise TypeError
+        payload = json.loads(canonical_json)
+        if not isinstance(payload, dict):
+            raise TypeError
+        method = Method.model_validate(payload)
+    except (
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+        tomllib.TOMLDecodeError,
+    ) as error:
+        raise NativeProvenanceError(
+            "Normalized method semantics are malformed"
+        ) from error
+    if _normalized_method_semantics(method) != text:
+        raise NativeProvenanceError("Normalized method semantics are not canonical")
+    return method
 
 
 def serialize_independent_parameters(
@@ -269,6 +510,8 @@ class BaselineReference:
     _construction_key: object = field(repr=False, compare=False)
     kind: Literal["occurrence", "bundle", "manifest"]
     identity: str
+    occurrence_identity: str
+    result_bundle_identity: str
 
     def __post_init__(self) -> None:
         if self._construction_key is not _BASELINE_REFERENCE_KEY:
@@ -282,6 +525,29 @@ class BaselineReference:
             "identity",
             _require_text(self.identity, "baseline reference identity"),
         )
+        object.__setattr__(
+            self,
+            "occurrence_identity",
+            _require_text(self.occurrence_identity, "baseline occurrence identity"),
+        )
+        object.__setattr__(
+            self,
+            "result_bundle_identity",
+            _require_text(
+                self.result_bundle_identity, "baseline result bundle identity"
+            ),
+        )
+        for value in (
+            self.identity,
+            self.occurrence_identity,
+            self.result_bundle_identity,
+        ):
+            if len(value) != 64 or any(
+                character not in "0123456789abcdef" for character in value
+            ):
+                raise NativeProvenanceError(
+                    "Baseline provenance identities must be SHA-256 values"
+                )
 
     @classmethod
     def from_occurrence(cls, occurrence: object) -> BaselineReference:
@@ -291,7 +557,29 @@ class BaselineReference:
         if not isinstance(occurrence, Occurrence):
             raise TypeError("Baseline occurrence reference requires Occurrence")
         canonical = Occurrence.from_record(occurrence.to_record())
-        return cls(_BASELINE_REFERENCE_KEY, "occurrence", canonical.identity)
+        if (
+            canonical.lifecycle != "SUCCEEDED"
+            or canonical.result_bundle_identity is None
+        ):
+            raise NativeProvenanceError(
+                "Baseline provenance requires a successful occurrence"
+            )
+        requested_identity = Occurrence(
+            canonical.execution_specification_identity,
+            canonical.case_identity,
+            canonical.actual_implementation_identity,
+            canonical.lane_reference,
+            canonical.lane_attestation_identity,
+            canonical.input_member_identities,
+            canonical.attempt_token,
+        ).identity
+        return cls(
+            _BASELINE_REFERENCE_KEY,
+            "occurrence",
+            canonical.identity,
+            requested_identity,
+            canonical.result_bundle_identity,
+        )
 
     @classmethod
     def from_result_bundle(cls, bundle: object) -> BaselineReference:
@@ -301,7 +589,13 @@ class BaselineReference:
         if not isinstance(bundle, ResultBundle):
             raise TypeError("Baseline bundle reference requires ResultBundle")
         canonical = ResultBundle.from_record(bundle.to_record())
-        return cls(_BASELINE_REFERENCE_KEY, "bundle", canonical.identity)
+        return cls(
+            _BASELINE_REFERENCE_KEY,
+            "bundle",
+            canonical.identity,
+            canonical.occurrence_identity,
+            canonical.identity,
+        )
 
     @classmethod
     def from_result_manifest(cls, bundle: object) -> BaselineReference:
@@ -311,7 +605,13 @@ class BaselineReference:
         if not isinstance(bundle, ResultBundle):
             raise TypeError("Baseline manifest reference requires ResultBundle")
         canonical = ResultBundle.from_record(bundle.to_record())
-        return cls(_BASELINE_REFERENCE_KEY, "manifest", canonical.manifest_identity)
+        return cls(
+            _BASELINE_REFERENCE_KEY,
+            "manifest",
+            canonical.manifest_identity,
+            canonical.occurrence_identity,
+            canonical.identity,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -417,6 +717,8 @@ class WorkflowProvenance:
     _construction_key: object = field(repr=False, compare=False)
     normalized_method_text: str
     selection: ProfileSelectionRecord
+    workflow_type: str
+    grouping_topology: tuple[tuple[str, tuple[str, ...]], ...]
     parameterization_identity: str
     evaluation_plan_identity: str
     policies: tuple[PolicyRecord, ...]
@@ -427,6 +729,7 @@ class WorkflowProvenance:
     baseline_references: tuple[BaselineReference, ...] = ()
     workflow_identity: str = field(init=False)
     method_identity: str = field(init=False)
+    execution_identity: str = field(init=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -434,23 +737,28 @@ class WorkflowProvenance:
             raise NativeProvenanceError(
                 "Workflow provenance must be canonically constructed"
             )
-        method_text = self.normalized_method_text
-        if not method_text.strip():
-            raise NativeProvenanceError("Normalized method text cannot be empty")
-        try:
-            method = tomllib.loads(method_text)
-        except tomllib.TOMLDecodeError as error:
-            raise NativeProvenanceError(
-                "Normalized method text must be TOML"
-            ) from error
-        format_version = next(
-            (value for key, value in method.items() if key.lower() == "format_version"),
-            None,
+        _validate_normalized_method_semantics(self.normalized_method_text)
+        object.__setattr__(
+            self,
+            "parameterization_identity",
+            _require_text(self.parameterization_identity, "parameterization identity"),
         )
-        if format_version != 2:
-            raise NativeProvenanceError(
-                "Normalized native method must declare FORMAT_VERSION = 2"
-            )
+        object.__setattr__(
+            self,
+            "evaluation_plan_identity",
+            _require_text(self.evaluation_plan_identity, "evaluation plan identity"),
+        )
+        object.__setattr__(
+            self,
+            "workflow_type",
+            _require_text(self.workflow_type, "workflow type"),
+        )
+        grouping = tuple((name, tuple(ids)) for name, ids in self.grouping_topology)
+        if len({name for name, _ids in grouping}) != len(grouping) or any(
+            not name or not ids or len(set(ids)) != len(ids) for name, ids in grouping
+        ):
+            raise NativeProvenanceError("Workflow grouping topology is invalid")
+        object.__setattr__(self, "grouping_topology", grouping)
         for name, records in (
             ("policy", self.policies),
             ("budget", self.budgets),
@@ -460,10 +768,42 @@ class WorkflowProvenance:
             if len(set(record_names)) != len(record_names):
                 raise NativeProvenanceError(f"{name.title()} names must be unique")
         baseline_keys = tuple(
-            (item.kind, item.identity) for item in self.baseline_references
+            (
+                item.kind,
+                item.identity,
+                item.occurrence_identity,
+                item.result_bundle_identity,
+            )
+            for item in self.baseline_references
         )
-        if len(set(baseline_keys)) != len(baseline_keys):
-            raise NativeProvenanceError("Baseline references must be unique")
+        if (
+            not {"occurrence", "bundle"}
+            <= {item.kind for item in self.baseline_references}
+            or len(self.baseline_references) not in {2, 3}
+            or (
+                len(self.baseline_references) == 3
+                and {item.kind for item in self.baseline_references}
+                != {"occurrence", "bundle", "manifest"}
+            )
+            or len({item.occurrence_identity for item in self.baseline_references}) != 1
+            or len({item.result_bundle_identity for item in self.baseline_references})
+            != 1
+            or next(
+                item.identity
+                for item in self.baseline_references
+                if item.kind == "occurrence"
+            )
+            != self.baseline_references[0].occurrence_identity
+            or next(
+                item.identity
+                for item in self.baseline_references
+                if item.kind == "bundle"
+            )
+            != self.baseline_references[0].result_bundle_identity
+        ):
+            raise NativeProvenanceError(
+                "Baseline provenance requires one linked occurrence/bundle pair"
+            )
         method_identity = _identity(
             "normalized-method-v2",
             self.normalized_method_sha256,
@@ -472,6 +812,14 @@ class WorkflowProvenance:
             "native-method-step-workflow",
             {
                 "method_identity": method_identity,
+                "workflow_type": self.workflow_type,
+                "grouping_topology": self.grouping_topology,
+            },
+        )
+        execution_identity = _identity(
+            "native-execution-configuration-v2",
+            {
+                "workflow_identity": workflow_identity,
                 "parameterization_identity": self.parameterization_identity,
                 "evaluation_plan_identity": self.evaluation_plan_identity,
                 "selection": self.selection.to_record(),
@@ -486,10 +834,12 @@ class WorkflowProvenance:
                     self.execution.workers,
                     self.execution.native_threads,
                 ),
+                "environment_identity": self.environment.identity,
             },
         )
         object.__setattr__(self, "method_identity", method_identity)
         object.__setattr__(self, "workflow_identity", workflow_identity)
+        object.__setattr__(self, "execution_identity", execution_identity)
         object.__setattr__(
             self,
             "identity",
@@ -497,6 +847,7 @@ class WorkflowProvenance:
                 "native-workflow-provenance",
                 {
                     "workflow_identity": self.workflow_identity,
+                    "execution_identity": self.execution_identity,
                     "method_identity": self.method_identity,
                     "normalized_method_sha256": self.normalized_method_sha256,
                     "parameterization_identity": self.parameterization_identity,
@@ -526,12 +877,15 @@ class WorkflowProvenance:
         *,
         parameterization: ActiveParameterization,
         plan: EvaluationPlan,
+        method: Method,
+        workflow_type: str,
+        grouping_topology: tuple[tuple[str, tuple[str, ...]], ...],
         policies: tuple[PolicyRecord, ...],
         budgets: tuple[BudgetRecord, ...],
         seeds: tuple[SeedRecord, ...],
         execution: ExecutionSettings,
         environment: ProvenanceEnvironment,
-        baseline_references: tuple[BaselineReference, ...] = (),
+        baseline_references: tuple[BaselineReference, ...],
     ) -> WorkflowProvenance:
         """Derive canonical method, selection, and workflow from executed inputs."""
         if (
@@ -543,12 +897,14 @@ class WorkflowProvenance:
             )
         return cls(
             _WORKFLOW_PROVENANCE_KEY,
-            _normalized_executed_method(parameterization, plan),
+            _normalized_method_semantics(method),
             ProfileSelectionRecord(
                 parameterization.binder.model_name,
                 tuple(profile.identity for profile in plan.profiles),
                 (),
             ),
+            workflow_type,
+            grouping_topology,
             parameterization.identity,
             plan.identity,
             policies,
@@ -567,13 +923,13 @@ class WorkflowProvenance:
         self,
         parameterization: ActiveParameterization,
         plan: EvaluationPlan,
+        method: Method,
     ) -> None:
         """Re-derive and validate every execution-owned method/selection field."""
         if (
             self.parameterization_identity != parameterization.identity
             or self.evaluation_plan_identity != plan.identity
-            or self.normalized_method_text
-            != _normalized_executed_method(parameterization, plan)
+            or self.normalized_method_text != _normalized_method_semantics(method)
             or self.selection
             != ProfileSelectionRecord(
                 parameterization.binder.model_name,
@@ -585,9 +941,209 @@ class WorkflowProvenance:
                 "Workflow method and selection differ from executed artifacts"
             )
 
+    @classmethod
+    def from_manifest_record(cls, manifest: dict[str, object]) -> WorkflowProvenance:
+        """Rebuild durable provenance without recreating live execution authority."""
+        try:
+            raw_children = tuple(
+                manifest[name]
+                for name in (
+                    "workflow",
+                    "method",
+                    "selection",
+                    "execution",
+                    "environment",
+                )
+            )
+            if not all(isinstance(item, dict) for item in raw_children):
+                raise TypeError
+            workflow, method, selection, execution, environment = (
+                cast(dict[str, object], item) for item in raw_children
+            )
+            if (
+                set(workflow)
+                != {
+                    "identity",
+                    "execution_identity",
+                    "provenance_identity",
+                    "type",
+                    "groups",
+                }
+                or set(method)
+                != {
+                    "identity",
+                    "normalized",
+                    "normalized_sha256",
+                    "parameterization_identity",
+                    "evaluation_plan_identity",
+                }
+                or set(selection) != {"model", "include", "exclude"}
+                or set(execution) != {"workers", "native_threads"}
+                or set(environment)
+                != {
+                    "identity",
+                    "chemex_version",
+                    "python_version",
+                    "python_implementation",
+                    "platform",
+                    "numpy_version",
+                    "scipy_version",
+                    "emcee_version",
+                    "numerical_libraries",
+                }
+            ):
+                raise TypeError
+            groups = workflow["groups"]
+            if not isinstance(groups, list) or any(
+                not isinstance(item, dict)
+                or set(item) != {"identity", "controlled_ids"}
+                for item in groups
+            ):
+                raise TypeError
+            group_records = cast(list[dict[str, object]], groups)
+            for name, fields in (
+                ("policies", {"name", "identity"}),
+                ("seeds", {"name", "value", "policy_identity"}),
+                (
+                    "baseline_references",
+                    {
+                        "kind",
+                        "identity",
+                        "occurrence_identity",
+                        "result_bundle_identity",
+                    },
+                ),
+            ):
+                children = manifest.get(name, [])
+                if not isinstance(children, list) or any(
+                    not isinstance(item, dict) or set(item) != fields
+                    for item in children
+                ):
+                    raise TypeError
+            budgets = manifest.get("budgets", [])
+            if not isinstance(budgets, list) or any(
+                not isinstance(item, dict)
+                or not {"name", "limit"} <= set(item)
+                or set(item) - {"name", "limit", "used"}
+                for item in budgets
+            ):
+                raise TypeError
+            libraries = environment.get("numerical_libraries", [])
+            if not isinstance(libraries, list) or any(
+                not isinstance(item, dict) or set(item) != {"kind", "name", "version"}
+                for item in libraries
+            ):
+                raise TypeError
+            library_records = cast(list[dict[str, object]], libraries)
+            policy_records = cast(list[dict[str, object]], manifest.get("policies", []))
+            budget_records = cast(list[dict[str, object]], manifest.get("budgets", []))
+            seed_records = cast(list[dict[str, object]], manifest.get("seeds", []))
+            baseline_records = cast(
+                list[dict[str, object]], manifest.get("baseline_references", [])
+            )
+            provenance = cls(
+                _WORKFLOW_PROVENANCE_KEY,
+                str(method["normalized"]),
+                ProfileSelectionRecord(
+                    str(selection["model"]),
+                    _record_strings(selection["include"], "selection include"),
+                    _record_strings(selection["exclude"], "selection exclude"),
+                ),
+                str(workflow["type"]),
+                tuple(
+                    (
+                        str(item["identity"]),
+                        _record_strings(item["controlled_ids"], "controlled IDs"),
+                    )
+                    for item in group_records
+                ),
+                str(method["parameterization_identity"]),
+                str(method["evaluation_plan_identity"]),
+                tuple(
+                    PolicyRecord(str(item["name"]), str(item["identity"]))
+                    for item in policy_records
+                ),
+                tuple(
+                    BudgetRecord(
+                        str(item["name"]),
+                        _record_int(item["limit"], "budget limit"),
+                        (
+                            None
+                            if "used" not in item
+                            else _record_int(item["used"], "budget used")
+                        ),
+                    )
+                    for item in budget_records
+                ),
+                tuple(
+                    SeedRecord(
+                        str(item["name"]),
+                        _record_int(item["value"], "seed value"),
+                        str(item["policy_identity"]),
+                    )
+                    for item in seed_records
+                ),
+                ExecutionSettings(
+                    workers=_record_int(execution["workers"], "workers"),
+                    native_threads=(
+                        None
+                        if execution["native_threads"] == "auto"
+                        else _record_int(execution["native_threads"], "native threads")
+                    ),
+                ),
+                ProvenanceEnvironment(
+                    str(environment["chemex_version"]),
+                    str(environment["python_version"]),
+                    str(environment["python_implementation"]),
+                    str(environment["platform"]),
+                    str(environment["numpy_version"]),
+                    str(environment["scipy_version"]),
+                    str(environment["emcee_version"]),
+                    tuple(
+                        (str(item["kind"]), str(item["name"]), str(item["version"]))
+                        for item in library_records
+                    ),
+                ),
+                tuple(
+                    BaselineReference(
+                        _BASELINE_REFERENCE_KEY,
+                        cast(
+                            Literal["occurrence", "bundle", "manifest"],
+                            str(item["kind"]),
+                        ),
+                        str(item["identity"]),
+                        str(item["occurrence_identity"]),
+                        str(item["result_bundle_identity"]),
+                    )
+                    for item in baseline_records
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise NativeProvenanceError(
+                "Native step workflow provenance is malformed"
+            ) from error
+        if (
+            workflow.get("identity") != provenance.workflow_identity
+            or workflow.get("execution_identity") != provenance.execution_identity
+            or workflow.get("provenance_identity") != provenance.identity
+            or method.get("identity") != provenance.method_identity
+            or method.get("normalized_sha256") != provenance.normalized_method_sha256
+            or environment.get("identity") != provenance.environment.identity
+        ):
+            raise NativeProvenanceError(
+                "Native step workflow identities do not match their children"
+            )
+        return provenance
+
     def to_record(self) -> dict[str, object]:
         return {
             "identity": self.workflow_identity,
+            "execution_identity": self.execution_identity,
+            "workflow_type": self.workflow_type,
+            "grouping_topology": [
+                {"identity": name, "controlled_ids": list(ids)}
+                for name, ids in self.grouping_topology
+            ],
             "provenance_identity": self.identity,
             "method": {
                 "identity": self.method_identity,
@@ -617,7 +1173,12 @@ class WorkflowProvenance:
             },
             "environment": self.environment.to_record(),
             "baseline_references": [
-                {"kind": item.kind, "identity": item.identity}
+                {
+                    "kind": item.kind,
+                    "identity": item.identity,
+                    "occurrence_identity": item.occurrence_identity,
+                    "result_bundle_identity": item.result_bundle_identity,
+                }
                 for item in self.baseline_references
             ],
         }
@@ -634,6 +1195,20 @@ class ArtifactReference:
     def __post_init__(self) -> None:
         object.__setattr__(self, "path", _require_text(self.path, "artifact path"))
         object.__setattr__(self, "role", _require_text(self.role, "artifact role"))
+        if (
+            Path(self.path).is_absolute()
+            or ".." in Path(self.path).parts
+            or Path(self.path).parts in {(), (".",)}
+            or self.role
+            not in {
+                "committed_restart_state",
+                "report_only_fitted_values",
+                "diagnostic_provenance",
+                "partial_evidence",
+                "product_output",
+            }
+        ):
+            raise NativeProvenanceError("Artifact link or role is invalid")
         digest = self.sha256.lower()
         if len(digest) != 64 or any(
             character not in "0123456789abcdef" for character in digest
@@ -645,9 +1220,301 @@ class ArtifactReference:
 
 
 @dataclass(frozen=True, slots=True)
+class CommittedRestartRecord:
+    """Durable exact binding from a restart file to one witnessed commit."""
+
+    starting_occurrence_identity: str
+    starting_revision: int
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
+    commit_operation_identity: str
+    commit_occurrence_identity: str
+    committed_occurrence_identity: str
+    committed_revision: int
+    workflow_identity: str
+    problem_identity: str
+    parameterization_identity: str
+    parameter_model_identity: str
+    configuration_identity: str
+    independent_items: tuple[tuple[str, str, str, str], ...]
+    restart_sha256: str
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        identities = (
+            self.starting_occurrence_identity,
+            self.accepted_result_identity,
+            self.accepted_occurrence_identity,
+            self.commit_operation_identity,
+            self.commit_occurrence_identity,
+            self.committed_occurrence_identity,
+            self.workflow_identity,
+            self.problem_identity,
+            self.parameterization_identity,
+            self.parameter_model_identity,
+            self.configuration_identity,
+        )
+        if any(not value for value in identities):
+            raise NativeProvenanceError("Committed restart lineage is incomplete")
+        if (
+            self.starting_revision < 0
+            or self.committed_revision != self.starting_revision + 1
+            or len(self.restart_sha256) != 64
+            or any(
+                character not in "0123456789abcdef" for character in self.restart_sha256
+            )
+        ):
+            raise NativeProvenanceError("Committed restart revisions are inconsistent")
+        items = tuple(self.independent_items)
+        ids = tuple(item[0] for item in items)
+        if not items or len(set(ids)) != len(ids) or tuple(sorted(ids)) != ids:
+            raise NativeProvenanceError(
+                "Committed restart independent frame is invalid"
+            )
+        for param_id, value, lower, upper in items:
+            try:
+                scalars = tuple(float.fromhex(item) for item in (value, lower, upper))
+            except ValueError as error:
+                raise NativeProvenanceError(
+                    "Committed restart contains malformed binary64 values"
+                ) from error
+            if (
+                not param_id
+                or not math.isfinite(scalars[0])
+                or math.isnan(scalars[1])
+                or math.isnan(scalars[2])
+                or tuple(item.hex() for item in scalars) != (value, lower, upper)
+            ):
+                raise NativeProvenanceError(
+                    "Committed restart contains non-finite independent values"
+                )
+            if not scalars[1] <= scalars[0] <= scalars[2]:
+                raise NativeProvenanceError(
+                    "Committed restart value is outside configured bounds"
+                )
+        object.__setattr__(self, "independent_items", items)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-committed-restart-v2",
+                (
+                    *identities,
+                    self.starting_revision,
+                    self.committed_revision,
+                    items,
+                    self.restart_sha256,
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": 2,
+            "identity": self.identity,
+            "starting_occurrence_identity": self.starting_occurrence_identity,
+            "starting_revision": self.starting_revision,
+            "accepted_result_identity": self.accepted_result_identity,
+            "accepted_occurrence_identity": self.accepted_occurrence_identity,
+            "commit_operation_identity": self.commit_operation_identity,
+            "commit_occurrence_identity": self.commit_occurrence_identity,
+            "committed_occurrence_identity": self.committed_occurrence_identity,
+            "committed_revision": self.committed_revision,
+            "workflow_identity": self.workflow_identity,
+            "problem_identity": self.problem_identity,
+            "parameterization_identity": self.parameterization_identity,
+            "parameter_model_identity": self.parameter_model_identity,
+            "configuration_identity": self.configuration_identity,
+            "independent_items": [
+                {"id": param_id, "value": value, "minimum": lower, "maximum": upper}
+                for param_id, value, lower, upper in self.independent_items
+            ],
+            "restart_sha256": self.restart_sha256,
+        }
+
+    @classmethod
+    def from_record(cls, record: object) -> CommittedRestartRecord:
+        if not isinstance(record, dict):
+            raise NativeProvenanceError("Committed restart provenance must be a record")
+        record = {str(key): value for key, value in record.items()}
+        keys = {
+            "schema_version",
+            "identity",
+            "starting_occurrence_identity",
+            "starting_revision",
+            "accepted_result_identity",
+            "accepted_occurrence_identity",
+            "commit_operation_identity",
+            "commit_occurrence_identity",
+            "committed_occurrence_identity",
+            "committed_revision",
+            "workflow_identity",
+            "problem_identity",
+            "parameterization_identity",
+            "parameter_model_identity",
+            "configuration_identity",
+            "independent_items",
+            "restart_sha256",
+        }
+        if set(record) != keys or record.get("schema_version") != 2:
+            raise NativeProvenanceError(
+                "Committed restart provenance fields are invalid"
+            )
+        raw_items = record.get("independent_items")
+        if not isinstance(raw_items, list) or any(
+            not isinstance(item, dict)
+            or set(item) != {"id", "value", "minimum", "maximum"}
+            for item in raw_items
+        ):
+            raise NativeProvenanceError(
+                "Committed restart independent frame is malformed"
+            )
+        item_records = cast(list[dict[str, object]], raw_items)
+        rebuilt = cls(
+            str(record["starting_occurrence_identity"]),
+            _record_int(record["starting_revision"], "starting revision"),
+            str(record["accepted_result_identity"]),
+            str(record["accepted_occurrence_identity"]),
+            str(record["commit_operation_identity"]),
+            str(record["commit_occurrence_identity"]),
+            str(record["committed_occurrence_identity"]),
+            _record_int(record["committed_revision"], "committed revision"),
+            str(record["workflow_identity"]),
+            str(record["problem_identity"]),
+            str(record["parameterization_identity"]),
+            str(record["parameter_model_identity"]),
+            str(record["configuration_identity"]),
+            tuple(
+                (
+                    str(item["id"]),
+                    str(item["value"]),
+                    str(item["minimum"]),
+                    str(item["maximum"]),
+                )
+                for item in item_records
+            ),
+            str(record["restart_sha256"]),
+        )
+        if record.get("identity") != rebuilt.identity:
+            raise NativeProvenanceError(
+                "Committed restart identity does not match children"
+            )
+        return rebuilt
+
+
+def published_step_reference_identity(
+    *,
+    publication_occurrence_identity: str,
+    lifecycle: str,
+    authority: str,
+    manifest_identity: str,
+    manifest_sha256: str,
+    provenance: WorkflowProvenance,
+    independent_ids: tuple[str, ...],
+    artifacts: tuple[ArtifactReference, ...],
+) -> str:
+    """Recompute a durable step-reference identity without minting live authority."""
+    return _identity(
+        "native-published-step-reference-v2",
+        {
+            "publication_occurrence_identity": publication_occurrence_identity,
+            "lifecycle": lifecycle,
+            "authority": authority,
+            "manifest_identity": manifest_identity,
+            "manifest_sha256": manifest_sha256,
+            "workflow_provenance_identity": provenance.identity,
+            "execution_identity": provenance.execution_identity,
+            "independent_ids": independent_ids,
+            "artifacts": tuple(
+                (item.path, item.role, item.sha256) for item in artifacts
+            ),
+        },
+    )
+
+
+class _PublishedStepWitness:
+    """Opaque process-local witness for one exact #608 publication occurrence."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls) -> _PublishedStepWitness:
+        raise TypeError("Published-step witnesses are minted only by publication")
+
+    def __reduce__(self) -> tuple[object, ...]:
+        raise TypeError("Published-step witnesses cannot be serialized")
+
+
+@dataclass(frozen=True, slots=True)
+class _PublishedStepBinding:
+    occurrence_identity: str
+    step_reference: ReferenceType[object] | None
+    publication: ReferenceType[object]
+
+
+_PUBLISHED_STEP_BINDINGS: WeakKeyDictionary[
+    _PublishedStepWitness, _PublishedStepBinding
+] = WeakKeyDictionary()
+_PUBLISHED_STEP_LOCK = RLock()
+
+
+def _mint_published_step_witness(
+    occurrence_identity: str,
+    publication: object,
+) -> _PublishedStepWitness:
+    witness = object.__new__(_PublishedStepWitness)
+    with _PUBLISHED_STEP_LOCK:
+        _PUBLISHED_STEP_BINDINGS[witness] = _PublishedStepBinding(
+            occurrence_identity,
+            None,
+            ref(publication),
+        )
+    return witness
+
+
+def _bind_published_step_reference(
+    witness: _PublishedStepWitness,
+    occurrence_identity: str,
+    step: object,
+) -> bool:
+    with _PUBLISHED_STEP_LOCK:
+        binding = _PUBLISHED_STEP_BINDINGS.get(witness)
+        if binding is None or binding.occurrence_identity != occurrence_identity:
+            return False
+        current = None if binding.step_reference is None else binding.step_reference()
+        if current is not None:
+            return current is step
+        _PUBLISHED_STEP_BINDINGS[witness] = _PublishedStepBinding(
+            occurrence_identity,
+            ref(step),
+            binding.publication,
+        )
+        return True
+
+
+def _is_exact_live_published_step(
+    witness: _PublishedStepWitness | None,
+    occurrence_identity: str,
+    step: object,
+) -> bool:
+    if witness is None:
+        return False
+    with _PUBLISHED_STEP_LOCK:
+        binding = _PUBLISHED_STEP_BINDINGS.get(witness)
+        return (
+            binding is not None
+            and binding.occurrence_identity == occurrence_identity
+            and binding.step_reference is not None
+            and binding.step_reference() is step
+            and binding.publication() is not None
+        )
+
+
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class PublishedStepReference:
     """Verified link from invocation provenance to one atomic step publication."""
 
+    _construction_key: object = field(repr=False, compare=False)
+    publication_occurrence_identity: str
     path: Path
     lifecycle: StepLifecycle
     authority: StepAuthority
@@ -656,8 +1523,22 @@ class PublishedStepReference:
     provenance: WorkflowProvenance
     independent_ids: tuple[str, ...]
     artifacts: tuple[ArtifactReference, ...]
+    identity: str = field(init=False)
+    _witness: _PublishedStepWitness | None = field(
+        repr=False,
+        compare=False,
+        kw_only=True,
+    )
 
     def __post_init__(self) -> None:
+        if self._construction_key is not _PUBLISHED_STEP_KEY:
+            raise NativeProvenanceError(
+                "Published step references require an exact live publication"
+            )
+        _require_text(
+            self.publication_occurrence_identity,
+            "publication occurrence identity",
+        )
         object.__setattr__(self, "path", Path(self.path).resolve())
         for field_name in (
             "lifecycle",
@@ -672,3 +1553,68 @@ class PublishedStepReference:
             raise NativeProvenanceError("Step manifest SHA-256 is malformed")
         if len(set(self.independent_ids)) != len(self.independent_ids):
             raise NativeProvenanceError("Published independent scope has duplicates")
+        object.__setattr__(
+            self,
+            "identity",
+            published_step_reference_identity(
+                publication_occurrence_identity=self.publication_occurrence_identity,
+                lifecycle=self.lifecycle,
+                authority=self.authority,
+                manifest_identity=self.manifest_identity,
+                manifest_sha256=self.manifest_sha256,
+                provenance=self.provenance,
+                independent_ids=self.independent_ids,
+                artifacts=self.artifacts,
+            ),
+        )
+        if self._witness is None or not _bind_published_step_reference(
+            self._witness,
+            self.publication_occurrence_identity,
+            self,
+        ):
+            raise NativeProvenanceError(
+                "Published step reference lacks its exact live publication"
+            )
+
+    def require_exact_live_publication(self) -> None:
+        """Reject reconstruction, replacement, and expired live publications."""
+        if not _is_exact_live_published_step(
+            self._witness,
+            self.publication_occurrence_identity,
+            self,
+        ):
+            raise NativeProvenanceError(
+                "Schema-v2 writing requires the exact live publication"
+            )
+
+
+def _published_step_from_successful_native_publication(
+    publication: object,
+    publication_occurrence_identity: str,
+    path: Path,
+    lifecycle: StepLifecycle,
+    authority: StepAuthority,
+    manifest_identity: str,
+    manifest_sha256: str,
+    provenance: WorkflowProvenance,
+    independent_ids: tuple[str, ...],
+    artifacts: tuple[ArtifactReference, ...],
+) -> PublishedStepReference:
+    """Internal post-rename adapter from one successful #608 publication."""
+    witness = _mint_published_step_witness(
+        publication_occurrence_identity,
+        publication,
+    )
+    return PublishedStepReference(
+        _PUBLISHED_STEP_KEY,
+        publication_occurrence_identity,
+        path,
+        lifecycle,
+        authority,
+        manifest_identity,
+        manifest_sha256,
+        provenance,
+        independent_ids,
+        artifacts,
+        _witness=witness,
+    )

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -45,12 +45,13 @@ from chemex.parameters.values import (
     InvalidAnalysisValuesCommitError,
     StaleAnalysisValuesError,
 )
+from chemex.runtime.execution import ExecutionSettings, native_thread_environment
 from chemex.typing import Array
 
 _SCHEMA_VERSION = 1
 _PROBLEM_VERSION = "native-direct-trf-problem-v1"
 _SCALARIZATION_VERSION = "ordered-pairwise-chi-square-v1"
-_INVOCATION_VERSION = "scipy-direct-trf-v1"
+_INVOCATION_VERSION = "scipy-direct-trf-v2"
 _CANDIDATE_ORDER_VERSION = "chi-square-vector-ordinal-v1"
 _BACKEND_SETTINGS = (
     ("method", "trf"),
@@ -1210,9 +1211,14 @@ class DirectTrfInvocation:
     ftol: float | None = 1.0e-8
     xtol: float | None = 1.0e-8
     gtol: float | None = 1.0e-8
+    execution_settings: ExecutionSettings = field(default_factory=ExecutionSettings)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        if self.execution_settings.workers != 1:
+            raise DirectTrfConstructionError(
+                "One Direct TRF invocation has exactly one ChemEx worker"
+            )
         if (
             isinstance(self.objective_request_budget, bool)
             or not isinstance(self.objective_request_budget, int)
@@ -1265,6 +1271,10 @@ class DirectTrfInvocation:
                         None if value is None else _float_token(value)
                         for value in tolerances
                     ),
+                    (
+                        self.execution_settings.workers,
+                        self.execution_settings.native_threads,
+                    ),
                     _BACKEND_SETTINGS,
                 ),
             ),
@@ -1280,6 +1290,7 @@ class DirectTrfInvocation:
         ftol: float | None = 1.0e-8,
         xtol: float | None = 1.0e-8,
         gtol: float | None = 1.0e-8,
+        execution_settings: ExecutionSettings | None = None,
     ) -> DirectTrfInvocation:
         """Resolve scalar/default scaling into one value per external coordinate."""
         dimension = len(problem.controlled_ids)
@@ -1298,6 +1309,7 @@ class DirectTrfInvocation:
             ftol,
             xtol,
             gtol,
+            ExecutionSettings() if execution_settings is None else execution_settings,
         )
 
 
@@ -2500,27 +2512,31 @@ def _invoke_least_squares(
     problem: OptimizationProblem,
     invocation: DirectTrfInvocation,
 ) -> object:
-    return least_squares(
-        live.objective,
-        np.asarray(problem.start, dtype=np.float64),
-        bounds=(
-            np.asarray(problem.lower_bounds, dtype=np.float64),
-            np.asarray(problem.upper_bounds, dtype=np.float64),
-        ),
-        method="trf",
-        jac="2-point",
-        diff_step=None,
-        tr_solver="exact",
-        tr_options={},
-        loss="linear",
-        f_scale=1.0,
-        x_scale=np.asarray(invocation.x_scale, dtype=np.float64),
-        ftol=invocation.ftol,
-        xtol=invocation.xtol,
-        gtol=invocation.gtol,
-        max_nfev=invocation.objective_request_budget,
-        verbose=0,
-    )
+    execution = invocation.execution_settings
+    with native_thread_environment(
+        execution.native_thread_env(parallel=execution.is_parallel)
+    ):
+        return least_squares(
+            live.objective,
+            np.asarray(problem.start, dtype=np.float64),
+            bounds=(
+                np.asarray(problem.lower_bounds, dtype=np.float64),
+                np.asarray(problem.upper_bounds, dtype=np.float64),
+            ),
+            method="trf",
+            jac="2-point",
+            diff_step=None,
+            tr_solver="exact",
+            tr_options={},
+            loss="linear",
+            f_scale=1.0,
+            x_scale=np.asarray(invocation.x_scale, dtype=np.float64),
+            ftol=invocation.ftol,
+            xtol=invocation.xtol,
+            gtol=invocation.gtol,
+            max_nfev=invocation.objective_request_budget,
+            verbose=0,
+        )
 
 
 def _terminal_backend_failure(

--- a/src/chemex/optimize/native_reporting.py
+++ b/src/chemex/optimize/native_reporting.py
@@ -10,22 +10,28 @@ import hashlib
 import json
 import math
 import shutil
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 from uuid import uuid4
 
 from chemex.atomic import publish_directory_noreplace
+from chemex.configuration.methods import Method
 from chemex.evaluation.native import EvaluationPlan, EvaluationResult
 from chemex.native_provenance import (
     ArtifactReference,
     ArtifactRole,
     BudgetRecord,
+    CommittedRestartRecord,
     NativeProvenanceError,
     PolicyRecord,
     PublishedStepReference,
     SeedRecord,
     WorkflowProvenance,
+    _published_step_from_successful_native_publication,
+    native_step_manifest_identity,
+    validate_native_step_manifest_bytes,
 )
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
@@ -130,11 +136,12 @@ class McmcPublication:
     summary: PosteriorSummary
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class CommittedFitPublication:
     """Exact committed anchor from which ordinary fitted output may be rendered."""
 
     plan: EvaluationPlan
+    method: Method
     parameterization: ActiveParameterization
     parameter_model: SealedParameterModel
     starting_snapshot: AnalysisValuesSnapshot
@@ -153,17 +160,18 @@ class CommittedFitPublication:
     mcmc: McmcPublication | None = None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class EvaluationPublication:
     """Authoritative evaluate-only result with no estimate or commit semantics."""
 
     plan: EvaluationPlan
+    method: Method
     parameterization: ActiveParameterization
     evaluation_result: EvaluationResult
     provenance: WorkflowProvenance = field(kw_only=True)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class SuppressedPublication:
     """Failure/uncommitted provenance with only genuine partial evidence."""
 
@@ -177,6 +185,7 @@ class SuppressedPublication:
         FitCommitOperation | DirectTrfExecution | ResamplingEvidence | McmcEvidence
     )
     plan: EvaluationPlan
+    method: Method
     parameterization: ActiveParameterization
     provenance: WorkflowProvenance = field(kw_only=True)
     primary_invocation: DirectTrfInvocation | None = field(
@@ -290,9 +299,10 @@ def _validate_provenance_context(
     provenance: WorkflowProvenance,
     plan: EvaluationPlan,
     parameterization: ActiveParameterization,
+    method: Method,
 ) -> None:
     try:
-        provenance.validate_execution_context(parameterization, plan)
+        provenance.validate_execution_context(parameterization, plan, method)
     except NativeProvenanceError as error:
         raise NativePublicationError(
             "Workflow method and selection provenance differ from execution"
@@ -320,6 +330,7 @@ def _validate_suppressed_execution_lineage(
         publication.provenance,
         publication.plan,
         publication.parameterization,
+        publication.method,
     )
     primary_policy, primary_budget = _validate_optional_primary_execution(publication)
     primary_problem = publication.primary_problem
@@ -380,6 +391,7 @@ def _validate_evaluation_only(publication: EvaluationPublication) -> None:
         publication.provenance,
         publication.plan,
         publication.parameterization,
+        publication.method,
     )
     _validate_exact_provenance_records(publication.provenance, (), (), ())
     if any(
@@ -562,6 +574,7 @@ def _validate_committed_fit(publication: CommittedFitPublication) -> None:
         publication.provenance,
         publication.plan,
         publication.parameterization,
+        publication.method,
     )
     _primary_execution_records(
         publication.primary_invocation,
@@ -839,7 +852,7 @@ def _render_suppressed(path: Path, publication: SuppressedPublication) -> None:
 def _render_committed_fit(
     path: Path,
     publication: CommittedFitPublication,
-) -> None:
+) -> CommittedRestartRecord:
     path.mkdir()
     write_parameter_reports(
         path / "Parameters",
@@ -851,6 +864,47 @@ def _render_committed_fit(
         publication.parameter_model,
         publication.parameterization,
         publication.committed_snapshot,
+    )
+    restart_path = path / "Parameters" / "restart.toml"
+    restart = CommittedRestartRecord(
+        publication.starting_snapshot.occurrence_identity,
+        publication.starting_snapshot.revision,
+        publication.accepted.identity,
+        publication.accepted.occurrence_identity,
+        publication.commit_operation.identity,
+        publication.commit_operation.occurrence_identity,
+        publication.committed_snapshot.occurrence_identity,
+        publication.committed_snapshot.revision,
+        publication.provenance.workflow_identity,
+        publication.primary_problem.identity,
+        publication.parameterization.identity,
+        publication.parameter_model.identity,
+        publication.committed_snapshot.configuration_identity,
+        tuple(
+            (
+                param_id,
+                float(publication.committed_snapshot[param_id]).hex(),
+                float(
+                    publication.parameter_model.configuration[param_id].lower_bound
+                ).hex(),
+                float(
+                    publication.parameter_model.configuration[param_id].upper_bound
+                ).hex(),
+            )
+            for param_id in publication.parameterization.independent_ids
+        ),
+        hashlib.sha256(restart_path.read_bytes()).hexdigest(),
+    )
+    (path / "Parameters" / "restart-provenance.json").write_text(
+        json.dumps(
+            restart.to_record(),
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
     )
     write_data(path / "Data", publication.plan, publication.accepted.evaluation_result)
     write_native_plots(
@@ -876,21 +930,24 @@ def _render_committed_fit(
         None if mcmc is None else mcmc.summary,
     )
     write_components(path / "Components", publication.components)
+    return restart
 
 
 def _artifact_role(relative_path: str) -> ArtifactRole:
     if relative_path == "Parameters/restart.toml":
         return "committed_restart_state"
+    if relative_path == "Parameters/restart-provenance.json":
+        return "committed_restart_state"
     if relative_path == "Parameters/fitted.toml":
         return "report_only_fitted_values"
-    if relative_path.startswith("Diagnostics/"):
+    if relative_path.startswith(("Diagnostics/", "Components/")):
         return "diagnostic_provenance"
     if relative_path.startswith("PartialEvidence/"):
         return "partial_evidence"
     return "product_output"
 
 
-def _write_manifest(
+def _write_manifest(  # noqa: C901 - deterministic TOML sections
     path: Path,
     fields: tuple[tuple[str, str | int], ...],
     provenance: WorkflowProvenance,
@@ -912,35 +969,17 @@ def _write_manifest(
         for item in sorted(path.rglob("*"))
         if item.is_file()
     )
-    manifest_identity = hashlib.sha256(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "fields": fields,
-                "provenance_identity": provenance.identity,
-                "artifacts": [
-                    (item.path, item.role, item.sha256) for item in artifacts
-                ],
-                "components": [
-                    (item.identity, item.disposition, item.controlled_ids)
-                    for item in components
-                ],
-                "evidence": evidence,
-            },
-            ensure_ascii=True,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode()
-    ).hexdigest()
     lines = [
         "# Atomic native method-step manifest.",
         "schema_version = 1",
-        f"manifest_identity = {json.dumps(manifest_identity)}",
+        'manifest_identity = ""',
         *(f"{name} = {json.dumps(value)}" for name, value in fields),
         "",
         "[workflow]",
         f"identity = {json.dumps(provenance.workflow_identity)}",
+        f"execution_identity = {json.dumps(provenance.execution_identity)}",
         f"provenance_identity = {json.dumps(provenance.identity)}",
+        f"type = {json.dumps(provenance.workflow_type)}",
         "",
         "[method]",
         f"identity = {json.dumps(provenance.method_identity)}",
@@ -968,6 +1007,15 @@ def _write_manifest(
         ),
         "",
     ]
+    for group_identity, controlled_ids in provenance.grouping_topology:
+        lines.extend(
+            (
+                "[[workflow.groups]]",
+                f"identity = {json.dumps(group_identity)}",
+                f"controlled_ids = {json.dumps(list(controlled_ids))}",
+                "",
+            )
+        )
     for kind, name, library_version in provenance.environment.numerical_libraries:
         lines.extend(
             (
@@ -1014,6 +1062,8 @@ def _write_manifest(
                 "[[baseline_references]]",
                 f"kind = {json.dumps(reference.kind)}",
                 f"identity = {json.dumps(reference.identity)}",
+                f"occurrence_identity = {json.dumps(reference.occurrence_identity)}",
+                f"result_bundle_identity = {json.dumps(reference.result_bundle_identity)}",
                 "",
             )
         )
@@ -1050,7 +1100,11 @@ def _write_manifest(
             )
         )
     manifest_path = path / "fit-manifest.toml"
+    provisional = "\n".join(lines)
+    manifest_identity = native_step_manifest_identity(tomllib.loads(provisional))
+    lines[2] = f"manifest_identity = {json.dumps(manifest_identity)}"
     manifest_path.write_text("\n".join(lines), encoding="utf-8")
+    validate_native_step_manifest_bytes(manifest_path.read_bytes())
     return (
         manifest_identity,
         hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
@@ -1061,6 +1115,8 @@ def _write_manifest(
 def _write_committed_manifest(
     path: Path,
     publication: CommittedFitPublication,
+    publication_occurrence_identity: str,
+    restart: CommittedRestartRecord,
 ) -> tuple[str, str, tuple[ArtifactReference, ...]]:
     evidence: list[tuple[str, str, str, str]] = []
     if publication.uncertainty is not None:
@@ -1105,6 +1161,7 @@ def _write_committed_manifest(
         (
             ("lifecycle", "committed"),
             ("authority", "committed_fit"),
+            ("publication_occurrence_identity", publication_occurrence_identity),
             ("starting_state_kind", "workflow_starting_provenance"),
             (
                 "starting_occurrence_identity",
@@ -1117,6 +1174,19 @@ def _write_committed_manifest(
                 publication.accepted.occurrence_identity,
             ),
             ("commit_receipt_identity", publication.commit_receipt.identity),
+            ("commit_operation_identity", publication.commit_operation.identity),
+            (
+                "commit_occurrence_identity",
+                publication.commit_operation.occurrence_identity,
+            ),
+            (
+                "committed_occurrence_identity",
+                publication.committed_snapshot.occurrence_identity,
+            ),
+            ("committed_revision", publication.committed_snapshot.revision),
+            ("problem_identity", publication.primary_problem.identity),
+            ("parameterization_identity", publication.parameterization.identity),
+            ("restart_record_identity", restart.identity),
         ),
         publication.provenance,
         components=publication.components,
@@ -1127,12 +1197,14 @@ def _write_committed_manifest(
 def _write_evaluation_manifest(
     path: Path,
     publication: EvaluationPublication,
+    publication_occurrence_identity: str,
 ) -> tuple[str, str, tuple[ArtifactReference, ...]]:
     return _write_manifest(
         path,
         (
             ("lifecycle", "successful_no_state_change"),
             ("authority", "evaluation_only"),
+            ("publication_occurrence_identity", publication_occurrence_identity),
         ),
         publication.provenance,
     )
@@ -1141,10 +1213,12 @@ def _write_evaluation_manifest(
 def _write_suppressed_manifest(
     path: Path,
     publication: SuppressedPublication,
+    publication_occurrence_identity: str,
 ) -> tuple[str, str, tuple[ArtifactReference, ...]]:
     fields: list[tuple[str, str | int]] = [
         ("lifecycle", publication.lifecycle),
         ("authority", "diagnostic_only"),
+        ("publication_occurrence_identity", publication_occurrence_identity),
         ("operation_identity", publication.operation.identity),
     ]
     if publication.accepted_result_identity is not None:
@@ -1198,6 +1272,58 @@ def _render_evaluation(path: Path, publication: EvaluationPublication) -> None:
     write_statistics(path, publication.plan, publication.evaluation_result, 0)
 
 
+def _validate_and_publish_staged_step(
+    staging: Path,
+    destination: Path,
+    manifest: tuple[str, str, tuple[ArtifactReference, ...]],
+    expected_restart: CommittedRestartRecord | None,
+) -> None:
+    """Seal the complete staged #608 tree immediately before atomic publication."""
+    manifest_identity, manifest_sha256, artifacts = manifest
+    manifest_path = staging / "fit-manifest.toml"
+    manifest_bytes = manifest_path.read_bytes()
+    record = validate_native_step_manifest_bytes(manifest_bytes)
+    if (
+        record.get("manifest_identity") != manifest_identity
+        or hashlib.sha256(manifest_bytes).hexdigest() != manifest_sha256
+    ):
+        raise NativePublicationError(
+            "Staged native manifest changed before publication"
+        )
+    expected = {item.path: item for item in artifacts}
+    actual_paths = {
+        str(item.relative_to(staging))
+        for item in staging.rglob("*")
+        if item.is_file() and item != manifest_path
+    }
+    if actual_paths != set(expected):
+        raise NativePublicationError("Staged native artifact catalogue changed")
+    for relative_path, artifact in expected.items():
+        if (
+            hashlib.sha256((staging / relative_path).read_bytes()).hexdigest()
+            != artifact.sha256
+        ):
+            raise NativePublicationError("Staged native artifact changed after hashing")
+    if record.get("lifecycle") == "committed":
+        restart_path = staging / "Parameters" / "restart.toml"
+        restart_record = CommittedRestartRecord.from_record(
+            json.loads(
+                (staging / "Parameters" / "restart-provenance.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+        )
+        if (
+            expected_restart is None
+            or restart_record != expected_restart
+            or restart_record.identity != record.get("restart_record_identity")
+            or restart_record.restart_sha256
+            != hashlib.sha256(restart_path.read_bytes()).hexdigest()
+        ):
+            raise NativePublicationError("Committed restart provenance changed")
+    publish_directory_noreplace(staging, destination)
+
+
 def publish_native_results(
     path: Path,
     publication: NativePublication,
@@ -1214,31 +1340,48 @@ def publish_native_results(
         raise FileExistsError(f"Native publication destination exists: {destination}")
     destination.parent.mkdir(parents=True, exist_ok=True)
     staging = destination.parent / f".{destination.name}.tmp-{uuid4().hex}"
+    publication_occurrence_identity = uuid4().hex
+    restart: CommittedRestartRecord | None = None
     try:
         if isinstance(publication, CommittedFitPublication):
-            _render_committed_fit(staging, publication)
-            manifest = _write_committed_manifest(staging, publication)
+            restart = _render_committed_fit(staging, publication)
+            manifest = _write_committed_manifest(
+                staging,
+                publication,
+                publication_occurrence_identity,
+                restart,
+            )
             lifecycle = "committed"
             authority = "committed_fit"
             independent_ids = publication.parameterization.independent_ids
         elif isinstance(publication, EvaluationPublication):
             _render_evaluation(staging, publication)
-            manifest = _write_evaluation_manifest(staging, publication)
+            manifest = _write_evaluation_manifest(
+                staging,
+                publication,
+                publication_occurrence_identity,
+            )
             lifecycle = "successful_no_state_change"
             authority = "evaluation_only"
             independent_ids = publication.parameterization.independent_ids
         else:
             _render_suppressed(staging, publication)
-            manifest = _write_suppressed_manifest(staging, publication)
+            manifest = _write_suppressed_manifest(
+                staging,
+                publication,
+                publication_occurrence_identity,
+            )
             lifecycle = publication.lifecycle
             authority = "diagnostic_only"
             independent_ids = publication.parameterization.independent_ids
-        publish_directory_noreplace(staging, destination)
+        _validate_and_publish_staged_step(staging, destination, manifest, restart)
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
         raise
     manifest_identity, manifest_sha256, artifacts = manifest
-    return PublishedStepReference(
+    return _published_step_from_successful_native_publication(
+        publication,
+        publication_occurrence_identity,
         destination,
         lifecycle,
         authority,

--- a/src/chemex/optimize/native_reporting.py
+++ b/src/chemex/optimize/native_reporting.py
@@ -6,25 +6,36 @@ legacy reporting path until the native migration gates promote these artifacts.
 
 from __future__ import annotations
 
-import ctypes
-import errno
+import hashlib
+import json
 import math
-import os
 import shutil
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 from uuid import uuid4
 
+from chemex.atomic import publish_directory_noreplace
 from chemex.evaluation.native import EvaluationPlan, EvaluationResult
+from chemex.native_provenance import (
+    ArtifactReference,
+    ArtifactRole,
+    BudgetRecord,
+    NativeProvenanceError,
+    PolicyRecord,
+    PublishedStepReference,
+    SeedRecord,
+    WorkflowProvenance,
+)
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     CommitReceipt,
     DirectTrfExecution,
+    DirectTrfInvocation,
     DirectTrfTerminal,
     FitCommitOperation,
     FitCommitTerminal,
+    OptimizationProblem,
     accepted_occurrence_is_authoritative,
     canonical_chi_square,
     committed_values_identity,
@@ -43,7 +54,11 @@ from chemex.optimize.native_resampling import (
     SummaryTerminal,
 )
 from chemex.optimize.uncertainty import UncertaintyEvidence
-from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    ParameterRole,
+    SealedParameterModel,
+)
 from chemex.parameters.values import AnalysisValues, AnalysisValuesSnapshot
 from chemex.plotters.native_reporting import write_native_plots
 from chemex.printers.native_reporting import (
@@ -54,6 +69,7 @@ from chemex.printers.native_reporting import (
     write_partial_mcmc,
     write_partial_resampling,
     write_resampling,
+    write_restart_parameters,
     write_statistics,
     write_suppressed_outcome,
     write_uncertainty,
@@ -120,11 +136,17 @@ class CommittedFitPublication:
 
     plan: EvaluationPlan
     parameterization: ActiveParameterization
+    parameter_model: SealedParameterModel
+    starting_snapshot: AnalysisValuesSnapshot
+    primary_problem: OptimizationProblem
+    primary_invocation: DirectTrfInvocation
+    primary_execution: DirectTrfExecution
     accepted: AcceptedFitResult
     commit_receipt: CommitReceipt
     committed_snapshot: AnalysisValuesSnapshot
     commit_operation: FitCommitOperation
     analysis_values: AnalysisValues = field(repr=False, compare=False)
+    provenance: WorkflowProvenance = field(kw_only=True)
     components: tuple[ComponentDiagnostic, ...] = ()
     uncertainty: UncertaintyEvidence | None = None
     resampling: tuple[ResamplingPublication, ...] = ()
@@ -138,6 +160,7 @@ class EvaluationPublication:
     plan: EvaluationPlan
     parameterization: ActiveParameterization
     evaluation_result: EvaluationResult
+    provenance: WorkflowProvenance = field(kw_only=True)
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,6 +176,18 @@ class SuppressedPublication:
     operation: (
         FitCommitOperation | DirectTrfExecution | ResamplingEvidence | McmcEvidence
     )
+    plan: EvaluationPlan
+    parameterization: ActiveParameterization
+    provenance: WorkflowProvenance = field(kw_only=True)
+    primary_invocation: DirectTrfInvocation | None = field(
+        default=None,
+        kw_only=True,
+    )
+    primary_execution: DirectTrfExecution | None = field(
+        default=None,
+        kw_only=True,
+    )
+    primary_problem: OptimizationProblem | None = field(default=None, kw_only=True)
     accepted_result_identity: str | None = None
     accepted_occurrence_identity: str | None = None
     components: tuple[ComponentDiagnostic, ...] = ()
@@ -164,75 +199,157 @@ type NativePublication = (
     CommittedFitPublication | EvaluationPublication | SuppressedPublication
 )
 
-_AT_FDCWD = -100
-_RENAME_NOREPLACE = 1
-_RENAME_EXCL = 4
 
-
-def _atomic_publish_noreplace(staging: Path, destination: Path) -> None:
-    """Atomically rename a staged directory without replacing any destination."""
-    if sys.platform == "win32":
-        try:
-            os.rename(staging, destination)
-        except FileExistsError as error:
-            raise FileExistsError(
-                errno.EEXIST,
-                "Native publication destination exists",
-                destination,
-            ) from error
-        return
-
-    source_bytes = os.fsencode(staging)
-    destination_bytes = os.fsencode(destination)
-    if sys.platform == "linux":
-        function_name = "renameat2"
-        argument_types = (
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        )
-        arguments = (
-            _AT_FDCWD,
-            source_bytes,
-            _AT_FDCWD,
-            destination_bytes,
-            _RENAME_NOREPLACE,
-        )
-    elif sys.platform == "darwin":
-        function_name = "renamex_np"
-        argument_types = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint)
-        arguments = (source_bytes, destination_bytes, _RENAME_EXCL)
-    else:
-        raise OSError(
-            errno.ENOTSUP,
-            "Atomic no-replace directory rename is unavailable on this platform",
-            destination,
+def _validate_exact_provenance_records(
+    provenance: WorkflowProvenance,
+    policies: tuple[PolicyRecord, ...],
+    budgets: tuple[BudgetRecord, ...],
+    seeds: tuple[SeedRecord, ...],
+) -> None:
+    """Reject missing, forged, or unrelated execution records."""
+    if (
+        provenance.policies != policies
+        or provenance.budgets != budgets
+        or provenance.seeds != seeds
+    ):
+        raise NativePublicationError(
+            "Workflow provenance differs from exact execution records"
         )
 
-    libc = ctypes.CDLL(None, use_errno=True)
+
+def _primary_execution_records(
+    invocation: DirectTrfInvocation,
+    execution: DirectTrfExecution,
+) -> tuple[PolicyRecord, BudgetRecord]:
+    if (
+        execution.problem_identity != invocation.problem_identity
+        or execution.invocation_identity != invocation.identity
+    ):
+        raise NativePublicationError(
+            "Primary invocation and execution provenance disagree"
+        )
+    return (
+        PolicyRecord("primary_direct_trf", invocation.identity),
+        BudgetRecord(
+            "primary_direct_trf_objective_requests",
+            invocation.objective_request_budget,
+            execution.counters.objective_requests_accepted,
+        ),
+    )
+
+
+def _stochastic_execution_records(
+    resampling: tuple[ResamplingEvidence, ...],
+    mcmc: McmcEvidence | None,
+) -> tuple[tuple[PolicyRecord, ...], tuple[BudgetRecord, ...], tuple[SeedRecord, ...]]:
+    policies: list[PolicyRecord] = []
+    budgets: list[BudgetRecord] = []
+    seeds: list[SeedRecord] = []
+    for evidence in resampling:
+        plan = evidence.plan
+        name = f"resampling_{plan.scheme.value}"
+        policies.append(PolicyRecord(name, plan.identity))
+        budgets.append(
+            BudgetRecord(
+                f"{name}_replicates",
+                plan.replicate_count,
+                evidence.completed_count,
+            )
+        )
+        objective_budget = int(
+            dict(plan.strategy_settings).get("objective_request_budget", "100")
+        )
+        budgets.append(
+            BudgetRecord(
+                f"{name}_objective_requests",
+                objective_budget * plan.replicate_count,
+                None,
+            )
+        )
+        seeds.append(
+            SeedRecord(f"{name}_root", plan.root_seed, plan.seed_policy_version)
+        )
+    if mcmc is None:
+        return tuple(policies), tuple(budgets), tuple(seeds)
+    policy = mcmc.plan.policy
+    policies.append(PolicyRecord("mcmc", policy.identity))
+    budgets.append(
+        BudgetRecord(
+            "mcmc_objective_requests",
+            policy.objective_request_budget,
+            mcmc.objective_request_count,
+        )
+    )
+    seeds.append(
+        SeedRecord("mcmc_root", policy.root_seed, policy.seed_policy_version),
+    )
+    return tuple(policies), tuple(budgets), tuple(seeds)
+
+
+def _validate_provenance_context(
+    provenance: WorkflowProvenance,
+    plan: EvaluationPlan,
+    parameterization: ActiveParameterization,
+) -> None:
     try:
-        rename_noreplace = getattr(libc, function_name)
-    except AttributeError as error:
-        raise OSError(
-            errno.ENOSYS,
-            f"{function_name} is unavailable for atomic native publication",
-            destination,
+        provenance.validate_execution_context(parameterization, plan)
+    except NativeProvenanceError as error:
+        raise NativePublicationError(
+            "Workflow method and selection provenance differ from execution"
         ) from error
-    rename_noreplace.argtypes = argument_types
-    rename_noreplace.restype = ctypes.c_int
-    result = rename_noreplace(*arguments)
-    if result == 0:
-        return
-    error_number = ctypes.get_errno()
-    if error_number == errno.EEXIST:
-        raise FileExistsError(
-            errno.EEXIST,
-            "Native publication destination exists",
-            destination,
+
+
+def _validate_optional_primary_execution(
+    publication: SuppressedPublication,
+) -> tuple[PolicyRecord | None, BudgetRecord | None]:
+    invocation = publication.primary_invocation
+    execution = publication.primary_execution
+    if invocation is None and execution is None:
+        return None, None
+    if invocation is None or execution is None:
+        raise NativePublicationError(
+            "Suppressed primary provenance requires invocation and execution"
         )
-    raise OSError(error_number, os.strerror(error_number), destination)
+    return _primary_execution_records(invocation, execution)
+
+
+def _validate_suppressed_execution_lineage(
+    publication: SuppressedPublication,
+) -> tuple[PolicyRecord | None, BudgetRecord | None]:
+    _validate_provenance_context(
+        publication.provenance,
+        publication.plan,
+        publication.parameterization,
+    )
+    primary_policy, primary_budget = _validate_optional_primary_execution(publication)
+    primary_problem = publication.primary_problem
+    if primary_policy is not None:
+        if (
+            primary_problem is None
+            or primary_problem.parameterization_identity
+            != publication.parameterization.identity
+            or primary_problem.evaluator_parameterization_identity
+            != publication.parameterization.evaluator_identity
+            or primary_problem.evaluation_plan_identity != publication.plan.identity
+            or publication.primary_invocation is None
+            or publication.primary_invocation.problem_identity
+            != primary_problem.identity
+        ):
+            raise NativePublicationError(
+                "Suppressed restart scope differs from primary execution lineage"
+            )
+    elif primary_problem is not None:
+        raise NativePublicationError(
+            "Suppressed primary problem requires its invocation and execution"
+        )
+    if isinstance(publication.operation, (FitCommitOperation, DirectTrfExecution)) and (
+        primary_problem is None
+        or primary_problem.identity != publication.operation.problem_identity
+    ):
+        raise NativePublicationError(
+            "Suppressed operation differs from primary problem lineage"
+        )
+    return primary_policy, primary_budget
 
 
 def _validate_evaluation_artifacts(
@@ -259,6 +376,12 @@ def _validate_evaluation_artifacts(
 
 
 def _validate_evaluation_only(publication: EvaluationPublication) -> None:
+    _validate_provenance_context(
+        publication.provenance,
+        publication.plan,
+        publication.parameterization,
+    )
+    _validate_exact_provenance_records(publication.provenance, (), (), ())
     if any(
         publication.parameterization.role(param_id) is ParameterRole.FIT
         for param_id in publication.parameterization.independent_ids
@@ -294,6 +417,7 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
             "Suppressed publication requires typed lifecycle provenance"
         )
     operation = publication.operation
+    primary_policy, primary_budget = _validate_suppressed_execution_lineage(publication)
     commit_failure = (
         isinstance(operation, FitCommitOperation)
         and fit_commit_operation_is_authoritative(operation)
@@ -361,6 +485,8 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
             != publication.accepted_result_identity
             or evidence.plan.accepted_occurrence_identity
             != publication.accepted_occurrence_identity
+            or evidence.plan.parameterization is not publication.parameterization
+            or evidence.plan.source_engine.plan.identity != publication.plan.identity
         ):
             raise NativePublicationError(
                 "Suppressed workflows may retain only genuine partial resampling"
@@ -374,10 +500,55 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
             != publication.accepted_result_identity
             or publication.partial_mcmc.plan.accepted_occurrence_identity
             != publication.accepted_occurrence_identity
+            or publication.partial_mcmc.plan.parameterization
+            is not publication.parameterization
+            or publication.partial_mcmc.plan.source_engine.plan.identity
+            != publication.plan.identity
         ):
             raise NativePublicationError(
                 "Suppressed workflows may retain only genuine partial MCMC evidence"
             )
+    stochastic_policies, stochastic_budgets, stochastic_seeds = (
+        _stochastic_execution_records(
+            publication.partial_resampling,
+            publication.partial_mcmc,
+        )
+    )
+    _validate_exact_provenance_records(
+        publication.provenance,
+        (() if primary_policy is None else (primary_policy,)) + stochastic_policies,
+        (() if primary_budget is None else (primary_budget,)) + stochastic_budgets,
+        stochastic_seeds,
+    )
+
+
+def _validate_committed_parameter_state(
+    publication: CommittedFitPublication,
+) -> None:
+    accepted = publication.accepted
+    committed = publication.committed_snapshot
+    parameter_model = publication.parameter_model
+    if (
+        parameter_model.identity
+        != publication.parameterization.program.parameter_model_identity
+        or parameter_model.model_identity != committed.model_identity
+        or parameter_model.definitions.identity != committed.definitions_identity
+        or parameter_model.configuration.identity != committed.configuration_identity
+    ):
+        raise NativePublicationError(
+            "Committed publication parameter model differs from committed state"
+        )
+    starting = publication.starting_snapshot
+    if (
+        starting.occurrence_identity != accepted.source_occurrence_identity
+        or starting.revision != accepted.source_revision
+        or starting.model_identity != committed.model_identity
+        or starting.definitions_identity != committed.definitions_identity
+        or starting.configuration_identity != committed.configuration_identity
+    ):
+        raise NativePublicationError(
+            "Committed publication starting state differs from accepted provenance"
+        )
 
 
 def _validate_committed_fit(publication: CommittedFitPublication) -> None:
@@ -386,6 +557,16 @@ def _validate_committed_fit(publication: CommittedFitPublication) -> None:
     committed = publication.committed_snapshot
     operation = publication.commit_operation
     current = publication.analysis_values.snapshot()
+    _validate_committed_parameter_state(publication)
+    _validate_provenance_context(
+        publication.provenance,
+        publication.plan,
+        publication.parameterization,
+    )
+    _primary_execution_records(
+        publication.primary_invocation,
+        publication.primary_execution,
+    )
     if not accepted_occurrence_is_authoritative(accepted):
         raise NativePublicationError(
             "Committed publication requires an authoritative accepted occurrence"
@@ -398,6 +579,18 @@ def _validate_committed_fit(publication: CommittedFitPublication) -> None:
         or operation.accepted_result_identity != accepted.identity
         or operation.accepted_occurrence_identity != accepted.occurrence_identity
         or operation.problem_identity != accepted.problem_identity
+        or publication.primary_problem.identity != accepted.problem_identity
+        or publication.primary_problem.parameterization_identity
+        != publication.parameterization.identity
+        or publication.primary_problem.evaluator_parameterization_identity
+        != publication.parameterization.evaluator_identity
+        or publication.primary_problem.evaluation_plan_identity
+        != publication.plan.identity
+        or publication.primary_invocation.problem_identity != accepted.problem_identity
+        or publication.primary_execution.problem_identity != accepted.problem_identity
+        or publication.primary_execution.invocation_identity
+        != accepted.invocation_identity
+        or publication.primary_execution.identity != accepted.execution_identity
         or current != committed
     ):
         raise NativePublicationError(
@@ -551,6 +744,27 @@ def _validate_typed_evidence(publication: CommittedFitPublication) -> None:
             raise NativePublicationError(
                 "MCMC evidence belongs to another accepted fit occurrence"
             )
+    stochastic_policies, stochastic_budgets, stochastic_seeds = (
+        _stochastic_execution_records(
+            tuple(item.evidence for item in publication.resampling),
+            None if mcmc is None else mcmc.evidence,
+        )
+    )
+    primary_policy, primary_budget = _primary_execution_records(
+        publication.primary_invocation,
+        publication.primary_execution,
+    )
+    uncertainty_policies = (
+        ()
+        if uncertainty is None
+        else (PolicyRecord("uncertainty", uncertainty.source_policy.identity),)
+    )
+    _validate_exact_provenance_records(
+        publication.provenance,
+        (primary_policy, *uncertainty_policies, *stochastic_policies),
+        (primary_budget, *stochastic_budgets),
+        stochastic_seeds,
+    )
 
 
 def _suppressed_operation_record(
@@ -632,6 +846,12 @@ def _render_committed_fit(
         publication.parameterization,
         publication.accepted.evaluation_result,
     )
+    write_restart_parameters(
+        path / "Parameters" / "restart.toml",
+        publication.parameter_model,
+        publication.parameterization,
+        publication.committed_snapshot,
+    )
     write_data(path / "Data", publication.plan, publication.accepted.evaluation_result)
     write_native_plots(
         path / "Plots", publication.plan, publication.accepted.evaluation_result
@@ -658,6 +878,313 @@ def _render_committed_fit(
     write_components(path / "Components", publication.components)
 
 
+def _artifact_role(relative_path: str) -> ArtifactRole:
+    if relative_path == "Parameters/restart.toml":
+        return "committed_restart_state"
+    if relative_path == "Parameters/fitted.toml":
+        return "report_only_fitted_values"
+    if relative_path.startswith("Diagnostics/"):
+        return "diagnostic_provenance"
+    if relative_path.startswith("PartialEvidence/"):
+        return "partial_evidence"
+    return "product_output"
+
+
+def _write_manifest(
+    path: Path,
+    fields: tuple[tuple[str, str | int], ...],
+    provenance: WorkflowProvenance,
+    *,
+    components: tuple[ComponentDiagnostic, ...] = (),
+    evidence: tuple[tuple[str, str, str, str], ...] = (),
+) -> tuple[str, str, tuple[ArtifactReference, ...]]:
+    native_threads = (
+        "auto"
+        if provenance.execution.native_threads is None
+        else provenance.execution.native_threads
+    )
+    artifacts = tuple(
+        ArtifactReference(
+            str(item.relative_to(path)),
+            _artifact_role(str(item.relative_to(path))),
+            hashlib.sha256(item.read_bytes()).hexdigest(),
+        )
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    )
+    manifest_identity = hashlib.sha256(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "fields": fields,
+                "provenance_identity": provenance.identity,
+                "artifacts": [
+                    (item.path, item.role, item.sha256) for item in artifacts
+                ],
+                "components": [
+                    (item.identity, item.disposition, item.controlled_ids)
+                    for item in components
+                ],
+                "evidence": evidence,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+    lines = [
+        "# Atomic native method-step manifest.",
+        "schema_version = 1",
+        f"manifest_identity = {json.dumps(manifest_identity)}",
+        *(f"{name} = {json.dumps(value)}" for name, value in fields),
+        "",
+        "[workflow]",
+        f"identity = {json.dumps(provenance.workflow_identity)}",
+        f"provenance_identity = {json.dumps(provenance.identity)}",
+        "",
+        "[method]",
+        f"identity = {json.dumps(provenance.method_identity)}",
+        f"parameterization_identity = {json.dumps(provenance.parameterization_identity)}",
+        f"evaluation_plan_identity = {json.dumps(provenance.evaluation_plan_identity)}",
+        f"normalized = {json.dumps(provenance.normalized_method_text)}",
+        f"normalized_sha256 = {json.dumps(provenance.normalized_method_sha256)}",
+        "",
+        "[selection]",
+        f"model = {json.dumps(provenance.selection.model_name)}",
+        f"include = {json.dumps(list(provenance.selection.include))}",
+        f"exclude = {json.dumps(list(provenance.selection.exclude))}",
+        "",
+        "[execution]",
+        f"workers = {provenance.execution.workers}",
+        f"native_threads = {json.dumps(native_threads)}"
+        if isinstance(native_threads, str)
+        else f"native_threads = {native_threads}",
+        "",
+        "[environment]",
+        *(
+            f"{name} = {json.dumps(value)}"
+            for name, value in provenance.environment.to_record().items()
+            if name != "numerical_libraries"
+        ),
+        "",
+    ]
+    for kind, name, library_version in provenance.environment.numerical_libraries:
+        lines.extend(
+            (
+                "[[environment.numerical_libraries]]",
+                f"kind = {json.dumps(kind)}",
+                f"name = {json.dumps(name)}",
+                f"version = {json.dumps(library_version)}",
+                "",
+            )
+        )
+    for policy in provenance.policies:
+        lines.extend(
+            (
+                "[[policies]]",
+                f"name = {json.dumps(policy.name)}",
+                f"identity = {json.dumps(policy.identity)}",
+                "",
+            )
+        )
+    for budget in provenance.budgets:
+        lines.extend(
+            (
+                "[[budgets]]",
+                f"name = {json.dumps(budget.name)}",
+                f"limit = {budget.limit}",
+            )
+        )
+        if budget.used is not None:
+            lines.append(f"used = {budget.used}")
+        lines.append("")
+    for seed in provenance.seeds:
+        lines.extend(
+            (
+                "[[seeds]]",
+                f"name = {json.dumps(seed.name)}",
+                f"value = {seed.value}",
+                f"policy_identity = {json.dumps(seed.policy_identity)}",
+                "",
+            )
+        )
+    for reference in provenance.baseline_references:
+        lines.extend(
+            (
+                "[[baseline_references]]",
+                f"kind = {json.dumps(reference.kind)}",
+                f"identity = {json.dumps(reference.identity)}",
+                "",
+            )
+        )
+    for component in components:
+        lines.extend(
+            (
+                "[[components]]",
+                f"identity = {json.dumps(component.identity)}",
+                f"disposition = {json.dumps(component.disposition)}",
+                f"controlled_ids = {json.dumps(list(component.controlled_ids))}",
+                'location = "Components/index.json"',
+                'authority = "diagnostic_only"',
+                "",
+            )
+        )
+    for family, identity, validity, location in evidence:
+        lines.extend(
+            (
+                "[[evidence]]",
+                f"family = {json.dumps(family)}",
+                f"identity = {json.dumps(identity)}",
+                f"validity = {json.dumps(validity)}",
+                f"location = {json.dumps(location)}",
+                "",
+            )
+        )
+    for artifact in artifacts:
+        lines.extend(
+            (
+                f"[artifacts.{json.dumps(artifact.path)}]",
+                f"role = {json.dumps(artifact.role)}",
+                f"sha256 = {json.dumps(artifact.sha256)}",
+                "",
+            )
+        )
+    manifest_path = path / "fit-manifest.toml"
+    manifest_path.write_text("\n".join(lines), encoding="utf-8")
+    return (
+        manifest_identity,
+        hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+        artifacts,
+    )
+
+
+def _write_committed_manifest(
+    path: Path,
+    publication: CommittedFitPublication,
+) -> tuple[str, str, tuple[ArtifactReference, ...]]:
+    evidence: list[tuple[str, str, str, str]] = []
+    if publication.uncertainty is not None:
+        evidence.append(
+            (
+                "covariance",
+                publication.uncertainty.identity,
+                "typed_claims_in_artifact",
+                "Statistics/Covariance/evidence.json",
+            )
+        )
+        if publication.uncertainty.requested_output_scope:
+            evidence.append(
+                (
+                    "constrained",
+                    publication.uncertainty.identity,
+                    "typed_claims_in_artifact",
+                    "Statistics/Constrained/evidence.json",
+                )
+            )
+    for item in publication.resampling:
+        scheme = item.evidence.plan.scheme.value
+        evidence.append(
+            (
+                f"resampling:{scheme}",
+                item.evidence.identity,
+                "required_claims_satisfied",
+                f"Statistics/Resampling/{scheme.upper()}/evidence.json",
+            )
+        )
+    if publication.mcmc is not None:
+        evidence.append(
+            (
+                "mcmc",
+                publication.mcmc.evidence.identity,
+                "integrity_validated",
+                "Statistics/MCMC/evidence.json",
+            )
+        )
+    return _write_manifest(
+        path,
+        (
+            ("lifecycle", "committed"),
+            ("authority", "committed_fit"),
+            ("starting_state_kind", "workflow_starting_provenance"),
+            (
+                "starting_occurrence_identity",
+                publication.starting_snapshot.occurrence_identity,
+            ),
+            ("starting_revision", publication.starting_snapshot.revision),
+            ("accepted_result_identity", publication.accepted.identity),
+            (
+                "accepted_occurrence_identity",
+                publication.accepted.occurrence_identity,
+            ),
+            ("commit_receipt_identity", publication.commit_receipt.identity),
+        ),
+        publication.provenance,
+        components=publication.components,
+        evidence=tuple(evidence),
+    )
+
+
+def _write_evaluation_manifest(
+    path: Path,
+    publication: EvaluationPublication,
+) -> tuple[str, str, tuple[ArtifactReference, ...]]:
+    return _write_manifest(
+        path,
+        (
+            ("lifecycle", "successful_no_state_change"),
+            ("authority", "evaluation_only"),
+        ),
+        publication.provenance,
+    )
+
+
+def _write_suppressed_manifest(
+    path: Path,
+    publication: SuppressedPublication,
+) -> tuple[str, str, tuple[ArtifactReference, ...]]:
+    fields: list[tuple[str, str | int]] = [
+        ("lifecycle", publication.lifecycle),
+        ("authority", "diagnostic_only"),
+        ("operation_identity", publication.operation.identity),
+    ]
+    if publication.accepted_result_identity is not None:
+        fields.append(
+            ("accepted_result_identity", publication.accepted_result_identity)
+        )
+    if publication.accepted_occurrence_identity is not None:
+        fields.append(
+            (
+                "accepted_occurrence_identity",
+                publication.accepted_occurrence_identity,
+            )
+        )
+    evidence = tuple(
+        (
+            f"partial_resampling:{item.plan.scheme.value}",
+            item.identity,
+            item.lifecycle.value,
+            f"PartialEvidence/Resampling/{item.plan.scheme.value.upper()}/evidence.json",
+        )
+        for item in publication.partial_resampling
+    )
+    if publication.partial_mcmc is not None:
+        evidence += (
+            (
+                "partial_mcmc",
+                publication.partial_mcmc.identity,
+                publication.partial_mcmc.lifecycle.value,
+                "PartialEvidence/MCMC/evidence.json",
+            ),
+        )
+    return _write_manifest(
+        path,
+        tuple(fields),
+        publication.provenance,
+        components=publication.components,
+        evidence=evidence,
+    )
+
+
 def _render_evaluation(path: Path, publication: EvaluationPublication) -> None:
     path.mkdir()
     write_parameter_reports(
@@ -674,7 +1201,7 @@ def _render_evaluation(path: Path, publication: EvaluationPublication) -> None:
 def publish_native_results(
     path: Path,
     publication: NativePublication,
-) -> None:
+) -> PublishedStepReference:
     """Validate and atomically publish one native method-step result tree."""
     if isinstance(publication, CommittedFitPublication):
         _validate_committed_fit(publication)
@@ -690,11 +1217,34 @@ def publish_native_results(
     try:
         if isinstance(publication, CommittedFitPublication):
             _render_committed_fit(staging, publication)
+            manifest = _write_committed_manifest(staging, publication)
+            lifecycle = "committed"
+            authority = "committed_fit"
+            independent_ids = publication.parameterization.independent_ids
         elif isinstance(publication, EvaluationPublication):
             _render_evaluation(staging, publication)
+            manifest = _write_evaluation_manifest(staging, publication)
+            lifecycle = "successful_no_state_change"
+            authority = "evaluation_only"
+            independent_ids = publication.parameterization.independent_ids
         else:
             _render_suppressed(staging, publication)
-        _atomic_publish_noreplace(staging, destination)
+            manifest = _write_suppressed_manifest(staging, publication)
+            lifecycle = publication.lifecycle
+            authority = "diagnostic_only"
+            independent_ids = publication.parameterization.independent_ids
+        publish_directory_noreplace(staging, destination)
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
         raise
+    manifest_identity, manifest_sha256, artifacts = manifest
+    return PublishedStepReference(
+        destination,
+        lifecycle,
+        authority,
+        manifest_identity,
+        manifest_sha256,
+        publication.provenance,
+        independent_ids,
+        artifacts,
+    )

--- a/src/chemex/optimize/native_reporting.py
+++ b/src/chemex/optimize/native_reporting.py
@@ -300,12 +300,21 @@ def _validate_provenance_context(
     plan: EvaluationPlan,
     parameterization: ActiveParameterization,
     method: Method,
+    invocation: DirectTrfInvocation | None,
+    native_execution: DirectTrfExecution | EvaluationResult,
 ) -> None:
     try:
-        provenance.validate_execution_context(parameterization, plan, method)
+        provenance.validate_execution_context(
+            parameterization,
+            plan,
+            method,
+            invocation,
+            native_execution,
+        )
     except NativeProvenanceError as error:
         raise NativePublicationError(
-            "Workflow method and selection provenance differ from execution"
+            "Workflow method and selection provenance, or execution provenance, "
+            "differ from execution"
         ) from error
 
 
@@ -326,11 +335,17 @@ def _validate_optional_primary_execution(
 def _validate_suppressed_execution_lineage(
     publication: SuppressedPublication,
 ) -> tuple[PolicyRecord | None, BudgetRecord | None]:
+    if publication.primary_execution is None:
+        raise NativePublicationError(
+            "Suppressed provenance requires the exact primary execution"
+        )
     _validate_provenance_context(
         publication.provenance,
         publication.plan,
         publication.parameterization,
         publication.method,
+        publication.primary_invocation,
+        publication.primary_execution,
     )
     primary_policy, primary_budget = _validate_optional_primary_execution(publication)
     primary_problem = publication.primary_problem
@@ -392,6 +407,8 @@ def _validate_evaluation_only(publication: EvaluationPublication) -> None:
         publication.plan,
         publication.parameterization,
         publication.method,
+        None,
+        publication.evaluation_result,
     )
     _validate_exact_provenance_records(publication.provenance, (), (), ())
     if any(
@@ -575,6 +592,8 @@ def _validate_committed_fit(publication: CommittedFitPublication) -> None:
         publication.plan,
         publication.parameterization,
         publication.method,
+        publication.primary_invocation,
+        publication.primary_execution,
     )
     _primary_execution_records(
         publication.primary_invocation,
@@ -1321,6 +1340,9 @@ def _validate_and_publish_staged_step(
             != hashlib.sha256(restart_path.read_bytes()).hexdigest()
         ):
             raise NativePublicationError("Committed restart provenance changed")
+    # Final ownership boundary: every ChemEx renderer and manifest writer has
+    # completed above. Keep the validation adjacent to this atomic primitive;
+    # staging is private and no application callback may run in between.
     publish_directory_noreplace(staging, destination)
 
 

--- a/src/chemex/printers/native_reporting.py
+++ b/src/chemex/printers/native_reporting.py
@@ -11,6 +11,7 @@ from typing import Protocol
 from scipy import stats
 
 from chemex.evaluation.native import EvaluationPlan, EvaluationResult
+from chemex.native_provenance import serialize_independent_parameters
 from chemex.optimize.direct_trf import canonical_chi_square
 from chemex.optimize.native_mcmc import (
     McmcEvidence,
@@ -23,7 +24,12 @@ from chemex.optimize.native_resampling import (
     ResamplingSummaryOutcome,
 )
 from chemex.optimize.uncertainty import UncertaintyEvidence
-from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    ParameterRole,
+    SealedParameterModel,
+)
+from chemex.parameters.values import AnalysisValuesSnapshot
 
 
 class ComponentDiagnosticRecord(Protocol):
@@ -104,6 +110,24 @@ def write_parameter_reports(
                 comment = f" # constrained: {expression}"
             lines.append(f"{_toml_key(param_id)} = {_toml_float(value)}{comment}")
         (path / filenames[role]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_restart_parameters(
+    path: Path,
+    parameter_model: SealedParameterModel,
+    parameterization: ActiveParameterization,
+    snapshot: AnalysisValuesSnapshot,
+) -> None:
+    """Write complete committed independent state in parameter-input form."""
+    path.write_text(
+        serialize_independent_parameters(
+            parameter_model,
+            parameterization.independent_ids,
+            snapshot,
+            state_kind="committed",
+        ),
+        encoding="utf-8",
+    )
 
 
 def write_data(

--- a/src/chemex/run_info.py
+++ b/src/chemex/run_info.py
@@ -6,19 +6,28 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import tomllib
 import uuid
 from argparse import Namespace
 from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from hashlib import blake2b
+from enum import StrEnum
+from hashlib import blake2b, sha256
 from pathlib import Path
 
 from chemex import __version__
+from chemex.atomic import publish_directory_noreplace
 from chemex.containers.experiments import Experiments
+from chemex.native_provenance import (
+    PublishedStepReference,
+    serialize_independent_parameters,
+)
 from chemex.parameters.database import ParameterStore
+from chemex.parameters.parameterization import SealedParameterModel
 from chemex.parameters.setting import ParamSetting
+from chemex.parameters.values import AnalysisValuesSnapshot
 
 SCHEMA_VERSION = 1
 _INPUT_CATEGORIES = ("experiments", "parameters", "methods")
@@ -36,6 +45,69 @@ class CopiedInputFile:
     provided_path: Path
     resolved_path: Path
     copied_path: Path
+    sha256: str
+
+
+class RunInformationKind(StrEnum):
+    """Supported meanings of historical and native run-information records."""
+
+    HISTORICAL_V1 = "historical_schema_v1"
+    NATIVE_V2 = "native_schema_v2"
+
+
+@dataclass(frozen=True, slots=True)
+class NativeRunInformation:
+    """Complete invocation state and links to atomic native step outcomes."""
+
+    invocation_identity: str
+    parameter_model: SealedParameterModel
+    starting_snapshot: AnalysisValuesSnapshot
+    steps: tuple[PublishedStepReference, ...]
+
+    def __post_init__(self) -> None:
+        if not self.invocation_identity.strip():
+            raise ValueError("Native invocation identity cannot be empty")
+        if not self.steps:
+            raise ValueError("Native run information requires at least one step")
+        snapshot = self.starting_snapshot
+        if (
+            snapshot.revision != 0
+            or snapshot.model_identity != self.parameter_model.model_identity
+            or snapshot.definitions_identity
+            != self.parameter_model.definitions.identity
+            or snapshot.configuration_identity
+            != self.parameter_model.configuration.identity
+        ):
+            raise ValueError(
+                "Native run starting state must be revision zero of its parameter model"
+            )
+        normalized_methods = {
+            step.provenance.normalized_method_text for step in self.steps
+        }
+        environments = {step.provenance.environment.identity for step in self.steps}
+        workflow_ids = {step.provenance.workflow_identity for step in self.steps}
+        if len(normalized_methods) != 1:
+            raise ValueError(
+                "Native steps must reference one normalized method archive"
+            )
+        if len(environments) != 1:
+            raise ValueError("Native steps must share one resolved environment")
+        if len(workflow_ids) != len(self.steps):
+            raise ValueError("Native workflow identities must be unique")
+
+
+def classify_run_information(path: Path) -> RunInformationKind:
+    """Classify schema-v1 as historical and schema-v2 as native product data."""
+    record = tomllib.loads(Path(path).read_text(encoding="utf-8"))
+    schema_version = record.get("schema_version")
+    if schema_version == 1:
+        return RunInformationKind.HISTORICAL_V1
+    if (
+        schema_version == 2
+        and record.get("schema_kind") == "native_product_run_information"
+    ):
+        return RunInformationKind.NATIVE_V2
+    raise ValueError("Unsupported run-information schema")
 
 
 def _quote_string(value: str) -> str:
@@ -184,6 +256,7 @@ def _copy_inputs(
                     input_file.provided_path,
                     resolved_path,
                     destination.relative_to(run_info_path),
+                    sha256(destination.read_bytes()).hexdigest(),
                 ),
             )
 
@@ -366,3 +439,260 @@ def write_run_info(
         (staging_path / "run.toml").write_text(run_text, encoding="utf-8")
 
         _replace_run_info(staging_path, run_info_path)
+
+
+def _native_independent_ids(run: NativeRunInformation) -> tuple[str, ...]:
+    requested = {param_id for step in run.steps for param_id in step.independent_ids}
+    if not requested:
+        raise ValueError("Native run information has no independent parameter scope")
+    ordered = tuple(
+        definition.param_id
+        for definition in run.parameter_model.definitions
+        if definition.param_id in requested
+    )
+    if set(ordered) != requested:
+        raise ValueError("Native step independent scope is not in the parameter model")
+    return ordered
+
+
+def _relative_step_path(step: PublishedStepReference, output: Path) -> Path:
+    try:
+        return step.path.relative_to(output)
+    except ValueError as error:
+        raise ValueError("Native step publication is outside the run output") from error
+
+
+def _validated_workflow_records(
+    run: NativeRunInformation,
+    output: Path,
+) -> dict[str, object]:
+    workflows: list[dict[str, object]] = []
+    for step in run.steps:
+        relative_step = _relative_step_path(step, output)
+        manifest_path = step.path / "fit-manifest.toml"
+        manifest_bytes = manifest_path.read_bytes()
+        if sha256(manifest_bytes).hexdigest() != step.manifest_sha256:
+            raise ValueError("Native step manifest changed before run publication")
+        manifest = tomllib.loads(manifest_bytes.decode("utf-8"))
+        if manifest.get("manifest_identity") != step.manifest_identity:
+            raise ValueError(
+                "Native step manifest identity changed before run publication"
+            )
+        if (
+            manifest.get("lifecycle") != step.lifecycle
+            or manifest.get("authority") != step.authority
+            or manifest.get("workflow", {}).get("identity")
+            != step.provenance.workflow_identity
+            or manifest.get("workflow", {}).get("provenance_identity")
+            != step.provenance.identity
+            or manifest.get("method", {}).get("identity")
+            != step.provenance.method_identity
+            or manifest.get("method", {}).get("parameterization_identity")
+            != step.provenance.parameterization_identity
+            or manifest.get("method", {}).get("evaluation_plan_identity")
+            != step.provenance.evaluation_plan_identity
+        ):
+            raise ValueError("Native step reference contradicts its manifest")
+        manifest_artifacts = manifest.get("artifacts")
+        expected_artifacts = {
+            artifact.path: {
+                "role": artifact.role,
+                "sha256": artifact.sha256,
+            }
+            for artifact in step.artifacts
+        }
+        if manifest_artifacts != expected_artifacts:
+            raise ValueError("Native step artifact references contradict its manifest")
+        artifact_records: list[dict[str, str]] = []
+        for artifact in step.artifacts:
+            artifact_path = step.path / artifact.path
+            if sha256(artifact_path.read_bytes()).hexdigest() != artifact.sha256:
+                raise ValueError("Native step artifact changed before run publication")
+            artifact_records.append(
+                {
+                    "path": str(relative_step / artifact.path),
+                    "role": artifact.role,
+                    "sha256": artifact.sha256,
+                }
+            )
+        record = step.provenance.to_record()
+        record["outcome"] = {
+            "lifecycle": step.lifecycle,
+            "authority": step.authority,
+        }
+        record["manifest"] = {
+            "path": str(relative_step / "fit-manifest.toml"),
+            "identity": step.manifest_identity,
+            "sha256": step.manifest_sha256,
+        }
+        record["artifacts"] = artifact_records
+        workflows.append(record)
+    return {
+        "schema_version": 1,
+        "invocation_identity": run.invocation_identity,
+        "workflows": workflows,
+    }
+
+
+def _serialize_native_run(
+    *,
+    run: NativeRunInformation,
+    timestamp: datetime,
+    working_directory: Path,
+    output_directory: Path,
+    argv: Sequence[str],
+    copied_inputs: Mapping[str, Sequence[CopiedInputFile]],
+    git_metadata: Mapping[str, str | bool] | None,
+    starting_sha256: str,
+    normalized_method_sha256: str,
+    workflow_records_sha256: str,
+) -> str:
+    environment = run.steps[0].provenance.environment
+    lines = [
+        "# Native ChemEx product-facing run information.",
+        "# schema_version = 1 records remain historical and are never rewritten.",
+        "",
+        "schema_version = 2",
+        'schema_kind = "native_product_run_information"',
+        f"invocation_identity = {_quote_string(run.invocation_identity)}",
+        f"created_at_utc = {_quote_string(timestamp.astimezone(UTC).isoformat())}",
+        "",
+        "[run]",
+        'kind = "fit"',
+        f"working_directory = {_quote_string(str(working_directory))}",
+        f"output_directory = {_quote_string(str(output_directory))}",
+        "",
+        "[command]",
+        f"arguments = {_format_string_list(argv)}",
+        "",
+        "[starting_state]",
+        'kind = "starting_independent_state"',
+        'path = "parameters_used.toml"',
+        f"sha256 = {_quote_string(starting_sha256)}",
+        f"occurrence_identity = {_quote_string(run.starting_snapshot.occurrence_identity)}",
+        f"revision = {run.starting_snapshot.revision}",
+        "",
+        "[normalized_method]",
+        'path = "normalized/method.toml"',
+        f"sha256 = {_quote_string(normalized_method_sha256)}",
+        "",
+        "[workflow_records]",
+        'path = "workflows.json"',
+        f"sha256 = {_quote_string(workflow_records_sha256)}",
+        "",
+        "[environment]",
+        f"identity = {_quote_string(environment.identity)}",
+        f"chemex_version = {_quote_string(environment.chemex_version)}",
+        f"python_version = {_quote_string(environment.python_version)}",
+        f"python_implementation = {_quote_string(environment.python_implementation)}",
+        f"platform = {_quote_string(environment.platform)}",
+        f"numpy_version = {_quote_string(environment.numpy_version)}",
+        f"scipy_version = {_quote_string(environment.scipy_version)}",
+        f"emcee_version = {_quote_string(environment.emcee_version)}",
+        "",
+    ]
+    for category, files in copied_inputs.items():
+        for copied_input in files:
+            lines.extend(
+                (
+                    f"[[inputs.{category}]]",
+                    f"provided_path = {_quote_string(str(copied_input.provided_path))}",
+                    f"resolved_path = {_quote_string(str(copied_input.resolved_path))}",
+                    f"copied_path = {_quote_string(str(copied_input.copied_path))}",
+                    f"sha256 = {_quote_string(copied_input.sha256)}",
+                    "",
+                )
+            )
+    for step in run.steps:
+        relative_step = _relative_step_path(step, output_directory)
+        lines.extend(
+            (
+                "[[steps]]",
+                f"path = {_quote_string(str(relative_step))}",
+                f"workflow_identity = {_quote_string(step.provenance.workflow_identity)}",
+                f"method_identity = {_quote_string(step.provenance.method_identity)}",
+                f"lifecycle = {_quote_string(step.lifecycle)}",
+                f"authority = {_quote_string(step.authority)}",
+                f"manifest_path = {_quote_string(str(relative_step / 'fit-manifest.toml'))}",
+                f"manifest_identity = {_quote_string(step.manifest_identity)}",
+                f"manifest_sha256 = {_quote_string(step.manifest_sha256)}",
+                "",
+            )
+        )
+    if git_metadata is not None:
+        lines.append("[git]")
+        for key, value in git_metadata.items():
+            formatted = (
+                str(value).lower() if isinstance(value, bool) else _quote_string(value)
+            )
+            lines.append(f"{key} = {formatted}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write_native_run_info(
+    args: Namespace,
+    run: NativeRunInformation,
+    *,
+    argv: Sequence[str] | None = None,
+    working_directory: Path | None = None,
+    timestamp: datetime | None = None,
+) -> None:
+    """Atomically write schema-v2 native invocation provenance and archives."""
+    cwd = (
+        Path.cwd().resolve()
+        if working_directory is None
+        else working_directory.resolve()
+    )
+    output_directory = _resolve_path(args.output, cwd)
+    run_info_path = output_directory / "run_info"
+    input_files = _collect_input_files(args, cwd)
+    git_metadata = _git_metadata()
+    independent_ids = _native_independent_ids(run)
+    normalized_method = run.steps[0].provenance.normalized_method_text
+    workflow_records = _validated_workflow_records(run, output_directory)
+
+    output_directory.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=output_directory,
+        prefix=".run_info-",
+    ) as staging_directory:
+        staging_path = Path(staging_directory)
+        copied_inputs = _copy_inputs(input_files, staging_path)
+        starting_text = serialize_independent_parameters(
+            run.parameter_model,
+            independent_ids,
+            run.starting_snapshot,
+            state_kind="starting",
+        )
+        starting_path = staging_path / "parameters_used.toml"
+        starting_path.write_text(starting_text, encoding="utf-8")
+        normalized_path = staging_path / "normalized" / "method.toml"
+        normalized_path.parent.mkdir()
+        normalized_path.write_text(normalized_method, encoding="utf-8")
+        workflow_path = staging_path / "workflows.json"
+        workflow_path.write_text(
+            json.dumps(
+                workflow_records,
+                allow_nan=False,
+                ensure_ascii=True,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        run_text = _serialize_native_run(
+            run=run,
+            timestamp=datetime.now(UTC) if timestamp is None else timestamp,
+            working_directory=cwd,
+            output_directory=output_directory,
+            argv=tuple(sys.argv if argv is None else argv),
+            copied_inputs=copied_inputs,
+            git_metadata=git_metadata,
+            starting_sha256=sha256(starting_path.read_bytes()).hexdigest(),
+            normalized_method_sha256=sha256(normalized_path.read_bytes()).hexdigest(),
+            workflow_records_sha256=sha256(workflow_path.read_bytes()).hexdigest(),
+        )
+        (staging_path / "run.toml").write_text(run_text, encoding="utf-8")
+        publish_directory_noreplace(staging_path, run_info_path)

--- a/src/chemex/run_info.py
+++ b/src/chemex/run_info.py
@@ -11,18 +11,26 @@ import uuid
 from argparse import Namespace
 from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from hashlib import blake2b, sha256
 from pathlib import Path
+from typing import cast
 
 from chemex import __version__
 from chemex.atomic import publish_directory_noreplace
 from chemex.containers.experiments import Experiments
 from chemex.native_provenance import (
+    ArtifactReference,
+    ArtifactRole,
+    CommittedRestartRecord,
+    NativeProvenanceError,
     PublishedStepReference,
+    WorkflowProvenance,
+    published_step_reference_identity,
     serialize_independent_parameters,
+    validate_native_step_manifest_bytes,
 )
 from chemex.parameters.database import ParameterStore
 from chemex.parameters.parameterization import SealedParameterModel
@@ -46,6 +54,79 @@ class CopiedInputFile:
     resolved_path: Path
     copied_path: Path
     sha256: str
+    identity: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedNativeInput:
+    """Immutable occurrence-start bytes plus non-authoritative source metadata."""
+
+    category: str
+    provided_path: Path
+    resolved_path: Path
+    archive_name: str
+    content: bytes = field(repr=False)
+    sha256: str = field(init=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        digest = sha256(self.content).hexdigest()
+        if (
+            self.category not in _INPUT_CATEGORIES
+            or not self.archive_name
+            or Path(self.archive_name).name != self.archive_name
+            or self.archive_name in {".", ".."}
+        ):
+            raise ValueError("Captured native input has an unsafe archive identity")
+        object.__setattr__(self, "sha256", digest)
+        object.__setattr__(
+            self,
+            "identity",
+            sha256(
+                json.dumps(
+                    (
+                        "native-input-v2",
+                        self.category,
+                        str(self.provided_path),
+                        str(self.resolved_path),
+                        self.archive_name,
+                        digest,
+                        len(self.content),
+                    ),
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                ).encode()
+            ).hexdigest(),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedNativeInputs:
+    """Canonical immutable input bundle captured before native execution begins."""
+
+    members: tuple[CapturedNativeInput, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        members = tuple(self.members)
+        keys = tuple((item.category, item.archive_name) for item in members)
+        if not members or len(set(keys)) != len(keys):
+            raise ValueError("Captured native inputs must have unique archive members")
+        object.__setattr__(self, "members", members)
+        object.__setattr__(
+            self,
+            "identity",
+            sha256(
+                json.dumps(
+                    (
+                        "native-input-bundle-v2",
+                        tuple(item.identity for item in members),
+                    ),
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                ).encode()
+            ).hexdigest(),
+        )
 
 
 class RunInformationKind(StrEnum):
@@ -60,9 +141,11 @@ class NativeRunInformation:
     """Complete invocation state and links to atomic native step outcomes."""
 
     invocation_identity: str
+    inputs: CapturedNativeInputs
     parameter_model: SealedParameterModel
     starting_snapshot: AnalysisValuesSnapshot
     steps: tuple[PublishedStepReference, ...]
+    execution_occurrence_identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         if not self.invocation_identity.strip():
@@ -81,19 +164,30 @@ class NativeRunInformation:
             raise ValueError(
                 "Native run starting state must be revision zero of its parameter model"
             )
-        normalized_methods = {
-            step.provenance.normalized_method_text for step in self.steps
-        }
         environments = {step.provenance.environment.identity for step in self.steps}
-        workflow_ids = {step.provenance.workflow_identity for step in self.steps}
-        if len(normalized_methods) != 1:
-            raise ValueError(
-                "Native steps must reference one normalized method archive"
-            )
         if len(environments) != 1:
             raise ValueError("Native steps must share one resolved environment")
-        if len(workflow_ids) != len(self.steps):
-            raise ValueError("Native workflow identities must be unique")
+        object.__setattr__(
+            self,
+            "execution_occurrence_identity",
+            _execution_occurrence_identity(
+                self.inputs.identity,
+                snapshot.occurrence_identity,
+                snapshot.revision,
+                tuple(step.identity for step in self.steps),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalNativeRunInformation:
+    """Recursively validated durable schema-v2 provenance without live authority."""
+
+    invocation_identity: str
+    input_bundle_identity: str
+    record_identity: str
+    published_step_identities: tuple[str, ...]
+    execution_occurrence_identity: str
 
 
 def classify_run_information(path: Path) -> RunInformationKind:
@@ -108,6 +202,44 @@ def classify_run_information(path: Path) -> RunInformationKind:
     ):
         return RunInformationKind.NATIVE_V2
     raise ValueError("Unsupported run-information schema")
+
+
+def _native_run_record_identity(record: Mapping[str, object]) -> str:
+    payload = dict(record)
+    payload.pop("record_identity", None)
+    return sha256(
+        json.dumps(
+            {
+                "kind": "native-run-information-v2",
+                "schema_version": 1,
+                "record": payload,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+
+
+def _execution_occurrence_identity(
+    input_bundle_identity: str,
+    starting_occurrence_identity: str,
+    starting_revision: int,
+    published_step_identities: tuple[str, ...],
+) -> str:
+    return sha256(
+        json.dumps(
+            (
+                "native-execution-occurrence-v2",
+                input_bundle_identity,
+                starting_occurrence_identity,
+                starting_revision,
+                published_step_identities,
+            ),
+            ensure_ascii=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
 
 
 def _quote_string(value: str) -> str:
@@ -215,6 +347,73 @@ def _copy_name(path: Path, *, collides: bool) -> str:
         return path.name
     digest = blake2b(str(path).encode(), digest_size=4).hexdigest()
     return f"{path.stem}__{digest}{path.suffix}"
+
+
+def capture_native_inputs(
+    args: Namespace,
+    *,
+    working_directory: Path | None = None,
+) -> CapturedNativeInputs:
+    """Capture native occurrence input bytes exactly once before execution."""
+    cwd = (
+        Path.cwd().resolve()
+        if working_directory is None
+        else working_directory.resolve()
+    )
+    input_files = _collect_input_files(args, cwd)
+    unique: list[tuple[InputFile, bytes]] = []
+    seen: set[tuple[str, Path]] = set()
+    for item in input_files:
+        key = (item.category, item.resolved_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append((item, item.resolved_path.read_bytes()))
+    counts = Counter((item.category, item.resolved_path.name) for item, _ in unique)
+    members: list[CapturedNativeInput] = []
+    for item, content in unique:
+        basename = item.resolved_path.name
+        if not basename or basename in {".", ".."}:
+            basename = "input"
+        collides = counts[(item.category, item.resolved_path.name)] > 1
+        if collides:
+            digest = blake2b(
+                (str(item.resolved_path) + sha256(content).hexdigest()).encode(),
+                digest_size=4,
+            ).hexdigest()
+            source = Path(basename)
+            basename = f"{source.stem}__{digest}{source.suffix}"
+        members.append(
+            CapturedNativeInput(
+                item.category,
+                item.provided_path,
+                item.resolved_path,
+                basename,
+                bytes(content),
+            )
+        )
+    return CapturedNativeInputs(tuple(members))
+
+
+def _write_captured_native_inputs(
+    inputs: CapturedNativeInputs,
+    run_info_path: Path,
+) -> dict[str, list[CopiedInputFile]]:
+    copied: defaultdict[str, list[CopiedInputFile]] = defaultdict(list)
+    for member in inputs.members:
+        destination = run_info_path / "inputs" / member.category / member.archive_name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(member.content)
+        copied[member.category].append(
+            CopiedInputFile(
+                member.provided_path,
+                member.resolved_path,
+                destination.relative_to(run_info_path),
+                member.sha256,
+                member.identity,
+            )
+        )
+    return dict(copied)
 
 
 def _copy_inputs(
@@ -462,34 +661,42 @@ def _relative_step_path(step: PublishedStepReference, output: Path) -> Path:
         raise ValueError("Native step publication is outside the run output") from error
 
 
-def _validated_workflow_records(
+def _validated_workflow_records(  # noqa: C901 - closed live/durable boundary
     run: NativeRunInformation,
     output: Path,
 ) -> dict[str, object]:
     workflows: list[dict[str, object]] = []
+    current_occurrence = run.starting_snapshot.occurrence_identity
+    current_revision = run.starting_snapshot.revision
     for step in run.steps:
+        step.require_exact_live_publication()
         relative_step = _relative_step_path(step, output)
         manifest_path = step.path / "fit-manifest.toml"
         manifest_bytes = manifest_path.read_bytes()
         if sha256(manifest_bytes).hexdigest() != step.manifest_sha256:
             raise ValueError("Native step manifest changed before run publication")
-        manifest = tomllib.loads(manifest_bytes.decode("utf-8"))
+        manifest = validate_native_step_manifest_bytes(manifest_bytes)
+        manifest_workflow = manifest.get("workflow")
+        manifest_method = manifest.get("method")
+        if not isinstance(manifest_workflow, dict) or not isinstance(
+            manifest_method, dict
+        ):
+            raise TypeError("Native step manifest provenance is malformed")
         if manifest.get("manifest_identity") != step.manifest_identity:
             raise ValueError(
                 "Native step manifest identity changed before run publication"
             )
         if (
-            manifest.get("lifecycle") != step.lifecycle
+            manifest.get("publication_occurrence_identity")
+            != step.publication_occurrence_identity
+            or manifest.get("lifecycle") != step.lifecycle
             or manifest.get("authority") != step.authority
-            or manifest.get("workflow", {}).get("identity")
-            != step.provenance.workflow_identity
-            or manifest.get("workflow", {}).get("provenance_identity")
-            != step.provenance.identity
-            or manifest.get("method", {}).get("identity")
-            != step.provenance.method_identity
-            or manifest.get("method", {}).get("parameterization_identity")
+            or manifest_workflow.get("identity") != step.provenance.workflow_identity
+            or manifest_workflow.get("provenance_identity") != step.provenance.identity
+            or manifest_method.get("identity") != step.provenance.method_identity
+            or manifest_method.get("parameterization_identity")
             != step.provenance.parameterization_identity
-            or manifest.get("method", {}).get("evaluation_plan_identity")
+            or manifest_method.get("evaluation_plan_identity")
             != step.provenance.evaluation_plan_identity
         ):
             raise ValueError("Native step reference contradicts its manifest")
@@ -503,6 +710,13 @@ def _validated_workflow_records(
         }
         if manifest_artifacts != expected_artifacts:
             raise ValueError("Native step artifact references contradict its manifest")
+        actual_members = {
+            str(item.relative_to(step.path))
+            for item in step.path.rglob("*")
+            if item.is_file()
+        }
+        if actual_members != {"fit-manifest.toml", *expected_artifacts}:
+            raise ValueError("Native step artifact catalogue is incomplete")
         artifact_records: list[dict[str, str]] = []
         for artifact in step.artifacts:
             artifact_path = step.path / artifact.path
@@ -515,7 +729,36 @@ def _validated_workflow_records(
                     "sha256": artifact.sha256,
                 }
             )
+        if step.lifecycle == "committed":
+            restart_record = CommittedRestartRecord.from_record(
+                json.loads(
+                    (step.path / "Parameters" / "restart-provenance.json").read_text(
+                        encoding="utf-8"
+                    )
+                )
+            )
+            if (
+                manifest.get("starting_occurrence_identity") != current_occurrence
+                or manifest.get("starting_revision") != current_revision
+                or restart_record.starting_occurrence_identity != current_occurrence
+                or restart_record.starting_revision != current_revision
+                or restart_record.parameter_model_identity
+                != run.parameter_model.identity
+                or restart_record.configuration_identity
+                != run.parameter_model.configuration.identity
+                or restart_record.workflow_identity != step.provenance.workflow_identity
+                or tuple(item[0] for item in restart_record.independent_items)
+                != step.independent_ids
+            ):
+                raise NativeProvenanceError(
+                    "Committed restart belongs to another run occurrence"
+                )
+            current_occurrence = restart_record.committed_occurrence_identity
+            current_revision = restart_record.committed_revision
         record = step.provenance.to_record()
+        record["published_step_identity"] = step.identity
+        record["publication_occurrence_identity"] = step.publication_occurrence_identity
+        record["independent_ids"] = list(step.independent_ids)
         record["outcome"] = {
             "lifecycle": step.lifecycle,
             "authority": step.authority,
@@ -530,6 +773,7 @@ def _validated_workflow_records(
     return {
         "schema_version": 1,
         "invocation_identity": run.invocation_identity,
+        "execution_occurrence_identity": run.execution_occurrence_identity,
         "workflows": workflows,
     }
 
@@ -544,8 +788,9 @@ def _serialize_native_run(
     copied_inputs: Mapping[str, Sequence[CopiedInputFile]],
     git_metadata: Mapping[str, str | bool] | None,
     starting_sha256: str,
-    normalized_method_sha256: str,
+    normalized_methods: Sequence[tuple[str, str, str, str]],
     workflow_records_sha256: str,
+    record_identity: str,
 ) -> str:
     environment = run.steps[0].provenance.environment
     lines = [
@@ -555,6 +800,9 @@ def _serialize_native_run(
         "schema_version = 2",
         'schema_kind = "native_product_run_information"',
         f"invocation_identity = {_quote_string(run.invocation_identity)}",
+        f"input_bundle_identity = {_quote_string(run.inputs.identity)}",
+        f"execution_occurrence_identity = {_quote_string(run.execution_occurrence_identity)}",
+        f"record_identity = {_quote_string(record_identity)}",
         f"created_at_utc = {_quote_string(timestamp.astimezone(UTC).isoformat())}",
         "",
         "[run]",
@@ -572,10 +820,6 @@ def _serialize_native_run(
         f"occurrence_identity = {_quote_string(run.starting_snapshot.occurrence_identity)}",
         f"revision = {run.starting_snapshot.revision}",
         "",
-        "[normalized_method]",
-        'path = "normalized/method.toml"',
-        f"sha256 = {_quote_string(normalized_method_sha256)}",
-        "",
         "[workflow_records]",
         'path = "workflows.json"',
         f"sha256 = {_quote_string(workflow_records_sha256)}",
@@ -591,6 +835,17 @@ def _serialize_native_run(
         f"emcee_version = {_quote_string(environment.emcee_version)}",
         "",
     ]
+    for workflow_identity, method_identity, path, digest in normalized_methods:
+        lines.extend(
+            (
+                "[[normalized_methods]]",
+                f"workflow_identity = {_quote_string(workflow_identity)}",
+                f"method_identity = {_quote_string(method_identity)}",
+                f"path = {_quote_string(path)}",
+                f"sha256 = {_quote_string(digest)}",
+                "",
+            )
+        )
     for category, files in copied_inputs.items():
         for copied_input in files:
             lines.extend(
@@ -600,6 +855,7 @@ def _serialize_native_run(
                     f"resolved_path = {_quote_string(str(copied_input.resolved_path))}",
                     f"copied_path = {_quote_string(str(copied_input.copied_path))}",
                     f"sha256 = {_quote_string(copied_input.sha256)}",
+                    f"identity = {_quote_string(copied_input.identity or '')}",
                     "",
                 )
             )
@@ -610,7 +866,11 @@ def _serialize_native_run(
                 "[[steps]]",
                 f"path = {_quote_string(str(relative_step))}",
                 f"workflow_identity = {_quote_string(step.provenance.workflow_identity)}",
+                f"execution_identity = {_quote_string(step.provenance.execution_identity)}",
                 f"method_identity = {_quote_string(step.provenance.method_identity)}",
+                f"provenance_identity = {_quote_string(step.provenance.identity)}",
+                f"published_step_identity = {_quote_string(step.identity)}",
+                f"publication_occurrence_identity = {_quote_string(step.publication_occurrence_identity)}",
                 f"lifecycle = {_quote_string(step.lifecycle)}",
                 f"authority = {_quote_string(step.authority)}",
                 f"manifest_path = {_quote_string(str(relative_step / 'fit-manifest.toml'))}",
@@ -630,6 +890,416 @@ def _serialize_native_run(
     return "\n".join(lines)
 
 
+def _safe_link(root: Path, value: object) -> Path:
+    text = str(value)
+    relative = Path(text)
+    if (
+        relative.is_absolute()
+        or ".." in relative.parts
+        or not relative.parts
+        or str(relative) != text
+    ):
+        raise NativeProvenanceError("Native run information contains an unsafe link")
+    return root / relative
+
+
+def read_native_run_information(  # noqa: C901 - closed durable schema
+    path: Path,
+) -> HistoricalNativeRunInformation:
+    """Recursively validate durable schema-v2 provenance without live authority."""
+    run_path = Path(path)
+    if run_path.is_dir():
+        run_path = run_path / "run.toml"
+    root = run_path.parent
+    try:
+        record = tomllib.loads(run_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise NativeProvenanceError("Native run information is unreadable") from error
+    required = {
+        "schema_version",
+        "schema_kind",
+        "invocation_identity",
+        "input_bundle_identity",
+        "execution_occurrence_identity",
+        "record_identity",
+        "created_at_utc",
+        "run",
+        "command",
+        "starting_state",
+        "normalized_methods",
+        "workflow_records",
+        "environment",
+        "inputs",
+        "steps",
+    }
+    if (
+        not required <= set(record)
+        or set(record) - required - {"git"}
+        or record.get("schema_version") != 2
+        or record.get("schema_kind") != "native_product_run_information"
+        or record.get("record_identity") != _native_run_record_identity(record)
+    ):
+        raise NativeProvenanceError("Native run record identity or fields are invalid")
+    run_record = record.get("run")
+    command = record.get("command")
+    run_environment = record.get("environment")
+    if (
+        not isinstance(record.get("created_at_utc"), str)
+        or not isinstance(record.get("invocation_identity"), str)
+        or not str(record["invocation_identity"]).strip()
+        or not isinstance(run_record, dict)
+        or set(run_record) != {"kind", "working_directory", "output_directory"}
+        or run_record.get("kind") != "fit"
+        or not isinstance(command, dict)
+        or set(command) != {"arguments"}
+        or not isinstance(command.get("arguments"), list)
+        or any(not isinstance(item, str) for item in command["arguments"])
+        or not isinstance(run_environment, dict)
+        or set(run_environment)
+        != {
+            "identity",
+            "chemex_version",
+            "python_version",
+            "python_implementation",
+            "platform",
+            "numpy_version",
+            "scipy_version",
+            "emcee_version",
+        }
+    ):
+        raise NativeProvenanceError("Native run metadata fields are malformed")
+    git = record.get("git")
+    if git is not None and (
+        not isinstance(git, dict)
+        or not {"commit", "working_tree_dirty"} <= set(git)
+        or set(git) - {"commit", "branch", "working_tree_dirty"}
+        or not isinstance(git.get("commit"), str)
+        or not isinstance(git.get("working_tree_dirty"), bool)
+        or ("branch" in git and not isinstance(git["branch"], str))
+    ):
+        raise NativeProvenanceError("Native run git metadata is malformed")
+    starting = record.get("starting_state")
+    normalized = record.get("normalized_methods")
+    workflow_link = record.get("workflow_records")
+    if (
+        not isinstance(starting, dict)
+        or set(starting)
+        != {"kind", "path", "sha256", "occurrence_identity", "revision"}
+        or starting.get("kind") != "starting_independent_state"
+        or not isinstance(normalized, list)
+        or not normalized
+        or any(
+            not isinstance(item, dict)
+            or set(item) != {"workflow_identity", "method_identity", "path", "sha256"}
+            for item in normalized
+        )
+        or not isinstance(workflow_link, dict)
+        or set(workflow_link) != {"path", "sha256"}
+    ):
+        raise NativeProvenanceError("Native run child links are malformed")
+    normalized_links = cast(list[dict[str, object]], normalized)
+    for link in (starting, workflow_link, *normalized_links):
+        member = _safe_link(root, link["path"])
+        if sha256(member.read_bytes()).hexdigest() != link["sha256"]:
+            raise NativeProvenanceError("Native run child hash does not match")
+    if len({str(link["path"]) for link in normalized_links}) != len(normalized_links):
+        raise NativeProvenanceError("Normalized method links are duplicated")
+
+    inputs = record.get("inputs")
+    if not isinstance(inputs, dict) or set(inputs) - set(_INPUT_CATEGORIES):
+        raise NativeProvenanceError("Native input archive is malformed")
+    captured: list[CapturedNativeInput] = []
+    expected_root_members = {
+        "run.toml",
+        str(starting["path"]),
+        str(workflow_link["path"]),
+        *(str(link["path"]) for link in normalized_links),
+    }
+    for category in _INPUT_CATEGORIES:
+        entries = inputs.get(category, [])
+        if not isinstance(entries, list):
+            raise NativeProvenanceError("Native input archive is malformed")
+        for item in entries:
+            if not isinstance(item, dict) or set(item) != {
+                "provided_path",
+                "resolved_path",
+                "copied_path",
+                "sha256",
+                "identity",
+            }:
+                raise NativeProvenanceError("Native input member is malformed")
+            member_path = _safe_link(root, item["copied_path"])
+            content = member_path.read_bytes()
+            archived = CapturedNativeInput(
+                category,
+                Path(str(item["provided_path"])),
+                Path(str(item["resolved_path"])),
+                member_path.name,
+                content,
+            )
+            if (
+                item["copied_path"] != f"inputs/{category}/{archived.archive_name}"
+                or item["sha256"] != archived.sha256
+                or item["identity"] != archived.identity
+            ):
+                raise NativeProvenanceError("Native input member identity is invalid")
+            captured.append(archived)
+            expected_root_members.add(str(item["copied_path"]))
+    bundle = CapturedNativeInputs(tuple(captured))
+    if record.get("input_bundle_identity") != bundle.identity:
+        raise NativeProvenanceError("Native input bundle identity is invalid")
+
+    try:
+        workflows = json.loads(_safe_link(root, workflow_link["path"]).read_text())
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise NativeProvenanceError("Native workflow records are malformed") from error
+    if (
+        not isinstance(workflows, dict)
+        or set(workflows)
+        != {
+            "schema_version",
+            "invocation_identity",
+            "execution_occurrence_identity",
+            "workflows",
+        }
+        or workflows.get("schema_version") != 1
+        or workflows.get("invocation_identity") != record.get("invocation_identity")
+        or not isinstance(workflows.get("workflows"), list)
+    ):
+        raise NativeProvenanceError("Native workflow record envelope is invalid")
+    steps = record.get("steps")
+    workflow_items = workflows["workflows"]
+    if (
+        not isinstance(steps, list)
+        or len(steps) != len(workflow_items)
+        or len(steps) != len(normalized_links)
+        or not steps
+    ):
+        raise NativeProvenanceError("Native run step links are incomplete")
+    published_ids: list[str] = []
+    output = root.parent
+    current_occurrence = str(starting["occurrence_identity"])
+    current_revision = int(starting["revision"])
+    for step, workflow, normalized_link in zip(
+        steps, workflow_items, normalized_links, strict=True
+    ):
+        if (
+            not isinstance(step, dict)
+            or set(step)
+            != {
+                "path",
+                "workflow_identity",
+                "execution_identity",
+                "method_identity",
+                "provenance_identity",
+                "published_step_identity",
+                "publication_occurrence_identity",
+                "lifecycle",
+                "authority",
+                "manifest_path",
+                "manifest_identity",
+                "manifest_sha256",
+            }
+            or not isinstance(workflow, dict)
+        ):
+            raise NativeProvenanceError("Native run step record is malformed")
+        step = cast(dict[str, object], step)
+        workflow = cast(dict[str, object], workflow)
+        step_path = _safe_link(output, step["path"])
+        if step["manifest_path"] != f"{step['path']}/fit-manifest.toml":
+            raise NativeProvenanceError("Native step manifest link is not canonical")
+        manifest_path = _safe_link(output, step["manifest_path"])
+        manifest_bytes = manifest_path.read_bytes()
+        manifest = validate_native_step_manifest_bytes(manifest_bytes)
+        provenance = WorkflowProvenance.from_manifest_record(manifest)
+        artifacts_record = workflow.get("artifacts")
+        independent_raw = workflow.get("independent_ids")
+        workflow_keys = {
+            "identity",
+            "execution_identity",
+            "workflow_type",
+            "grouping_topology",
+            "provenance_identity",
+            "method",
+            "selection",
+            "policies",
+            "budgets",
+            "seeds",
+            "execution",
+            "environment",
+            "baseline_references",
+            "published_step_identity",
+            "publication_occurrence_identity",
+            "independent_ids",
+            "outcome",
+            "manifest",
+            "artifacts",
+        }
+        if (
+            set(workflow) != workflow_keys
+            or not isinstance(artifacts_record, list)
+            or not isinstance(independent_raw, list)
+            or any(
+                not isinstance(item, dict)
+                or set(item) != {"path", "role", "sha256"}
+                or not str(cast(dict[str, object], item).get("path")).startswith(
+                    f"{step['path']}/"
+                )
+                for item in artifacts_record
+            )
+        ):
+            raise NativeProvenanceError("Native workflow children are malformed")
+        artifact_records = cast(list[dict[str, object]], artifacts_record)
+        artifacts = tuple(
+            ArtifactReference(
+                str(item["path"]).removeprefix(f"{step['path']}/"),
+                cast(ArtifactRole, str(item["role"])),
+                str(item["sha256"]),
+            )
+            for item in artifact_records
+        )
+        independent_ids = tuple(str(item) for item in independent_raw)
+        rebuilt_step_identity = published_step_reference_identity(
+            publication_occurrence_identity=str(
+                manifest["publication_occurrence_identity"]
+            ),
+            lifecycle=str(manifest["lifecycle"]),
+            authority=str(manifest["authority"]),
+            manifest_identity=str(manifest["manifest_identity"]),
+            manifest_sha256=sha256(manifest_bytes).hexdigest(),
+            provenance=provenance,
+            independent_ids=independent_ids,
+            artifacts=artifacts,
+        )
+        canonical_workflow = provenance.to_record()
+        if (
+            step["manifest_sha256"] != sha256(manifest_bytes).hexdigest()
+            or step["manifest_identity"] != manifest["manifest_identity"]
+            or step["publication_occurrence_identity"]
+            != manifest["publication_occurrence_identity"]
+            or step["lifecycle"] != manifest["lifecycle"]
+            or step["authority"] != manifest["authority"]
+            or step["workflow_identity"] != provenance.workflow_identity
+            or step["execution_identity"] != provenance.execution_identity
+            or step["method_identity"] != provenance.method_identity
+            or step["provenance_identity"] != provenance.identity
+            or step["published_step_identity"] != rebuilt_step_identity
+            or any(
+                workflow.get(key) != value for key, value in canonical_workflow.items()
+            )
+            or workflow.get("published_step_identity") != rebuilt_step_identity
+            or workflow.get("publication_occurrence_identity")
+            != manifest["publication_occurrence_identity"]
+            or workflow.get("independent_ids") != list(independent_ids)
+            or workflow.get("outcome")
+            != {
+                "lifecycle": manifest["lifecycle"],
+                "authority": manifest["authority"],
+            }
+            or workflow.get("manifest")
+            != {
+                "path": step["manifest_path"],
+                "identity": manifest["manifest_identity"],
+                "sha256": step["manifest_sha256"],
+            }
+            or normalized_link["workflow_identity"] != provenance.workflow_identity
+            or normalized_link["method_identity"] != provenance.method_identity
+            or _safe_link(root, normalized_link["path"]).read_text(encoding="utf-8")
+            != provenance.normalized_method_text
+            or provenance.environment.to_record()
+            != {
+                **run_environment,
+                "numerical_libraries": provenance.environment.to_record()[
+                    "numerical_libraries"
+                ],
+            }
+        ):
+            raise NativeProvenanceError("Native run step lineage is contradictory")
+        manifest_artifacts = manifest["artifacts"]
+        if {
+            item.path: {"role": item.role, "sha256": item.sha256} for item in artifacts
+        } != manifest_artifacts:
+            raise NativeProvenanceError(
+                "Native run artifact catalogue is contradictory"
+            )
+        actual_step_members = {
+            str(item.relative_to(step_path))
+            for item in step_path.rglob("*")
+            if item.is_file()
+        }
+        if actual_step_members != {
+            "fit-manifest.toml",
+            *(item.path for item in artifacts),
+        }:
+            raise NativeProvenanceError(
+                "Native run step artifact catalogue is incomplete"
+            )
+        for artifact in artifacts:
+            artifact_path = _safe_link(step_path, artifact.path)
+            if sha256(artifact_path.read_bytes()).hexdigest() != artifact.sha256:
+                raise NativeProvenanceError("Native run artifact hash does not match")
+        if manifest["lifecycle"] == "committed":
+            restart_record = CommittedRestartRecord.from_record(
+                json.loads(
+                    (step_path / "Parameters" / "restart-provenance.json").read_text()
+                )
+            )
+            if (
+                restart_record.identity != manifest["restart_record_identity"]
+                or restart_record.starting_occurrence_identity != current_occurrence
+                or restart_record.starting_revision != current_revision
+                or restart_record.workflow_identity != provenance.workflow_identity
+                or restart_record.accepted_result_identity
+                != manifest["accepted_result_identity"]
+                or restart_record.accepted_occurrence_identity
+                != manifest["accepted_occurrence_identity"]
+                or restart_record.commit_operation_identity
+                != manifest["commit_operation_identity"]
+                or restart_record.commit_occurrence_identity
+                != manifest["commit_occurrence_identity"]
+                or restart_record.committed_occurrence_identity
+                != manifest["committed_occurrence_identity"]
+                or restart_record.committed_revision != manifest["committed_revision"]
+                or restart_record.problem_identity != manifest["problem_identity"]
+                or restart_record.parameterization_identity
+                != manifest["parameterization_identity"]
+                or tuple(item[0] for item in restart_record.independent_items)
+                != independent_ids
+            ):
+                raise NativeProvenanceError(
+                    "Native committed restart lineage is invalid"
+                )
+            current_occurrence = restart_record.committed_occurrence_identity
+            current_revision = restart_record.committed_revision
+        published_ids.append(rebuilt_step_identity)
+
+    execution_occurrence_identity = _execution_occurrence_identity(
+        bundle.identity,
+        str(starting["occurrence_identity"]),
+        int(starting["revision"]),
+        tuple(published_ids),
+    )
+    if (
+        record.get("execution_occurrence_identity") != execution_occurrence_identity
+        or workflows.get("execution_occurrence_identity")
+        != execution_occurrence_identity
+    ):
+        raise NativeProvenanceError("Native execution occurrence identity is invalid")
+
+    actual_root_members = {
+        str(item.relative_to(root)) for item in root.rglob("*") if item.is_file()
+    }
+    if actual_root_members != expected_root_members:
+        raise NativeProvenanceError("Native run information member catalogue changed")
+    return HistoricalNativeRunInformation(
+        str(record["invocation_identity"]),
+        bundle.identity,
+        str(record["record_identity"]),
+        tuple(published_ids),
+        execution_occurrence_identity,
+    )
+
+
 def write_native_run_info(
     args: Namespace,
     run: NativeRunInformation,
@@ -646,10 +1316,8 @@ def write_native_run_info(
     )
     output_directory = _resolve_path(args.output, cwd)
     run_info_path = output_directory / "run_info"
-    input_files = _collect_input_files(args, cwd)
     git_metadata = _git_metadata()
     independent_ids = _native_independent_ids(run)
-    normalized_method = run.steps[0].provenance.normalized_method_text
     workflow_records = _validated_workflow_records(run, output_directory)
 
     output_directory.mkdir(parents=True, exist_ok=True)
@@ -658,7 +1326,7 @@ def write_native_run_info(
         prefix=".run_info-",
     ) as staging_directory:
         staging_path = Path(staging_directory)
-        copied_inputs = _copy_inputs(input_files, staging_path)
+        copied_inputs = _write_captured_native_inputs(run.inputs, staging_path)
         starting_text = serialize_independent_parameters(
             run.parameter_model,
             independent_ids,
@@ -667,9 +1335,24 @@ def write_native_run_info(
         )
         starting_path = staging_path / "parameters_used.toml"
         starting_path.write_text(starting_text, encoding="utf-8")
-        normalized_path = staging_path / "normalized" / "method.toml"
-        normalized_path.parent.mkdir()
-        normalized_path.write_text(normalized_method, encoding="utf-8")
+        normalized_directory = staging_path / "normalized"
+        normalized_directory.mkdir()
+        normalized_methods: list[tuple[str, str, str, str]] = []
+        for index, step in enumerate(run.steps, start=1):
+            relative_path = f"normalized/method-{index:04d}.toml"
+            normalized_path = staging_path / relative_path
+            normalized_path.write_text(
+                step.provenance.normalized_method_text,
+                encoding="utf-8",
+            )
+            normalized_methods.append(
+                (
+                    step.provenance.workflow_identity,
+                    step.provenance.method_identity,
+                    relative_path,
+                    sha256(normalized_path.read_bytes()).hexdigest(),
+                )
+            )
         workflow_path = staging_path / "workflows.json"
         workflow_path.write_text(
             json.dumps(
@@ -682,17 +1365,47 @@ def write_native_run_info(
             + "\n",
             encoding="utf-8",
         )
-        run_text = _serialize_native_run(
+        created_at = datetime.now(UTC) if timestamp is None else timestamp
+        starting_sha256 = sha256(starting_path.read_bytes()).hexdigest()
+        workflow_records_sha256 = sha256(workflow_path.read_bytes()).hexdigest()
+        provisional = _serialize_native_run(
             run=run,
-            timestamp=datetime.now(UTC) if timestamp is None else timestamp,
+            timestamp=created_at,
             working_directory=cwd,
             output_directory=output_directory,
             argv=tuple(sys.argv if argv is None else argv),
             copied_inputs=copied_inputs,
             git_metadata=git_metadata,
-            starting_sha256=sha256(starting_path.read_bytes()).hexdigest(),
-            normalized_method_sha256=sha256(normalized_path.read_bytes()).hexdigest(),
-            workflow_records_sha256=sha256(workflow_path.read_bytes()).hexdigest(),
+            starting_sha256=starting_sha256,
+            normalized_methods=normalized_methods,
+            workflow_records_sha256=workflow_records_sha256,
+            record_identity="0" * 64,
+        )
+        provisional_record = tomllib.loads(provisional)
+        run_text = _serialize_native_run(
+            run=run,
+            timestamp=created_at,
+            working_directory=cwd,
+            output_directory=output_directory,
+            argv=tuple(sys.argv if argv is None else argv),
+            copied_inputs=copied_inputs,
+            git_metadata=git_metadata,
+            starting_sha256=starting_sha256,
+            normalized_methods=normalized_methods,
+            workflow_records_sha256=workflow_records_sha256,
+            record_identity=_native_run_record_identity(provisional_record),
         )
         (staging_path / "run.toml").write_text(run_text, encoding="utf-8")
+        historical = read_native_run_information(staging_path)
+        if (
+            historical.invocation_identity != run.invocation_identity
+            or historical.input_bundle_identity != run.inputs.identity
+            or historical.published_step_identities
+            != tuple(step.identity for step in run.steps)
+            or historical.execution_occurrence_identity
+            != run.execution_occurrence_identity
+        ):
+            raise NativeProvenanceError(
+                "Staged native run information differs from the live occurrence"
+            )
         publish_directory_noreplace(staging_path, run_info_path)

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import math
+import os
 import pickle
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -60,7 +61,8 @@ from chemex.parameters.parameterization import (
 from chemex.parameters.sealed import ParamConfig, SealedConfiguration
 from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.values import AnalysisValuesSnapshot, StaleAnalysisValuesError
-from chemex.runtime import AnalysisSession
+from chemex.runtime import AnalysisSession, ExecutionSettings
+from chemex.runtime.execution import NATIVE_THREAD_ENV_VARS
 from chemex.typing import Array
 
 ROOT = Path(__file__).parent.parent
@@ -844,6 +846,48 @@ def test_non_convergence_keeps_last_iterate_diagnostic_and_commits_nothing() -> 
     assert outcome.accepted_result is None
     assert session.analysis_values.snapshot() == before
     assert _legacy_values(session, problem.commit_scope) == legacy_before
+
+
+def test_invocation_execution_settings_drive_the_solver_environment() -> None:
+    _session, _experiments, parameterization, engine, problem, invocation = (
+        _qualification_fit()
+    )
+    invocation = dataclasses.replace(
+        invocation,
+        execution_settings=ExecutionSettings(workers=1, native_threads=7),
+    )
+    previous = {name: os.environ.get(name) for name in NATIVE_THREAD_ENV_VARS}
+
+    def inspect_execution_settings(
+        fun: Callable[[Array], Array], x0: Array, **settings: object
+    ) -> object:
+        assert "workers" not in settings
+        assert all(os.environ.get(name) == "7" for name in NATIVE_THREAD_ENV_VARS)
+        return _one_request_converged_backend(fun, x0)
+
+    with patch(
+        "chemex.optimize.direct_trf.least_squares",
+        inspect_execution_settings,
+    ):
+        outcome = execute_direct_trf(problem, invocation, parameterization, engine)
+
+    assert outcome.terminal is DirectTrfOutcomeTerminal.ACCEPTED
+    assert {name: os.environ.get(name) for name in NATIVE_THREAD_ENV_VARS} == previous
+
+
+def test_direct_trf_rejects_a_parallel_worker_claim() -> None:
+    _session, _experiments, _parameterization, _engine, _problem, invocation = (
+        _qualification_fit()
+    )
+
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="exactly one ChemEx worker",
+    ):
+        dataclasses.replace(
+            invocation,
+            execution_settings=ExecutionSettings(workers=2),
+        )
 
 
 def test_budget_exhaustion_has_exact_counters_and_no_accepted_candidate() -> None:

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -137,10 +137,14 @@ def _workflow_provenance(
     method: Method,
     invocation: DirectTrfInvocation | None = None,
     execution: DirectTrfExecution | None = None,
+    evaluation_result: EvaluationResult | None = None,
     uncertainty: UncertaintyEvidence | None = None,
     resampling: tuple[ResamplingPublication, ...] = (),
     mcmc: McmcPublication | None = None,
 ) -> WorkflowProvenance:
+    assert (execution is not None) != (evaluation_result is not None)
+    native_execution = execution if execution is not None else evaluation_result
+    assert native_execution is not None
     requested = Occurrence(
         "a" * 64,
         "b" * 64,
@@ -220,12 +224,11 @@ def _workflow_provenance(
         parameterization=parameterization,
         plan=plan,
         method=method,
-        workflow_type="direct_trf",
-        grouping_topology=(("aggregate", parameterization.independent_ids),),
+        invocation=invocation,
+        native_execution=native_execution,
         policies=tuple(policies),
         budgets=tuple(budgets),
         seeds=tuple(seeds),
-        execution=ExecutionSettings(workers=2, native_threads=1),
         environment=ProvenanceEnvironment(
             chemex_version="2026.8",
             python_version="3.14.5",
@@ -300,6 +303,7 @@ def _committed_fit(
     invocation = DirectTrfInvocation.for_problem(
         problem,
         objective_request_budget=80,
+        execution_settings=ExecutionSettings(workers=1, native_threads=1),
     )
     outcome = execute_direct_trf(
         problem,
@@ -485,6 +489,7 @@ def _evaluation_only(method: Method | None = None) -> EvaluationPublication:
             parameterization=parameterization,
             plan=engine.plan,
             method=method,
+            evaluation_result=result,
         ),
     )
 
@@ -819,7 +824,7 @@ def test_committed_native_fit_publishes_only_aggregate_step_root(
         "include": [profile.identity for profile in publication.plan.profiles],
         "exclude": [],
     }
-    assert manifest["execution"] == {"workers": 2, "native_threads": 1}
+    assert manifest["execution"] == {"workers": 1, "native_threads": 1}
     assert manifest["budgets"][0] == {
         "name": "primary_direct_trf_objective_requests",
         "limit": publication.primary_invocation.objective_request_budget,
@@ -1126,6 +1131,41 @@ def test_execution_identity_covers_every_non_method_execution_choice(
 
     assert changed.method_identity == base.method_identity
     assert changed.execution_identity != base.execution_identity
+
+
+@pytest.mark.parametrize(
+    ("changes", "description"),
+    (
+        ({"workflow_type": "grid"}, "GRID workflow"),
+        ({"workflow_type": "de"}, "DE workflow"),
+        (
+            {"grouping_topology": (("foreign-component", ("FOREIGN",)),)},
+            "grouping topology",
+        ),
+        (
+            {"execution": ExecutionSettings(workers=999, native_threads=1)},
+            "worker count",
+        ),
+        (
+            {"execution": ExecutionSettings(workers=1, native_threads=999)},
+            "native thread count",
+        ),
+    ),
+)
+def test_committed_publication_rejects_recomputed_false_execution_provenance(
+    tmp_path: Path,
+    changes: dict[str, object],
+    description: str,
+) -> None:
+    publication = _committed_fit()
+    forged_provenance = replace(publication.provenance, **changes)
+
+    with pytest.raises(ValueError, match="execution provenance"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(publication, provenance=forged_provenance),
+        )
+    assert not (tmp_path / "STEP").exists(), description
 
 
 def test_committed_publication_rejects_unsuccessful_component_diagnostics(
@@ -1540,6 +1580,32 @@ def test_final_rename_failure_removes_complete_staging_tree(
         publish_native_results(output, publication)
 
     assert not output.exists()
+    assert not _staging_residue(tmp_path, output.name)
+
+
+def test_final_publication_primitive_receives_the_unchanged_validated_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "STEP"
+    original = native_reporting.publish_directory_noreplace
+    candidate_at_atomic_boundary: dict[str, bytes] = {}
+
+    def observe_atomic_boundary(staging: Path, destination: Path) -> None:
+        candidate_at_atomic_boundary.update(_tree_bytes(staging))
+        original(staging, destination)
+
+    monkeypatch.setattr(
+        native_reporting,
+        "publish_directory_noreplace",
+        observe_atomic_boundary,
+    )
+
+    publish_native_results(output, publication)
+
+    assert candidate_at_atomic_boundary
+    assert _tree_bytes(output) == candidate_at_atomic_boundary
     assert not _staging_residue(tmp_path, output.name)
 
 

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -9,22 +9,45 @@ from __future__ import annotations
 
 import json
 import tomllib
+from argparse import Namespace
 from dataclasses import replace
+from datetime import UTC, datetime
+from hashlib import sha256
 from pathlib import Path
 from typing import Literal
 
 import numpy as np
 import pytest
 
+from chemex.baselines import (
+    LegacyObservationImplementation,
+    Occurrence,
+    ResultBundle,
+    ResultMember,
+)
 from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
-from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFrame,
+    EvaluationPlan,
+    EvaluationResult,
+)
 from chemex.experiments.builder import build_experiments
+from chemex.native_provenance import (
+    BaselineReference,
+    BudgetRecord,
+    PolicyRecord,
+    ProvenanceEnvironment,
+    SeedRecord,
+    WorkflowProvenance,
+)
 from chemex.optimize import native_reporting
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     CancellationToken,
     CommitReceipt,
+    DirectTrfExecution,
     DirectTrfInvocation,
     FitCommitOperation,
     FitCommitTerminal,
@@ -68,17 +91,134 @@ from chemex.optimize.native_resampling import (
 from chemex.optimize.uncertainty import (
     ParameterUnit,
     ResidualVarianceScaling,
+    UncertaintyEvidence,
     UncertaintyPolicy,
     compile_constraint_linearization_capabilities,
     derive_uncertainty_evidence,
 )
+from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.spin_system import SpinSystem
-from chemex.runtime import AnalysisSession
+from chemex.run_info import (
+    NativeRunInformation,
+    RunInformationKind,
+    classify_run_information,
+    write_native_run_info,
+)
+from chemex.runtime import AnalysisSession, ExecutionSettings
 
 ROOT = Path(__file__).parent.parent
 EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
 PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
 METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+def _workflow_provenance(
+    *,
+    parameterization: ActiveParameterization,
+    plan: EvaluationPlan,
+    invocation: DirectTrfInvocation | None = None,
+    execution: DirectTrfExecution | None = None,
+    uncertainty: UncertaintyEvidence | None = None,
+    resampling: tuple[ResamplingPublication, ...] = (),
+    mcmc: McmcPublication | None = None,
+) -> WorkflowProvenance:
+    requested = Occurrence(
+        "a" * 64,
+        "b" * 64,
+        "c" * 64,
+        "unqualified-local-lane-v1",
+        None,
+        ("d" * 64,),
+        "issue-609-baseline-attempt",
+    )
+    bundle = ResultBundle.create(
+        requested.identity,
+        requested.execution_specification_identity,
+        LegacyObservationImplementation(),
+        (ResultMember("result", "e" * 64, 1),),
+    )
+    occurrence = requested.succeeded(bundle)
+    policies: list[PolicyRecord] = []
+    budgets: list[BudgetRecord] = []
+    seeds: list[SeedRecord] = []
+    if invocation is not None or execution is not None:
+        assert invocation is not None
+        assert execution is not None
+        policies.append(PolicyRecord("primary_direct_trf", invocation.identity))
+        budgets.append(
+            BudgetRecord(
+                "primary_direct_trf_objective_requests",
+                invocation.objective_request_budget,
+                execution.counters.objective_requests_accepted,
+            )
+        )
+    if uncertainty is not None:
+        policies.append(PolicyRecord("uncertainty", uncertainty.source_policy.identity))
+    for item in resampling:
+        resampling_plan = item.evidence.plan
+        name = f"resampling_{resampling_plan.scheme.value}"
+        policies.append(PolicyRecord(name, resampling_plan.identity))
+        budgets.append(
+            BudgetRecord(
+                f"{name}_replicates",
+                resampling_plan.replicate_count,
+                item.evidence.completed_count,
+            )
+        )
+        objective_budget = int(
+            dict(resampling_plan.strategy_settings).get(
+                "objective_request_budget", "100"
+            )
+        )
+        budgets.append(
+            BudgetRecord(
+                f"{name}_objective_requests",
+                objective_budget * resampling_plan.replicate_count,
+                None,
+            )
+        )
+        seeds.append(
+            SeedRecord(
+                f"{name}_root",
+                resampling_plan.root_seed,
+                resampling_plan.seed_policy_version,
+            )
+        )
+    if mcmc is not None:
+        policy = mcmc.evidence.plan.policy
+        policies.append(PolicyRecord("mcmc", policy.identity))
+        budgets.append(
+            BudgetRecord(
+                "mcmc_objective_requests",
+                policy.objective_request_budget,
+                mcmc.evidence.objective_request_count,
+            )
+        )
+        seeds.append(
+            SeedRecord("mcmc_root", policy.root_seed, policy.seed_policy_version)
+        )
+    return WorkflowProvenance.create(
+        parameterization=parameterization,
+        plan=plan,
+        policies=tuple(policies),
+        budgets=tuple(budgets),
+        seeds=tuple(seeds),
+        execution=ExecutionSettings(workers=2, native_threads=1),
+        environment=ProvenanceEnvironment(
+            chemex_version="2026.8",
+            python_version="3.14.5",
+            python_implementation="CPython",
+            platform="macOS-arm64",
+            numpy_version="2.5.1",
+            scipy_version="1.17.0",
+            emcee_version="3.1.6",
+            numerical_libraries=(("blas", "accelerate", "unknown"),),
+        ),
+        baseline_references=(
+            BaselineReference.from_occurrence(occurrence),
+            BaselineReference.from_result_bundle(bundle),
+        ),
+    )
 
 
 def _committed_fit(
@@ -125,16 +265,23 @@ def _committed_fit(
                 offset = stop
         engine = EvaluationEngine.from_experiments(experiments, parameterization)
     configuration = session.parameter_factory.sealed_configuration
+    parameter_model = session.parameter_factory.sealed_parameter_model
     assert configuration is not None
+    assert parameter_model is not None
+    starting_snapshot = session.analysis_values.snapshot()
     problem = OptimizationProblem.from_native(
         engine.plan,
         parameterization,
         configuration,
-        session.analysis_values.snapshot(),
+        starting_snapshot,
+    )
+    invocation = DirectTrfInvocation.for_problem(
+        problem,
+        objective_request_budget=80,
     )
     outcome = execute_direct_trf(
         problem,
-        DirectTrfInvocation.for_problem(problem, objective_request_budget=80),
+        invocation,
         parameterization,
         engine,
     )
@@ -261,11 +408,25 @@ def _committed_fit(
     return CommittedFitPublication(
         engine.plan,
         parameterization,
+        parameter_model,
+        starting_snapshot,
+        problem,
+        invocation,
+        outcome.execution,
         accepted,
         receipt,
         committed,
         commit_operation,
         session.analysis_values,
+        provenance=_workflow_provenance(
+            parameterization=parameterization,
+            plan=engine.plan,
+            invocation=invocation,
+            execution=outcome.execution,
+            uncertainty=uncertainty,
+            resampling=resampling,
+            mcmc=mcmc,
+        ),
         uncertainty=uncertainty,
         resampling=resampling,
         mcmc=mcmc,
@@ -292,10 +453,26 @@ def _evaluation_only() -> EvaluationPublication:
     )
     result = engine.new_evaluator().evaluate(frame)
     assert isinstance(result, EvaluationResult)
-    return EvaluationPublication(engine.plan, parameterization, result)
+    return EvaluationPublication(
+        engine.plan,
+        parameterization,
+        result,
+        provenance=_workflow_provenance(
+            parameterization=parameterization,
+            plan=engine.plan,
+        ),
+    )
 
 
-def _failed_commit_operation() -> FitCommitOperation:
+def _failed_commit_operation() -> tuple[
+    FitCommitOperation,
+    EvaluationPlan,
+    ActiveParameterization,
+    OptimizationProblem,
+    DirectTrfInvocation,
+    DirectTrfExecution,
+    WorkflowProvenance,
+]:
     session = AnalysisSession.create()
     session.set_model("2st")
     experiments = build_experiments(
@@ -310,14 +487,20 @@ def _failed_commit_operation() -> FitCommitOperation:
     )
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
     configuration = session.parameter_factory.sealed_configuration
+    parameter_model = session.parameter_factory.sealed_parameter_model
     assert configuration is not None
+    assert parameter_model is not None
     source = session.analysis_values.snapshot()
     problem = OptimizationProblem.from_native(
         engine.plan, parameterization, configuration, source
     )
+    invocation = DirectTrfInvocation.for_problem(
+        problem,
+        objective_request_budget=80,
+    )
     outcome = execute_direct_trf(
         problem,
-        DirectTrfInvocation.for_problem(problem, objective_request_budget=80),
+        invocation,
         parameterization,
         engine,
     )
@@ -336,7 +519,20 @@ def _failed_commit_operation() -> FitCommitOperation:
         analysis_values=session.analysis_values,
     )
     assert operation.terminal is FitCommitTerminal.FAILED
-    return operation
+    return (
+        operation,
+        engine.plan,
+        parameterization,
+        problem,
+        invocation,
+        outcome.execution,
+        _workflow_provenance(
+            parameterization=parameterization,
+            plan=engine.plan,
+            invocation=invocation,
+            execution=outcome.execution,
+        ),
+    )
 
 
 def _publication_from_direct_commit_and_fabricated_evidence() -> (
@@ -356,11 +552,18 @@ def _publication_from_direct_commit_and_fabricated_evidence() -> (
     )
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
     configuration = session.parameter_factory.sealed_configuration
+    parameter_model = session.parameter_factory.sealed_parameter_model
     assert configuration is not None
+    assert parameter_model is not None
     source = session.analysis_values.snapshot()
     problem = OptimizationProblem.from_native(
         engine.plan, parameterization, configuration, source
     )
+    invocation = DirectTrfInvocation.for_problem(
+        problem,
+        objective_request_budget=80,
+    )
+    outcome = execute_direct_trf(problem, invocation, parameterization, engine)
     frame = EvaluationFrame.from_lifecycle_frame(
         parameterization,
         problem.lifecycle_frame(problem.start, parameterization),
@@ -413,11 +616,22 @@ def _publication_from_direct_commit_and_fabricated_evidence() -> (
     return CommittedFitPublication(
         engine.plan,
         parameterization,
+        parameter_model,
+        source,
+        problem,
+        invocation,
+        outcome.execution,
         accepted,
         receipt,
         committed,
         fabricated_operation,
         session.analysis_values,
+        provenance=_workflow_provenance(
+            parameterization=parameterization,
+            plan=engine.plan,
+            invocation=invocation,
+            execution=outcome.execution,
+        ),
     )
 
 
@@ -446,6 +660,7 @@ def test_committed_native_fit_publishes_only_aggregate_step_root(
         "Parameters",
         "Plots",
         "Statistics",
+        "fit-manifest.toml",
         "statistics.toml",
     }
     assert (output / "Data" / "profile_0000.tsv").is_file()
@@ -458,6 +673,61 @@ def test_committed_native_fit_publishes_only_aggregate_step_root(
     assert "stderr" not in fitted.lower()
     assert "error" not in fitted.lower()
     assert "±" not in fitted
+
+    restart_path = output / "Parameters" / "restart.toml"
+    restart_defaults = read_defaults([restart_path])
+    assert len(restart_defaults) == len(publication.parameterization.independent_ids)
+    assert all(
+        setting.min is not None and setting.max is not None
+        for _name, setting in restart_defaults
+    )
+
+    manifest = tomllib.loads((output / "fit-manifest.toml").read_text())
+    assert manifest["schema_version"] == 1
+    assert manifest["lifecycle"] == "committed"
+    assert manifest["authority"] == "committed_fit"
+    assert manifest["accepted_result_identity"] == publication.accepted.identity
+    assert manifest["commit_receipt_identity"] == publication.commit_receipt.identity
+    assert manifest["starting_state_kind"] == "workflow_starting_provenance"
+    assert manifest["starting_revision"] == 0
+    assert manifest["workflow"]["identity"] == publication.provenance.workflow_identity
+    assert manifest["method"]["identity"] == publication.provenance.method_identity
+    assert (
+        manifest["method"]["normalized_sha256"]
+        == sha256(publication.provenance.normalized_method_text.encode()).hexdigest()
+    )
+    assert manifest["selection"] == {
+        "model": "2st",
+        "include": [profile.identity for profile in publication.plan.profiles],
+        "exclude": [],
+    }
+    assert manifest["execution"] == {"workers": 2, "native_threads": 1}
+    assert manifest["budgets"][0] == {
+        "name": "primary_direct_trf_objective_requests",
+        "limit": publication.primary_invocation.objective_request_budget,
+        "used": publication.primary_execution.counters.objective_requests_accepted,
+    }
+    assert "seeds" not in manifest
+    assert manifest["environment"]["numpy_version"] == "2.5.1"
+    assert manifest["baseline_references"] == [
+        {
+            "kind": "occurrence",
+            "identity": publication.provenance.baseline_references[0].identity,
+        },
+        {
+            "kind": "bundle",
+            "identity": publication.provenance.baseline_references[1].identity,
+        },
+    ]
+    assert manifest["artifacts"]["Parameters/restart.toml"]["role"] == (
+        "committed_restart_state"
+    )
+    assert manifest["artifacts"]["Parameters/fitted.toml"]["role"] == (
+        "report_only_fitted_values"
+    )
+    for relative_path, artifact in manifest["artifacts"].items():
+        artifact_path = output / relative_path
+        assert artifact["sha256"] == sha256(artifact_path.read_bytes()).hexdigest()
 
     statistics = tomllib.loads((output / "statistics.toml").read_text())
     residual_count = len(publication.accepted.evaluation_result.residuals)
@@ -485,11 +755,17 @@ def test_many_components_are_diagnostic_views_without_authoritative_copies(
     publication = CommittedFitPublication(
         base.plan,
         base.parameterization,
+        base.parameter_model,
+        base.starting_snapshot,
+        base.primary_problem,
+        base.primary_invocation,
+        base.primary_execution,
         base.accepted,
         base.commit_receipt,
         base.committed_snapshot,
         base.commit_operation,
         base.analysis_values,
+        provenance=base.provenance,
         components=(
             ComponentDiagnostic(
                 "component-alpha",
@@ -516,6 +792,16 @@ def test_many_components_are_diagnostic_views_without_authoritative_copies(
         "component-beta",
     ]
     assert components["authority"] == "diagnostic_only"
+    manifest = tomllib.loads((output / "fit-manifest.toml").read_text())
+    assert [item["identity"] for item in manifest["components"]] == [
+        "component-alpha",
+        "component-beta",
+    ]
+    assert all(
+        item["location"] == "Components/index.json"
+        and item["authority"] == "diagnostic_only"
+        for item in manifest["components"]
+    )
     assert not list((output / "Components").rglob("Parameters"))
     assert not list((output / "Components").rglob("Data"))
     assert not list((output / "Components").rglob("Plots"))
@@ -616,6 +902,42 @@ def test_committed_publication_rejects_a_copied_successful_commit_operation(
     assert not (tmp_path / "STEP").exists()
 
 
+def test_committed_publication_rejects_forged_execution_budget_provenance(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    source = publication.provenance.budgets[0]
+    forged_provenance = replace(
+        publication.provenance,
+        budgets=(BudgetRecord(source.name, source.limit, source.used - 1),),
+    )
+
+    with pytest.raises(ValueError, match="execution record"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(publication, provenance=forged_provenance),
+        )
+    assert not (tmp_path / "STEP").exists()
+
+
+def test_committed_publication_rejects_a_foreign_normalized_method(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    other = _committed_fit(Method(fit=["PB"], fix=["R1A_A", "KEX_AB"]))
+    forged_provenance = replace(
+        publication.provenance,
+        normalized_method_text=other.provenance.normalized_method_text,
+    )
+
+    with pytest.raises(ValueError, match="method and selection provenance"):
+        publish_native_results(
+            tmp_path / "STEP",
+            replace(publication, provenance=forged_provenance),
+        )
+    assert not (tmp_path / "STEP").exists()
+
+
 def test_committed_publication_rejects_unsuccessful_component_diagnostics(
     tmp_path: Path,
 ) -> None:
@@ -644,6 +966,12 @@ def test_zero_component_evaluation_publishes_no_fitted_estimate(tmp_path: Path) 
     assert (output / "Statistics").is_dir()
     assert not (output / "Parameters" / "fitted.toml").exists()
     assert not (output / "Components").exists()
+    manifest = tomllib.loads((output / "fit-manifest.toml").read_text())
+    assert manifest["lifecycle"] == "successful_no_state_change"
+    assert manifest["authority"] == "evaluation_only"
+    assert "accepted_result_identity" not in manifest
+    assert "commit_receipt_identity" not in manifest
+    assert "Parameters/restart.toml" not in manifest["artifacts"]
     statistics = tomllib.loads((output / "statistics.toml").read_text())
     residual_count = len(publication.evaluation_result.residuals)
     normalization_count = sum(
@@ -706,6 +1034,13 @@ def test_resampling_and_posterior_evidence_keep_family_specific_semantics(
     )
     assert resampling["artifact_type"] == "native_resampling_summary"
     assert resampling["scheme"] == "mc"
+    resampling_manifest = tomllib.loads(
+        (resampling_output / "fit-manifest.toml").read_text()
+    )
+    assert resampling_manifest["evidence"][0]["family"] == "resampling:mc"
+    assert resampling_manifest["evidence"][0]["validity"] == (
+        "required_claims_satisfied"
+    )
     assert all("standard_deviation" in item for item in resampling["distributions"])
     assert posterior["artifact_type"] == "native_posterior_summary"
     assert all(
@@ -806,9 +1141,25 @@ def test_incomplete_resampling_is_retained_only_as_partial_evidence(
         outcomes,
         terminal,
     )
+    partial_resampling = ResamplingPublication(
+        incomplete,
+        summarize_resampling_evidence(incomplete),
+    )
     suppressed = SuppressedPublication(
         suppressed_lifecycle,
         incomplete,
+        publication.plan,
+        publication.parameterization,
+        provenance=_workflow_provenance(
+            parameterization=publication.parameterization,
+            plan=publication.plan,
+            invocation=publication.primary_invocation,
+            execution=publication.primary_execution,
+            resampling=(partial_resampling,),
+        ),
+        primary_invocation=publication.primary_invocation,
+        primary_execution=publication.primary_execution,
+        primary_problem=publication.primary_problem,
         accepted_result_identity=publication.accepted.identity,
         accepted_occurrence_identity=publication.accepted.occurrence_identity,
         partial_resampling=(incomplete,),
@@ -991,7 +1342,7 @@ def test_final_rename_failure_removes_complete_staging_tree(
     def fail_rename(_source: Path, _destination: Path) -> None:
         raise OSError("injected atomic rename failure")
 
-    monkeypatch.setattr(native_reporting, "_atomic_publish_noreplace", fail_rename)
+    monkeypatch.setattr(native_reporting, "publish_directory_noreplace", fail_rename)
 
     with pytest.raises(OSError, match="injected atomic rename failure"):
         publish_native_results(output, publication)
@@ -1027,6 +1378,18 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
     foreign_occurrence = SuppressedPublication(
         "cancelled",
         operation.evidence,
+        committed.plan,
+        committed.parameterization,
+        provenance=_workflow_provenance(
+            parameterization=committed.parameterization,
+            plan=committed.plan,
+            invocation=committed.primary_invocation,
+            execution=committed.primary_execution,
+            mcmc=replace(committed.mcmc, evidence=operation.evidence),
+        ),
+        primary_invocation=committed.primary_invocation,
+        primary_execution=committed.primary_execution,
+        primary_problem=committed.primary_problem,
         accepted_result_identity=committed.accepted.identity,
         accepted_occurrence_identity="foreign-accepted-occurrence",
         partial_mcmc=operation.evidence,
@@ -1034,11 +1397,25 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
     with pytest.raises(ValueError, match="genuine partial MCMC"):
         publish_native_results(tmp_path / "FOREIGN", foreign_occurrence)
 
-    failed_commit = _failed_commit_operation()
+    (
+        failed_commit,
+        failed_plan,
+        failed_parameterization,
+        failed_problem,
+        failed_invocation,
+        failed_execution,
+        failed_provenance,
+    ) = _failed_commit_operation()
     forged_commit = replace(failed_commit, occurrence_identity="forged-occurrence")
     forged = SuppressedPublication(
         "accepted_uncommitted",
         forged_commit,
+        failed_plan,
+        failed_parameterization,
+        provenance=failed_provenance,
+        primary_invocation=failed_invocation,
+        primary_execution=failed_execution,
+        primary_problem=failed_problem,
         accepted_result_identity=forged_commit.accepted_result_identity,
         accepted_occurrence_identity=forged_commit.accepted_occurrence_identity,
     )
@@ -1048,6 +1425,12 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
     invalid = SuppressedPublication(
         "accepted_uncommitted",
         failed_commit,
+        failed_plan,
+        failed_parameterization,
+        provenance=failed_provenance,
+        primary_invocation=failed_invocation,
+        primary_execution=failed_execution,
+        primary_problem=failed_problem,
         accepted_result_identity=failed_commit.accepted_result_identity,
         accepted_occurrence_identity=failed_commit.accepted_occurrence_identity,
         partial_mcmc=operation.evidence,
@@ -1061,16 +1444,40 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
     publication = SuppressedPublication(
         "accepted_uncommitted",
         failed_commit,
+        failed_plan,
+        failed_parameterization,
+        provenance=failed_provenance,
+        primary_invocation=failed_invocation,
+        primary_execution=failed_execution,
+        primary_problem=failed_problem,
         accepted_result_identity=failed_commit.accepted_result_identity,
         accepted_occurrence_identity=failed_commit.accepted_occurrence_identity,
     )
 
-    publish_native_results(output, publication)
+    foreign = _committed_fit(Method(fit=["PB"], fix=["R1A_A", "KEX_AB"]))
+    with pytest.raises(ValueError, match="method and selection provenance"):
+        publish_native_results(
+            tmp_path / "FOREIGN-SCOPE",
+            replace(publication, parameterization=foreign.parameterization),
+        )
 
-    assert {path.name for path in output.iterdir()} == {"Diagnostics"}
+    published_step = publish_native_results(output, publication)
+
+    assert {path.name for path in output.iterdir()} == {
+        "Diagnostics",
+        "fit-manifest.toml",
+    }
     diagnostics = json.loads((output / "Diagnostics" / "outcome.json").read_text())
     assert diagnostics["operation"]["identity"] == failed_commit.identity
     assert diagnostics["operation"]["terminal"] == "failed"
+    manifest = tomllib.loads((output / "fit-manifest.toml").read_text())
+    assert manifest["lifecycle"] == "accepted_uncommitted"
+    assert manifest["authority"] == "diagnostic_only"
+    assert manifest["operation_identity"] == failed_commit.identity
+    assert (
+        manifest["artifacts"]["Diagnostics/outcome.json"]["sha256"]
+        == sha256((output / "Diagnostics" / "outcome.json").read_bytes()).hexdigest()
+    )
     assert not (output / "PartialEvidence").exists()
     for normal_name in (
         "Parameters",
@@ -1081,3 +1488,181 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
         "Components",
     ):
         assert not (output / normal_name).exists()
+
+    assert published_step.independent_ids == failed_parameterization.independent_ids
+    write_native_run_info(
+        Namespace(
+            experiments=[EXPERIMENT],
+            parameters=[PARAMETERS],
+            method=[METHOD],
+            output=tmp_path,
+        ),
+        NativeRunInformation(
+            invocation_identity="issue-609-suppressed-only-run",
+            parameter_model=committed.parameter_model,
+            starting_snapshot=committed.starting_snapshot,
+            steps=(published_step,),
+        ),
+        working_directory=ROOT,
+    )
+    run = tomllib.loads((tmp_path / "run_info" / "run.toml").read_text())
+    assert run["steps"][0]["lifecycle"] == "accepted_uncommitted"
+
+
+def test_native_run_information_archives_replay_complete_provenance(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    published_step = publish_native_results(output / "STEP", publication)
+    args = Namespace(
+        experiments=[EXPERIMENT],
+        parameters=[PARAMETERS],
+        method=[METHOD],
+        output=output,
+    )
+
+    write_native_run_info(
+        args,
+        NativeRunInformation(
+            invocation_identity="issue-609-invocation",
+            parameter_model=publication.parameter_model,
+            starting_snapshot=publication.starting_snapshot,
+            steps=(published_step,),
+        ),
+        argv=("chemex", "fit", "--model", "2st"),
+        working_directory=ROOT,
+        timestamp=datetime(2026, 8, 12, 18, 0, tzinfo=UTC),
+    )
+
+    run_info = output / "run_info"
+    run = tomllib.loads((run_info / "run.toml").read_text())
+    assert run["schema_version"] == 2
+    assert run["schema_kind"] == "native_product_run_information"
+    assert run["invocation_identity"] == "issue-609-invocation"
+    assert run["starting_state"]["kind"] == "starting_independent_state"
+    assert run["starting_state"]["revision"] == 0
+    assert (
+        run["normalized_method"]["sha256"]
+        == sha256(publication.provenance.normalized_method_text.encode()).hexdigest()
+    )
+    assert run["workflow_records"]["path"] == "workflows.json"
+    assert "lmfit" not in (run_info / "run.toml").read_text().lower()
+    assert "numdifftools" not in (run_info / "run.toml").read_text().lower()
+
+    copied_experiment = run["inputs"]["experiments"][0]
+    archived_experiment = run_info / copied_experiment["copied_path"]
+    assert archived_experiment.read_bytes() == EXPERIMENT.read_bytes()
+    assert copied_experiment["sha256"] == sha256(EXPERIMENT.read_bytes()).hexdigest()
+
+    starting = read_defaults([run_info / "parameters_used.toml"])
+    restart = read_defaults([output / "STEP" / "Parameters" / "restart.toml"])
+    assert len(starting) == len(publication.parameterization.independent_ids)
+    assert len(restart) == len(publication.parameterization.independent_ids)
+    assert (run_info / "parameters_used.toml").read_bytes() != (
+        output / "STEP" / "Parameters" / "restart.toml"
+    ).read_bytes()
+
+    workflows = json.loads((run_info / "workflows.json").read_text())
+    assert workflows["workflows"][0]["identity"] == (
+        publication.provenance.workflow_identity
+    )
+    assert workflows["workflows"][0]["outcome"]["lifecycle"] == "committed"
+    assert workflows["workflows"][0]["manifest"] == {
+        "path": "STEP/fit-manifest.toml",
+        "identity": published_step.manifest_identity,
+        "sha256": published_step.manifest_sha256,
+    }
+    assert workflows["workflows"][0]["artifacts"]
+
+    historical = tmp_path / "historical-v1.toml"
+    historical.write_text("schema_version = 1\n", encoding="utf-8")
+    assert classify_run_information(historical) is RunInformationKind.HISTORICAL_V1
+    assert classify_run_information(run_info / "run.toml") is (
+        RunInformationKind.NATIVE_V2
+    )
+
+    original_tree = _tree_bytes(run_info)
+    with pytest.raises(FileExistsError, match="destination exists"):
+        write_native_run_info(
+            args,
+            NativeRunInformation(
+                invocation_identity="issue-609-second-invocation",
+                parameter_model=publication.parameter_model,
+                starting_snapshot=publication.starting_snapshot,
+                steps=(published_step,),
+            ),
+            working_directory=ROOT,
+        )
+    assert _tree_bytes(run_info) == original_tree
+    assert not list(output.glob(".run_info-*"))
+
+
+def test_native_run_information_rejects_changed_step_artifacts_without_replacement(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    published_step = publish_native_results(output / "STEP", publication)
+    run_info = output / "run_info"
+    run_info.mkdir()
+    existing = run_info / "run.toml"
+    existing.write_text("schema_version = 1\n", encoding="utf-8")
+    (output / "STEP" / "statistics.toml").write_text(
+        'tampered = "after publication"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="artifact changed"):
+        write_native_run_info(
+            Namespace(
+                experiments=[EXPERIMENT],
+                parameters=[PARAMETERS],
+                method=[METHOD],
+                output=output,
+            ),
+            NativeRunInformation(
+                invocation_identity="issue-609-tampered-invocation",
+                parameter_model=publication.parameter_model,
+                starting_snapshot=publication.starting_snapshot,
+                steps=(published_step,),
+            ),
+            working_directory=ROOT,
+        )
+
+    assert existing.read_text(encoding="utf-8") == "schema_version = 1\n"
+    assert not list(output.glob(".run_info-*"))
+
+
+@pytest.mark.parametrize("field", ("lifecycle", "authority", "artifacts"))
+def test_native_run_information_rejects_forged_step_references(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    step = publish_native_results(output / "STEP", publication)
+    if field == "lifecycle":
+        forged = replace(step, lifecycle="failed")
+    elif field == "authority":
+        forged = replace(step, authority="diagnostic_only")
+    else:
+        forged = replace(step, artifacts=step.artifacts[:-1])
+
+    with pytest.raises(ValueError, match="contradict.*manifest"):
+        write_native_run_info(
+            Namespace(
+                experiments=[EXPERIMENT],
+                parameters=[PARAMETERS],
+                method=[METHOD],
+                output=output,
+            ),
+            NativeRunInformation(
+                invocation_identity="issue-609-forged-reference",
+                parameter_model=publication.parameter_model,
+                starting_snapshot=publication.starting_snapshot,
+                steps=(forged,),
+            ),
+            working_directory=ROOT,
+        )
+    assert not (output / "run_info").exists()

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -19,6 +19,7 @@ from typing import Literal
 import numpy as np
 import pytest
 
+import chemex.run_info as run_info_module
 from chemex.baselines import (
     LegacyObservationImplementation,
     Occurrence,
@@ -35,10 +36,12 @@ from chemex.evaluation.native import (
 )
 from chemex.experiments.builder import build_experiments
 from chemex.native_provenance import (
+    ArtifactReference,
     BaselineReference,
     BudgetRecord,
     PolicyRecord,
     ProvenanceEnvironment,
+    PublishedStepReference,
     SeedRecord,
     WorkflowProvenance,
 )
@@ -99,9 +102,12 @@ from chemex.optimize.uncertainty import (
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.spin_system import SpinSystem
 from chemex.run_info import (
+    CapturedNativeInputs,
     NativeRunInformation,
     RunInformationKind,
+    capture_native_inputs,
     classify_run_information,
+    read_native_run_information,
     write_native_run_info,
 )
 from chemex.runtime import AnalysisSession, ExecutionSettings
@@ -112,10 +118,23 @@ PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.
 METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
 
 
+def _captured_inputs(output: Path) -> CapturedNativeInputs:
+    return capture_native_inputs(
+        Namespace(
+            experiments=[EXPERIMENT],
+            parameters=[PARAMETERS],
+            method=[METHOD],
+            output=output,
+        ),
+        working_directory=ROOT,
+    )
+
+
 def _workflow_provenance(
     *,
     parameterization: ActiveParameterization,
     plan: EvaluationPlan,
+    method: Method,
     invocation: DirectTrfInvocation | None = None,
     execution: DirectTrfExecution | None = None,
     uncertainty: UncertaintyEvidence | None = None,
@@ -200,6 +219,9 @@ def _workflow_provenance(
     return WorkflowProvenance.create(
         parameterization=parameterization,
         plan=plan,
+        method=method,
+        workflow_type="direct_trf",
+        grouping_topology=(("aggregate", parameterization.independent_ids),),
         policies=tuple(policies),
         budgets=tuple(budgets),
         seeds=tuple(seeds),
@@ -407,6 +429,7 @@ def _committed_fit(
         mcmc = McmcPublication(operation.evidence, posterior, summary)
     return CommittedFitPublication(
         engine.plan,
+        selected_method,
         parameterization,
         parameter_model,
         starting_snapshot,
@@ -421,6 +444,7 @@ def _committed_fit(
         provenance=_workflow_provenance(
             parameterization=parameterization,
             plan=engine.plan,
+            method=selected_method,
             invocation=invocation,
             execution=outcome.execution,
             uncertainty=uncertainty,
@@ -433,7 +457,7 @@ def _committed_fit(
     )
 
 
-def _evaluation_only() -> EvaluationPublication:
+def _evaluation_only(method: Method | None = None) -> EvaluationPublication:
     session = AnalysisSession.create()
     session.set_model("2st")
     experiments = build_experiments(
@@ -443,9 +467,8 @@ def _evaluation_only() -> EvaluationPublication:
     )
     session.parameters.set_defaults(read_defaults([PARAMETERS]))
     assert session.try_build_analysis_values()
-    parameterization = session.compile_parameterization(
-        Method(fix=["R1A_A", "PB", "KEX_AB"]), experiments.param_ids
-    )
+    method = Method(fix=["R1A_A", "PB", "KEX_AB"]) if method is None else method
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
     frame = EvaluationFrame.from_lifecycle_frame(
         parameterization,
@@ -455,13 +478,107 @@ def _evaluation_only() -> EvaluationPublication:
     assert isinstance(result, EvaluationResult)
     return EvaluationPublication(
         engine.plan,
+        method,
         parameterization,
         result,
         provenance=_workflow_provenance(
             parameterization=parameterization,
             plan=engine.plan,
+            method=method,
         ),
     )
+
+
+def _sequential_committed_steps(
+    output: Path,
+) -> tuple[
+    tuple[CommittedFitPublication, CommittedFitPublication],
+    tuple[PublishedStepReference, PublishedStepReference],
+]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values()
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    configuration = session.parameter_factory.sealed_configuration
+    assert parameter_model is not None
+    assert configuration is not None
+    publications: list[CommittedFitPublication] = []
+    steps: list[PublishedStepReference] = []
+    for method in (
+        Method(fit=["PB"], fix=["R1A_A", "KEX_AB"]),
+        Method(fit=["KEX_AB"], fix=["R1A_A", "PB"]),
+    ):
+        parameterization = session.compile_parameterization(
+            method,
+            experiments.param_ids,
+        )
+        engine = EvaluationEngine.from_experiments(experiments, parameterization)
+        starting = session.analysis_values.snapshot()
+        problem = OptimizationProblem.from_native(
+            engine.plan,
+            parameterization,
+            configuration,
+            starting,
+        )
+        invocation = DirectTrfInvocation.for_problem(
+            problem,
+            objective_request_budget=80,
+        )
+        outcome = execute_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+        assert outcome.accepted_result is not None
+        assert outcome.commit_authority is not None
+        accepted = outcome.accepted_result
+        operation = execute_fit_commit(
+            accepted,
+            outcome.commit_authority,
+            problem=problem,
+            parameterization=parameterization,
+            analysis_values=session.analysis_values,
+        )
+        assert operation.receipt is not None
+        assert operation.committed_snapshot is not None
+        publications.append(
+            CommittedFitPublication(
+                engine.plan,
+                method,
+                parameterization,
+                parameter_model,
+                starting,
+                problem,
+                invocation,
+                outcome.execution,
+                accepted,
+                operation.receipt,
+                operation.committed_snapshot,
+                operation,
+                session.analysis_values,
+                provenance=_workflow_provenance(
+                    parameterization=parameterization,
+                    plan=engine.plan,
+                    method=method,
+                    invocation=invocation,
+                    execution=outcome.execution,
+                ),
+            )
+        )
+        steps.append(
+            publish_native_results(
+                output / f"STEP-{len(publications)}",
+                publications[-1],
+            )
+        )
+    return (publications[0], publications[1]), (steps[0], steps[1])
 
 
 def _failed_commit_operation() -> tuple[
@@ -482,9 +599,8 @@ def _failed_commit_operation() -> tuple[
     )
     session.parameters.set_defaults(read_defaults([PARAMETERS]))
     assert session.try_build_analysis_values()
-    parameterization = session.compile_parameterization(
-        read_methods([METHOD])["DEFAULT"], experiments.param_ids
-    )
+    method = read_methods([METHOD])["DEFAULT"]
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
     configuration = session.parameter_factory.sealed_configuration
     parameter_model = session.parameter_factory.sealed_parameter_model
@@ -529,6 +645,7 @@ def _failed_commit_operation() -> tuple[
         _workflow_provenance(
             parameterization=parameterization,
             plan=engine.plan,
+            method=method,
             invocation=invocation,
             execution=outcome.execution,
         ),
@@ -547,9 +664,8 @@ def _publication_from_direct_commit_and_fabricated_evidence() -> (
     )
     session.parameters.set_defaults(read_defaults([PARAMETERS]))
     assert session.try_build_analysis_values()
-    parameterization = session.compile_parameterization(
-        read_methods([METHOD])["DEFAULT"], experiments.param_ids
-    )
+    method = read_methods([METHOD])["DEFAULT"]
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
     configuration = session.parameter_factory.sealed_configuration
     parameter_model = session.parameter_factory.sealed_parameter_model
@@ -615,6 +731,7 @@ def _publication_from_direct_commit_and_fabricated_evidence() -> (
     )
     return CommittedFitPublication(
         engine.plan,
+        method,
         parameterization,
         parameter_model,
         source,
@@ -629,6 +746,7 @@ def _publication_from_direct_commit_and_fabricated_evidence() -> (
         provenance=_workflow_provenance(
             parameterization=parameterization,
             plan=engine.plan,
+            method=method,
             invocation=invocation,
             execution=outcome.execution,
         ),
@@ -713,10 +831,22 @@ def test_committed_native_fit_publishes_only_aggregate_step_root(
         {
             "kind": "occurrence",
             "identity": publication.provenance.baseline_references[0].identity,
+            "occurrence_identity": publication.provenance.baseline_references[
+                0
+            ].occurrence_identity,
+            "result_bundle_identity": publication.provenance.baseline_references[
+                0
+            ].result_bundle_identity,
         },
         {
             "kind": "bundle",
             "identity": publication.provenance.baseline_references[1].identity,
+            "occurrence_identity": publication.provenance.baseline_references[
+                1
+            ].occurrence_identity,
+            "result_bundle_identity": publication.provenance.baseline_references[
+                1
+            ].result_bundle_identity,
         },
     ]
     assert manifest["artifacts"]["Parameters/restart.toml"]["role"] == (
@@ -754,6 +884,7 @@ def test_many_components_are_diagnostic_views_without_authoritative_copies(
     )
     publication = CommittedFitPublication(
         base.plan,
+        base.method,
         base.parameterization,
         base.parameter_model,
         base.starting_snapshot,
@@ -786,6 +917,10 @@ def test_many_components_are_diagnostic_views_without_authoritative_copies(
     publish_native_results(output, publication)
 
     components = json.loads((output / "Components" / "index.json").read_text())
+    manifest = tomllib.loads((output / "fit-manifest.toml").read_text())
+    assert manifest["artifacts"]["Components/index.json"]["role"] == (
+        "diagnostic_provenance"
+    )
     assert [item["ordinal"] for item in components["components"]] == [0, 1]
     assert [item["identity"] for item in components["components"]] == [
         "component-alpha",
@@ -936,6 +1071,61 @@ def test_committed_publication_rejects_a_foreign_normalized_method(
             replace(publication, provenance=forged_provenance),
         )
     assert not (tmp_path / "STEP").exists()
+
+
+def test_normalized_method_rejects_noncanonical_nested_payload() -> None:
+    publication = _committed_fit()
+    with pytest.raises(ValueError, match="Normalized method semantics"):
+        replace(
+            publication.provenance,
+            normalized_method_text=(
+                'FORMAT_VERSION = 2\n[METHOD]\nCANONICAL_JSON = "{}"\n'
+            ),
+        )
+
+
+def test_workflow_provenance_rejects_substituted_baseline_occurrence() -> None:
+    publication = _committed_fit()
+    occurrence, bundle = publication.provenance.baseline_references
+    with pytest.raises(ValueError, match="linked occurrence/bundle"):
+        replace(
+            publication.provenance,
+            baseline_references=(replace(occurrence, identity="f" * 64), bundle),
+        )
+
+
+@pytest.mark.parametrize(
+    "change",
+    ("workflow", "grouping", "selection", "policy", "budget", "seed", "execution"),
+)
+def test_execution_identity_covers_every_non_method_execution_choice(
+    change: str,
+) -> None:
+    publication = _committed_fit()
+    base = publication.provenance
+    changes: dict[str, object]
+    if change == "workflow":
+        changes = {"workflow_type": "grid"}
+    elif change == "grouping":
+        changes = {"grouping_topology": (("separate", base.grouping_topology[0][1]),)}
+    elif change == "selection":
+        changes = {"selection": replace(base.selection, include=("foreign",))}
+    elif change == "policy":
+        changes = {"policies": (PolicyRecord("primary_direct_trf", "foreign"),)}
+    elif change == "budget":
+        budget = base.budgets[0]
+        changes = {
+            "budgets": (BudgetRecord(budget.name, budget.limit + 1, budget.used),)
+        }
+    elif change == "seed":
+        changes = {"seeds": (SeedRecord("root", 609, "seed-policy"),)}
+    else:
+        changes = {"execution": ExecutionSettings(workers=3, native_threads=1)}
+
+    changed = replace(base, **changes)
+
+    assert changed.method_identity == base.method_identity
+    assert changed.execution_identity != base.execution_identity
 
 
 def test_committed_publication_rejects_unsuccessful_component_diagnostics(
@@ -1149,10 +1339,12 @@ def test_incomplete_resampling_is_retained_only_as_partial_evidence(
         suppressed_lifecycle,
         incomplete,
         publication.plan,
+        publication.method,
         publication.parameterization,
         provenance=_workflow_provenance(
             parameterization=publication.parameterization,
             plan=publication.plan,
+            method=publication.method,
             invocation=publication.primary_invocation,
             execution=publication.primary_execution,
             resampling=(partial_resampling,),
@@ -1351,6 +1543,46 @@ def test_final_rename_failure_removes_complete_staging_tree(
     assert not _staging_residue(tmp_path, output.name)
 
 
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "statistics.toml",
+        "Parameters/restart.toml",
+        "Parameters/restart-provenance.json",
+        "Parameters/fitted.toml",
+    ),
+)
+def test_staged_artifact_mutation_after_manifest_prevents_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    relative_path: str,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "STEP"
+    original = native_reporting._write_committed_manifest
+
+    def write_then_mutate(
+        staging: Path,
+        source: CommittedFitPublication,
+        occurrence_identity: str,
+        restart: object,
+    ) -> object:
+        result = original(staging, source, occurrence_identity, restart)
+        (staging / relative_path).write_bytes(b"mutated after manifest\n")
+        return result
+
+    monkeypatch.setattr(
+        native_reporting,
+        "_write_committed_manifest",
+        write_then_mutate,
+    )
+
+    with pytest.raises(ValueError, match="changed after hashing"):
+        publish_native_results(output, publication)
+    assert not output.exists()
+    assert not _staging_residue(tmp_path, output.name)
+
+
 def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
     tmp_path: Path,
 ) -> None:
@@ -1379,10 +1611,12 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
         "cancelled",
         operation.evidence,
         committed.plan,
+        committed.method,
         committed.parameterization,
         provenance=_workflow_provenance(
             parameterization=committed.parameterization,
             plan=committed.plan,
+            method=committed.method,
             invocation=committed.primary_invocation,
             execution=committed.primary_execution,
             mcmc=replace(committed.mcmc, evidence=operation.evidence),
@@ -1411,6 +1645,7 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
         "accepted_uncommitted",
         forged_commit,
         failed_plan,
+        read_methods([METHOD])["DEFAULT"],
         failed_parameterization,
         provenance=failed_provenance,
         primary_invocation=failed_invocation,
@@ -1426,6 +1661,7 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
         "accepted_uncommitted",
         failed_commit,
         failed_plan,
+        read_methods([METHOD])["DEFAULT"],
         failed_parameterization,
         provenance=failed_provenance,
         primary_invocation=failed_invocation,
@@ -1445,6 +1681,7 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
         "accepted_uncommitted",
         failed_commit,
         failed_plan,
+        read_methods([METHOD])["DEFAULT"],
         failed_parameterization,
         provenance=failed_provenance,
         primary_invocation=failed_invocation,
@@ -1462,6 +1699,25 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
         )
 
     published_step = publish_native_results(output, publication)
+
+    with pytest.raises(ValueError, match="exact live publication"):
+        replace(
+            published_step,
+            lifecycle="committed",
+            authority="committed_fit",
+        )
+    with pytest.raises(ValueError, match="exact live publication"):
+        replace(
+            published_step,
+            artifacts=(
+                *published_step.artifacts,
+                ArtifactReference(
+                    "Parameters/restart.toml",
+                    "committed_restart_state",
+                    "0" * 64,
+                ),
+            ),
+        )
 
     assert {path.name for path in output.iterdir()} == {
         "Diagnostics",
@@ -1499,6 +1755,7 @@ def test_uncommitted_workflow_suppresses_output_and_downstream_evidence(
         ),
         NativeRunInformation(
             invocation_identity="issue-609-suppressed-only-run",
+            inputs=_captured_inputs(tmp_path),
             parameter_model=committed.parameter_model,
             starting_snapshot=committed.starting_snapshot,
             steps=(published_step,),
@@ -1526,6 +1783,7 @@ def test_native_run_information_archives_replay_complete_provenance(
         args,
         NativeRunInformation(
             invocation_identity="issue-609-invocation",
+            inputs=_captured_inputs(output),
             parameter_model=publication.parameter_model,
             starting_snapshot=publication.starting_snapshot,
             steps=(published_step,),
@@ -1543,7 +1801,7 @@ def test_native_run_information_archives_replay_complete_provenance(
     assert run["starting_state"]["kind"] == "starting_independent_state"
     assert run["starting_state"]["revision"] == 0
     assert (
-        run["normalized_method"]["sha256"]
+        run["normalized_methods"][0]["sha256"]
         == sha256(publication.provenance.normalized_method_text.encode()).hexdigest()
     )
     assert run["workflow_records"]["path"] == "workflows.json"
@@ -1588,6 +1846,7 @@ def test_native_run_information_archives_replay_complete_provenance(
             args,
             NativeRunInformation(
                 invocation_identity="issue-609-second-invocation",
+                inputs=_captured_inputs(output),
                 parameter_model=publication.parameter_model,
                 starting_snapshot=publication.starting_snapshot,
                 steps=(published_step,),
@@ -1596,6 +1855,70 @@ def test_native_run_information_archives_replay_complete_provenance(
         )
     assert _tree_bytes(run_info) == original_tree
     assert not list(output.glob(".run_info-*"))
+
+
+def test_native_run_information_archives_each_method_section(
+    tmp_path: Path,
+) -> None:
+    run_state = _committed_fit()
+    first = _evaluation_only(Method(fitmethod="leastsq", fix=["R1A_A", "PB", "KEX_AB"]))
+    second = _evaluation_only(Method(fitmethod="trf", fix=["R1A_A", "PB", "KEX_AB"]))
+    output = tmp_path / "Output"
+    steps = (
+        publish_native_results(output / "STEP-1", first),
+        publish_native_results(output / "STEP-2", second),
+    )
+    write_native_run_info(
+        Namespace(output=output),
+        NativeRunInformation(
+            invocation_identity="issue-609-multi-method",
+            inputs=_captured_inputs(output),
+            parameter_model=run_state.parameter_model,
+            starting_snapshot=run_state.starting_snapshot,
+            steps=steps,
+        ),
+        working_directory=ROOT,
+    )
+
+    run = tomllib.loads((output / "run_info" / "run.toml").read_text())
+    assert len(run["normalized_methods"]) == 2
+    assert {item["method_identity"] for item in run["normalized_methods"]} == {
+        first.provenance.method_identity,
+        second.provenance.method_identity,
+    }
+    assert read_native_run_information(
+        output / "run_info"
+    ).published_step_identities == (
+        steps[0].identity,
+        steps[1].identity,
+    )
+
+
+def test_native_run_information_walks_sequential_committed_revisions(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    publications, steps = _sequential_committed_steps(output)
+    first = publications[0]
+    assert steps[0].lifecycle == steps[1].lifecycle == "committed"
+    write_native_run_info(
+        Namespace(output=output),
+        NativeRunInformation(
+            invocation_identity="issue-609-sequential-commits",
+            inputs=_captured_inputs(output),
+            parameter_model=first.parameter_model,
+            starting_snapshot=first.starting_snapshot,
+            steps=steps,
+        ),
+        working_directory=ROOT,
+    )
+
+    assert read_native_run_information(
+        output / "run_info"
+    ).published_step_identities == (
+        steps[0].identity,
+        steps[1].identity,
+    )
 
 
 def test_native_run_information_rejects_changed_step_artifacts_without_replacement(
@@ -1623,6 +1946,7 @@ def test_native_run_information_rejects_changed_step_artifacts_without_replaceme
             ),
             NativeRunInformation(
                 invocation_identity="issue-609-tampered-invocation",
+                inputs=_captured_inputs(output),
                 parameter_model=publication.parameter_model,
                 starting_snapshot=publication.starting_snapshot,
                 steps=(published_step,),
@@ -1634,6 +1958,29 @@ def test_native_run_information_rejects_changed_step_artifacts_without_replaceme
     assert not list(output.glob(".run_info-*"))
 
 
+def test_native_run_information_rejects_unlisted_step_artifact(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    step = publish_native_results(output / "STEP", publication)
+    (output / "STEP" / "foreign.bin").write_bytes(b"not catalogued")
+
+    with pytest.raises(ValueError, match="catalogue is incomplete"):
+        write_native_run_info(
+            Namespace(output=output),
+            NativeRunInformation(
+                invocation_identity="issue-609-extra-artifact",
+                inputs=_captured_inputs(output),
+                parameter_model=publication.parameter_model,
+                starting_snapshot=publication.starting_snapshot,
+                steps=(step,),
+            ),
+            working_directory=ROOT,
+        )
+    assert not (output / "run_info").exists()
+
+
 @pytest.mark.parametrize("field", ("lifecycle", "authority", "artifacts"))
 def test_native_run_information_rejects_forged_step_references(
     tmp_path: Path,
@@ -1642,27 +1989,270 @@ def test_native_run_information_rejects_forged_step_references(
     publication = _committed_fit()
     output = tmp_path / "Output"
     step = publish_native_results(output / "STEP", publication)
-    if field == "lifecycle":
-        forged = replace(step, lifecycle="failed")
-    elif field == "authority":
-        forged = replace(step, authority="diagnostic_only")
-    else:
-        forged = replace(step, artifacts=step.artifacts[:-1])
+    changes = {
+        "lifecycle": {"lifecycle": "failed"},
+        "authority": {"authority": "diagnostic_only"},
+        "artifacts": {"artifacts": step.artifacts[:-1]},
+    }
+    with pytest.raises(ValueError, match="exact live publication"):
+        replace(step, **changes[field])
+    assert not (output / "run_info").exists()
 
-    with pytest.raises(ValueError, match="contradict.*manifest"):
+
+def test_native_run_information_rejects_reconstructed_live_step_reference(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    step = publish_native_results(output / "STEP", publication)
+    assert not hasattr(type(step), "from_live_publication")
+    with pytest.raises(ValueError, match="exact live publication"):
+        type(step)(
+            object(),
+            step.publication_occurrence_identity,
+            step.path,
+            step.lifecycle,
+            step.authority,
+            step.manifest_identity,
+            step.manifest_sha256,
+            step.provenance,
+            step.independent_ids,
+            step.artifacts,
+            _witness=None,
+        )
+
+
+def test_native_run_information_rejects_manifest_selection_with_new_file_hash(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    step = publish_native_results(output / "STEP", publication)
+    manifest_path = output / "STEP" / "fit-manifest.toml"
+    manifest_path.write_text(
+        manifest_path.read_text().replace(
+            'model = "2st"',
+            'model = "FOREIGN"',
+            1,
+        )
+    )
+    with pytest.raises(ValueError, match="exact live publication"):
+        replace(
+            step,
+            manifest_sha256=sha256(manifest_path.read_bytes()).hexdigest(),
+        )
+
+
+def test_native_run_information_rejects_relabel_and_foreign_workflow_reference(
+    tmp_path: Path,
+) -> None:
+    first = _committed_fit()
+    second = _committed_fit()
+    output = tmp_path / "Output"
+    step = publish_native_results(output / "STEP", first)
+    for changes in (
+        {"lifecycle": "failed", "authority": "diagnostic_only"},
+        {"provenance": second.provenance},
+        {"artifacts": step.artifacts[:-2]},
+    ):
+        with pytest.raises(ValueError, match="exact live publication"):
+            replace(step, **changes)
+
+
+def test_native_run_information_rejects_foreign_equivalent_publication(
+    tmp_path: Path,
+) -> None:
+    run_occurrence = _committed_fit()
+    foreign_occurrence = _committed_fit()
+    output = tmp_path / "Output"
+    foreign_step = publish_native_results(output / "STEP", foreign_occurrence)
+
+    with pytest.raises(ValueError, match="another run occurrence"):
         write_native_run_info(
-            Namespace(
-                experiments=[EXPERIMENT],
-                parameters=[PARAMETERS],
-                method=[METHOD],
-                output=output,
-            ),
+            Namespace(output=output),
             NativeRunInformation(
-                invocation_identity="issue-609-forged-reference",
-                parameter_model=publication.parameter_model,
-                starting_snapshot=publication.starting_snapshot,
-                steps=(forged,),
+                invocation_identity="issue-609-foreign-publication",
+                inputs=_captured_inputs(output),
+                parameter_model=run_occurrence.parameter_model,
+                starting_snapshot=run_occurrence.starting_snapshot,
+                steps=(foreign_step,),
             ),
             working_directory=ROOT,
         )
     assert not (output / "run_info").exists()
+
+
+def test_committed_restart_provenance_binds_exact_commit_occurrence(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "STEP"
+    publish_native_results(output, publication)
+
+    record = json.loads((output / "Parameters" / "restart-provenance.json").read_text())
+    assert record["starting_occurrence_identity"] == (
+        publication.starting_snapshot.occurrence_identity
+    )
+    assert record["starting_revision"] == publication.starting_snapshot.revision
+    assert record["accepted_result_identity"] == publication.accepted.identity
+    assert record["accepted_occurrence_identity"] == (
+        publication.accepted.occurrence_identity
+    )
+    assert record["commit_operation_identity"] == publication.commit_operation.identity
+    assert record["commit_occurrence_identity"] == (
+        publication.commit_operation.occurrence_identity
+    )
+    assert record["committed_occurrence_identity"] == (
+        publication.committed_snapshot.occurrence_identity
+    )
+    assert record["committed_revision"] == publication.committed_snapshot.revision
+    assert [item["id"] for item in record["independent_items"]] == list(
+        publication.parameterization.independent_ids
+    )
+
+
+def test_durable_native_run_rejects_child_tampering_with_new_outer_hash(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    step = publish_native_results(output / "STEP", publication)
+    write_native_run_info(
+        Namespace(output=output),
+        NativeRunInformation(
+            invocation_identity="issue-609-durable-tamper",
+            inputs=_captured_inputs(output),
+            parameter_model=publication.parameter_model,
+            starting_snapshot=publication.starting_snapshot,
+            steps=(step,),
+        ),
+        working_directory=ROOT,
+    )
+    run_info = output / "run_info"
+    historical = read_native_run_information(run_info)
+    assert historical.published_step_identities == (step.identity,)
+
+    workflow_path = run_info / "workflows.json"
+    workflows = json.loads(workflow_path.read_text())
+    workflows["workflows"][0]["published_step_identity"] = "0" * 64
+    workflow_path.write_text(json.dumps(workflows, sort_keys=True) + "\n")
+    run_path = run_info / "run.toml"
+    run_text = run_path.read_text()
+    parsed = tomllib.loads(run_text)
+    old_workflow_hash = parsed["workflow_records"]["sha256"]
+    new_workflow_hash = sha256(workflow_path.read_bytes()).hexdigest()
+    run_text = run_text.replace(old_workflow_hash, new_workflow_hash)
+    parsed = tomllib.loads(run_text)
+    old_record_identity = parsed["record_identity"]
+    new_record_identity = run_info_module._native_run_record_identity(parsed)
+    run_path.write_text(run_text.replace(old_record_identity, new_record_identity))
+
+    with pytest.raises(ValueError, match="step lineage"):
+        read_native_run_information(run_info)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "parameters_used.toml",
+        "normalized/method-0001.toml",
+        "workflows.json",
+        "run.toml",
+        "inputs/experiments/800mhz.toml",
+    ),
+)
+def test_staged_run_info_mutation_prevents_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    relative_path: str,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    step = publish_native_results(output / "STEP", publication)
+    original = run_info_module.read_native_run_information
+
+    def mutate_then_validate(path: Path) -> object:
+        (path / relative_path).write_bytes(b"mutated before final publication\n")
+        return original(path)
+
+    monkeypatch.setattr(
+        run_info_module,
+        "read_native_run_information",
+        mutate_then_validate,
+    )
+    with pytest.raises((ValueError, KeyError)):
+        write_native_run_info(
+            Namespace(output=output),
+            NativeRunInformation(
+                invocation_identity="issue-609-staged-run-mutation",
+                inputs=_captured_inputs(output),
+                parameter_model=publication.parameter_model,
+                starting_snapshot=publication.starting_snapshot,
+                steps=(step,),
+            ),
+            working_directory=ROOT,
+        )
+    assert not (output / "run_info").exists()
+    assert not list(output.glob(".run_info-*"))
+
+
+def test_native_run_information_uses_occurrence_start_input_bytes(
+    tmp_path: Path,
+) -> None:
+    publication = _committed_fit()
+    output = tmp_path / "Output"
+    step = publish_native_results(output / "STEP", publication)
+    first = tmp_path / "one" / "input.toml"
+    second = tmp_path / "two" / "input.toml"
+    target_a = tmp_path / "target-a.toml"
+    target_b = tmp_path / "target-b.toml"
+    link = tmp_path / "linked.toml"
+    traversal_like = tmp_path / "..input.toml"
+    for path, content in (
+        (first, b'A = "first"\n'),
+        (second, b'A = "second"\n'),
+        (target_a, b'A = "symlink-a"\n'),
+        (target_b, b'A = "symlink-b"\n'),
+        (traversal_like, b'A = "safe-name"\n'),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    link.symlink_to(target_a)
+    capture_args = Namespace(
+        experiments=[first, second, link, traversal_like],
+        parameters=None,
+        method=None,
+        output=output,
+    )
+    captured = capture_native_inputs(capture_args, working_directory=tmp_path)
+
+    first.write_bytes(b'A = "mutated"\n')
+    second.unlink()
+    link.unlink()
+    link.symlink_to(target_b)
+    write_native_run_info(
+        Namespace(output=output),
+        NativeRunInformation(
+            invocation_identity="issue-609-input-capture",
+            inputs=captured,
+            parameter_model=publication.parameter_model,
+            starting_snapshot=publication.starting_snapshot,
+            steps=(step,),
+        ),
+        working_directory=tmp_path,
+    )
+
+    run = tomllib.loads((output / "run_info" / "run.toml").read_text())
+    archived = {
+        item["provided_path"]: (output / "run_info" / item["copied_path"]).read_bytes()
+        for item in run["inputs"]["experiments"]
+    }
+    assert archived[str(first)] == b'A = "first"\n'
+    assert archived[str(second)] == b'A = "second"\n'
+    assert archived[str(link)] == b'A = "symlink-a"\n'
+    assert archived[str(traversal_like)] == b'A = "safe-name"\n'
+    copied_names = [
+        Path(item["copied_path"]).name for item in run["inputs"]["experiments"]
+    ]
+    assert len(copied_names) == len(set(copied_names))
+    assert all(name not in {"", ".", ".."} for name in copied_names)

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -442,3 +442,22 @@ def test_failed_replacement_restores_existing_run_info(
     assert existing_run.read_text(encoding="utf-8") == "schema_version = 1\n"
     assert staging_path.exists()
     assert not list(tmp_path.glob(".run_info-backup-*"))
+
+
+@pytest.mark.parametrize(
+    "content",
+    (
+        "schema_version = 3\n",
+        'schema_version = 2\nschema_kind = "foreign"\n',
+        'schema_version = "2"\n',
+    ),
+)
+def test_run_information_classifier_rejects_unknown_schema_meanings(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    path = tmp_path / "run.toml"
+    path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported run-information schema"):
+        run_info_module.classify_run_information(path)


### PR DESCRIPTION
Closes #609.

## Summary

Adds the schema-v2 native qualification path for product-facing run provenance,
restart state, step manifests, and artifact lineage.

- Captures immutable verbatim inputs and hashes at occurrence start.
- Separates normalized method semantics from execution/workflow provenance.
- Records complete starting and committed independent-parameter restart states.
- Binds committed provenance to the exact accepted, commit, and publication occurrences.
- Publishes atomic no-clobber run information and lifecycle-aware step manifests.
- Recursively validates durable provenance and artifact hashes.
- Preserves historical schema-v1 behavior unchanged.
- Keeps failed, uncommitted, diagnostic, and partial evidence distinct from committed restart state.
- Does not change current CLI or scientific calculations.

## Validation

- Full suite: green on final HEAD
- Focused review tests: 117 passed
- `ty`: passed
- Ruff lint/format: passed
- `git diff --check`: passed
- Independent review: MERGE
- Standards: 0 Blocking/Important findings
- Spec: 0 Blocking/Important findings