### PR TITLE
Implement the closed native method-step workflow composer

### DIFF
--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -1463,6 +1463,21 @@ class EvaluationEngine:
         plan, sources = _build_plan(experiments, parameterization)
         return cls(plan, parameterization, sources)
 
+    def rebind_parameterization(
+        self,
+        parameterization: ActiveParameterization,
+    ) -> EvaluationEngine:
+        """Bind the frozen plan and copied kernels to a fresh state occurrence."""
+        sources = tuple(
+            (descriptor.experiment_ordinal, descriptor.profile_ordinal, source)
+            for descriptor, source in zip(
+                self.plan.profiles,
+                self._sources,
+                strict=True,
+            )
+        )
+        return type(self)(self.plan, parameterization, sources)
+
     @classmethod
     def bind(
         cls,

--- a/src/chemex/native_provenance.py
+++ b/src/chemex/native_provenance.py
@@ -38,6 +38,7 @@ class NativeProvenanceError(ValueError):
 type StepLifecycle = Literal[
     "committed",
     "successful_no_state_change",
+    "no_objective_data",
     "failed",
     "accepted_uncommitted",
     "cancelled",
@@ -179,7 +180,7 @@ def validate_native_step_manifest_bytes(  # noqa: C901 - closed durable schema
         if authority != "committed_fit" or not common | committed <= set(record):
             raise NativeProvenanceError("Committed manifest lacks lifecycle authority")
         forbidden = {"operation_identity"}
-    elif lifecycle == "successful_no_state_change":
+    elif lifecycle in {"successful_no_state_change", "no_objective_data"}:
         if authority != "evaluation_only" or not common <= set(record):
             raise NativeProvenanceError("Evaluation manifest lacks lifecycle authority")
         forbidden = committed | {"operation_identity"}
@@ -922,6 +923,80 @@ class WorkflowProvenance:
             environment,
             baseline_references,
         )
+
+    @classmethod
+    def create_method_step(
+        cls,
+        *,
+        parameterization: ActiveParameterization,
+        plan: EvaluationPlan,
+        method: Method,
+        semantic_workflow_identity: str,
+        grouping_topology: tuple[tuple[str, tuple[str, ...]], ...],
+        policies: tuple[PolicyRecord, ...],
+        budgets: tuple[BudgetRecord, ...],
+        seeds: tuple[SeedRecord, ...],
+        execution: ExecutionSettings,
+        environment: ProvenanceEnvironment,
+        baseline_references: tuple[BaselineReference, ...],
+    ) -> WorkflowProvenance:
+        """Capture one already-compiled closed method-step composition."""
+        if (
+            not semantic_workflow_identity
+            or plan.parameterization_identity != parameterization.evaluator_identity
+            or plan.constraint_program_identity != parameterization.program.fingerprint
+        ):
+            raise NativeProvenanceError(
+                "Method-step provenance requires its exact compiled native context"
+            )
+        return cls(
+            _WORKFLOW_PROVENANCE_KEY,
+            _normalized_method_semantics(method),
+            ProfileSelectionRecord(
+                parameterization.binder.model_name,
+                tuple(profile.identity for profile in plan.profiles),
+                (),
+            ),
+            f"method_step:{semantic_workflow_identity}",
+            grouping_topology,
+            parameterization.identity,
+            plan.identity,
+            policies,
+            budgets,
+            seeds,
+            execution,
+            environment,
+            baseline_references,
+        )
+
+    def validate_method_step_context(
+        self,
+        *,
+        parameterization: ActiveParameterization,
+        plan: EvaluationPlan,
+        method: Method,
+        semantic_workflow_identity: str,
+        grouping_topology: tuple[tuple[str, tuple[str, ...]], ...],
+        execution: ExecutionSettings,
+    ) -> None:
+        """Revalidate an exact closed method-step context for publication."""
+        if (
+            self.parameterization_identity != parameterization.identity
+            or self.evaluation_plan_identity != plan.identity
+            or self.normalized_method_text != _normalized_method_semantics(method)
+            or self.selection
+            != ProfileSelectionRecord(
+                parameterization.binder.model_name,
+                tuple(profile.identity for profile in plan.profiles),
+                (),
+            )
+            or self.workflow_type != f"method_step:{semantic_workflow_identity}"
+            or self.grouping_topology != grouping_topology
+            or self.execution != execution
+        ):
+            raise NativeProvenanceError(
+                "Method-step provenance differs from its compiled execution context"
+            )
 
     @staticmethod
     def _derive_live_execution_facts(

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -3561,23 +3561,47 @@ def _consume_fit_commit_authority(
         )
     with _LIVE_FIT_COMMIT_AUTHORITIES_LOCK:
         binding = _LIVE_FIT_COMMIT_AUTHORITIES.get(authority)
-        if (
-            binding is None
-            or binding.accepted_result is not accepted
-            or binding.accepted_result_identity != accepted.identity
-            or binding.accepted_occurrence_identity != accepted.occurrence_identity
-            or binding.problem_identity != problem.identity
-            or binding.snapshot_context_identity
-            != _snapshot_commit_context_identity(problem.source_snapshot)
-            or binding.source_occurrence_identity
-            != problem.source_snapshot.occurrence_identity
-            or binding.source_revision != problem.source_snapshot.revision
-            or binding.origin_context_identity != accepted.origin_context_identity
-        ):
+        if not _fit_commit_authority_binding_matches(binding, accepted, problem):
             raise DirectTrfConstructionError(
                 "Accepted result lacks its exact live Direct TRF commit authority"
             )
         del _LIVE_FIT_COMMIT_AUTHORITIES[authority]
+
+
+def _fit_commit_authority_binding_matches(
+    binding: _CommitAuthorityBinding | None,
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+) -> bool:
+    return bool(
+        binding is not None
+        and binding.accepted_result is accepted
+        and binding.accepted_result_identity == accepted.identity
+        and binding.accepted_occurrence_identity == accepted.occurrence_identity
+        and binding.problem_identity == problem.identity
+        and binding.snapshot_context_identity
+        == _snapshot_commit_context_identity(problem.source_snapshot)
+        and binding.source_occurrence_identity
+        == problem.source_snapshot.occurrence_identity
+        and binding.source_revision == problem.source_snapshot.revision
+        and binding.origin_context_identity == accepted.origin_context_identity
+    )
+
+
+def fit_commit_authority_is_authoritative(
+    accepted: AcceptedFitResult,
+    authority: LiveFitCommitAuthority,
+    problem: OptimizationProblem,
+) -> bool:
+    """Check an exact live acceptance/authority pairing without consuming it."""
+    if not isinstance(authority, LiveFitCommitAuthority):
+        return False
+    with _LIVE_FIT_COMMIT_AUTHORITIES_LOCK:
+        return _fit_commit_authority_binding_matches(
+            _LIVE_FIT_COMMIT_AUTHORITIES.get(authority),
+            accepted,
+            problem,
+        )
 
 
 def commit_accepted_fit(

--- a/src/chemex/optimize/method_step.py
+++ b/src/chemex/optimize/method_step.py
@@ -12,10 +12,10 @@ import json
 import weakref
 from argparse import Namespace
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, is_dataclass, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Literal, Protocol, Self, cast
+from typing import Any, Literal, Protocol, Self, cast
 from uuid import uuid4
 
 from chemex.configuration.methods import Method
@@ -33,6 +33,7 @@ from chemex.native_provenance import (
     PublishedStepReference,
     SeedRecord,
     WorkflowProvenance,
+    published_step_reference_identity,
 )
 from chemex.optimize.de_direct_trf import (
     AcceptedDeDirectTrfResult,
@@ -49,7 +50,9 @@ from chemex.optimize.direct_trf import (
     FitCommitOperation,
     FitCommitTerminal,
     OptimizationProblem,
+    accepted_occurrence_is_authoritative,
     execute_fit_commit,
+    fit_commit_operation_is_authoritative,
 )
 from chemex.optimize.grid_direct_trf import (
     AcceptedGridDirectTrfResult,
@@ -438,6 +441,93 @@ def _snapshot_identity(snapshot: AnalysisValuesSnapshot) -> str:
     return hashlib.sha256(snapshot.to_json().encode("ascii")).hexdigest()
 
 
+def _validate_snapshot_integrity(snapshot: AnalysisValuesSnapshot) -> None:
+    try:
+        restored = AnalysisValuesSnapshot.from_json(snapshot.to_json())
+    except Exception as error:
+        raise ValueError("Method-step snapshot integrity validation failed") from error
+    if restored != snapshot or tuple(snapshot.items()) != tuple(restored.items()):
+        raise ValueError("Method-step snapshot integrity validation failed")
+
+
+def _validate_rederived_identity(
+    value: object,
+    *,
+    identity_attribute: str = "identity",
+) -> None:
+    """Reconstruct one frozen declarative child and compare its current identity."""
+    try:
+        expected = replace(cast("Any", value))
+    except Exception as error:
+        raise ValueError(
+            f"Method-step child integrity validation failed for {type(value).__name__}"
+        ) from error
+    if getattr(expected, identity_attribute) != getattr(value, identity_attribute):
+        raise ValueError(
+            f"Method-step child integrity validation failed for {type(value).__name__}"
+        )
+
+
+def _validate_recursive_dataclass_children(  # noqa: C901 - closed evidence tree
+    value: object,
+    *,
+    seen: set[int] | None = None,
+) -> None:
+    """Reconstruct the closed native evidence tree while skipping live authorities."""
+    visited = set() if seen is None else seen
+    if id(value) in visited:
+        return
+    visited.add(id(value))
+    if isinstance(value, tuple):
+        for item in value:
+            _validate_recursive_dataclass_children(item, seen=visited)
+        return
+    if isinstance(value, AnalysisValuesSnapshot):
+        _validate_snapshot_integrity(value)
+        return
+    if isinstance(value, (AcceptedFitResult, FitCommitOperation)) or not is_dataclass(
+        value
+    ):
+        return
+    for declared in fields(value):
+        if "witness" in declared.name or "authority" in declared.name:
+            continue
+        _validate_recursive_dataclass_children(
+            getattr(value, declared.name),
+            seen=visited,
+        )
+    if type(value).__module__.startswith("chemex."):
+        reconstructed = replace(cast("Any", value))
+        for identity_attribute in ("identity", "fingerprint"):
+            if hasattr(value, identity_attribute) and getattr(
+                reconstructed, identity_attribute
+            ) != getattr(value, identity_attribute):
+                raise ValueError(
+                    "Method-step recursive child integrity validation failed for "
+                    f"{type(value).__name__}"
+                )
+
+
+def _semantic_method_record(method: Method) -> dict[str, object]:
+    """Return the closed scientific/lifecycle Method fields used by #641."""
+    record = cast("dict[str, object]", method.model_dump(mode="json"))
+    statistics = record.get("statistics")
+    if isinstance(statistics, dict):
+        mcmc = statistics.get("mcmc")
+        if isinstance(mcmc, dict):
+            # Worker allocation changes execution, not the requested posterior.
+            mcmc.pop("workers", None)
+    return record
+
+
+def _operational_method_record(method: Method) -> dict[str, object]:
+    """Return Method-owned execution controls excluded from semantic identity."""
+    mcmc = None if method.statistics is None else method.statistics.mcmc
+    return {
+        "mcmc_workers": None if mcmc is None else mcmc.workers,
+    }
+
+
 def _direct_policy_semantics(invocation: DirectTrfInvocation) -> tuple[object, ...]:
     return (
         invocation.objective_request_budget,
@@ -705,56 +795,17 @@ class MethodStepWorkflow:
                 raise ValueError(
                     "Resampling request metadata must cover the exact EvaluationPlan"
                 )
-        semantic_identity = _identity(
-            "native-method-step-workflow-semantics-v1",
-            {
-                "primary": primary_record,
-                "parameter_model_identity": self.parameter_model.identity,
-                "parameterization_program": program.fingerprint,
-                "evaluation_plan_identity": self.engine.plan.identity,
-                "method": self.method.model_dump(mode="json"),
-                "publication": (
-                    None
-                    if self.publication is None
-                    else "native-step-root-no-clobber-v1"
-                ),
-                "derivations": tuple(
-                    (kind, item.identity)
-                    for kind, item in zip(
-                        derivation_kinds,
-                        self.derivations,
-                        strict=True,
-                    )
-                ),
-                "failure_policy": "closed-method-step-failure-v1",
-            },
+        semantic_identity, binding_identity = _rederive_workflow_identities(
+            self,
+            primary_record=primary_record,
+            derivation_kinds=derivation_kinds,
         )
         object.__setattr__(self, "semantic_identity", semantic_identity)
-        object.__setattr__(
-            self,
-            "binding_identity",
-            _identity(
-                "native-method-step-workflow-binding-v1",
-                {
-                    "semantic_identity": semantic_identity,
-                    "starting_state_identity": _snapshot_identity(snapshot),
-                    "occurrence_identity": snapshot.occurrence_identity,
-                    "revision": snapshot.revision,
-                    "parameterization_identity": self.parameterization.identity,
-                    "invocation_identity": (
-                        None if self.invocation is None else self.invocation.identity
-                    ),
-                    "uncertainty_environments": tuple(
-                        item.resolved_environment_identity
-                        for item in self.derivations
-                        if isinstance(item, UncertaintyDerivationRequest)
-                    ),
-                    "publication_request_identity": (
-                        None if self.publication is None else self.publication.identity
-                    ),
-                },
-            ),
-        )
+        object.__setattr__(self, "binding_identity", binding_identity)
+
+    def validate_integrity(self) -> None:
+        """Rederive this workflow and every identity-bearing child."""
+        _validate_method_step_workflow(self)
 
     @classmethod
     def for_evaluation(
@@ -809,6 +860,255 @@ class MethodStepWorkflow:
             derivations=derivations,
             publication=publication,
         )
+
+
+def _rederive_workflow_identities(
+    workflow: MethodStepWorkflow,
+    *,
+    primary_record: dict[str, object] | None = None,
+    derivation_kinds: tuple[str, ...] | None = None,
+) -> tuple[str, str]:
+    """Compute the two workflow identities solely from current declarative fields."""
+    if primary_record is None:
+        if workflow.evaluation_purpose is not None:
+            primary_record = {
+                "kind": "evaluation_only",
+                "purpose": workflow.evaluation_purpose.value,
+            }
+        else:
+            primary_record = _optimization_semantics(
+                cast("OptimizationProblem", workflow.problem),
+                cast("FitDecomposition", workflow.decomposition),
+                cast("MethodStepStrategy", workflow.strategy),
+                cast("MethodStepInvocation", workflow.invocation),
+            )
+    if derivation_kinds is None:
+        derivation_kinds = tuple(
+            _derivation_stage(item) for item in workflow.derivations
+        )
+    semantic_identity = _identity(
+        "native-method-step-workflow-semantics-v1",
+        {
+            "primary": primary_record,
+            "parameter_model_identity": workflow.parameter_model.identity,
+            "parameterization_program": workflow.parameterization.program.fingerprint,
+            "evaluation_plan_identity": workflow.engine.plan.identity,
+            "method": _semantic_method_record(workflow.method),
+            "publication": (
+                None
+                if workflow.publication is None
+                else "native-step-root-no-clobber-v1"
+            ),
+            "derivations": tuple(
+                (kind, item.identity)
+                for kind, item in zip(
+                    derivation_kinds,
+                    workflow.derivations,
+                    strict=True,
+                )
+            ),
+            "failure_policy": "closed-method-step-failure-v1",
+        },
+    )
+    snapshot = workflow.starting_snapshot
+    binding_identity = _identity(
+        "native-method-step-workflow-binding-v1",
+        {
+            "semantic_identity": semantic_identity,
+            "starting_state_identity": _snapshot_identity(snapshot),
+            "occurrence_identity": snapshot.occurrence_identity,
+            "revision": snapshot.revision,
+            "parameterization_identity": workflow.parameterization.identity,
+            "operational_method": _operational_method_record(workflow.method),
+            "invocation_identity": (
+                None if workflow.invocation is None else workflow.invocation.identity
+            ),
+            "uncertainty_environments": tuple(
+                item.resolved_environment_identity
+                for item in workflow.derivations
+                if isinstance(item, UncertaintyDerivationRequest)
+            ),
+            "publication_request_identity": (
+                None if workflow.publication is None else workflow.publication.identity
+            ),
+        },
+    )
+    return semantic_identity, binding_identity
+
+
+def _validate_derivation_request_integrity(
+    request: MethodStepDerivationRequest,
+) -> None:
+    if isinstance(request, UncertaintyDerivationRequest):
+        _validate_rederived_identity(request.policy)
+        if request.compiled_capabilities is not None:
+            _validate_rederived_identity(request.compiled_capabilities)
+    elif isinstance(request, ResamplingDerivationRequest):
+        _validate_rederived_identity(request.summary_policy)
+    else:
+        _validate_rederived_identity(request.policy)
+    _validate_rederived_identity(request)
+
+
+def _validate_invocation_integrity(invocation: MethodStepInvocation) -> None:
+    if isinstance(invocation, GroupedDirectTrfInvocation):
+        for component in invocation.component_invocations:
+            _validate_rederived_identity(component)
+    elif isinstance(invocation, GridDirectTrfInvocation):
+        for axis in invocation.axes:
+            _validate_rederived_identity(axis)
+        for seed in invocation.seeds:
+            if seed.problem is not None:
+                _validate_snapshot_integrity(seed.problem.source_snapshot)
+                _validate_rederived_identity(seed.problem)
+            if seed.invocation is not None:
+                _validate_rederived_identity(seed.invocation)
+            _validate_rederived_identity(seed)
+    else:
+        _validate_snapshot_integrity(invocation.root_problem.source_snapshot)
+        _validate_snapshot_integrity(invocation.search_problem.source_snapshot)
+        _validate_rederived_identity(invocation.root_problem)
+        _validate_rederived_identity(invocation.search_problem)
+        for coordinate in invocation.search_coordinates:
+            _validate_rederived_identity(coordinate)
+        _validate_rederived_identity(invocation.population)
+    _validate_rederived_identity(invocation)
+
+
+def _validate_publication_request_integrity(
+    publication: MethodStepPublicationRequest,
+) -> None:
+    _validate_rederived_identity(publication.environment)
+    for reference in publication.baseline_references:
+        _validate_rederived_identity(reference)
+    if publication.run_provenance is not None:
+        run = publication.run_provenance
+        _validate_snapshot_integrity(run.starting_snapshot)
+        _validate_rederived_identity(run.inputs)
+        for reference in run.prior_steps:
+            reference.require_exact_live_publication()
+        _validate_rederived_identity(run)
+    _validate_rederived_identity(publication)
+
+
+def _validate_method_step_workflow(  # noqa: C901 - closed recursive workflow tree
+    workflow: MethodStepWorkflow,
+) -> None:
+    """Canonically rederive one workflow without trusting construction-time hashes."""
+    _validate_snapshot_integrity(workflow.starting_snapshot)
+    _validate_rederived_identity(workflow.parameter_model)
+    _validate_rederived_identity(
+        workflow.parameterization.program,
+        identity_attribute="fingerprint",
+    )
+    _validate_rederived_identity(workflow.parameterization)
+    try:
+        canonical_method = Method.model_validate(
+            workflow.method.model_dump(exclude_none=True)
+        )
+    except Exception as error:
+        raise ValueError("Method-step Method integrity validation failed") from error
+    if canonical_method.model_dump() != workflow.method.model_dump():
+        raise ValueError("Method-step Method integrity validation failed")
+    try:
+        restored_plan = type(workflow.engine.plan).from_record(
+            workflow.engine.plan.to_record()
+        )
+    except Exception as error:
+        raise ValueError(
+            "Method-step evaluation-plan integrity validation failed"
+        ) from error
+    if restored_plan.identity != workflow.engine.plan.identity:
+        raise ValueError("Method-step evaluation-plan integrity validation failed")
+    if workflow.engine._parameterization is not workflow.parameterization:
+        raise ValueError("Method-step engine integrity validation failed")
+    if workflow.problem is not None:
+        _validate_snapshot_integrity(workflow.problem.source_snapshot)
+        _validate_rederived_identity(workflow.problem)
+    if workflow.decomposition is not None:
+        for component in workflow.decomposition.components:
+            _validate_snapshot_integrity(component.problem.source_snapshot)
+            _validate_rederived_identity(component.problem)
+            _validate_rederived_identity(component)
+        _validate_rederived_identity(workflow.decomposition.partition_proof)
+        _validate_rederived_identity(workflow.decomposition)
+    if workflow.invocation is not None:
+        _validate_invocation_integrity(workflow.invocation)
+    for request in workflow.derivations:
+        _validate_derivation_request_integrity(request)
+    if workflow.publication is not None:
+        _validate_publication_request_integrity(workflow.publication)
+    retained = workflow.engine.plan.retained_observation_count
+    if workflow.evaluation_purpose is not None:
+        if any(
+            item is not None
+            for item in (
+                workflow.problem,
+                workflow.decomposition,
+                workflow.strategy,
+                workflow.invocation,
+            )
+        ) or (
+            workflow.evaluation_purpose is not EvaluationPurpose.NO_OBJECTIVE_DATA
+            and retained < 1
+        ):
+            raise ValueError("Method-step workflow integrity validation failed")
+    else:
+        problem = workflow.problem
+        decomposition = workflow.decomposition
+        strategy = workflow.strategy
+        invocation = workflow.invocation
+        if (
+            problem is None
+            or decomposition is None
+            or strategy is None
+            or invocation is None
+            or retained < 1
+            or problem.source_snapshot is not workflow.starting_snapshot
+            or decomposition.root_problem_identity != problem.identity
+            or decomposition.root_plan_identity != workflow.engine.plan.identity
+        ):
+            raise ValueError("Method-step workflow integrity validation failed")
+        if strategy is MethodStepStrategy.DIRECT_TRF:
+            compatible = (
+                isinstance(invocation, GroupedDirectTrfInvocation)
+                and invocation.root_problem_identity == problem.identity
+                and invocation.decomposition_identity == decomposition.identity
+            )
+        elif strategy is MethodStepStrategy.GRID_DIRECT_TRF:
+            compatible = (
+                isinstance(invocation, GridDirectTrfInvocation)
+                and invocation.root_problem_identity == problem.identity
+            )
+        else:
+            compatible = (
+                isinstance(invocation, DeDirectTrfInvocation)
+                and invocation.root_problem_identity == problem.identity
+                and len(decomposition.components) == 1
+            )
+        if not compatible:
+            raise ValueError("Method-step workflow integrity validation failed")
+    ordered = tuple(
+        sorted(
+            workflow.derivations,
+            key=lambda item: {"uncertainty": 0, "resampling": 1, "mcmc": 2}[
+                _derivation_stage(item)
+            ],
+        )
+    )
+    derivation_kinds = tuple(_derivation_stage(item) for item in workflow.derivations)
+    if (
+        ordered != workflow.derivations
+        or len(set(derivation_kinds)) != len(derivation_kinds)
+        or (workflow.evaluation_purpose is not None and workflow.derivations)
+    ):
+        raise ValueError("Method-step workflow integrity validation failed")
+    semantic_identity, binding_identity = _rederive_workflow_identities(workflow)
+    if (
+        semantic_identity != workflow.semantic_identity
+        or binding_identity != workflow.binding_identity
+    ):
+        raise ValueError("Method-step workflow integrity validation failed")
 
 
 @dataclass(frozen=True, slots=True, weakref_slot=True, eq=False)
@@ -867,6 +1167,12 @@ class MethodStepOutcome:
         repr=False,
         compare=False,
     )
+    source_workflow: MethodStepWorkflow | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        kw_only=True,
+    )
     record_identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -900,6 +1206,11 @@ class MethodStepOutcome:
             "record_identity",
             _identity("native-method-step-outcome-v1", self._record_payload()),
         )
+        _validate_method_step_outcome(self)
+
+    def validate_integrity(self) -> None:
+        """Rederive this outcome and every available live child."""
+        _validate_method_step_outcome(self)
 
     def _record_payload(self) -> dict[str, object]:
         return {
@@ -938,6 +1249,7 @@ class MethodStepOutcome:
 
     def to_record(self) -> dict[str, object]:
         """Serialize historical evidence without any process-local authority."""
+        self.validate_integrity()
         return {**self._record_payload(), "identity": self.record_identity}
 
     @classmethod
@@ -1023,12 +1335,265 @@ class MethodStepOutcome:
         )
         if typed_record["identity"] != outcome.record_identity:
             raise ValueError("Method-step outcome identity differs from its payload")
+        outcome.validate_integrity()
         return outcome
+
+
+def _validate_derivation_outcome_integrity(outcome: DerivationOutcome) -> None:
+    expected = DerivationOutcome(
+        outcome.request_identity,
+        outcome.stage,
+        outcome.disposition,
+        outcome.operation_identity,
+        outcome.artifact_identities,
+        outcome.message,
+        operation=outcome.operation,
+        artifacts=outcome.artifacts,
+    )
+    if expected.identity != outcome.identity:
+        raise ValueError("Method-step derivation outcome integrity validation failed")
+
+
+def _validate_published_step_integrity(
+    reference: PublishedStepReference,
+    *,
+    workflow: MethodStepWorkflow | None = None,
+) -> None:
+    _validate_recursive_dataclass_children(reference.provenance)
+    if workflow is not None:
+        reference.provenance.validate_method_step_context(
+            parameterization=workflow.parameterization,
+            plan=workflow.engine.plan,
+            method=workflow.method,
+            semantic_workflow_identity=workflow.semantic_identity,
+            grouping_topology=reference.provenance.grouping_topology,
+            execution=reference.provenance.execution,
+        )
+    expected_identity = published_step_reference_identity(
+        publication_occurrence_identity=reference.publication_occurrence_identity,
+        lifecycle=reference.lifecycle,
+        authority=reference.authority,
+        manifest_identity=reference.manifest_identity,
+        manifest_sha256=reference.manifest_sha256,
+        provenance=reference.provenance,
+        independent_ids=reference.independent_ids,
+        artifacts=reference.artifacts,
+    )
+    if expected_identity != reference.identity:
+        raise ValueError("Method-step publication integrity failed")
+    reference.require_exact_live_publication()
+
+
+def _validate_outcome_lifecycle(outcome: MethodStepOutcome) -> None:
+    lifecycle = outcome.lifecycle
+    has_evaluation = outcome.evaluation_result_identity is not None
+    has_evaluation_failure = outcome.evaluation_failure_identity is not None
+    has_primary = outcome.primary_execution_identity is not None
+    has_accepted = outcome.accepted_result_identity is not None
+    has_commit = outcome.commit_operation_identity is not None
+    has_successor = outcome.successor_state_identity is not None
+    if has_evaluation and has_evaluation_failure:
+        raise ValueError(
+            "Method-step outcome integrity has conflicting evaluation truth"
+        )
+    if lifecycle is MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE:
+        valid = (
+            has_evaluation
+            and has_successor
+            and not any((has_evaluation_failure, has_primary, has_accepted, has_commit))
+        )
+    elif lifecycle is MethodStepLifecycle.NO_OBJECTIVE_DATA:
+        valid = not any(
+            (
+                has_evaluation,
+                has_evaluation_failure,
+                has_primary,
+                has_accepted,
+                has_commit,
+                has_successor,
+            )
+        )
+    elif lifecycle is MethodStepLifecycle.COMMITTED:
+        valid = (
+            has_primary
+            and has_accepted
+            and has_commit
+            and has_successor
+            and outcome.primary_terminal == "accepted"
+            and not has_evaluation
+            and not has_evaluation_failure
+        )
+    elif lifecycle is MethodStepLifecycle.ACCEPTED_UNCOMMITTED:
+        valid = (
+            has_primary
+            and has_accepted
+            and has_commit
+            and not has_successor
+            and not has_evaluation
+            and not has_evaluation_failure
+        )
+    elif lifecycle is MethodStepLifecycle.PUBLICATION_FAILED:
+        committed_failure = (
+            has_primary
+            and has_accepted
+            and has_commit
+            and has_successor
+            and outcome.primary_terminal == "accepted"
+        )
+        evaluation_failure = has_evaluation and not any(
+            (has_primary, has_accepted, has_commit, has_successor)
+        )
+        valid = bool(outcome.publication_failure) and (
+            committed_failure or evaluation_failure
+        )
+    else:
+        valid = not has_successor and not has_commit
+        if lifecycle is MethodStepLifecycle.FAILED:
+            valid = valid and (has_evaluation_failure or has_primary)
+        elif lifecycle in {
+            MethodStepLifecycle.CANCELLED,
+            MethodStepLifecycle.INTERRUPTED,
+        }:
+            valid = valid and outcome.primary_terminal == lifecycle.value
+    if not valid:
+        raise ValueError("Method-step outcome lifecycle integrity validation failed")
+
+
+def _validate_method_step_outcome(  # noqa: C901 - closed recursive outcome tree
+    outcome: MethodStepOutcome,
+) -> None:
+    """Canonically rederive one outcome without trusting its stored outer hash."""
+    for derivation in outcome.derivations:
+        _validate_derivation_outcome_integrity(derivation)
+    if outcome.record_identity != _identity(
+        "native-method-step-outcome-v1",
+        outcome._record_payload(),
+    ):
+        raise ValueError("Method-step outcome integrity validation failed")
+    _validate_outcome_lifecycle(outcome)
+    workflow = outcome.source_workflow
+    if workflow is None:
+        return
+    workflow.validate_integrity()
+    if (
+        outcome.workflow_identity != workflow.semantic_identity
+        or outcome.workflow_binding_identity != workflow.binding_identity
+        or outcome.starting_state_identity
+        != _snapshot_identity(workflow.starting_snapshot)
+    ):
+        raise ValueError("Method-step outcome source-workflow integrity failed")
+    if outcome.evaluation_result is not None:
+        if (
+            outcome.evaluation_result.identity != outcome.evaluation_result_identity
+            or outcome.evaluation_result.plan_identity != workflow.engine.plan.identity
+            or outcome.evaluation_result.parameterization_identity
+            != workflow.parameterization.evaluator_identity
+        ):
+            raise ValueError("Method-step evaluation-result integrity failed")
+        type(outcome.evaluation_result).from_record(
+            outcome.evaluation_result.to_record(),
+            workflow.engine.plan,
+        )
+    if outcome.evaluation_failure is not None and (
+        outcome.evaluation_failure.identity != outcome.evaluation_failure_identity
+    ):
+        raise ValueError("Method-step evaluation-failure integrity failed")
+    if outcome.primary_execution is not None:
+        _validate_recursive_dataclass_children(outcome.primary_execution)
+        expected_primary_identity = _primary_execution_identity(
+            outcome.primary_execution
+        )
+        if expected_primary_identity != outcome.primary_execution_identity:
+            raise ValueError("Method-step primary-outcome integrity failed")
+        replace(outcome.primary_execution)
+    if outcome.accepted_result is not None:
+        accepted = outcome.accepted_result
+        reconstructed = replace(accepted, occurrence_witness=None)
+        if (
+            reconstructed.identity != accepted.identity
+            or accepted.identity != outcome.accepted_result_identity
+            or not accepted_occurrence_is_authoritative(accepted)
+            or accepted.source_occurrence_identity
+            != workflow.starting_snapshot.occurrence_identity
+            or accepted.source_revision != workflow.starting_snapshot.revision
+        ):
+            raise ValueError("Method-step accepted-result integrity failed")
+        if (
+            outcome.primary_execution is None
+            or outcome.primary_execution.accepted_result is not accepted
+        ):
+            raise ValueError("Method-step aggregate acceptance integrity failed")
+    if outcome.commit_operation is not None:
+        operation = outcome.commit_operation
+        if operation.receipt is not None:
+            _validate_rederived_identity(operation.receipt)
+        if operation.failure is not None:
+            _validate_rederived_identity(operation.failure)
+        if operation.committed_snapshot is not None:
+            _validate_snapshot_integrity(operation.committed_snapshot)
+        reconstructed = replace(operation, _occurrence_witness=None)
+        if (
+            reconstructed.identity != operation.identity
+            or operation.identity != outcome.commit_operation_identity
+            or not fit_commit_operation_is_authoritative(operation)
+            or outcome.accepted_result is None
+            or operation.accepted_result_identity != outcome.accepted_result.identity
+            or operation.accepted_occurrence_identity
+            != outcome.accepted_result.occurrence_identity
+        ):
+            raise ValueError("Method-step commit-operation integrity failed")
+    if outcome.publication is not None:
+        if outcome.publication.identity != outcome.publication_identity:
+            raise ValueError("Method-step publication integrity failed")
+        _validate_published_step_integrity(outcome.publication, workflow=workflow)
+    if outcome.run_provenance is not None:
+        run = outcome.run_provenance
+        _validate_rederived_identity(run.inputs)
+        _validate_rederived_identity(run.parameter_model)
+        _validate_snapshot_integrity(run.starting_snapshot)
+        for step in run.steps:
+            _validate_published_step_integrity(step)
+        reconstructed = replace(run)
+        if (
+            reconstructed.execution_occurrence_identity
+            != run.execution_occurrence_identity
+            or run.execution_occurrence_identity != outcome.run_provenance_identity
+            or run.parameter_model.identity != workflow.parameter_model.identity
+            or (
+                outcome.publication is not None
+                and run.steps[-1] is not outcome.publication
+            )
+        ):
+            raise ValueError("Method-step run-provenance integrity failed")
+    if outcome.successor_state_identity is not None:
+        expected_successor = (
+            outcome.commit_operation.committed_snapshot
+            if outcome.commit_operation is not None
+            else workflow.starting_snapshot
+        )
+        if (
+            expected_successor is None
+            or _snapshot_identity(expected_successor)
+            != outcome.successor_state_identity
+        ):
+            raise ValueError("Method-step successor-state integrity failed")
+
+
+@dataclass(frozen=True, slots=True)
+class _SuccessorAuthorityBinding:
+    outcome: weakref.ReferenceType[MethodStepOutcome]
+    workflow: MethodStepWorkflow
+    snapshot: AnalysisValuesSnapshot
+    outcome_record_identity: str
+    workflow_binding_identity: str
+    snapshot_identity: str
+    occurrence_identity: str
+    revision: int
 
 
 _SUCCESSOR_AUTHORITIES: dict[
     int,
-    tuple[weakref.ReferenceType[MethodStepOutcome], AnalysisValuesSnapshot, str],
+    _SuccessorAuthorityBinding,
 ] = {}
 _PUBLICATION_SOURCES: dict[
     int,
@@ -1040,15 +1605,28 @@ def _grant_successor_authority(
     outcome: MethodStepOutcome,
     snapshot: AnalysisValuesSnapshot,
 ) -> None:
+    outcome.validate_integrity()
+    workflow = outcome.source_workflow
+    if workflow is None or outcome.lifecycle not in {
+        MethodStepLifecycle.COMMITTED,
+        MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE,
+    }:
+        raise ValueError("Method-step outcome cannot mint successor authority")
+    _validate_snapshot_integrity(snapshot)
     key = id(outcome)
 
     def remove(_reference: weakref.ReferenceType[MethodStepOutcome]) -> None:
         _SUCCESSOR_AUTHORITIES.pop(key, None)
 
-    _SUCCESSOR_AUTHORITIES[key] = (
+    _SUCCESSOR_AUTHORITIES[key] = _SuccessorAuthorityBinding(
         weakref.ref(outcome, remove),
+        workflow,
         snapshot,
         outcome.record_identity,
+        workflow.binding_identity,
+        _snapshot_identity(snapshot),
+        snapshot.occurrence_identity,
+        snapshot.revision,
     )
 
 
@@ -1069,15 +1647,34 @@ def require_successor_state(
     analysis_values: AnalysisValues,
 ) -> AnalysisValuesSnapshot:
     """Return the exact live successor or reject historical/failed evidence."""
+    try:
+        outcome.validate_integrity()
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            "Method-step outcome integrity blocks successor authority"
+        ) from error
     binding = _SUCCESSOR_AUTHORITIES.get(id(outcome))
+    current = analysis_values.snapshot()
     if (
         binding is None
-        or binding[0]() is not outcome
-        or binding[2] != outcome.record_identity
-        or analysis_values.snapshot() != binding[1]
+        or binding.outcome() is not outcome
+        or outcome.source_workflow is not binding.workflow
+        or binding.outcome_record_identity != outcome.record_identity
+        or binding.workflow_binding_identity != binding.workflow.binding_identity
+        or outcome.lifecycle
+        not in {
+            MethodStepLifecycle.COMMITTED,
+            MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE,
+        }
+        or _snapshot_identity(binding.snapshot) != binding.snapshot_identity
+        or binding.snapshot.occurrence_identity != binding.occurrence_identity
+        or binding.snapshot.revision != binding.revision
+        or current != binding.snapshot
+        or current.occurrence_identity != binding.occurrence_identity
+        or current.revision != binding.revision
     ):
         raise ValueError("Method-step outcome has no live successor authority")
-    return binding[1]
+    return binding.snapshot
 
 
 def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycle
@@ -1088,6 +1685,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
     checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None = None,
 ) -> MethodStepOutcome:
     """Execute one exact native workflow occurrence."""
+    workflow.validate_integrity()
     current = analysis_values.snapshot()
     if current != workflow.starting_snapshot:
         raise ValueError("Method-step workflow no longer has its exact starting state")
@@ -1098,6 +1696,16 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
             analysis_values=analysis_values,
             cancellation=cancellation,
             checkpoint_observer=checkpoint_observer,
+        )
+    if cancellation is not None and cancellation.is_cancelled:
+        return MethodStepOutcome(
+            workflow.semantic_identity,
+            workflow.binding_identity,
+            uuid4().hex,
+            starting_state_identity,
+            MethodStepLifecycle.CANCELLED,
+            primary_terminal="cancelled",
+            source_workflow=workflow,
         )
     if workflow.evaluation_purpose is EvaluationPurpose.NO_OBJECTIVE_DATA:
         publication: PublishedStepReference | None = None
@@ -1126,6 +1734,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
             ),
             publication=publication,
             run_provenance=run_provenance,
+            source_workflow=workflow,
         )
     frame = EvaluationFrame.from_lifecycle_frame(
         workflow.parameterization,
@@ -1161,6 +1770,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
             evaluation_failure=result,
             publication=publication,
             run_provenance=run_provenance,
+            source_workflow=workflow,
         )
     publication: PublishedStepReference | None = None
     run_provenance: NativeRunInformation | None = None
@@ -1195,6 +1805,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
         evaluation_result=result,
         publication=publication,
         run_provenance=run_provenance,
+        source_workflow=workflow,
     )
     if lifecycle is MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE:
         _grant_successor_authority(outcome, workflow.starting_snapshot)
@@ -1259,6 +1870,7 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
     cancellation: CancellationToken | None,
     checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None,
 ) -> MethodStepOutcome:
+    workflow.validate_integrity()
     problem = cast("OptimizationProblem", workflow.problem)
     decomposition = cast("FitDecomposition", workflow.decomposition)
     strategy = cast("MethodStepStrategy", workflow.strategy)
@@ -1356,6 +1968,7 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
             primary_execution=execution,
             publication=publication,
             run_provenance=run_provenance,
+            source_workflow=workflow,
         )
     if checkpoint_observer is not None:
         checkpoint_observer(MethodStepCheckpoint.AGGREGATE_ACCEPTED)
@@ -1401,6 +2014,7 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
             accepted_result=accepted,
             publication=publication,
             run_provenance=run_provenance,
+            source_workflow=workflow,
         )
     if strategy is MethodStepStrategy.GRID_DIRECT_TRF:
         validate_grid_commit_lineage(
@@ -1497,6 +2111,7 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
         commit_operation=operation,
         publication=publication,
         run_provenance=run_provenance,
+        source_workflow=workflow,
     )
     if successor is not None and lifecycle is MethodStepLifecycle.COMMITTED:
         _grant_successor_authority(outcome, successor)
@@ -1724,6 +2339,7 @@ def _publish_evaluation_method_step(
     workflow: MethodStepWorkflow,
     result: EvaluationResult,
 ) -> PublishedStepReference:
+    workflow.validate_integrity()
     request = cast("MethodStepPublicationRequest", workflow.publication)
     provenance = _method_step_provenance(workflow, None)
     publication = EvaluationPublication(
@@ -1749,6 +2365,7 @@ def _publish_evaluation_failure_method_step(
     workflow: MethodStepWorkflow,
     failure: EvaluationFailure,
 ) -> PublishedStepReference:
+    workflow.validate_integrity()
     request = cast("MethodStepPublicationRequest", workflow.publication)
     publication = SuppressedPublication(
         "failed",
@@ -1767,6 +2384,7 @@ def _publish_evaluation_failure_method_step(
 def _publish_no_objective_method_step(
     workflow: MethodStepWorkflow,
 ) -> PublishedStepReference:
+    workflow.validate_integrity()
     request = cast("MethodStepPublicationRequest", workflow.publication)
     publication = NoObjectivePublication(
         workflow.engine.plan,
@@ -1790,6 +2408,7 @@ def _publish_suppressed_method_step(
     accepted: AcceptedFitResult | None = None,
     terminal: MethodStepPrimaryTerminal | None = None,
 ) -> PublishedStepReference:
+    workflow.validate_integrity()
     request = cast("MethodStepPublicationRequest", workflow.publication)
     primary = _method_step_primary_record(
         workflow,
@@ -1837,6 +2456,7 @@ def _publish_run_provenance(
     workflow: MethodStepWorkflow,
     publication: PublishedStepReference,
 ) -> NativeRunInformation | None:
+    workflow.validate_integrity()
     publication_request = cast("MethodStepPublicationRequest", workflow.publication)
     request = publication_request.run_provenance
     if request is None:
@@ -1866,6 +2486,7 @@ def _publish_committed_method_step(
     derivations: tuple[DerivationOutcome, ...],
     analysis_values: AnalysisValues,
 ) -> PublishedStepReference:
+    workflow.validate_integrity()
     request = cast("MethodStepPublicationRequest", workflow.publication)
     if operation.receipt is None or operation.committed_snapshot is None:
         raise ValueError("Committed publication requires exact commit artifacts")
@@ -1964,8 +2585,10 @@ def _execute_derivations(
     accepted: AcceptedFitResult,
     cancellation: CancellationToken,
 ) -> tuple[DerivationOutcome, ...]:
+    workflow.validate_integrity()
     outcomes: list[DerivationOutcome] = []
     for index, request in enumerate(workflow.derivations):
+        workflow.validate_integrity()
         if cancellation.is_cancelled:
             outcomes.extend(_stopped_derivations(workflow.derivations[index:]))
             break
@@ -2015,6 +2638,7 @@ def _execute_uncertainty(
     request: UncertaintyDerivationRequest,
     cancellation: CancellationToken,
 ) -> DerivationOutcome:
+    workflow.validate_integrity()
     problem = cast("OptimizationProblem", workflow.problem)
 
     def cancellation_probe() -> UncertaintyOperationTerminal | None:
@@ -2062,6 +2686,7 @@ def _execute_resampling(
     request: ResamplingDerivationRequest,
     cancellation: CancellationToken,
 ) -> DerivationOutcome:
+    workflow.validate_integrity()
     plan = ResamplingPlan.for_accepted(
         accepted,
         dataset=ResamplingDatasetManifest(
@@ -2134,6 +2759,7 @@ def _execute_mcmc(
     request: McmcDerivationRequest,
     cancellation: CancellationToken,
 ) -> DerivationOutcome:
+    workflow.validate_integrity()
     plan = McmcPlan.for_accepted(
         accepted,
         source_problem=cast("OptimizationProblem", workflow.problem),

--- a/src/chemex/optimize/method_step.py
+++ b/src/chemex/optimize/method_step.py
@@ -1,0 +1,2230 @@
+"""Closed qualification-only composition of one native method step.
+
+This module is deliberately not connected to the production ``run_methods``
+dispatcher.  It composes already-compiled native artifacts and preserves the
+live AnalysisValues occurrence boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import weakref
+from argparse import Namespace
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal, Protocol, Self, cast
+from uuid import uuid4
+
+from chemex.configuration.methods import Method
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationResult,
+)
+from chemex.native_provenance import (
+    BaselineReference,
+    BudgetRecord,
+    PolicyRecord,
+    ProvenanceEnvironment,
+    PublishedStepReference,
+    SeedRecord,
+    WorkflowProvenance,
+)
+from chemex.optimize.de_direct_trf import (
+    AcceptedDeDirectTrfResult,
+    DeDirectTrfInterrupted,
+    DeDirectTrfInvocation,
+    DeDirectTrfOutcome,
+    execute_de_direct_trf,
+    validate_de_commit_lineage,
+)
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    CancellationToken,
+    DirectTrfInvocation,
+    FitCommitOperation,
+    FitCommitTerminal,
+    OptimizationProblem,
+    execute_fit_commit,
+)
+from chemex.optimize.grid_direct_trf import (
+    AcceptedGridDirectTrfResult,
+    GridDirectTrfInterrupted,
+    GridDirectTrfInvocation,
+    GridDirectTrfOutcome,
+    validate_grid_commit_lineage,
+)
+from chemex.optimize.grouped_direct_trf import (
+    FitDecomposition,
+    GroupedDirectTrfInvocation,
+    GroupedDirectTrfOutcome,
+    execute_grouped_direct_trf,
+)
+from chemex.optimize.grouped_grid_direct_trf import (
+    GroupedGridDirectTrfOutcome,
+    GroupedGridSeedOutcome,
+    execute_grouped_grid_direct_trf,
+)
+from chemex.optimize.native_mcmc import (
+    McmcEvidence,
+    McmcOperationTerminal,
+    McmcPlan,
+    PosteriorSampleEvidence,
+    PosteriorSummary,
+    ResolvedMcmcPolicy,
+    derive_posterior_sample_evidence,
+    derive_posterior_summary,
+    derive_retained_sample_view,
+    execute_mcmc_evidence,
+)
+from chemex.optimize.native_reporting import (
+    CommittedFitPublication,
+    ComponentDiagnostic,
+    EvaluationPublication,
+    McmcPublication,
+    MethodStepPrimaryRecord,
+    MethodStepPrimaryTerminal,
+    NoObjectivePublication,
+    ResamplingPublication,
+    ResamplingSummaryFailurePublication,
+    SuppressedPublication,
+    publication_provenance_records,
+    publish_native_results,
+)
+from chemex.optimize.native_resampling import (
+    OperationTerminal as ResamplingOperationTerminal,
+)
+from chemex.optimize.native_resampling import (
+    OptimizationStrategy,
+    ResamplingDatasetManifest,
+    ResamplingEvidence,
+    ResamplingPlan,
+    ResamplingScheme,
+    ResamplingSummaryPolicy,
+    SummaryFailure,
+    execute_resampling_evidence,
+    summarize_resampling_evidence,
+)
+from chemex.optimize.uncertainty import (
+    CompiledConstraintLinearizationCapabilities,
+    ParameterUnit,
+    UncertaintyEvidence,
+    UncertaintyPolicy,
+    derive_uncertainty_evidence,
+)
+from chemex.optimize.uncertainty import (
+    OperationTerminal as UncertaintyOperationTerminal,
+)
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    ParameterRole,
+    SealedParameterModel,
+)
+from chemex.parameters.values import AnalysisValues, AnalysisValuesSnapshot
+from chemex.run_info import (
+    CapturedNativeInputs,
+    NativeRunInformation,
+    write_native_run_info,
+)
+from chemex.runtime import ExecutionSettings
+
+
+class EvaluationPurpose(StrEnum):
+    """Closed meanings of an evaluation-only method step."""
+
+    EVALUATE_ONLY = "evaluate_only"
+    NO_OPTIMIZATION_REQUIRED = "no_optimization_required"
+    NO_OBJECTIVE_DATA = "no_objective_data"
+
+
+class MethodStepLifecycle(StrEnum):
+    """Closed terminal lifecycle of one native method-step occurrence."""
+
+    SUCCESSFUL_NO_STATE_CHANGE = "successful_no_state_change"
+    NO_OBJECTIVE_DATA = "no_objective_data"
+    COMMITTED = "committed"
+    ACCEPTED_UNCOMMITTED = "accepted_uncommitted"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+    PUBLICATION_FAILED = "publication_failed"
+
+
+class MethodStepStrategy(StrEnum):
+    """Closed primary optimization strategies supported by the composer."""
+
+    DIRECT_TRF = "direct_trf"
+    GRID_DIRECT_TRF = "grid_direct_trf"
+    DE_DIRECT_TRF = "de_direct_trf"
+
+
+class MethodStepCheckpoint(StrEnum):
+    """Occurrence-only observation points that cannot change workflow identity."""
+
+    AGGREGATE_ACCEPTED = "aggregate_accepted"
+    COMMIT_COMPLETED = "commit_completed"
+
+
+class DerivationDisposition(StrEnum):
+    """Closed terminal truth for a requested post-commit evidence stage."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+    BLOCKED_BY_PREREQUISITE = "blocked_by_prerequisite"
+    NOT_STARTED_BY_WORKFLOW_STOP = "not_started_by_workflow_stop"
+
+
+@dataclass(frozen=True, slots=True)
+class UncertaintyDerivationRequest:
+    """Exact covariance and optional constrained-propagation request."""
+
+    policy: UncertaintyPolicy
+    constrained_scope: tuple[str, ...] = ()
+    constrained_units: tuple[tuple[str, ParameterUnit], ...] = ()
+    constrained_scales: tuple[tuple[str, float], ...] = ()
+    compiled_capabilities: CompiledConstraintLinearizationCapabilities | None = None
+    resolved_environment_identity: str = ""
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.resolved_environment_identity:
+            raise ValueError("Uncertainty request requires an environment identity")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-method-step-uncertainty-request-v1",
+                (
+                    self.policy.identity,
+                    self.constrained_scope,
+                    tuple((key, value.value) for key, value in self.constrained_units),
+                    tuple(
+                        (key, float(value).hex())
+                        for key, value in self.constrained_scales
+                    ),
+                    None
+                    if self.compiled_capabilities is None
+                    else self.compiled_capabilities.identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingDerivationRequest:
+    """Exact deterministic resampling population requested after commit."""
+
+    references: tuple[bool, ...]
+    nucleus_groups: tuple[str, ...]
+    observation_descriptors: tuple[str, ...]
+    scheme: ResamplingScheme
+    replicate_count: int
+    replicate_structural_identities: tuple[str, ...]
+    replicate_component_identities: tuple[tuple[str, ...], ...]
+    root_seed: int
+    output_scope: tuple[str, ...]
+    output_units: tuple[str, ...]
+    minimum_successful_count: int
+    strategy: OptimizationStrategy
+    strategy_settings: tuple[tuple[str, str], ...]
+    summary_policy: ResamplingSummaryPolicy
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-method-step-resampling-request-v1",
+                (
+                    self.references,
+                    self.nucleus_groups,
+                    self.observation_descriptors,
+                    self.scheme.value,
+                    self.replicate_count,
+                    self.replicate_structural_identities,
+                    self.replicate_component_identities,
+                    self.root_seed,
+                    self.output_scope,
+                    self.output_units,
+                    self.minimum_successful_count,
+                    self.strategy.value,
+                    self.strategy_settings,
+                    self.summary_policy.identity,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class McmcDerivationRequest:
+    """Exact MCMC execution and typed posterior-summary request."""
+
+    policy: ResolvedMcmcPolicy
+    coordinate_units: tuple[tuple[str, ParameterUnit], ...]
+    output_units: tuple[tuple[str, ParameterUnit], ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-method-step-mcmc-request-v1",
+                (
+                    self.policy.identity,
+                    tuple((key, value.value) for key, value in self.coordinate_units),
+                    tuple((key, value.value) for key, value in self.output_units),
+                ),
+            ),
+        )
+
+
+type MethodStepDerivationRequest = (
+    UncertaintyDerivationRequest | ResamplingDerivationRequest | McmcDerivationRequest
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DerivationOutcome:
+    """One requested stage disposition referencing its existing source artifacts."""
+
+    request_identity: str
+    stage: str
+    disposition: DerivationDisposition
+    operation_identity: str | None = None
+    artifact_identities: tuple[str, ...] = ()
+    message: str = ""
+    operation: object | None = field(default=None, repr=False, compare=False)
+    artifacts: tuple[object, ...] = field(default=(), repr=False, compare=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.operation is not None and getattr(self.operation, "identity", None) != (
+            self.operation_identity
+        ):
+            raise ValueError("Derivation operation identity differs from its artifact")
+        if self.artifacts and tuple(
+            getattr(item, "identity", None) for item in self.artifacts
+        ) != (self.artifact_identities):
+            raise ValueError("Derivation artifact identities differ from their sources")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-method-step-derivation-outcome-v1",
+                (
+                    self.request_identity,
+                    self.stage,
+                    self.disposition.value,
+                    self.operation_identity,
+                    self.artifact_identities,
+                    self.message,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MethodStepPublicationRequest:
+    """Exact native step-root publication destination and provenance context."""
+
+    path: Path
+    environment: ProvenanceEnvironment
+    baseline_references: tuple[BaselineReference, ...]
+    run_provenance: MethodStepRunProvenanceRequest | None = None
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        destination = Path(self.path).resolve()
+        object.__setattr__(self, "path", destination)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-method-step-publication-request-v1",
+                (
+                    str(destination),
+                    self.environment.identity,
+                    tuple(
+                        (
+                            item.kind,
+                            item.identity,
+                            item.occurrence_identity,
+                            item.result_bundle_identity,
+                        )
+                        for item in self.baseline_references
+                    ),
+                    None
+                    if self.run_provenance is None
+                    else self.run_provenance.identity,
+                    "native-step-root-no-clobber-v1",
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MethodStepRunProvenanceRequest:
+    """Occurrence-owned #609 run-information request captured before execution."""
+
+    output_directory: Path
+    invocation_identity: str
+    inputs: CapturedNativeInputs
+    starting_snapshot: AnalysisValuesSnapshot
+    prior_steps: tuple[PublishedStepReference, ...] = ()
+    argv: tuple[str, ...] = ()
+    working_directory: Path = field(default_factory=Path.cwd)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        output = Path(self.output_directory).resolve()
+        working = Path(self.working_directory).resolve()
+        if not self.invocation_identity.strip():
+            raise ValueError("Run-provenance invocation identity cannot be empty")
+        object.__setattr__(self, "output_directory", output)
+        object.__setattr__(self, "working_directory", working)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-method-step-run-provenance-request-v1",
+                (
+                    str(output),
+                    self.invocation_identity,
+                    self.inputs.identity,
+                    _snapshot_identity(self.starting_snapshot),
+                    tuple(item.identity for item in self.prior_steps),
+                    self.argv,
+                    str(working),
+                ),
+            ),
+        )
+
+
+type MethodStepInvocation = (
+    GroupedDirectTrfInvocation | GridDirectTrfInvocation | DeDirectTrfInvocation
+)
+type MethodStepPrimaryExecution = (
+    GroupedDirectTrfOutcome
+    | GroupedGridDirectTrfOutcome
+    | GridDirectTrfOutcome
+    | DeDirectTrfOutcome
+)
+
+
+def _identity(kind: str, record: object) -> str:
+    encoded = json.dumps(
+        (kind, record),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class _IdentifiedArtifact(Protocol):
+    @property
+    def identity(self) -> str: ...
+
+
+def _snapshot_identity(snapshot: AnalysisValuesSnapshot) -> str:
+    return hashlib.sha256(snapshot.to_json().encode("ascii")).hexdigest()
+
+
+def _direct_policy_semantics(invocation: DirectTrfInvocation) -> tuple[object, ...]:
+    return (
+        invocation.objective_request_budget,
+        tuple(float(value).hex() for value in invocation.x_scale),
+        tuple(
+            None if value is None else float(value).hex()
+            for value in (
+                invocation.ftol,
+                invocation.xtol,
+                invocation.gtol,
+            )
+        ),
+    )
+
+
+def _optimization_semantics(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    strategy: MethodStepStrategy,
+    invocation: MethodStepInvocation,
+) -> dict[str, object]:
+    """Value/lifecycle semantics with occurrence and runtime facts removed."""
+    problem_record = (
+        problem.evaluation_plan_identity,
+        problem.evaluator_parameterization_identity,
+        problem.constraint_program_identity,
+        problem.configuration_identity,
+        tuple((key, float(value).hex()) for key, value in problem.independent_items),
+        problem.controlled_ids,
+        tuple((key, float(value).hex()) for key, value in problem.held_items),
+        tuple(float(value).hex() for value in problem.start),
+        tuple(float(value).hex() for value in problem.lower_bounds),
+        tuple(float(value).hex() for value in problem.upper_bounds),
+        problem.commit_scope,
+        problem.affine_feasibility_identity,
+        problem.scalarization_version,
+    )
+    decomposition_record = tuple(
+        (component.controlled_ids, component.root_profile_indices)
+        for component in decomposition.components
+    )
+    if isinstance(invocation, GroupedDirectTrfInvocation):
+        invocation_record: object = tuple(
+            _direct_policy_semantics(item) for item in invocation.component_invocations
+        )
+    elif isinstance(invocation, GridDirectTrfInvocation):
+        invocation_record = (
+            tuple(axis.identity for axis in invocation.axes),
+            invocation.objective_request_budget,
+            tuple(float(value).hex() for value in invocation.x_scale),
+            tuple(
+                None if value is None else float(value).hex()
+                for value in (invocation.ftol, invocation.xtol, invocation.gtol)
+            ),
+        )
+    else:
+        invocation_record = (
+            tuple(item.identity for item in invocation.search_coordinates),
+            invocation.root_seed,
+            invocation.population.identity,
+            invocation.de_objective_request_budget,
+            invocation.polish_objective_request_budget,
+            invocation.mutation,
+            float(invocation.recombination).hex(),
+            float(invocation.tol).hex(),
+            float(invocation.atol).hex(),
+            tuple(float(value).hex() for value in invocation.polish_x_scale),
+            tuple(
+                None if value is None else float(value).hex()
+                for value in (
+                    invocation.polish_ftol,
+                    invocation.polish_xtol,
+                    invocation.polish_gtol,
+                )
+            ),
+        )
+    return {
+        "kind": "optimization",
+        "strategy": strategy.value,
+        "problem": problem_record,
+        "decomposition": decomposition_record,
+        "invocation": invocation_record,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class MethodStepWorkflow:
+    """One immutable exact native method-step composition root."""
+
+    starting_snapshot: AnalysisValuesSnapshot = field(repr=False, compare=False)
+    parameter_model: SealedParameterModel = field(repr=False, compare=False)
+    parameterization: ActiveParameterization = field(repr=False, compare=False)
+    engine: EvaluationEngine = field(repr=False, compare=False)
+    method: Method = field(repr=False, compare=False)
+    evaluation_purpose: EvaluationPurpose | None = None
+    problem: OptimizationProblem | None = field(default=None, repr=False, compare=False)
+    decomposition: FitDecomposition | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    strategy: MethodStepStrategy | None = None
+    invocation: MethodStepInvocation | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    derivations: tuple[MethodStepDerivationRequest, ...] = ()
+    publication: MethodStepPublicationRequest | None = None
+    semantic_identity: str = field(init=False)
+    binding_identity: str = field(init=False)
+
+    def __post_init__(self) -> None:  # noqa: C901 - closed construction boundary
+        snapshot = self.starting_snapshot
+        program = self.parameterization.program
+        if (
+            self.parameter_model.identity != program.parameter_model_identity
+            or snapshot.occurrence_identity != self.parameterization.occurrence_identity
+            or snapshot.revision != self.parameterization.source_revision
+            or snapshot.model_identity != program.model_identity
+            or snapshot.definitions_identity != program.definitions_identity
+            or snapshot.configuration_identity != program.configuration_identity
+            or self.engine.plan.parameterization_identity
+            != self.parameterization.evaluator_identity
+            or self.engine.plan.constraint_program_identity != program.fingerprint
+        ):
+            raise ValueError("Method-step workflow has an incompatible starting state")
+        retained = self.engine.plan.retained_observation_count
+        if self.evaluation_purpose is not None:
+            if any(
+                value is not None
+                for value in (
+                    self.problem,
+                    self.decomposition,
+                    self.strategy,
+                    self.invocation,
+                )
+            ):
+                raise ValueError("Evaluation-only workflow cannot own optimization")
+            fitted = tuple(
+                param_id
+                for param_id in self.parameterization.independent_ids
+                if self.parameterization.role(param_id) is ParameterRole.FIT
+            )
+            if self.evaluation_purpose is EvaluationPurpose.NO_OBJECTIVE_DATA:
+                if retained:
+                    raise ValueError("NO_OBJECTIVE_DATA requires an empty objective")
+            elif retained < 1:
+                raise ValueError(
+                    "Evaluation-only workflow requires retained objective data"
+                )
+            elif (
+                self.evaluation_purpose is EvaluationPurpose.NO_OPTIMIZATION_REQUIRED
+                and fitted
+            ):
+                raise ValueError(
+                    "NO_OPTIMIZATION_REQUIRED cannot retain controlled coordinates"
+                )
+            primary_record: dict[str, object] = {
+                "kind": "evaluation_only",
+                "purpose": self.evaluation_purpose.value,
+            }
+        else:
+            if (
+                self.problem is None
+                or self.decomposition is None
+                or self.strategy is None
+                or self.invocation is None
+            ):
+                raise ValueError("Optimization workflow is missing its primary inputs")
+            if retained < 1:
+                raise ValueError("Optimization workflow requires objective data")
+            if self.problem.source_snapshot is not snapshot:
+                raise ValueError("Optimization problem has another starting state")
+            try:
+                exact_decomposition = FitDecomposition.from_root(
+                    self.problem,
+                    self.parameterization,
+                    self.engine,
+                )
+            except Exception as error:
+                raise ValueError(
+                    f"Method-step optimization decomposition is invalid: {error}"
+                ) from error
+            if (
+                not self.decomposition.components
+                or exact_decomposition.identity != self.decomposition.identity
+                or self.decomposition.root_problem_identity != self.problem.identity
+            ):
+                raise ValueError(
+                    "Method-step optimization requires its exact non-empty decomposition"
+                )
+            if self.strategy is MethodStepStrategy.DIRECT_TRF:
+                direct_invocation = cast(
+                    "GroupedDirectTrfInvocation",
+                    self.invocation,
+                )
+                supported = isinstance(self.invocation, GroupedDirectTrfInvocation)
+                supported = supported and (
+                    direct_invocation.decomposition_identity
+                    == self.decomposition.identity
+                    and direct_invocation.root_problem_identity == self.problem.identity
+                )
+                if (
+                    supported
+                    and len(
+                        {
+                            item.execution_settings
+                            for item in direct_invocation.component_invocations
+                        }
+                    )
+                    != 1
+                ):
+                    raise ValueError(
+                        "Grouped Direct TRF requires one resolved execution setting"
+                    )
+            elif self.strategy is MethodStepStrategy.GRID_DIRECT_TRF:
+                supported = isinstance(self.invocation, GridDirectTrfInvocation)
+                supported = supported and (
+                    self.invocation.root_problem_identity == self.problem.identity
+                )
+            else:
+                supported = isinstance(self.invocation, DeDirectTrfInvocation)
+                supported = supported and (
+                    self.invocation.root_problem_identity == self.problem.identity
+                    and len(self.decomposition.components) == 1
+                )
+            if not supported:
+                raise ValueError(
+                    "Primary strategy and invocation are unsupported or incompatible"
+                )
+            primary_record = _optimization_semantics(
+                self.problem,
+                self.decomposition,
+                self.strategy,
+                self.invocation,
+            )
+        ordered_derivations = tuple(
+            sorted(
+                self.derivations,
+                key=lambda item: {
+                    "uncertainty": 0,
+                    "resampling": 1,
+                    "mcmc": 2,
+                }[_derivation_stage(item)],
+            )
+        )
+        object.__setattr__(self, "derivations", ordered_derivations)
+        derivation_kinds = tuple(
+            _derivation_stage(item) for item in ordered_derivations
+        )
+        if len(set(derivation_kinds)) != len(derivation_kinds):
+            raise ValueError("Method-step derivation kinds must be unique")
+        if self.evaluation_purpose is not None and self.derivations:
+            raise ValueError("Evaluation-only workflow cannot request fit derivations")
+        for item in self.derivations:
+            if isinstance(item, ResamplingDerivationRequest) and any(
+                len(values) != self.engine.plan.observation_count
+                for values in (
+                    item.references,
+                    item.nucleus_groups,
+                    item.observation_descriptors,
+                )
+            ):
+                raise ValueError(
+                    "Resampling request metadata must cover the exact EvaluationPlan"
+                )
+        semantic_identity = _identity(
+            "native-method-step-workflow-semantics-v1",
+            {
+                "primary": primary_record,
+                "parameter_model_identity": self.parameter_model.identity,
+                "parameterization_program": program.fingerprint,
+                "evaluation_plan_identity": self.engine.plan.identity,
+                "method": self.method.model_dump(mode="json"),
+                "publication": (
+                    None
+                    if self.publication is None
+                    else "native-step-root-no-clobber-v1"
+                ),
+                "derivations": tuple(
+                    (kind, item.identity)
+                    for kind, item in zip(
+                        derivation_kinds,
+                        self.derivations,
+                        strict=True,
+                    )
+                ),
+                "failure_policy": "closed-method-step-failure-v1",
+            },
+        )
+        object.__setattr__(self, "semantic_identity", semantic_identity)
+        object.__setattr__(
+            self,
+            "binding_identity",
+            _identity(
+                "native-method-step-workflow-binding-v1",
+                {
+                    "semantic_identity": semantic_identity,
+                    "starting_state_identity": _snapshot_identity(snapshot),
+                    "occurrence_identity": snapshot.occurrence_identity,
+                    "revision": snapshot.revision,
+                    "parameterization_identity": self.parameterization.identity,
+                    "invocation_identity": (
+                        None if self.invocation is None else self.invocation.identity
+                    ),
+                    "uncertainty_environments": tuple(
+                        item.resolved_environment_identity
+                        for item in self.derivations
+                        if isinstance(item, UncertaintyDerivationRequest)
+                    ),
+                    "publication_request_identity": (
+                        None if self.publication is None else self.publication.identity
+                    ),
+                },
+            ),
+        )
+
+    @classmethod
+    def for_evaluation(
+        cls,
+        *,
+        starting_snapshot: AnalysisValuesSnapshot,
+        parameter_model: SealedParameterModel,
+        parameterization: ActiveParameterization,
+        engine: EvaluationEngine,
+        method: Method,
+        purpose: EvaluationPurpose,
+        publication: MethodStepPublicationRequest | None = None,
+    ) -> Self:
+        """Bind an explicit evaluation-only meaning to exact native inputs."""
+        return cls(
+            starting_snapshot,
+            parameter_model,
+            parameterization,
+            engine,
+            method,
+            evaluation_purpose=purpose,
+            publication=publication,
+        )
+
+    @classmethod
+    def for_optimization(
+        cls,
+        *,
+        starting_snapshot: AnalysisValuesSnapshot,
+        parameter_model: SealedParameterModel,
+        parameterization: ActiveParameterization,
+        engine: EvaluationEngine,
+        method: Method,
+        problem: OptimizationProblem,
+        decomposition: FitDecomposition,
+        strategy: MethodStepStrategy,
+        invocation: MethodStepInvocation,
+        derivations: tuple[MethodStepDerivationRequest, ...] = (),
+        publication: MethodStepPublicationRequest | None = None,
+    ) -> Self:
+        """Bind one explicit supported strategy to its exact decomposition."""
+        return cls(
+            starting_snapshot,
+            parameter_model,
+            parameterization,
+            engine,
+            method,
+            problem=problem,
+            decomposition=decomposition,
+            strategy=strategy,
+            invocation=invocation,
+            derivations=derivations,
+            publication=publication,
+        )
+
+
+@dataclass(frozen=True, slots=True, weakref_slot=True, eq=False)
+class MethodStepOutcome:
+    """Immutable occurrence evidence; live transition authority stays external."""
+
+    workflow_identity: str
+    workflow_binding_identity: str
+    occurrence_identity: str
+    starting_state_identity: str
+    lifecycle: MethodStepLifecycle
+    primary_strategy: MethodStepStrategy | None = None
+    primary_terminal: str | None = None
+    primary_execution_identity: str | None = None
+    evaluation_result_identity: str | None = None
+    evaluation_failure_identity: str | None = None
+    accepted_result_identity: str | None = None
+    commit_operation_identity: str | None = None
+    derivations: tuple[DerivationOutcome, ...] = ()
+    publication_identity: str | None = None
+    publication_failure: str = ""
+    run_provenance_identity: str | None = None
+    successor_state_identity: str | None = None
+    evaluation_result: EvaluationResult | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    evaluation_failure: EvaluationFailure | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    primary_execution: MethodStepPrimaryExecution | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    accepted_result: AcceptedFitResult | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    commit_operation: FitCommitOperation | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    publication: PublishedStepReference | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    run_provenance: NativeRunInformation | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    record_identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.evaluation_result is not None and (
+            self.evaluation_result_identity != self.evaluation_result.identity
+        ):
+            raise ValueError("Method-step evaluation identity differs from its result")
+        if self.evaluation_failure is not None and (
+            self.evaluation_failure_identity != self.evaluation_failure.identity
+        ):
+            raise ValueError("Method-step evaluation identity differs from its failure")
+        if self.accepted_result is not None and (
+            self.accepted_result_identity != self.accepted_result.identity
+        ):
+            raise ValueError("Method-step accepted identity differs from its result")
+        if self.commit_operation is not None and (
+            self.commit_operation_identity != self.commit_operation.identity
+        ):
+            raise ValueError("Method-step commit identity differs from its operation")
+        if self.publication is not None and (
+            self.publication_identity != self.publication.identity
+        ):
+            raise ValueError("Method-step publication identity differs from its source")
+        if self.run_provenance is not None and (
+            self.run_provenance_identity
+            != self.run_provenance.execution_occurrence_identity
+        ):
+            raise ValueError("Method-step run provenance differs from its source")
+        object.__setattr__(
+            self,
+            "record_identity",
+            _identity("native-method-step-outcome-v1", self._record_payload()),
+        )
+
+    def _record_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "workflow_identity": self.workflow_identity,
+            "workflow_binding_identity": self.workflow_binding_identity,
+            "occurrence_identity": self.occurrence_identity,
+            "starting_state_identity": self.starting_state_identity,
+            "lifecycle": self.lifecycle.value,
+            "primary_strategy": (
+                None if self.primary_strategy is None else self.primary_strategy.value
+            ),
+            "primary_terminal": self.primary_terminal,
+            "primary_execution_identity": self.primary_execution_identity,
+            "evaluation_result_identity": self.evaluation_result_identity,
+            "evaluation_failure_identity": self.evaluation_failure_identity,
+            "accepted_result_identity": self.accepted_result_identity,
+            "commit_operation_identity": self.commit_operation_identity,
+            "derivations": [
+                {
+                    "identity": item.identity,
+                    "request_identity": item.request_identity,
+                    "stage": item.stage,
+                    "disposition": item.disposition.value,
+                    "operation_identity": item.operation_identity,
+                    "artifact_identities": list(item.artifact_identities),
+                    "message": item.message,
+                }
+                for item in self.derivations
+            ],
+            "publication_identity": self.publication_identity,
+            "publication_failure": self.publication_failure,
+            "run_provenance_identity": self.run_provenance_identity,
+            "successor_state_identity": self.successor_state_identity,
+        }
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize historical evidence without any process-local authority."""
+        return {**self._record_payload(), "identity": self.record_identity}
+
+    @classmethod
+    def from_record(cls, record: object) -> MethodStepOutcome:
+        """Restore historical evidence without recreating successor authority."""
+        if not isinstance(record, dict):
+            raise TypeError("Method-step outcome record must be a mapping")
+        typed_record = cast("dict[str, object]", record)
+        required = {
+            "schema_version",
+            "workflow_identity",
+            "workflow_binding_identity",
+            "occurrence_identity",
+            "starting_state_identity",
+            "lifecycle",
+            "primary_strategy",
+            "primary_terminal",
+            "primary_execution_identity",
+            "evaluation_result_identity",
+            "evaluation_failure_identity",
+            "accepted_result_identity",
+            "commit_operation_identity",
+            "derivations",
+            "publication_identity",
+            "publication_failure",
+            "run_provenance_identity",
+            "successor_state_identity",
+            "identity",
+        }
+        if set(typed_record) != required or typed_record.get("schema_version") != 1:
+            raise ValueError("Malformed method-step outcome record")
+        if not isinstance(typed_record.get("derivations"), list):
+            raise TypeError("Historical method-step derivations must be a list")
+        derivation_records = cast("list[object]", typed_record["derivations"])
+        derivations: list[DerivationOutcome] = []
+        for raw in derivation_records:
+            if not isinstance(raw, dict):
+                raise TypeError("Historical derivation outcome must be a mapping")
+            item = cast("dict[str, object]", raw)
+            if set(item) != {
+                "identity",
+                "request_identity",
+                "stage",
+                "disposition",
+                "operation_identity",
+                "artifact_identities",
+                "message",
+            } or not isinstance(item["artifact_identities"], list):
+                raise ValueError("Malformed historical derivation outcome")
+            derivation = DerivationOutcome(
+                str(item["request_identity"]),
+                str(item["stage"]),
+                DerivationDisposition(str(item["disposition"])),
+                cast("str | None", item["operation_identity"]),
+                tuple(str(value) for value in item["artifact_identities"]),
+                str(item["message"]),
+            )
+            if item["identity"] != derivation.identity:
+                raise ValueError("Historical derivation identity differs from payload")
+            derivations.append(derivation)
+        outcome = cls(
+            str(typed_record["workflow_identity"]),
+            str(typed_record["workflow_binding_identity"]),
+            str(typed_record["occurrence_identity"]),
+            str(typed_record["starting_state_identity"]),
+            MethodStepLifecycle(str(typed_record["lifecycle"])),
+            (
+                None
+                if typed_record["primary_strategy"] is None
+                else MethodStepStrategy(str(typed_record["primary_strategy"]))
+            ),
+            cast("str | None", typed_record["primary_terminal"]),
+            cast("str | None", typed_record["primary_execution_identity"]),
+            cast("str | None", typed_record["evaluation_result_identity"]),
+            cast("str | None", typed_record["evaluation_failure_identity"]),
+            cast("str | None", typed_record["accepted_result_identity"]),
+            cast("str | None", typed_record["commit_operation_identity"]),
+            tuple(derivations),
+            cast("str | None", typed_record["publication_identity"]),
+            str(typed_record["publication_failure"]),
+            cast("str | None", typed_record["run_provenance_identity"]),
+            cast("str | None", typed_record["successor_state_identity"]),
+        )
+        if typed_record["identity"] != outcome.record_identity:
+            raise ValueError("Method-step outcome identity differs from its payload")
+        return outcome
+
+
+_SUCCESSOR_AUTHORITIES: dict[
+    int,
+    tuple[weakref.ReferenceType[MethodStepOutcome], AnalysisValuesSnapshot, str],
+] = {}
+_PUBLICATION_SOURCES: dict[
+    int,
+    tuple[weakref.ReferenceType[PublishedStepReference], object],
+] = {}
+
+
+def _grant_successor_authority(
+    outcome: MethodStepOutcome,
+    snapshot: AnalysisValuesSnapshot,
+) -> None:
+    key = id(outcome)
+
+    def remove(_reference: weakref.ReferenceType[MethodStepOutcome]) -> None:
+        _SUCCESSOR_AUTHORITIES.pop(key, None)
+
+    _SUCCESSOR_AUTHORITIES[key] = (
+        weakref.ref(outcome, remove),
+        snapshot,
+        outcome.record_identity,
+    )
+
+
+def _retain_publication_source(
+    reference: PublishedStepReference,
+    source: object,
+) -> None:
+    key = id(reference)
+
+    def remove(_reference: weakref.ReferenceType[PublishedStepReference]) -> None:
+        _PUBLICATION_SOURCES.pop(key, None)
+
+    _PUBLICATION_SOURCES[key] = (weakref.ref(reference, remove), source)
+
+
+def require_successor_state(
+    outcome: MethodStepOutcome,
+    analysis_values: AnalysisValues,
+) -> AnalysisValuesSnapshot:
+    """Return the exact live successor or reject historical/failed evidence."""
+    binding = _SUCCESSOR_AUTHORITIES.get(id(outcome))
+    if (
+        binding is None
+        or binding[0]() is not outcome
+        or binding[2] != outcome.record_identity
+        or analysis_values.snapshot() != binding[1]
+    ):
+        raise ValueError("Method-step outcome has no live successor authority")
+    return binding[1]
+
+
+def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycle
+    workflow: MethodStepWorkflow,
+    *,
+    analysis_values: AnalysisValues,
+    cancellation: CancellationToken | None = None,
+    checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None = None,
+) -> MethodStepOutcome:
+    """Execute one exact native workflow occurrence."""
+    current = analysis_values.snapshot()
+    if current != workflow.starting_snapshot:
+        raise ValueError("Method-step workflow no longer has its exact starting state")
+    starting_state_identity = _snapshot_identity(workflow.starting_snapshot)
+    if workflow.evaluation_purpose is None:
+        return _execute_optimization(
+            workflow,
+            analysis_values=analysis_values,
+            cancellation=cancellation,
+            checkpoint_observer=checkpoint_observer,
+        )
+    if workflow.evaluation_purpose is EvaluationPurpose.NO_OBJECTIVE_DATA:
+        publication: PublishedStepReference | None = None
+        run_provenance: NativeRunInformation | None = None
+        publication_failure = ""
+        if workflow.publication is not None:
+            try:
+                publication = _publish_no_objective_method_step(workflow)
+                run_provenance = _publish_run_provenance(workflow, publication)
+            except Exception as error:  # noqa: BLE001 - typed outcome stays truthful
+                publication_failure = f"{type(error).__name__}: {error}"
+        return MethodStepOutcome(
+            workflow.semantic_identity,
+            workflow.binding_identity,
+            uuid4().hex,
+            starting_state_identity,
+            MethodStepLifecycle.NO_OBJECTIVE_DATA,
+            publication_identity=(
+                None if publication is None else publication.identity
+            ),
+            publication_failure=publication_failure,
+            run_provenance_identity=(
+                None
+                if run_provenance is None
+                else run_provenance.execution_occurrence_identity
+            ),
+            publication=publication,
+            run_provenance=run_provenance,
+        )
+    frame = EvaluationFrame.from_lifecycle_frame(
+        workflow.parameterization,
+        workflow.parameterization.frame_from_snapshot(workflow.starting_snapshot),
+    )
+    result = workflow.engine.new_evaluator().evaluate(frame)
+    if isinstance(result, EvaluationFailure):
+        publication: PublishedStepReference | None = None
+        run_provenance: NativeRunInformation | None = None
+        publication_failure = ""
+        if workflow.publication is not None:
+            try:
+                publication = _publish_evaluation_failure_method_step(workflow, result)
+                run_provenance = _publish_run_provenance(workflow, publication)
+            except Exception as error:  # noqa: BLE001 - failure evidence remains truthful
+                publication_failure = f"{type(error).__name__}: {error}"
+        return MethodStepOutcome(
+            workflow.semantic_identity,
+            workflow.binding_identity,
+            uuid4().hex,
+            starting_state_identity,
+            MethodStepLifecycle.FAILED,
+            evaluation_failure_identity=result.identity,
+            publication_identity=(
+                None if publication is None else publication.identity
+            ),
+            publication_failure=publication_failure,
+            run_provenance_identity=(
+                None
+                if run_provenance is None
+                else run_provenance.execution_occurrence_identity
+            ),
+            evaluation_failure=result,
+            publication=publication,
+            run_provenance=run_provenance,
+        )
+    publication: PublishedStepReference | None = None
+    run_provenance: NativeRunInformation | None = None
+    publication_failure = ""
+    lifecycle = MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE
+    if workflow.publication is not None:
+        try:
+            publication = _publish_evaluation_method_step(workflow, result)
+            run_provenance = _publish_run_provenance(workflow, publication)
+        except Exception as error:  # noqa: BLE001 - evaluated evidence remains truthful
+            lifecycle = MethodStepLifecycle.PUBLICATION_FAILED
+            publication_failure = f"{type(error).__name__}: {error}"
+    outcome = MethodStepOutcome(
+        workflow.semantic_identity,
+        workflow.binding_identity,
+        uuid4().hex,
+        starting_state_identity,
+        lifecycle,
+        evaluation_result_identity=result.identity,
+        publication_identity=(None if publication is None else publication.identity),
+        publication_failure=publication_failure,
+        run_provenance_identity=(
+            None
+            if run_provenance is None
+            else run_provenance.execution_occurrence_identity
+        ),
+        successor_state_identity=(
+            starting_state_identity
+            if lifecycle is MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE
+            else None
+        ),
+        evaluation_result=result,
+        publication=publication,
+        run_provenance=run_provenance,
+    )
+    if lifecycle is MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE:
+        _grant_successor_authority(outcome, workflow.starting_snapshot)
+    return outcome
+
+
+def _primary_execution_identity(execution: MethodStepPrimaryExecution) -> str:
+    if isinstance(execution, GroupedGridDirectTrfOutcome):
+        return _identity(
+            "native-method-step-grouped-grid-execution",
+            (
+                execution.terminal.value,
+                tuple(item.identity for item in execution.attempts),
+                None
+                if execution.accepted_result is None
+                else execution.accepted_result.identity,
+                None if execution.failure is None else execution.failure.identity,
+            ),
+        )
+    if isinstance(execution, GroupedDirectTrfOutcome):
+        return _identity(
+            "native-method-step-grouped-direct-execution",
+            (
+                execution.terminal.value,
+                tuple(item.identity for item in execution.components),
+                None
+                if execution.accepted_result is None
+                else execution.accepted_result.identity,
+                None if execution.failure is None else execution.failure.identity,
+            ),
+        )
+    if isinstance(execution, GridDirectTrfOutcome):
+        return _identity(
+            "native-method-step-grid-execution",
+            (
+                execution.terminal.value,
+                tuple(item.identity for item in execution.attempts),
+                None
+                if execution.accepted_result is None
+                else execution.accepted_result.identity,
+                None if execution.failure is None else execution.failure.identity,
+            ),
+        )
+    return _identity(
+        "native-method-step-de-execution",
+        (
+            execution.terminal.value,
+            execution.search.identity,
+            execution.accounting.identity,
+            None
+            if execution.accepted_result is None
+            else execution.accepted_result.identity,
+            None if execution.failure is None else execution.failure.identity,
+        ),
+    )
+
+
+def _execute_optimization(  # noqa: C901 - closed primary transition
+    workflow: MethodStepWorkflow,
+    *,
+    analysis_values: AnalysisValues,
+    cancellation: CancellationToken | None,
+    checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None,
+) -> MethodStepOutcome:
+    problem = cast("OptimizationProblem", workflow.problem)
+    decomposition = cast("FitDecomposition", workflow.decomposition)
+    strategy = cast("MethodStepStrategy", workflow.strategy)
+    invocation = cast("MethodStepInvocation", workflow.invocation)
+    token = CancellationToken() if cancellation is None else cancellation
+    try:
+        if strategy is MethodStepStrategy.DIRECT_TRF:
+            execution: MethodStepPrimaryExecution = execute_grouped_direct_trf(
+                problem,
+                decomposition,
+                cast("GroupedDirectTrfInvocation", invocation),
+                workflow.parameterization,
+                workflow.engine,
+                cancellation=token,
+            )
+        elif strategy is MethodStepStrategy.GRID_DIRECT_TRF:
+            execution = execute_grouped_grid_direct_trf(
+                problem,
+                decomposition,
+                cast("GridDirectTrfInvocation", invocation),
+                workflow.parameterization,
+                workflow.engine,
+                cancellation=token,
+            )
+        else:
+            execution = execute_de_direct_trf(
+                problem,
+                cast("DeDirectTrfInvocation", invocation),
+                workflow.parameterization,
+                workflow.engine,
+                cancellation=token,
+            )
+    except GridDirectTrfInterrupted as error:
+        execution = error.outcome
+    except DeDirectTrfInterrupted as error:
+        execution = error.outcome
+    primary_identity = _primary_execution_identity(execution)
+    terminal = execution.terminal
+    accepted = execution.accepted_result
+    authority = execution.commit_authority
+    if accepted is None or authority is None:
+        if terminal.value == "cancelled":
+            lifecycle = MethodStepLifecycle.CANCELLED
+        elif terminal.value == "interrupted":
+            lifecycle = MethodStepLifecycle.INTERRUPTED
+        else:
+            lifecycle = MethodStepLifecycle.FAILED
+        derivations = (
+            _stopped_derivations(workflow.derivations)
+            if lifecycle
+            in {MethodStepLifecycle.CANCELLED, MethodStepLifecycle.INTERRUPTED}
+            else tuple(
+                DerivationOutcome(
+                    item.identity,
+                    _derivation_stage(item),
+                    DerivationDisposition.BLOCKED_BY_PREREQUISITE,
+                    message="Successful aggregate acceptance prerequisite was unavailable",
+                )
+                for item in workflow.derivations
+            )
+        )
+        publication: PublishedStepReference | None = None
+        run_provenance: NativeRunInformation | None = None
+        publication_failure = ""
+        if workflow.publication is not None:
+            try:
+                publication = _publish_suppressed_method_step(
+                    workflow,
+                    execution,
+                    primary_identity,
+                    lifecycle,
+                )
+                run_provenance = _publish_run_provenance(workflow, publication)
+            except Exception as error:  # noqa: BLE001 - primary evidence remains truthful
+                publication_failure = f"{type(error).__name__}: {error}"
+        return MethodStepOutcome(
+            workflow.semantic_identity,
+            workflow.binding_identity,
+            uuid4().hex,
+            _snapshot_identity(workflow.starting_snapshot),
+            lifecycle,
+            strategy,
+            terminal.value,
+            primary_identity,
+            derivations=derivations,
+            publication_identity=(
+                None if publication is None else publication.identity
+            ),
+            publication_failure=publication_failure,
+            run_provenance_identity=(
+                None
+                if run_provenance is None
+                else run_provenance.execution_occurrence_identity
+            ),
+            primary_execution=execution,
+            publication=publication,
+            run_provenance=run_provenance,
+        )
+    if checkpoint_observer is not None:
+        checkpoint_observer(MethodStepCheckpoint.AGGREGATE_ACCEPTED)
+    if token.is_cancelled:
+        derivations = _stopped_derivations(workflow.derivations)
+        publication: PublishedStepReference | None = None
+        run_provenance: NativeRunInformation | None = None
+        publication_failure = ""
+        if workflow.publication is not None:
+            try:
+                publication = _publish_suppressed_method_step(
+                    workflow,
+                    execution,
+                    primary_identity,
+                    MethodStepLifecycle.CANCELLED,
+                    accepted=accepted,
+                    terminal="cancelled",
+                )
+                run_provenance = _publish_run_provenance(workflow, publication)
+            except Exception as error:  # noqa: BLE001 - accepted evidence stays truthful
+                publication_failure = f"{type(error).__name__}: {error}"
+        return MethodStepOutcome(
+            workflow.semantic_identity,
+            workflow.binding_identity,
+            uuid4().hex,
+            _snapshot_identity(workflow.starting_snapshot),
+            MethodStepLifecycle.CANCELLED,
+            strategy,
+            "cancelled",
+            primary_identity,
+            accepted_result_identity=accepted.identity,
+            derivations=derivations,
+            publication_identity=(
+                None if publication is None else publication.identity
+            ),
+            publication_failure=publication_failure,
+            run_provenance_identity=(
+                None
+                if run_provenance is None
+                else run_provenance.execution_occurrence_identity
+            ),
+            primary_execution=execution,
+            accepted_result=accepted,
+            publication=publication,
+            run_provenance=run_provenance,
+        )
+    if strategy is MethodStepStrategy.GRID_DIRECT_TRF:
+        validate_grid_commit_lineage(
+            cast("AcceptedGridDirectTrfResult", accepted),
+            problem,
+        )
+    elif strategy is MethodStepStrategy.DE_DIRECT_TRF:
+        validate_de_commit_lineage(
+            cast("AcceptedDeDirectTrfResult", accepted),
+            problem,
+        )
+    operation = execute_fit_commit(
+        accepted,
+        authority,
+        problem=problem,
+        parameterization=workflow.parameterization,
+        analysis_values=analysis_values,
+    )
+    if checkpoint_observer is not None:
+        checkpoint_observer(MethodStepCheckpoint.COMMIT_COMPLETED)
+    committed = operation.terminal is FitCommitTerminal.COMMITTED
+    successor = operation.committed_snapshot if committed else None
+    derivations = (
+        _execute_derivations(workflow, accepted, token)
+        if committed
+        else tuple(
+            DerivationOutcome(
+                item.identity,
+                _derivation_stage(item),
+                DerivationDisposition.BLOCKED_BY_PREREQUISITE,
+                message="Successful fit commit prerequisite was unavailable",
+            )
+            for item in workflow.derivations
+        )
+    )
+    publication: PublishedStepReference | None = None
+    run_provenance: NativeRunInformation | None = None
+    publication_failure = ""
+    lifecycle = (
+        MethodStepLifecycle.COMMITTED
+        if committed
+        else MethodStepLifecycle.ACCEPTED_UNCOMMITTED
+    )
+    if workflow.publication is not None:
+        try:
+            if committed:
+                publication = _publish_committed_method_step(
+                    workflow,
+                    execution,
+                    primary_identity,
+                    accepted,
+                    operation,
+                    derivations,
+                    analysis_values,
+                )
+            else:
+                publication = _publish_suppressed_method_step(
+                    workflow,
+                    execution,
+                    primary_identity,
+                    MethodStepLifecycle.ACCEPTED_UNCOMMITTED,
+                    operation=operation,
+                    accepted=accepted,
+                )
+            run_provenance = _publish_run_provenance(workflow, publication)
+        except Exception as error:  # noqa: BLE001 - commit remains authoritative
+            if committed:
+                lifecycle = MethodStepLifecycle.PUBLICATION_FAILED
+            publication_failure = f"{type(error).__name__}: {error}"
+    outcome = MethodStepOutcome(
+        workflow.semantic_identity,
+        workflow.binding_identity,
+        uuid4().hex,
+        _snapshot_identity(workflow.starting_snapshot),
+        lifecycle,
+        strategy,
+        terminal.value,
+        primary_identity,
+        accepted_result_identity=accepted.identity,
+        commit_operation_identity=operation.identity,
+        derivations=derivations,
+        publication_identity=(None if publication is None else publication.identity),
+        publication_failure=publication_failure,
+        run_provenance_identity=(
+            None
+            if run_provenance is None
+            else run_provenance.execution_occurrence_identity
+        ),
+        successor_state_identity=(
+            None if successor is None else _snapshot_identity(successor)
+        ),
+        primary_execution=execution,
+        accepted_result=accepted,
+        commit_operation=operation,
+        publication=publication,
+        run_provenance=run_provenance,
+    )
+    if successor is not None and lifecycle is MethodStepLifecycle.COMMITTED:
+        _grant_successor_authority(outcome, successor)
+    return outcome
+
+
+def _method_step_primary_record(
+    workflow: MethodStepWorkflow,
+    execution: MethodStepPrimaryExecution,
+    aggregate_execution_identity: str,
+    accepted: AcceptedFitResult | None,
+    *,
+    terminal: MethodStepPrimaryTerminal | None = None,
+) -> MethodStepPrimaryRecord:
+    decomposition = cast("FitDecomposition", workflow.decomposition)
+    invocation = cast("MethodStepInvocation", workflow.invocation)
+    grouping = tuple(
+        (component.identity, component.controlled_ids)
+        for component in decomposition.components
+    )
+    if isinstance(invocation, GroupedDirectTrfInvocation):
+        limit = sum(
+            item.objective_request_budget for item in invocation.component_invocations
+        )
+        settings = invocation.component_invocations[0].execution_settings
+        used = None
+        seeds: tuple[SeedRecord, ...] = ()
+    elif isinstance(invocation, GridDirectTrfInvocation):
+        limit = invocation.objective_request_budget * len(invocation.seeds)
+        settings = ExecutionSettings()
+        used = None
+        seeds = ()
+    else:
+        de_execution = cast("DeDirectTrfOutcome", execution)
+        limit = (
+            invocation.de_objective_request_budget
+            + invocation.polish_objective_request_budget
+        )
+        settings = ExecutionSettings()
+        used = de_execution.accounting.de_counters.objective_requests_accepted + (
+            0
+            if de_execution.accounting.polish_counters is None
+            else de_execution.accounting.polish_counters.objective_requests_accepted
+        )
+        seeds = (
+            SeedRecord("primary_de_root", invocation.root_seed, invocation.identity),
+        )
+    strategy = cast("MethodStepStrategy", workflow.strategy)
+    return MethodStepPrimaryRecord(
+        workflow.semantic_identity,
+        cast("OptimizationProblem", workflow.problem).identity,
+        invocation.identity if accepted is None else accepted.invocation_identity,
+        (
+            aggregate_execution_identity
+            if accepted is None
+            else accepted.execution_identity
+        ),
+        aggregate_execution_identity,
+        execution.terminal.value if terminal is None else terminal,
+        grouping,
+        settings,
+        PolicyRecord(f"primary_{strategy.value}", invocation.identity),
+        BudgetRecord(f"primary_{strategy.value}_objective_requests", limit, used),
+        seeds,
+    )
+
+
+def _components_for_publication(
+    workflow: MethodStepWorkflow,
+    execution: MethodStepPrimaryExecution,
+) -> tuple[ComponentDiagnostic, ...]:
+    decomposition = cast("FitDecomposition", workflow.decomposition)
+    if isinstance(execution, GroupedDirectTrfOutcome):
+        return tuple(
+            ComponentDiagnostic(
+                item.identity,
+                item.disposition.value,
+                item.controlled_ids,
+                None if item.candidate is None else item.candidate.chi_square,
+            )
+            for item in execution.components
+        )
+    if isinstance(execution, GroupedGridDirectTrfOutcome):
+        selected = None
+        if execution.selection is not None:
+            selected = execution.selection.selected_record
+        components = (
+            tuple(
+                component
+                for attempt in execution.attempts
+                for component in attempt.components
+            )
+            if selected is None
+            else cast("GroupedGridSeedOutcome", selected).components
+        )
+        return tuple(
+            ComponentDiagnostic(
+                item.identity,
+                item.disposition.value,
+                item.controlled_ids,
+                None if item.candidate is None else item.candidate.chi_square,
+            )
+            for item in components
+        )
+    terminal = execution.terminal.value
+    disposition = (
+        "succeeded"
+        if terminal == "accepted"
+        else terminal
+        if terminal in {"cancelled", "interrupted"}
+        else "failed"
+    )
+    return tuple(
+        ComponentDiagnostic(
+            component.identity,
+            disposition,
+            component.controlled_ids,
+        )
+        for component in decomposition.components
+    )
+
+
+def _publication_evidence(
+    workflow: MethodStepWorkflow,
+    derivations: tuple[DerivationOutcome, ...],
+) -> tuple[
+    UncertaintyEvidence | None,
+    tuple[ResamplingPublication, ...],
+    McmcPublication | None,
+    tuple[ResamplingEvidence, ...],
+    tuple[ResamplingSummaryFailurePublication, ...],
+    McmcEvidence | None,
+]:
+    uncertainty: UncertaintyEvidence | None = None
+    resampling: list[ResamplingPublication] = []
+    mcmc: McmcPublication | None = None
+    partial_resampling: list[ResamplingEvidence] = []
+    resampling_summary_failures: list[ResamplingSummaryFailurePublication] = []
+    partial_mcmc: McmcEvidence | None = None
+    requests = {item.identity: item for item in workflow.derivations}
+    for outcome in derivations:
+        request = requests[outcome.request_identity]
+        if isinstance(request, UncertaintyDerivationRequest):
+            if outcome.artifacts:
+                uncertainty = cast("UncertaintyEvidence", outcome.artifacts[0])
+        elif isinstance(request, ResamplingDerivationRequest):
+            if not outcome.artifacts:
+                continue
+            evidence = cast("ResamplingEvidence", outcome.artifacts[0])
+            if outcome.disposition is DerivationDisposition.COMPLETED:
+                summary = summarize_resampling_evidence(
+                    evidence,
+                    request.summary_policy,
+                )
+                resampling.append(
+                    ResamplingPublication(
+                        evidence,
+                        summary,
+                    )
+                )
+            elif (
+                evidence.lifecycle.value == "completed"
+                and len(outcome.artifacts) > 1
+                and isinstance(outcome.artifacts[1], SummaryFailure)
+            ):
+                resampling_summary_failures.append(
+                    ResamplingSummaryFailurePublication(
+                        evidence,
+                        outcome.artifacts[1],
+                    )
+                )
+            else:
+                partial_resampling.append(evidence)
+        else:
+            if not outcome.artifacts:
+                continue
+            evidence = cast("McmcEvidence", outcome.artifacts[0])
+            if outcome.disposition is DerivationDisposition.COMPLETED:
+                posterior = cast("PosteriorSampleEvidence", outcome.artifacts[1])
+                summary = cast("PosteriorSummary", outcome.artifacts[2])
+                mcmc = McmcPublication(evidence, posterior, summary)
+            else:
+                partial_mcmc = evidence
+    return (
+        uncertainty,
+        tuple(resampling),
+        mcmc,
+        tuple(partial_resampling),
+        tuple(resampling_summary_failures),
+        partial_mcmc,
+    )
+
+
+def _method_step_provenance(
+    workflow: MethodStepWorkflow,
+    primary: MethodStepPrimaryRecord | None,
+    *,
+    policies: tuple[PolicyRecord, ...] = (),
+    budgets: tuple[BudgetRecord, ...] = (),
+    seeds: tuple[SeedRecord, ...] = (),
+) -> WorkflowProvenance:
+    request = cast("MethodStepPublicationRequest", workflow.publication)
+    grouping = (
+        (("aggregate", workflow.parameterization.independent_ids),)
+        if primary is None
+        else primary.grouping_topology
+    )
+    execution = ExecutionSettings() if primary is None else primary.execution_settings
+    return WorkflowProvenance.create_method_step(
+        parameterization=workflow.parameterization,
+        plan=workflow.engine.plan,
+        method=workflow.method,
+        semantic_workflow_identity=workflow.semantic_identity,
+        grouping_topology=grouping,
+        policies=policies,
+        budgets=budgets,
+        seeds=seeds,
+        execution=execution,
+        environment=request.environment,
+        baseline_references=request.baseline_references,
+    )
+
+
+def _publish_evaluation_method_step(
+    workflow: MethodStepWorkflow,
+    result: EvaluationResult,
+) -> PublishedStepReference:
+    request = cast("MethodStepPublicationRequest", workflow.publication)
+    provenance = _method_step_provenance(workflow, None)
+    publication = EvaluationPublication(
+        workflow.engine.plan,
+        workflow.method,
+        workflow.parameterization,
+        result,
+        provenance=provenance,
+        method_step_semantic_identity=workflow.semantic_identity,
+        allow_controlled=(
+            workflow.evaluation_purpose is EvaluationPurpose.EVALUATE_ONLY
+        ),
+    )
+    reference = publish_native_results(
+        request.path,
+        publication,
+    )
+    _retain_publication_source(reference, publication)
+    return reference
+
+
+def _publish_evaluation_failure_method_step(
+    workflow: MethodStepWorkflow,
+    failure: EvaluationFailure,
+) -> PublishedStepReference:
+    request = cast("MethodStepPublicationRequest", workflow.publication)
+    publication = SuppressedPublication(
+        "failed",
+        failure,
+        workflow.engine.plan,
+        workflow.method,
+        workflow.parameterization,
+        provenance=_method_step_provenance(workflow, None),
+        method_step_semantic_identity=workflow.semantic_identity,
+    )
+    reference = publish_native_results(request.path, publication)
+    _retain_publication_source(reference, publication)
+    return reference
+
+
+def _publish_no_objective_method_step(
+    workflow: MethodStepWorkflow,
+) -> PublishedStepReference:
+    request = cast("MethodStepPublicationRequest", workflow.publication)
+    publication = NoObjectivePublication(
+        workflow.engine.plan,
+        workflow.method,
+        workflow.parameterization,
+        workflow.semantic_identity,
+        provenance=_method_step_provenance(workflow, None),
+    )
+    reference = publish_native_results(request.path, publication)
+    _retain_publication_source(reference, publication)
+    return reference
+
+
+def _publish_suppressed_method_step(
+    workflow: MethodStepWorkflow,
+    execution: MethodStepPrimaryExecution,
+    aggregate_execution_identity: str,
+    lifecycle: MethodStepLifecycle,
+    *,
+    operation: FitCommitOperation | None = None,
+    accepted: AcceptedFitResult | None = None,
+    terminal: MethodStepPrimaryTerminal | None = None,
+) -> PublishedStepReference:
+    request = cast("MethodStepPublicationRequest", workflow.publication)
+    primary = _method_step_primary_record(
+        workflow,
+        execution,
+        aggregate_execution_identity,
+        accepted,
+        terminal=terminal,
+    )
+    provenance = _method_step_provenance(
+        workflow,
+        primary,
+        policies=(primary.policy,),
+        budgets=(primary.budget,),
+        seeds=primary.seeds,
+    )
+    suppressed_lifecycle = cast(
+        "Literal['failed', 'accepted_uncommitted', 'cancelled', 'interrupted']",
+        lifecycle.value,
+    )
+    publication = SuppressedPublication(
+        suppressed_lifecycle,
+        primary if operation is None else operation,
+        workflow.engine.plan,
+        workflow.method,
+        workflow.parameterization,
+        provenance=provenance,
+        primary_invocation=primary,
+        primary_execution=primary,
+        primary_problem=cast("OptimizationProblem", workflow.problem),
+        accepted_result_identity=(None if accepted is None else accepted.identity),
+        accepted_occurrence_identity=(
+            None if accepted is None else accepted.occurrence_identity
+        ),
+        components=_components_for_publication(workflow, execution),
+    )
+    reference = publish_native_results(
+        request.path,
+        publication,
+    )
+    _retain_publication_source(reference, publication)
+    return reference
+
+
+def _publish_run_provenance(
+    workflow: MethodStepWorkflow,
+    publication: PublishedStepReference,
+) -> NativeRunInformation | None:
+    publication_request = cast("MethodStepPublicationRequest", workflow.publication)
+    request = publication_request.run_provenance
+    if request is None:
+        return None
+    run = NativeRunInformation(
+        request.invocation_identity,
+        request.inputs,
+        workflow.parameter_model,
+        request.starting_snapshot,
+        (*request.prior_steps, publication),
+    )
+    write_native_run_info(
+        Namespace(output=request.output_directory),
+        run,
+        argv=request.argv,
+        working_directory=request.working_directory,
+    )
+    return run
+
+
+def _publish_committed_method_step(
+    workflow: MethodStepWorkflow,
+    execution: MethodStepPrimaryExecution,
+    aggregate_execution_identity: str,
+    accepted: AcceptedFitResult,
+    operation: FitCommitOperation,
+    derivations: tuple[DerivationOutcome, ...],
+    analysis_values: AnalysisValues,
+) -> PublishedStepReference:
+    request = cast("MethodStepPublicationRequest", workflow.publication)
+    if operation.receipt is None or operation.committed_snapshot is None:
+        raise ValueError("Committed publication requires exact commit artifacts")
+    primary = _method_step_primary_record(
+        workflow,
+        execution,
+        aggregate_execution_identity,
+        accepted,
+    )
+    (
+        uncertainty,
+        resampling,
+        mcmc,
+        partial_resampling,
+        resampling_summary_failures,
+        partial_mcmc,
+    ) = _publication_evidence(workflow, derivations)
+    policies, budgets, seeds = publication_provenance_records(
+        primary,
+        uncertainty=uncertainty,
+        resampling=(
+            *(item.evidence for item in resampling),
+            *partial_resampling,
+            *(item.evidence for item in resampling_summary_failures),
+        ),
+        mcmc=(partial_mcmc if mcmc is None else mcmc.evidence),
+    )
+    provenance = WorkflowProvenance.create_method_step(
+        parameterization=workflow.parameterization,
+        plan=workflow.engine.plan,
+        method=workflow.method,
+        semantic_workflow_identity=workflow.semantic_identity,
+        grouping_topology=primary.grouping_topology,
+        policies=policies,
+        budgets=budgets,
+        seeds=seeds,
+        execution=primary.execution_settings,
+        environment=request.environment,
+        baseline_references=request.baseline_references,
+    )
+    publication = CommittedFitPublication(
+        workflow.engine.plan,
+        workflow.method,
+        workflow.parameterization,
+        workflow.parameter_model,
+        workflow.starting_snapshot,
+        cast("OptimizationProblem", workflow.problem),
+        primary,
+        primary,
+        accepted,
+        operation.receipt,
+        operation.committed_snapshot,
+        operation,
+        analysis_values,
+        provenance=provenance,
+        components=_components_for_publication(workflow, execution),
+        uncertainty=uncertainty,
+        resampling=resampling,
+        mcmc=mcmc,
+        partial_resampling=partial_resampling,
+        resampling_summary_failures=resampling_summary_failures,
+        partial_mcmc=partial_mcmc,
+    )
+    reference = publish_native_results(
+        request.path,
+        publication,
+    )
+    _retain_publication_source(reference, publication)
+    return reference
+
+
+def _derivation_stage(request: MethodStepDerivationRequest) -> str:
+    if isinstance(request, UncertaintyDerivationRequest):
+        return "uncertainty"
+    if isinstance(request, ResamplingDerivationRequest):
+        return "resampling"
+    return "mcmc"
+
+
+def _stopped_derivations(
+    requests: tuple[MethodStepDerivationRequest, ...],
+) -> tuple[DerivationOutcome, ...]:
+    return tuple(
+        DerivationOutcome(
+            item.identity,
+            _derivation_stage(item),
+            DerivationDisposition.NOT_STARTED_BY_WORKFLOW_STOP,
+            message="Workflow stop was observed before the requested stage started",
+        )
+        for item in requests
+    )
+
+
+def _execute_derivations(
+    workflow: MethodStepWorkflow,
+    accepted: AcceptedFitResult,
+    cancellation: CancellationToken,
+) -> tuple[DerivationOutcome, ...]:
+    outcomes: list[DerivationOutcome] = []
+    for index, request in enumerate(workflow.derivations):
+        if cancellation.is_cancelled:
+            outcomes.extend(_stopped_derivations(workflow.derivations[index:]))
+            break
+        try:
+            if isinstance(request, UncertaintyDerivationRequest):
+                outcome = _execute_uncertainty(
+                    workflow, accepted, request, cancellation
+                )
+            elif isinstance(request, ResamplingDerivationRequest):
+                outcome = _execute_resampling(workflow, accepted, request, cancellation)
+            else:
+                outcome = _execute_mcmc(workflow, accepted, request, cancellation)
+        except KeyboardInterrupt:
+            outcomes.append(
+                DerivationOutcome(
+                    request.identity,
+                    _derivation_stage(request),
+                    DerivationDisposition.INTERRUPTED,
+                    message="Derivation was interrupted",
+                )
+            )
+            outcomes.extend(_stopped_derivations(workflow.derivations[index + 1 :]))
+            break
+        except Exception as error:  # noqa: BLE001 - branch-local typed evidence
+            outcomes.append(
+                DerivationOutcome(
+                    request.identity,
+                    _derivation_stage(request),
+                    DerivationDisposition.FAILED,
+                    message=f"{type(error).__name__}: {error}",
+                )
+            )
+            continue
+        outcomes.append(outcome)
+        if outcome.disposition in {
+            DerivationDisposition.CANCELLED,
+            DerivationDisposition.INTERRUPTED,
+        }:
+            outcomes.extend(_stopped_derivations(workflow.derivations[index + 1 :]))
+            break
+    return tuple(outcomes)
+
+
+def _execute_uncertainty(
+    workflow: MethodStepWorkflow,
+    accepted: AcceptedFitResult,
+    request: UncertaintyDerivationRequest,
+    cancellation: CancellationToken,
+) -> DerivationOutcome:
+    problem = cast("OptimizationProblem", workflow.problem)
+
+    def cancellation_probe() -> UncertaintyOperationTerminal | None:
+        return (
+            UncertaintyOperationTerminal.CANCELLED
+            if cancellation.is_cancelled
+            else None
+        )
+
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=workflow.parameterization,
+        engine=workflow.engine,
+        policy=request.policy,
+        constrained_scope=request.constrained_scope,
+        constrained_units=request.constrained_units,
+        constrained_scales=request.constrained_scales,
+        compiled_constraint_linearization=request.compiled_capabilities,
+        cancellation_probe=cancellation_probe,
+        resolved_environment_identity=request.resolved_environment_identity,
+    )
+    terminals = {item.terminal for item in evidence.operations}
+    disposition = (
+        DerivationDisposition.CANCELLED
+        if UncertaintyOperationTerminal.CANCELLED in terminals
+        else DerivationDisposition.INTERRUPTED
+        if UncertaintyOperationTerminal.INTERRUPTED in terminals
+        else DerivationDisposition.FAILED
+        if evidence.failures
+        else DerivationDisposition.COMPLETED
+    )
+    return DerivationOutcome(
+        request.identity,
+        "uncertainty",
+        disposition,
+        artifact_identities=(evidence.identity,),
+        artifacts=(evidence,),
+    )
+
+
+def _execute_resampling(
+    workflow: MethodStepWorkflow,
+    accepted: AcceptedFitResult,
+    request: ResamplingDerivationRequest,
+    cancellation: CancellationToken,
+) -> DerivationOutcome:
+    plan = ResamplingPlan.for_accepted(
+        accepted,
+        dataset=ResamplingDatasetManifest(
+            workflow.engine.plan,
+            tuple(
+                float(value)
+                for value in accepted.evaluation_result.normalized_calculations
+            ),
+            request.references,
+            request.nucleus_groups,
+            request.observation_descriptors,
+        ),
+        source_problem=cast("OptimizationProblem", workflow.problem),
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        scheme=request.scheme,
+        replicate_count=request.replicate_count,
+        replicate_structural_identities=request.replicate_structural_identities,
+        replicate_component_identities=request.replicate_component_identities,
+        root_seed=request.root_seed,
+        output_scope=request.output_scope,
+        output_units=request.output_units,
+        minimum_successful_count=request.minimum_successful_count,
+        strategy=request.strategy,
+        strategy_settings=request.strategy_settings,
+    )
+    operation = execute_resampling_evidence(
+        accepted,
+        plan,
+        cancellation_probe=lambda: cancellation.is_cancelled,
+    )
+    artifacts: list[_IdentifiedArtifact] = []
+    if operation.evidence is not None:
+        artifacts.append(operation.evidence)
+        summary = summarize_resampling_evidence(
+            operation.evidence,
+            request.summary_policy,
+        )
+        summary_payload = (
+            summary.summary if summary.summary is not None else summary.failure
+        )
+        if summary_payload is not None:
+            artifacts.append(summary_payload)
+        summary_failed = summary.terminal.value != "completed"
+    else:
+        summary_failed = False
+    disposition = (
+        DerivationDisposition.CANCELLED
+        if operation.terminal is ResamplingOperationTerminal.CANCELLED
+        else DerivationDisposition.INTERRUPTED
+        if operation.terminal is ResamplingOperationTerminal.INTERRUPTED
+        else DerivationDisposition.FAILED
+        if summary_failed
+        else DerivationDisposition.COMPLETED
+    )
+    return DerivationOutcome(
+        request.identity,
+        "resampling",
+        disposition,
+        operation.identity,
+        tuple(item.identity for item in artifacts),
+        operation=operation,
+        artifacts=tuple(artifacts),
+    )
+
+
+def _execute_mcmc(
+    workflow: MethodStepWorkflow,
+    accepted: AcceptedFitResult,
+    request: McmcDerivationRequest,
+    cancellation: CancellationToken,
+) -> DerivationOutcome:
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=cast("OptimizationProblem", workflow.problem),
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        policy=request.policy,
+        coordinate_units=request.coordinate_units,
+    )
+    operation = execute_mcmc_evidence(
+        accepted,
+        plan,
+        cancellation=cancellation,
+    )
+    artifacts: list[_IdentifiedArtifact] = []
+    if operation.evidence is not None:
+        artifacts.append(operation.evidence)
+    if operation.terminal is McmcOperationTerminal.COMPLETED:
+        evidence = cast("McmcEvidence", operation.evidence)
+        try:
+            selection = derive_retained_sample_view(
+                evidence,
+                cancellation=cancellation,
+            )
+            posterior: PosteriorSampleEvidence = derive_posterior_sample_evidence(
+                selection,
+                request.output_units,
+                cancellation=cancellation,
+            )
+            summary: PosteriorSummary = derive_posterior_summary(
+                posterior,
+                cancellation=cancellation,
+            )
+        except KeyboardInterrupt:
+            return DerivationOutcome(
+                request.identity,
+                "mcmc",
+                DerivationDisposition.INTERRUPTED,
+                operation.identity,
+                (evidence.identity,),
+                "KeyboardInterrupt: MCMC posterior derivation was interrupted",
+                operation=operation,
+                artifacts=(evidence,),
+            )
+        except Exception as error:  # noqa: BLE001 - retain completed primary evidence
+            return DerivationOutcome(
+                request.identity,
+                "mcmc",
+                (
+                    DerivationDisposition.CANCELLED
+                    if cancellation.is_cancelled
+                    else DerivationDisposition.FAILED
+                ),
+                operation.identity,
+                (evidence.identity,),
+                f"{type(error).__name__}: {error}",
+                operation=operation,
+                artifacts=(evidence,),
+            )
+        artifacts.extend((posterior, summary))
+        disposition = DerivationDisposition.COMPLETED
+    elif operation.terminal is McmcOperationTerminal.CANCELLED:
+        disposition = DerivationDisposition.CANCELLED
+    elif operation.terminal is McmcOperationTerminal.INTERRUPTED:
+        disposition = DerivationDisposition.INTERRUPTED
+    else:
+        disposition = DerivationDisposition.FAILED
+    return DerivationOutcome(
+        request.identity,
+        "mcmc",
+        disposition,
+        operation.identity,
+        tuple(item.identity for item in artifacts),
+        operation=operation,
+        artifacts=tuple(artifacts),
+    )
+
+
+__all__ = [
+    "DerivationDisposition",
+    "DerivationOutcome",
+    "EvaluationPurpose",
+    "McmcDerivationRequest",
+    "MethodStepCheckpoint",
+    "MethodStepLifecycle",
+    "MethodStepOutcome",
+    "MethodStepPublicationRequest",
+    "MethodStepRunProvenanceRequest",
+    "MethodStepStrategy",
+    "MethodStepWorkflow",
+    "ResamplingDerivationRequest",
+    "UncertaintyDerivationRequest",
+    "execute_method_step",
+    "require_successor_state",
+]

--- a/src/chemex/optimize/method_step.py
+++ b/src/chemex/optimize/method_step.py
@@ -49,9 +49,11 @@ from chemex.optimize.direct_trf import (
     DirectTrfInvocation,
     FitCommitOperation,
     FitCommitTerminal,
+    LiveFitCommitAuthority,
     OptimizationProblem,
     accepted_occurrence_is_authoritative,
     execute_fit_commit,
+    fit_commit_authority_is_authoritative,
     fit_commit_operation_is_authoritative,
 )
 from chemex.optimize.grid_direct_trf import (
@@ -1111,6 +1113,79 @@ def _validate_method_step_workflow(  # noqa: C901 - closed recursive workflow tr
         raise ValueError("Method-step workflow integrity validation failed")
 
 
+@dataclass(frozen=True, slots=True)
+class _ExecutionStartWorkflowContext:
+    semantic_identity: str
+    binding_identity: str
+    starting_snapshot: AnalysisValuesSnapshot
+    starting_snapshot_object: AnalysisValuesSnapshot
+    parameter_model: SealedParameterModel
+    parameterization: ActiveParameterization
+    engine: EvaluationEngine
+    method: Method
+    problem: OptimizationProblem | None
+    decomposition: FitDecomposition | None
+    strategy: MethodStepStrategy | None
+    invocation: MethodStepInvocation | None
+    derivations: tuple[MethodStepDerivationRequest, ...]
+    publication: MethodStepPublicationRequest | None
+    evaluation_purpose: EvaluationPurpose | None
+
+
+def _pin_execution_start_workflow(
+    workflow: MethodStepWorkflow,
+) -> _ExecutionStartWorkflowContext:
+    """Capture an execution-owned context after full recursive validation."""
+    workflow.validate_integrity()
+    semantic_identity, binding_identity = _rederive_workflow_identities(workflow)
+    return _ExecutionStartWorkflowContext(
+        semantic_identity,
+        binding_identity,
+        AnalysisValuesSnapshot.from_json(workflow.starting_snapshot.to_json()),
+        workflow.starting_snapshot,
+        workflow.parameter_model,
+        workflow.parameterization,
+        workflow.engine,
+        workflow.method,
+        workflow.problem,
+        workflow.decomposition,
+        workflow.strategy,
+        workflow.invocation,
+        workflow.derivations,
+        workflow.publication,
+        workflow.evaluation_purpose,
+    )
+
+
+def _validate_execution_start_workflow(
+    workflow: MethodStepWorkflow,
+    expected: _ExecutionStartWorkflowContext,
+) -> None:
+    """Reject callback retargeting, including a fully rehashed replacement."""
+    workflow.validate_integrity()
+    semantic_identity, binding_identity = _rederive_workflow_identities(workflow)
+    if (
+        semantic_identity != expected.semantic_identity
+        or binding_identity != expected.binding_identity
+        or workflow.starting_snapshot is not expected.starting_snapshot_object
+        or workflow.starting_snapshot != expected.starting_snapshot
+        or _snapshot_identity(workflow.starting_snapshot)
+        != _snapshot_identity(expected.starting_snapshot)
+        or workflow.parameter_model is not expected.parameter_model
+        or workflow.parameterization is not expected.parameterization
+        or workflow.engine is not expected.engine
+        or workflow.method is not expected.method
+        or workflow.problem is not expected.problem
+        or workflow.decomposition is not expected.decomposition
+        or workflow.strategy is not expected.strategy
+        or workflow.invocation is not expected.invocation
+        or workflow.derivations is not expected.derivations
+        or workflow.publication is not expected.publication
+        or workflow.evaluation_purpose is not expected.evaluation_purpose
+    ):
+        raise ValueError("Method-step execution-start workflow integrity failed")
+
+
 @dataclass(frozen=True, slots=True, weakref_slot=True, eq=False)
 class MethodStepOutcome:
     """Immutable occurrence evidence; live transition authority stays external."""
@@ -1685,7 +1760,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
     checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None = None,
 ) -> MethodStepOutcome:
     """Execute one exact native workflow occurrence."""
-    workflow.validate_integrity()
+    execution_start = _pin_execution_start_workflow(workflow)
     current = analysis_values.snapshot()
     if current != workflow.starting_snapshot:
         raise ValueError("Method-step workflow no longer has its exact starting state")
@@ -1693,6 +1768,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
     if workflow.evaluation_purpose is None:
         return _execute_optimization(
             workflow,
+            execution_start=execution_start,
             analysis_values=analysis_values,
             cancellation=cancellation,
             checkpoint_observer=checkpoint_observer,
@@ -1863,14 +1939,119 @@ def _primary_execution_identity(execution: MethodStepPrimaryExecution) -> str:
     )
 
 
+def _validate_fit_commit_boundary(
+    workflow: MethodStepWorkflow,
+    expected: _ExecutionStartWorkflowContext,
+    execution: MethodStepPrimaryExecution,
+    primary_identity: str,
+    accepted: AcceptedFitResult,
+    authority: LiveFitCommitAuthority,
+    analysis_values: AnalysisValues,
+) -> None:
+    """Prove exact workflow, acceptance, and authority lineage before commit."""
+    _validate_execution_start_workflow(workflow, expected)
+    problem = expected.problem
+    invocation = expected.invocation
+    strategy = expected.strategy
+    current = analysis_values.snapshot()
+    if (
+        problem is None
+        or invocation is None
+        or strategy is None
+        or current != expected.starting_snapshot
+        or current.occurrence_identity != expected.starting_snapshot.occurrence_identity
+        or current.revision != expected.starting_snapshot.revision
+        or problem is not workflow.problem
+        or problem.source_snapshot is not workflow.starting_snapshot
+        or _primary_execution_identity(execution) != primary_identity
+        or execution.accepted_result is not accepted
+        or execution.commit_authority is not authority
+        or not accepted_occurrence_is_authoritative(accepted)
+        or accepted.problem_identity != problem.identity
+        or accepted.parameterization_identity != expected.parameterization.identity
+        or accepted.evaluator_parameterization_identity
+        != expected.parameterization.evaluator_identity
+        or accepted.source_occurrence_identity
+        != expected.starting_snapshot.occurrence_identity
+        or accepted.source_revision != expected.starting_snapshot.revision
+        or accepted.controlled_ids != problem.controlled_ids
+        or accepted.commit_scope != problem.commit_scope
+        or accepted.evaluation_result.plan_identity != expected.engine.plan.identity
+    ):
+        raise ValueError("Method-step fit-commit boundary integrity failed")
+    reconstructed = replace(accepted, occurrence_witness=None)
+    if reconstructed.identity != accepted.identity:
+        raise ValueError("Method-step accepted-result integrity failed before commit")
+    if strategy is MethodStepStrategy.DIRECT_TRF:
+        if accepted.invocation_identity != invocation.identity:
+            raise ValueError(
+                "Method-step Direct invocation lineage changed before commit"
+            )
+    elif strategy is MethodStepStrategy.GRID_DIRECT_TRF:
+        typed = cast("AcceptedGridDirectTrfResult", accepted)
+        if typed.workflow_invocation is not invocation:
+            raise ValueError(
+                "Method-step GRID invocation lineage changed before commit"
+            )
+        validate_grid_commit_lineage(typed, problem)
+    else:
+        typed_de = cast("AcceptedDeDirectTrfResult", accepted)
+        if typed_de.workflow_invocation is not invocation:
+            raise ValueError("Method-step DE invocation lineage changed before commit")
+        validate_de_commit_lineage(typed_de, problem)
+    if not fit_commit_authority_is_authoritative(accepted, authority, problem):
+        raise ValueError("Method-step fit-commit authority pairing is no longer live")
+
+
+def _precommit_failure_outcome(
+    expected: _ExecutionStartWorkflowContext,
+    primary_identity: str,
+    accepted: AcceptedFitResult,
+    *,
+    interrupted: bool = False,
+) -> MethodStepOutcome:
+    """Retain non-authoritative acceptance diagnostics after a fenced stop."""
+    disposition = (
+        DerivationDisposition.NOT_STARTED_BY_WORKFLOW_STOP
+        if interrupted
+        else DerivationDisposition.BLOCKED_BY_PREREQUISITE
+    )
+    derivations = tuple(
+        DerivationOutcome(
+            item.identity,
+            _derivation_stage(item),
+            disposition,
+            message="Fit commit boundary validation did not permit transition",
+        )
+        for item in expected.derivations
+    )
+    return MethodStepOutcome(
+        expected.semantic_identity,
+        expected.binding_identity,
+        uuid4().hex,
+        _snapshot_identity(expected.starting_snapshot),
+        (
+            MethodStepLifecycle.INTERRUPTED
+            if interrupted
+            else MethodStepLifecycle.FAILED
+        ),
+        expected.strategy,
+        "interrupted" if interrupted else "accepted",
+        primary_identity,
+        accepted_result_identity=accepted.identity,
+        derivations=derivations,
+    )
+
+
 def _execute_optimization(  # noqa: C901 - closed primary transition
     workflow: MethodStepWorkflow,
     *,
+    execution_start: _ExecutionStartWorkflowContext,
     analysis_values: AnalysisValues,
     cancellation: CancellationToken | None,
     checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None,
 ) -> MethodStepOutcome:
-    workflow.validate_integrity()
+    _validate_execution_start_workflow(workflow, execution_start)
     problem = cast("OptimizationProblem", workflow.problem)
     decomposition = cast("FitDecomposition", workflow.decomposition)
     strategy = cast("MethodStepStrategy", workflow.strategy)
@@ -1971,7 +2152,37 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
             source_workflow=workflow,
         )
     if checkpoint_observer is not None:
-        checkpoint_observer(MethodStepCheckpoint.AGGREGATE_ACCEPTED)
+        try:
+            checkpoint_observer(MethodStepCheckpoint.AGGREGATE_ACCEPTED)
+        except KeyboardInterrupt:
+            return _precommit_failure_outcome(
+                execution_start,
+                primary_identity,
+                accepted,
+                interrupted=True,
+            )
+        except Exception:  # noqa: BLE001 - observer failure is a typed stop
+            return _precommit_failure_outcome(
+                execution_start,
+                primary_identity,
+                accepted,
+            )
+    try:
+        _validate_fit_commit_boundary(
+            workflow,
+            execution_start,
+            execution,
+            primary_identity,
+            accepted,
+            authority,
+            analysis_values,
+        )
+    except Exception:  # noqa: BLE001 - integrity failure is a typed stop
+        return _precommit_failure_outcome(
+            execution_start,
+            primary_identity,
+            accepted,
+        )
     if token.is_cancelled:
         derivations = _stopped_derivations(workflow.derivations)
         publication: PublishedStepReference | None = None
@@ -2016,16 +2227,6 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
             run_provenance=run_provenance,
             source_workflow=workflow,
         )
-    if strategy is MethodStepStrategy.GRID_DIRECT_TRF:
-        validate_grid_commit_lineage(
-            cast("AcceptedGridDirectTrfResult", accepted),
-            problem,
-        )
-    elif strategy is MethodStepStrategy.DE_DIRECT_TRF:
-        validate_de_commit_lineage(
-            cast("AcceptedDeDirectTrfResult", accepted),
-            problem,
-        )
     operation = execute_fit_commit(
         accepted,
         authority,
@@ -2035,6 +2236,7 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
     )
     if checkpoint_observer is not None:
         checkpoint_observer(MethodStepCheckpoint.COMMIT_COMPLETED)
+        _validate_execution_start_workflow(workflow, execution_start)
     committed = operation.terminal is FitCommitTerminal.COMMITTED
     successor = operation.committed_snapshot if committed else None
     derivations = (

--- a/src/chemex/optimize/native_reporting.py
+++ b/src/chemex/optimize/native_reporting.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 
 from chemex.atomic import publish_directory_noreplace
 from chemex.configuration.methods import Method
-from chemex.evaluation.native import EvaluationPlan, EvaluationResult
+from chemex.evaluation.native import EvaluationFailure, EvaluationPlan, EvaluationResult
 from chemex.native_provenance import (
     ArtifactReference,
     ArtifactRole,
@@ -57,6 +57,7 @@ from chemex.optimize.native_resampling import (
     ResamplingEvidence,
     ResamplingLifecycle,
     ResamplingSummaryOutcome,
+    SummaryFailure,
     SummaryTerminal,
 )
 from chemex.optimize.uncertainty import UncertaintyEvidence
@@ -70,20 +71,111 @@ from chemex.plotters.native_reporting import write_native_plots
 from chemex.printers.native_reporting import (
     write_components,
     write_data,
+    write_evaluated_parameters,
     write_mcmc,
     write_parameter_reports,
     write_partial_mcmc,
     write_partial_resampling,
     write_resampling,
+    write_resampling_summary_failure,
     write_restart_parameters,
     write_statistics,
     write_suppressed_outcome,
     write_uncertainty,
 )
+from chemex.runtime import ExecutionSettings
 
 
 class NativePublicationError(ValueError):
     """Raised before publication when authoritative source artifacts disagree."""
+
+
+type MethodStepPrimaryTerminal = Literal[
+    "accepted",
+    "component_failure",
+    "execution_failure",
+    "decomposition_validation_failure",
+    "no_eligible_candidate",
+    "materialization_failure",
+    "search_unsuccessful",
+    "polish_unsuccessful",
+    "cancelled",
+    "interrupted",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class MethodStepPrimaryRecord:
+    """Exact aggregate-primary view used by the existing reporting seam."""
+
+    semantic_workflow_identity: str
+    problem_identity: str
+    invocation_identity: str
+    execution_identity: str
+    aggregate_execution_identity: str
+    terminal: MethodStepPrimaryTerminal
+    grouping_topology: tuple[tuple[str, tuple[str, ...]], ...]
+    execution_settings: ExecutionSettings
+    policy: PolicyRecord
+    budget: BudgetRecord
+    seeds: tuple[SeedRecord, ...] = ()
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            not self.semantic_workflow_identity
+            or not self.problem_identity
+            or not self.invocation_identity
+            or not self.execution_identity
+            or not self.aggregate_execution_identity
+            or self.terminal
+            not in {
+                "accepted",
+                "component_failure",
+                "execution_failure",
+                "decomposition_validation_failure",
+                "no_eligible_candidate",
+                "materialization_failure",
+                "search_unsuccessful",
+                "polish_unsuccessful",
+                "cancelled",
+                "interrupted",
+            }
+            or not self.grouping_topology
+        ):
+            raise NativePublicationError(
+                "Method-step primary reporting lineage is incomplete"
+            )
+        object.__setattr__(
+            self,
+            "identity",
+            hashlib.sha256(
+                json.dumps(
+                    (
+                        "native-method-step-primary-reporting-v1",
+                        self.semantic_workflow_identity,
+                        self.problem_identity,
+                        self.invocation_identity,
+                        self.execution_identity,
+                        self.aggregate_execution_identity,
+                        self.terminal,
+                        self.grouping_topology,
+                        (
+                            self.execution_settings.workers,
+                            self.execution_settings.native_threads,
+                        ),
+                        (self.policy.name, self.policy.identity),
+                        (self.budget.name, self.budget.limit, self.budget.used),
+                        tuple(
+                            (item.name, item.value, item.policy_identity)
+                            for item in self.seeds
+                        ),
+                    ),
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                ).encode()
+            ).hexdigest(),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,6 +220,14 @@ class ResamplingPublication:
 
 
 @dataclass(frozen=True, slots=True)
+class ResamplingSummaryFailurePublication:
+    """Completed primary resampling evidence whose derived summary failed."""
+
+    evidence: ResamplingEvidence
+    failure: SummaryFailure
+
+
+@dataclass(frozen=True, slots=True)
 class McmcPublication:
     """Primary chain topology plus explicitly derived posterior evidence."""
 
@@ -146,8 +246,8 @@ class CommittedFitPublication:
     parameter_model: SealedParameterModel
     starting_snapshot: AnalysisValuesSnapshot
     primary_problem: OptimizationProblem
-    primary_invocation: DirectTrfInvocation
-    primary_execution: DirectTrfExecution
+    primary_invocation: DirectTrfInvocation | MethodStepPrimaryRecord
+    primary_execution: DirectTrfExecution | MethodStepPrimaryRecord
     accepted: AcceptedFitResult
     commit_receipt: CommitReceipt
     committed_snapshot: AnalysisValuesSnapshot
@@ -158,6 +258,9 @@ class CommittedFitPublication:
     uncertainty: UncertaintyEvidence | None = None
     resampling: tuple[ResamplingPublication, ...] = ()
     mcmc: McmcPublication | None = None
+    partial_resampling: tuple[ResamplingEvidence, ...] = ()
+    resampling_summary_failures: tuple[ResamplingSummaryFailurePublication, ...] = ()
+    partial_mcmc: McmcEvidence | None = None
 
 
 @dataclass(frozen=True, slots=True, weakref_slot=True)
@@ -168,6 +271,19 @@ class EvaluationPublication:
     method: Method
     parameterization: ActiveParameterization
     evaluation_result: EvaluationResult
+    provenance: WorkflowProvenance = field(kw_only=True)
+    method_step_semantic_identity: str | None = field(default=None, kw_only=True)
+    allow_controlled: bool = field(default=False, kw_only=True)
+
+
+@dataclass(frozen=True, slots=True, weakref_slot=True)
+class NoObjectivePublication:
+    """Typed no-objective occurrence with diagnostic-only method-step output."""
+
+    plan: EvaluationPlan
+    method: Method
+    parameterization: ActiveParameterization
+    semantic_workflow_identity: str
     provenance: WorkflowProvenance = field(kw_only=True)
 
 
@@ -182,21 +298,27 @@ class SuppressedPublication:
         "interrupted",
     ]
     operation: (
-        FitCommitOperation | DirectTrfExecution | ResamplingEvidence | McmcEvidence
+        FitCommitOperation
+        | DirectTrfExecution
+        | MethodStepPrimaryRecord
+        | EvaluationFailure
+        | ResamplingEvidence
+        | McmcEvidence
     )
     plan: EvaluationPlan
     method: Method
     parameterization: ActiveParameterization
     provenance: WorkflowProvenance = field(kw_only=True)
-    primary_invocation: DirectTrfInvocation | None = field(
+    primary_invocation: DirectTrfInvocation | MethodStepPrimaryRecord | None = field(
         default=None,
         kw_only=True,
     )
-    primary_execution: DirectTrfExecution | None = field(
+    primary_execution: DirectTrfExecution | MethodStepPrimaryRecord | None = field(
         default=None,
         kw_only=True,
     )
     primary_problem: OptimizationProblem | None = field(default=None, kw_only=True)
+    method_step_semantic_identity: str | None = field(default=None, kw_only=True)
     accepted_result_identity: str | None = None
     accepted_occurrence_identity: str | None = None
     components: tuple[ComponentDiagnostic, ...] = ()
@@ -205,7 +327,10 @@ class SuppressedPublication:
 
 
 type NativePublication = (
-    CommittedFitPublication | EvaluationPublication | SuppressedPublication
+    CommittedFitPublication
+    | EvaluationPublication
+    | NoObjectivePublication
+    | SuppressedPublication
 )
 
 
@@ -227,9 +352,17 @@ def _validate_exact_provenance_records(
 
 
 def _primary_execution_records(
-    invocation: DirectTrfInvocation,
-    execution: DirectTrfExecution,
+    invocation: DirectTrfInvocation | MethodStepPrimaryRecord,
+    execution: DirectTrfExecution | MethodStepPrimaryRecord,
 ) -> tuple[PolicyRecord, BudgetRecord]:
+    if isinstance(invocation, MethodStepPrimaryRecord):
+        if execution is not invocation:
+            raise NativePublicationError(
+                "Method-step reporting requires one exact aggregate primary record"
+            )
+        return invocation.policy, invocation.budget
+    if not isinstance(execution, DirectTrfExecution):
+        raise NativePublicationError("Direct TRF reporting execution is incompatible")
     if (
         execution.problem_identity != invocation.problem_identity
         or execution.invocation_identity != invocation.identity
@@ -245,6 +378,13 @@ def _primary_execution_records(
             execution.counters.objective_requests_accepted,
         ),
     )
+
+
+def _primary_execution_seeds(
+    invocation: DirectTrfInvocation | MethodStepPrimaryRecord,
+) -> tuple[SeedRecord, ...]:
+    """Return aggregate-primary seeds, if the selected strategy owns any."""
+    return invocation.seeds if isinstance(invocation, MethodStepPrimaryRecord) else ()
 
 
 def _stochastic_execution_records(
@@ -295,22 +435,63 @@ def _stochastic_execution_records(
     return tuple(policies), tuple(budgets), tuple(seeds)
 
 
+def publication_provenance_records(
+    primary: MethodStepPrimaryRecord,
+    *,
+    uncertainty: UncertaintyEvidence | None = None,
+    resampling: tuple[ResamplingEvidence, ...] = (),
+    mcmc: McmcEvidence | None = None,
+) -> tuple[tuple[PolicyRecord, ...], tuple[BudgetRecord, ...], tuple[SeedRecord, ...]]:
+    """Return the exact records expected by native committed publication."""
+    stochastic_policies, stochastic_budgets, stochastic_seeds = (
+        _stochastic_execution_records(resampling, mcmc)
+    )
+    uncertainty_policies = (
+        ()
+        if uncertainty is None
+        else (PolicyRecord("uncertainty", uncertainty.source_policy.identity),)
+    )
+    return (
+        (primary.policy, *uncertainty_policies, *stochastic_policies),
+        (primary.budget, *stochastic_budgets),
+        (*primary.seeds, *stochastic_seeds),
+    )
+
+
 def _validate_provenance_context(
     provenance: WorkflowProvenance,
     plan: EvaluationPlan,
     parameterization: ActiveParameterization,
     method: Method,
-    invocation: DirectTrfInvocation | None,
-    native_execution: DirectTrfExecution | EvaluationResult,
+    invocation: DirectTrfInvocation | MethodStepPrimaryRecord | None,
+    native_execution: DirectTrfExecution | MethodStepPrimaryRecord | EvaluationResult,
 ) -> None:
     try:
-        provenance.validate_execution_context(
-            parameterization,
-            plan,
-            method,
-            invocation,
-            native_execution,
-        )
+        if isinstance(invocation, MethodStepPrimaryRecord):
+            if native_execution is not invocation:
+                raise NativeProvenanceError(
+                    "Method-step publication uses another aggregate primary"
+                )
+            provenance.validate_method_step_context(
+                parameterization=parameterization,
+                plan=plan,
+                method=method,
+                semantic_workflow_identity=invocation.semantic_workflow_identity,
+                grouping_topology=invocation.grouping_topology,
+                execution=invocation.execution_settings,
+            )
+        else:
+            if isinstance(native_execution, MethodStepPrimaryRecord):
+                raise NativeProvenanceError(
+                    "Direct publication cannot use method-step primary evidence"
+                )
+            provenance.validate_execution_context(
+                parameterization,
+                plan,
+                method,
+                invocation,
+                native_execution,
+            )
     except NativeProvenanceError as error:
         raise NativePublicationError(
             "Workflow method and selection provenance, or execution provenance, "
@@ -335,6 +516,37 @@ def _validate_optional_primary_execution(
 def _validate_suppressed_execution_lineage(
     publication: SuppressedPublication,
 ) -> tuple[PolicyRecord | None, BudgetRecord | None]:
+    if isinstance(publication.operation, EvaluationFailure):
+        failure = publication.operation
+        if (
+            publication.primary_invocation is not None
+            or publication.primary_execution is not None
+            or publication.primary_problem is not None
+            or publication.method_step_semantic_identity is None
+            or failure.plan_identity != publication.plan.identity
+            or failure.parameterization_identity
+            != publication.parameterization.evaluator_identity
+        ):
+            raise NativePublicationError(
+                "Suppressed evaluation failure has incompatible lineage"
+            )
+        EvaluationFailure.from_record(failure.to_record(), publication.plan)
+        try:
+            publication.provenance.validate_method_step_context(
+                parameterization=publication.parameterization,
+                plan=publication.plan,
+                method=publication.method,
+                semantic_workflow_identity=publication.method_step_semantic_identity,
+                grouping_topology=(
+                    ("aggregate", publication.parameterization.independent_ids),
+                ),
+                execution=ExecutionSettings(),
+            )
+        except NativeProvenanceError as error:
+            raise NativePublicationError(
+                "Suppressed evaluation provenance differs from its method step"
+            ) from error
+        return None, None
     if publication.primary_execution is None:
         raise NativePublicationError(
             "Suppressed provenance requires the exact primary execution"
@@ -368,7 +580,10 @@ def _validate_suppressed_execution_lineage(
         raise NativePublicationError(
             "Suppressed primary problem requires its invocation and execution"
         )
-    if isinstance(publication.operation, (FitCommitOperation, DirectTrfExecution)) and (
+    if isinstance(
+        publication.operation,
+        (FitCommitOperation, DirectTrfExecution, MethodStepPrimaryRecord),
+    ) and (
         primary_problem is None
         or primary_problem.identity != publication.operation.problem_identity
     ):
@@ -402,16 +617,33 @@ def _validate_evaluation_artifacts(
 
 
 def _validate_evaluation_only(publication: EvaluationPublication) -> None:
-    _validate_provenance_context(
-        publication.provenance,
-        publication.plan,
-        publication.parameterization,
-        publication.method,
-        None,
-        publication.evaluation_result,
-    )
+    if publication.method_step_semantic_identity is None:
+        _validate_provenance_context(
+            publication.provenance,
+            publication.plan,
+            publication.parameterization,
+            publication.method,
+            None,
+            publication.evaluation_result,
+        )
+    else:
+        try:
+            publication.provenance.validate_method_step_context(
+                parameterization=publication.parameterization,
+                plan=publication.plan,
+                method=publication.method,
+                semantic_workflow_identity=publication.method_step_semantic_identity,
+                grouping_topology=(
+                    ("aggregate", publication.parameterization.independent_ids),
+                ),
+                execution=ExecutionSettings(),
+            )
+        except NativeProvenanceError as error:
+            raise NativePublicationError(
+                "Evaluation publication differs from its method-step context"
+            ) from error
     _validate_exact_provenance_records(publication.provenance, (), (), ())
-    if any(
+    if not publication.allow_controlled and any(
         publication.parameterization.role(param_id) is ParameterRole.FIT
         for param_id in publication.parameterization.independent_ids
     ):
@@ -423,6 +655,27 @@ def _validate_evaluation_only(publication: EvaluationPublication) -> None:
         publication.parameterization,
         publication.evaluation_result,
     )
+
+
+def _validate_no_objective(publication: NoObjectivePublication) -> None:
+    try:
+        publication.provenance.validate_method_step_context(
+            parameterization=publication.parameterization,
+            plan=publication.plan,
+            method=publication.method,
+            semantic_workflow_identity=publication.semantic_workflow_identity,
+            grouping_topology=(
+                ("aggregate", publication.parameterization.independent_ids),
+            ),
+            execution=ExecutionSettings(),
+        )
+    except NativeProvenanceError as error:
+        raise NativePublicationError(
+            "No-objective publication differs from its method-step context"
+        ) from error
+    _validate_exact_provenance_records(publication.provenance, (), (), ())
+    if publication.plan.retained_observation_count:
+        raise NativePublicationError("No-objective publication retained objective data")
 
 
 def _validate_suppressed(publication: SuppressedPublication) -> None:
@@ -458,6 +711,10 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
     direct_terminal = (
         operation.terminal if isinstance(operation, DirectTrfExecution) else None
     )
+    method_step_terminal = (
+        operation.terminal if isinstance(operation, MethodStepPrimaryRecord) else None
+    )
+    evaluation_failed = isinstance(operation, EvaluationFailure)
     stochastic_terminal = (
         operation.terminal.value
         if isinstance(operation, McmcEvidence)
@@ -472,6 +729,9 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
             and (
                 direct_terminal
                 not in (None, DirectTrfTerminal.CONVERGED, DirectTrfTerminal.CANCELLED)
+                or method_step_terminal
+                not in (None, "accepted", "cancelled", "interrupted")
+                or evaluation_failed
                 or stochastic_terminal == "partial"
             )
         )
@@ -479,6 +739,7 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
             publication.lifecycle == "cancelled"
             and (
                 direct_terminal is DirectTrfTerminal.CANCELLED
+                or method_step_terminal == "cancelled"
                 or stochastic_terminal == "cancelled"
             )
         )
@@ -486,6 +747,7 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
             publication.lifecycle == "interrupted"
             and (
                 direct_terminal is DirectTrfTerminal.INTERRUPTED
+                or method_step_terminal == "interrupted"
                 or stochastic_terminal == "interrupted"
             )
         )
@@ -547,7 +809,12 @@ def _validate_suppressed(publication: SuppressedPublication) -> None:
         publication.provenance,
         (() if primary_policy is None else (primary_policy,)) + stochastic_policies,
         (() if primary_budget is None else (primary_budget,)) + stochastic_budgets,
-        stochastic_seeds,
+        (
+            ()
+            if publication.primary_invocation is None
+            else _primary_execution_seeds(publication.primary_invocation)
+        )
+        + stochastic_seeds,
     )
 
 
@@ -603,6 +870,24 @@ def _validate_committed_fit(publication: CommittedFitPublication) -> None:
         raise NativePublicationError(
             "Committed publication requires an authoritative accepted occurrence"
         )
+    primary_invocation = publication.primary_invocation
+    primary_execution = publication.primary_execution
+    if isinstance(primary_invocation, MethodStepPrimaryRecord):
+        primary_matches = (
+            primary_execution is primary_invocation
+            and primary_invocation.terminal == "accepted"
+            and primary_invocation.problem_identity == accepted.problem_identity
+            and primary_invocation.invocation_identity == accepted.invocation_identity
+            and primary_invocation.execution_identity == accepted.execution_identity
+        )
+    else:
+        primary_matches = (
+            isinstance(primary_execution, DirectTrfExecution)
+            and primary_invocation.problem_identity == accepted.problem_identity
+            and primary_execution.problem_identity == accepted.problem_identity
+            and primary_execution.invocation_identity == accepted.invocation_identity
+            and primary_execution.identity == accepted.execution_identity
+        )
     if (
         not fit_commit_operation_is_authoritative(operation)
         or operation.terminal is not FitCommitTerminal.COMMITTED
@@ -618,11 +903,7 @@ def _validate_committed_fit(publication: CommittedFitPublication) -> None:
         != publication.parameterization.evaluator_identity
         or publication.primary_problem.evaluation_plan_identity
         != publication.plan.identity
-        or publication.primary_invocation.problem_identity != accepted.problem_identity
-        or publication.primary_execution.problem_identity != accepted.problem_identity
-        or publication.primary_execution.invocation_identity
-        != accepted.invocation_identity
-        or publication.primary_execution.identity != accepted.execution_identity
+        or not primary_matches
         or current != committed
     ):
         raise NativePublicationError(
@@ -712,7 +993,9 @@ def _validate_committed_fit(publication: CommittedFitPublication) -> None:
     _validate_typed_evidence(publication)
 
 
-def _validate_typed_evidence(publication: CommittedFitPublication) -> None:
+def _validate_typed_evidence(  # noqa: C901 - closed evidence families
+    publication: CommittedFitPublication,
+) -> None:
     """Fail closed when any requested evidence has a foreign anchor."""
     accepted = publication.accepted
     uncertainty = publication.uncertainty
@@ -776,10 +1059,69 @@ def _validate_typed_evidence(publication: CommittedFitPublication) -> None:
             raise NativePublicationError(
                 "MCMC evidence belongs to another accepted fit occurrence"
             )
+    ordinary_schemes = {
+        item.evidence.plan.scheme.value for item in publication.resampling
+    }
+    for evidence in publication.partial_resampling:
+        evidence.validate_integrity()
+        if (
+            evidence.plan.scheme.value in ordinary_schemes
+            or evidence.plan.accepted_result_identity != accepted.identity
+            or evidence.plan.accepted_occurrence_identity
+            != accepted.occurrence_identity
+            or evidence.plan.parameterization is not publication.parameterization
+            or evidence.plan.source_engine.plan.identity != publication.plan.identity
+        ):
+            raise NativePublicationError(
+                "Partial resampling evidence belongs to another committed fit"
+            )
+    partial_schemes = {
+        evidence.plan.scheme.value for evidence in publication.partial_resampling
+    }
+    failed_summary_schemes: set[str] = set()
+    for item in publication.resampling_summary_failures:
+        item.evidence.validate_integrity()
+        scheme = item.evidence.plan.scheme.value
+        if (
+            item.evidence.lifecycle is not ResamplingLifecycle.COMPLETED
+            or item.failure.source_evidence_identity != item.evidence.identity
+            or scheme in ordinary_schemes
+            or scheme in partial_schemes
+            or scheme in failed_summary_schemes
+            or item.evidence.plan.accepted_result_identity != accepted.identity
+            or item.evidence.plan.accepted_occurrence_identity
+            != accepted.occurrence_identity
+            or item.evidence.plan.parameterization is not publication.parameterization
+            or item.evidence.plan.source_engine.plan.identity
+            != publication.plan.identity
+        ):
+            raise NativePublicationError(
+                "Resampling summary failure belongs to another committed fit"
+            )
+        failed_summary_schemes.add(scheme)
+    if publication.partial_mcmc is not None:
+        publication.partial_mcmc.validate_integrity()
+        if (
+            mcmc is not None
+            or publication.partial_mcmc.accepted_result_identity != accepted.identity
+            or publication.partial_mcmc.plan.accepted_occurrence_identity
+            != accepted.occurrence_identity
+            or publication.partial_mcmc.plan.parameterization
+            is not publication.parameterization
+            or publication.partial_mcmc.plan.source_engine.plan.identity
+            != publication.plan.identity
+        ):
+            raise NativePublicationError(
+                "Partial MCMC evidence belongs to another committed fit"
+            )
     stochastic_policies, stochastic_budgets, stochastic_seeds = (
         _stochastic_execution_records(
-            tuple(item.evidence for item in publication.resampling),
-            None if mcmc is None else mcmc.evidence,
+            (
+                *(item.evidence for item in publication.resampling),
+                *publication.partial_resampling,
+                *(item.evidence for item in publication.resampling_summary_failures),
+            ),
+            (publication.partial_mcmc if mcmc is None else mcmc.evidence),
         )
     )
     primary_policy, primary_budget = _primary_execution_records(
@@ -795,18 +1137,35 @@ def _validate_typed_evidence(publication: CommittedFitPublication) -> None:
         publication.provenance,
         (primary_policy, *uncertainty_policies, *stochastic_policies),
         (primary_budget, *stochastic_budgets),
-        stochastic_seeds,
+        (*_primary_execution_seeds(publication.primary_invocation), *stochastic_seeds),
     )
 
 
 def _suppressed_operation_record(
     operation: FitCommitOperation
     | DirectTrfExecution
+    | MethodStepPrimaryRecord
+    | EvaluationFailure
     | ResamplingEvidence
     | McmcEvidence,
 ) -> dict[str, object]:
     if isinstance(operation, FitCommitOperation):
         return operation.to_record()
+    if isinstance(operation, EvaluationFailure):
+        return {
+            "artifact_type": "native_evaluation_failure",
+            **operation.to_record(),
+        }
+    if isinstance(operation, MethodStepPrimaryRecord):
+        return {
+            "artifact_type": "native_method_step_primary",
+            "identity": operation.identity,
+            "problem_identity": operation.problem_identity,
+            "invocation_identity": operation.invocation_identity,
+            "execution_identity": operation.execution_identity,
+            "aggregate_execution_identity": operation.aggregate_execution_identity,
+            "terminal": operation.terminal,
+        }
     if isinstance(operation, McmcEvidence):
         return {"artifact_type": "native_mcmc_evidence", **operation.to_record()}
     if isinstance(operation, ResamplingEvidence):
@@ -851,6 +1210,7 @@ def _render_suppressed(path: Path, publication: SuppressedPublication) -> None:
         accepted_occurrence_identity=publication.accepted_occurrence_identity,
         components=publication.components,
     )
+    write_components(path / "Components", publication.components)
     if not publication.partial_resampling and publication.partial_mcmc is None:
         return
     partial = path / "PartialEvidence"
@@ -948,6 +1308,32 @@ def _render_committed_fit(
         None if mcmc is None else mcmc.posterior_samples,
         None if mcmc is None else mcmc.summary,
     )
+    if (
+        publication.partial_resampling
+        or publication.resampling_summary_failures
+        or publication.partial_mcmc is not None
+    ):
+        partial = path / "PartialEvidence"
+        partial.mkdir()
+        if publication.partial_resampling or publication.resampling_summary_failures:
+            resampling_path = partial / "Resampling"
+            resampling_path.mkdir()
+            for evidence in publication.partial_resampling:
+                family = resampling_path / evidence.plan.scheme.value.upper()
+                family.mkdir()
+                write_partial_resampling(family / "evidence.json", evidence)
+            for item in publication.resampling_summary_failures:
+                family = resampling_path / item.evidence.plan.scheme.value.upper()
+                family.mkdir()
+                write_partial_resampling(family / "evidence.json", item.evidence)
+                write_resampling_summary_failure(
+                    family / "summary-failure.json",
+                    item.failure,
+                )
+        if publication.partial_mcmc is not None:
+            mcmc_path = partial / "MCMC"
+            mcmc_path.mkdir()
+            write_partial_mcmc(mcmc_path / "evidence.json", publication.partial_mcmc)
     write_components(path / "Components", publication.components)
     return restart
 
@@ -1166,6 +1552,34 @@ def _write_committed_manifest(
                 f"Statistics/Resampling/{scheme.upper()}/evidence.json",
             )
         )
+    for item in publication.partial_resampling:
+        scheme = item.plan.scheme.value
+        evidence.append(
+            (
+                f"partial_resampling:{scheme}",
+                item.identity,
+                item.lifecycle.value,
+                f"PartialEvidence/Resampling/{scheme.upper()}/evidence.json",
+            )
+        )
+    for item in publication.resampling_summary_failures:
+        scheme = item.evidence.plan.scheme.value
+        evidence.extend(
+            (
+                (
+                    f"partial_resampling:{scheme}",
+                    item.evidence.identity,
+                    "summary_failed",
+                    f"PartialEvidence/Resampling/{scheme.upper()}/evidence.json",
+                ),
+                (
+                    f"resampling_summary_failure:{scheme}",
+                    item.failure.identity,
+                    item.failure.category,
+                    f"PartialEvidence/Resampling/{scheme.upper()}/summary-failure.json",
+                ),
+            )
+        )
     if publication.mcmc is not None:
         evidence.append(
             (
@@ -1173,6 +1587,15 @@ def _write_committed_manifest(
                 publication.mcmc.evidence.identity,
                 "integrity_validated",
                 "Statistics/MCMC/evidence.json",
+            )
+        )
+    if publication.partial_mcmc is not None:
+        evidence.append(
+            (
+                "partial_mcmc",
+                publication.partial_mcmc.identity,
+                publication.partial_mcmc.lifecycle.value,
+                "PartialEvidence/MCMC/evidence.json",
             )
         )
     return _write_manifest(
@@ -1280,15 +1703,55 @@ def _write_suppressed_manifest(
 
 def _render_evaluation(path: Path, publication: EvaluationPublication) -> None:
     path.mkdir()
-    write_parameter_reports(
-        path / "Parameters",
-        publication.parameterization,
-        publication.evaluation_result,
-    )
+    if publication.allow_controlled:
+        write_evaluated_parameters(
+            path / "Parameters",
+            publication.parameterization,
+            publication.evaluation_result,
+        )
+    else:
+        write_parameter_reports(
+            path / "Parameters",
+            publication.parameterization,
+            publication.evaluation_result,
+        )
     write_data(path / "Data", publication.plan, publication.evaluation_result)
     write_native_plots(path / "Plots", publication.plan, publication.evaluation_result)
     (path / "Statistics").mkdir()
     write_statistics(path, publication.plan, publication.evaluation_result, 0)
+
+
+def _render_no_objective(path: Path) -> None:
+    path.mkdir()
+    diagnostics = path / "Diagnostics"
+    diagnostics.mkdir()
+    write_suppressed_outcome(
+        diagnostics / "outcome.json",
+        lifecycle="no_objective_data",
+        operation_record={
+            "artifact_type": "native_no_objective_data",
+            "terminal": "no_objective_data",
+        },
+        accepted_result_identity=None,
+        accepted_occurrence_identity=None,
+        components=(),
+    )
+
+
+def _write_no_objective_manifest(
+    path: Path,
+    publication: NoObjectivePublication,
+    publication_occurrence_identity: str,
+) -> tuple[str, str, tuple[ArtifactReference, ...]]:
+    return _write_manifest(
+        path,
+        (
+            ("lifecycle", "no_objective_data"),
+            ("authority", "evaluation_only"),
+            ("publication_occurrence_identity", publication_occurrence_identity),
+        ),
+        publication.provenance,
+    )
 
 
 def _validate_and_publish_staged_step(
@@ -1355,6 +1818,8 @@ def publish_native_results(
         _validate_committed_fit(publication)
     elif isinstance(publication, EvaluationPublication):
         _validate_evaluation_only(publication)
+    elif isinstance(publication, NoObjectivePublication):
+        _validate_no_objective(publication)
     else:
         _validate_suppressed(publication)
     destination = Path(path)
@@ -1384,6 +1849,16 @@ def publish_native_results(
                 publication_occurrence_identity,
             )
             lifecycle = "successful_no_state_change"
+            authority = "evaluation_only"
+            independent_ids = publication.parameterization.independent_ids
+        elif isinstance(publication, NoObjectivePublication):
+            _render_no_objective(staging)
+            manifest = _write_no_objective_manifest(
+                staging,
+                publication,
+                publication_occurrence_identity,
+            )
+            lifecycle = "no_objective_data"
             authority = "evaluation_only"
             independent_ids = publication.parameterization.independent_ids
         else:

--- a/src/chemex/printers/native_reporting.py
+++ b/src/chemex/printers/native_reporting.py
@@ -22,6 +22,7 @@ from chemex.optimize.native_mcmc import (
 from chemex.optimize.native_resampling import (
     ResamplingEvidence,
     ResamplingSummaryOutcome,
+    SummaryFailure,
 )
 from chemex.optimize.uncertainty import UncertaintyEvidence
 from chemex.parameters.parameterization import (
@@ -110,6 +111,21 @@ def write_parameter_reports(
                 comment = f" # constrained: {expression}"
             lines.append(f"{_toml_key(param_id)} = {_toml_float(value)}{comment}")
         (path / filenames[role]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_evaluated_parameters(
+    path: Path,
+    parameterization: ActiveParameterization,
+    result: EvaluationResult,
+) -> None:
+    """Write evaluate-only values without claiming fitted or restart authority."""
+    path.mkdir()
+    lines = ["[parameters]"]
+    for param_id in parameterization.scope_ids:
+        role = parameterization.role(param_id).value
+        value = result.resolved_values[param_id]
+        lines.append(f"{_toml_key(param_id)} = {_toml_float(value)} # {role}")
+    (path / "evaluated.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def write_restart_parameters(
@@ -565,6 +581,21 @@ def write_suppressed_outcome(
 def write_partial_resampling(path: Path, evidence: ResamplingEvidence) -> None:
     """Write genuine partial primary resampling evidence."""
     write_json(path, resampling_evidence_record(evidence))
+
+
+def write_resampling_summary_failure(path: Path, failure: SummaryFailure) -> None:
+    """Write the typed reason completed resampling lacked a usable summary."""
+    write_json(
+        path,
+        {
+            "artifact_type": "native_resampling_summary_failure",
+            "schema_version": 1,
+            "identity": failure.identity,
+            "source_evidence_identity": failure.source_evidence_identity,
+            "category": failure.category,
+            "message": failure.message,
+        },
+    )
 
 
 def write_partial_mcmc(path: Path, evidence: McmcEvidence) -> None:

--- a/tests/test_native_method_step.py
+++ b/tests/test_native_method_step.py
@@ -1,0 +1,1436 @@
+"""Behavioral qualification for the closed native method-step composer (#641).
+
+The public seam is an immutable ``MethodStepWorkflow`` executed against the
+exact session-owned AnalysisValues occurrence.  Tests observe only its typed
+outcome and the explicit successor-state gate.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TypedDict
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from chemex.baselines import (
+    LegacyObservationImplementation,
+    Occurrence,
+    ResultBundle,
+    ResultMember,
+)
+from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.parameters import read_defaults
+from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
+from chemex.experiments.builder import build_experiments
+from chemex.native_provenance import BaselineReference, ProvenanceEnvironment
+from chemex.optimize.de_direct_trf import (
+    DeCoordinateSemantics,
+    DeDirectTrfInvocation,
+    DeDirectTrfOutcome,
+)
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    CancellationToken,
+    DirectTrfConstructionError,
+    MaterializationTerminal,
+    OptimizationProblem,
+    RootMaterializationFailure,
+    TerminalFailure,
+)
+from chemex.optimize.grid_direct_trf import GridDirectTrfInvocation
+from chemex.optimize.grouped_direct_trf import (
+    FitDecomposition,
+    GroupedDirectTrfInvocation,
+    GroupedDirectTrfOutcome,
+)
+from chemex.optimize.grouped_grid_direct_trf import GroupedGridDirectTrfOutcome
+from chemex.optimize.method_step import (
+    DerivationDisposition,
+    EvaluationPurpose,
+    McmcDerivationRequest,
+    MethodStepCheckpoint,
+    MethodStepLifecycle,
+    MethodStepPublicationRequest,
+    MethodStepRunProvenanceRequest,
+    MethodStepStrategy,
+    MethodStepWorkflow,
+    ResamplingDerivationRequest,
+    UncertaintyDerivationRequest,
+    execute_method_step,
+    require_successor_state,
+)
+from chemex.optimize.native_mcmc import ExpertMcmcPolicy, McmcEvidence
+from chemex.optimize.native_resampling import (
+    OperationTerminal as ResamplingOperationTerminal,
+)
+from chemex.optimize.native_resampling import (
+    OptimizationStrategy,
+    ResamplingEvidence,
+    ResamplingOperation,
+    ResamplingPlan,
+    ResamplingScheme,
+    ResamplingSummaryOutcome,
+    ResamplingSummaryPolicy,
+    SummaryFailure,
+    SummaryTerminal,
+    execute_resampling_evidence,
+)
+from chemex.optimize.uncertainty import (
+    ParameterUnit,
+    ResidualVarianceScaling,
+    UncertaintyPolicy,
+    compile_constraint_linearization_capabilities,
+)
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    SealedParameterModel,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.run_info import capture_native_inputs
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parent.parent
+EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
+METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+class _OptimizationInputs(TypedDict):
+    starting_snapshot: AnalysisValuesSnapshot
+    parameter_model: SealedParameterModel
+    parameterization: ActiveParameterization
+    engine: EvaluationEngine
+    method: Method
+    problem: OptimizationProblem
+    decomposition: FitDecomposition
+
+
+def _evaluation_workflow(
+    *,
+    purpose: EvaluationPurpose = EvaluationPurpose.NO_OPTIMIZATION_REQUIRED,
+) -> tuple[AnalysisSession, MethodStepWorkflow]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("G2N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values()
+    method = (
+        Method(fit=["PB"], fix=["R1A_A", "KEX_AB"])
+        if purpose is EvaluationPurpose.EVALUATE_ONLY
+        else Method(fix=["R1A_A", "PB", "KEX_AB"])
+    )
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    if purpose is EvaluationPurpose.NO_OBJECTIVE_DATA:
+        for experiment in experiments:
+            for profile in experiment.profiles:
+                profile.is_scaled = False
+                profile.data.mask = np.zeros(profile.data.size, dtype=np.bool_)
+                profile.data.mark_dirty()
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    workflow = MethodStepWorkflow.for_evaluation(
+        starting_snapshot=session.analysis_values.snapshot(),
+        parameter_model=parameter_model,
+        parameterization=parameterization,
+        engine=engine,
+        method=method,
+        purpose=purpose,
+    )
+    return session, workflow
+
+
+def _optimization_inputs(
+    *,
+    all_profiles: bool = False,
+    method: Method | None = None,
+    stabilize_data: bool = False,
+) -> tuple[AnalysisSession, _OptimizationInputs]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(
+            include=(None if all_profiles else [SpinSystem.from_name("G2N-HN")]),
+            exclude=None,
+        ),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values()
+    method = read_methods([METHOD])["DEFAULT"] if method is None else method
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    if stabilize_data:
+        frame = EvaluationFrame.from_lifecycle_frame(
+            parameterization,
+            parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+        )
+        initial = engine.new_evaluator().evaluate(frame)
+        assert isinstance(initial, EvaluationResult)
+        offset = 0
+        for experiment in experiments:
+            for profile in experiment.profiles:
+                stop = offset + profile.data.size
+                profile.data.exp = np.asarray(
+                    initial.normalized_calculations[offset:stop],
+                    dtype=np.float64,
+                ).copy()
+                profile.data.mark_dirty()
+                offset = stop
+        engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    configuration = session.parameter_factory.sealed_configuration
+    assert parameter_model is not None
+    assert configuration is not None
+    starting = session.analysis_values.snapshot()
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        starting,
+    )
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    return session, {
+        "starting_snapshot": starting,
+        "parameter_model": parameter_model,
+        "parameterization": parameterization,
+        "engine": engine,
+        "method": method,
+        "problem": problem,
+        "decomposition": decomposition,
+    }
+
+
+def _direct_workflow(
+    *,
+    all_profiles: bool = False,
+    stabilize_data: bool = False,
+    derivations: tuple[
+        UncertaintyDerivationRequest
+        | ResamplingDerivationRequest
+        | McmcDerivationRequest,
+        ...,
+    ] = (),
+) -> tuple[AnalysisSession, MethodStepWorkflow]:
+    session, inputs = _optimization_inputs(
+        all_profiles=all_profiles,
+        stabilize_data=stabilize_data,
+    )
+    decomposition = inputs["decomposition"]
+    assert isinstance(decomposition, FitDecomposition)
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(80,) * len(decomposition.components),
+    )
+    workflow = MethodStepWorkflow.for_optimization(
+        **inputs,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=invocation,
+        derivations=derivations,
+    )
+    return session, workflow
+
+
+def _grid_workflow(
+    *,
+    all_profiles: bool = False,
+) -> tuple[AnalysisSession, MethodStepWorkflow]:
+    session, inputs = _optimization_inputs(all_profiles=all_profiles)
+    problem = inputs["problem"]
+    assert isinstance(problem, OptimizationProblem)
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((problem.controlled_ids[0], (problem.start[0],)),),
+        objective_request_budget=80,
+    )
+    return session, MethodStepWorkflow.for_optimization(
+        **inputs,
+        strategy=MethodStepStrategy.GRID_DIRECT_TRF,
+        invocation=invocation,
+    )
+
+
+def _de_workflow() -> tuple[AnalysisSession, MethodStepWorkflow]:
+    session, inputs = _optimization_inputs()
+    problem = inputs["problem"]
+    assert isinstance(problem, OptimizationProblem)
+    invocation = DeDirectTrfInvocation.for_problem(
+        problem,
+        search_coordinates=(
+            (
+                problem.controlled_ids[0],
+                0.5 * problem.start[0],
+                1.5 * problem.start[0],
+                DeCoordinateSemantics.LINEAR,
+            ),
+        ),
+        root_seed=641,
+        de_objective_request_budget=30,
+        polish_objective_request_budget=80,
+        population_multiplier=4,
+        maximum_generations=5,
+    )
+    return session, MethodStepWorkflow.for_optimization(
+        **inputs,
+        strategy=MethodStepStrategy.DE_DIRECT_TRF,
+        invocation=invocation,
+    )
+
+
+def _uncertainty_request(workflow: MethodStepWorkflow) -> UncertaintyDerivationRequest:
+    controlled_id = workflow.problem.controlled_ids[0] if workflow.problem else ""
+    policy = UncertaintyPolicy(
+        calibration_identity="issue-641-qualification-v1",
+        numerical_compatibility_requirement=(
+            "binary64-scipy-economical-svd-fixed-pairwise-v1"
+        ),
+        coordinate_scales=((controlled_id, 1.0),),
+        coordinate_units=((controlled_id, ParameterUnit.RATE_PER_SECOND),),
+        residual_variance_scaling=(
+            ResidualVarianceScaling.ESTIMATED_COMMON_RESIDUAL_VARIANCE
+        ),
+        relative_step_tolerance=1.0e-4,
+        roundoff_multiplier=64.0,
+        smaller_step_extent=8,
+        larger_step_extent=8,
+        svd_driver="gesdd",
+        rank_absolute_tolerance=0.0,
+        rank_relative_tolerance=1.0e-12,
+        weak_relative_tolerance=1.0e-6,
+        singular_value_cluster_relative_tolerance=1.0e-10,
+        conditioning_limit=1.0e12,
+        correlation_roundoff_multiplier=64.0,
+        affine_feasibility_policy="canonical-root-affine-halfspace-zeta-gt-3-v1",
+    )
+    capabilities = compile_constraint_linearization_capabilities(
+        workflow.parameterization,
+        (),
+        (),
+    )
+    return UncertaintyDerivationRequest(
+        policy,
+        compiled_capabilities=capabilities,
+        resolved_environment_identity="issue-641-local-environment",
+    )
+
+
+def _resampling_request(workflow: MethodStepWorkflow) -> ResamplingDerivationRequest:
+    size = workflow.engine.plan.observation_count
+    scope = workflow.problem.commit_scope if workflow.problem else ()
+    return ResamplingDerivationRequest(
+        references=(False,) * size,
+        nucleus_groups=("G2N",) * size,
+        observation_descriptors=tuple(f"ordinal={index}" for index in range(size)),
+        scheme=ResamplingScheme.MONTE_CARLO,
+        replicate_count=2,
+        replicate_structural_identities=("replicate-alpha", "replicate-beta"),
+        replicate_component_identities=(("component-alpha",), ("component-beta",)),
+        root_seed=641,
+        output_scope=scope,
+        output_units=("native",) * len(scope),
+        minimum_successful_count=1,
+        strategy=OptimizationStrategy.DIRECT_TRF,
+        strategy_settings=(("objective_request_budget", "80"),),
+        summary_policy=ResamplingSummaryPolicy(),
+    )
+
+
+def _publication_request(path: Path) -> MethodStepPublicationRequest:
+    requested = Occurrence(
+        "a" * 64,
+        "b" * 64,
+        "c" * 64,
+        "unqualified-local-lane-v1",
+        None,
+        ("d" * 64,),
+        "issue-641-publication-baseline",
+    )
+    bundle = ResultBundle.create(
+        requested.identity,
+        requested.execution_specification_identity,
+        LegacyObservationImplementation(),
+        (ResultMember("result", "e" * 64, 1),),
+    )
+    occurrence = requested.succeeded(bundle)
+    return MethodStepPublicationRequest(
+        path,
+        ProvenanceEnvironment.from_current_process(),
+        (
+            BaselineReference.from_occurrence(occurrence),
+            BaselineReference.from_result_bundle(bundle),
+        ),
+    )
+
+
+def test_evaluation_only_retains_objective_without_fit_acceptance_or_commit() -> None:
+    session, workflow = _evaluation_workflow()
+    starting = session.analysis_values.snapshot()
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE, (
+        outcome.publication_failure
+    )
+    assert isinstance(outcome.evaluation_result, EvaluationResult)
+    assert outcome.evaluation_result.residuals.size > 0
+    assert outcome.accepted_result is None
+    assert outcome.commit_operation is None
+    assert session.analysis_values.snapshot() == starting
+    assert require_successor_state(outcome, session.analysis_values) is (
+        workflow.starting_snapshot
+    )
+
+
+def test_no_objective_data_is_typed_and_does_not_evaluate_or_continue() -> None:
+    session, workflow = _evaluation_workflow(
+        purpose=EvaluationPurpose.NO_OBJECTIVE_DATA
+    )
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.NO_OBJECTIVE_DATA
+    assert outcome.evaluation_result is None
+    with pytest.raises(ValueError, match="successor authority"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_no_objective_data_publishes_typed_diagnostics(tmp_path: Path) -> None:
+    session, base = _evaluation_workflow(purpose=EvaluationPurpose.NO_OBJECTIVE_DATA)
+    output = tmp_path / "no-objective"
+    workflow = dataclasses.replace(base, publication=_publication_request(output))
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.NO_OBJECTIVE_DATA
+    assert outcome.publication is not None, outcome.publication_failure
+    assert (output / "Diagnostics" / "outcome.json").is_file()
+    assert not (output / "Parameters").exists()
+
+
+def test_explicit_evaluate_only_with_fit_roles_can_publish(tmp_path: Path) -> None:
+    session, base = _evaluation_workflow(purpose=EvaluationPurpose.EVALUATE_ONLY)
+    output = tmp_path / "evaluate-only"
+    workflow = dataclasses.replace(base, publication=_publication_request(output))
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE, (
+        outcome.publication_failure
+    )
+    assert outcome.publication is not None, outcome.publication_failure
+    assert outcome.accepted_result is None
+    assert outcome.commit_operation is None
+    assert require_successor_state(outcome, session.analysis_values).revision == 0
+
+
+def test_serialized_outcome_cannot_recreate_successor_authority() -> None:
+    session, workflow = _evaluation_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    historical = type(outcome).from_record(outcome.to_record())
+
+    assert historical.to_record() == outcome.to_record()
+    with pytest.raises(ValueError, match="successor authority"):
+        require_successor_state(historical, session.analysis_values)
+
+
+def test_workflow_rejects_a_starting_snapshot_from_another_occurrence() -> None:
+    _session, workflow = _evaluation_workflow()
+    foreign_session, _foreign_workflow = _evaluation_workflow()
+
+    with pytest.raises(ValueError, match="starting state"):
+        MethodStepWorkflow.for_evaluation(
+            starting_snapshot=foreign_session.analysis_values.snapshot(),
+            parameter_model=workflow.parameter_model,
+            parameterization=workflow.parameterization,
+            engine=workflow.engine,
+            method=read_methods([METHOD])["DEFAULT"],
+            purpose=EvaluationPurpose.NO_OPTIMIZATION_REQUIRED,
+        )
+
+
+def test_one_component_direct_trf_uses_decomposition_aggregate_and_one_commit() -> None:
+    session, workflow = _direct_workflow()
+    assert workflow.decomposition is not None
+    assert len(workflow.decomposition.components) == 1
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert isinstance(outcome.primary_execution, GroupedDirectTrfOutcome)
+    assert len(outcome.primary_execution.components) == 1
+    assert outcome.accepted_result is outcome.primary_execution.accepted_result
+    assert outcome.commit_operation is not None
+    assert outcome.commit_operation.receipt is not None
+    assert outcome.commit_operation.receipt.new_revision == 1
+    successor = require_successor_state(outcome, session.analysis_values)
+    assert successor.revision == 1
+
+
+def test_optimization_workflow_rejects_foreign_or_zero_component_decomposition() -> (
+    None
+):
+    _session, workflow = _direct_workflow()
+    _foreign_session, foreign = _direct_workflow()
+    assert workflow.problem is not None
+    assert workflow.decomposition is not None
+    assert workflow.invocation is not None
+    assert foreign.decomposition is not None
+
+    with pytest.raises(DirectTrfConstructionError, match="decomposition"):
+        dataclasses.replace(workflow.decomposition, components=())
+
+    with pytest.raises(ValueError, match="decomposition"):
+        MethodStepWorkflow.for_optimization(
+            starting_snapshot=workflow.starting_snapshot,
+            parameter_model=workflow.parameter_model,
+            parameterization=workflow.parameterization,
+            engine=workflow.engine,
+            method=workflow.method,
+            problem=workflow.problem,
+            decomposition=foreign.decomposition,
+            strategy=MethodStepStrategy.DIRECT_TRF,
+            invocation=workflow.invocation,
+        )
+
+
+def test_multi_component_direct_trf_keeps_components_non_authoritative() -> None:
+    session, workflow = _direct_workflow(all_profiles=True)
+    assert workflow.decomposition is not None
+    assert len(workflow.decomposition.components) > 1
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert isinstance(outcome.primary_execution, GroupedDirectTrfOutcome)
+    assert len(outcome.primary_execution.components) == len(
+        workflow.decomposition.components
+    )
+    assert all(
+        component.candidate is not None
+        for component in outcome.primary_execution.components
+    )
+    assert outcome.primary_execution.accepted_result is outcome.accepted_result
+
+
+@pytest.mark.parametrize("all_profiles", [False, True])
+def test_grid_then_trf_always_uses_grouped_decomposition(all_profiles: bool) -> None:
+    session, workflow = _grid_workflow(all_profiles=all_profiles)
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert isinstance(outcome.primary_execution, GroupedGridDirectTrfOutcome)
+    assert outcome.accepted_result is outcome.primary_execution.accepted_result
+    assert outcome.commit_operation is not None
+    assert outcome.commit_operation.receipt is not None
+
+
+def test_de_then_trf_routes_existing_seeded_search_and_commits_once() -> None:
+    session, workflow = _de_workflow()
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert isinstance(outcome.primary_execution, DeDirectTrfOutcome)
+    assert outcome.accepted_result is outcome.primary_execution.accepted_result
+    assert outcome.commit_operation is not None
+    assert outcome.commit_operation.receipt is not None
+
+
+def test_cancellation_before_primary_starts_blocks_commit_and_successor() -> None:
+    session, workflow = _direct_workflow()
+    cancellation = CancellationToken()
+    cancellation.cancel()
+
+    outcome = execute_method_step(
+        workflow,
+        analysis_values=session.analysis_values,
+        cancellation=cancellation,
+    )
+
+    assert outcome.lifecycle is MethodStepLifecycle.CANCELLED
+    assert outcome.accepted_result is None
+    assert outcome.commit_operation is None
+    with pytest.raises(ValueError, match="successor authority"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_stale_commit_retains_accepted_diagnostics_and_blocks_successor() -> None:
+    session, workflow = _direct_workflow()
+
+    def make_stale(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is not MethodStepCheckpoint.AGGREGATE_ACCEPTED:
+            return
+        current = session.analysis_values.snapshot()
+        session.analysis_values.commit(
+            dict(current.items()),
+            expected=current,
+            scope=tuple(current),
+        )
+
+    outcome = execute_method_step(
+        workflow,
+        analysis_values=session.analysis_values,
+        checkpoint_observer=make_stale,
+    )
+
+    assert outcome.lifecycle is MethodStepLifecycle.ACCEPTED_UNCOMMITTED
+    assert outcome.accepted_result is not None
+    assert outcome.commit_operation is not None
+    assert outcome.commit_operation.failure is not None
+    assert outcome.commit_operation.failure.category.value == "stale_revision"
+    with pytest.raises(ValueError, match="successor authority"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_stale_first_step_cannot_compile_a_required_second_step() -> None:
+    session, workflow = _direct_workflow()
+
+    def make_stale(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is MethodStepCheckpoint.AGGREGATE_ACCEPTED:
+            current = session.analysis_values.snapshot()
+            session.analysis_values.commit(
+                dict(current.items()),
+                expected=current,
+                scope=tuple(current),
+            )
+
+    first = execute_method_step(
+        workflow,
+        analysis_values=session.analysis_values,
+        checkpoint_observer=make_stale,
+    )
+    second_compilation_count = 0
+
+    def compile_second() -> None:
+        nonlocal second_compilation_count
+        require_successor_state(first, session.analysis_values)
+        second_compilation_count += 1
+
+    with pytest.raises(ValueError, match="successor authority"):
+        compile_second()
+    assert second_compilation_count == 0
+
+
+def test_optimizer_non_convergence_is_typed_and_never_committed() -> None:
+    session, workflow = _direct_workflow()
+
+    def unsuccessful(*_args: object, **_kwargs: object) -> object:
+        problem = workflow.problem
+        assert problem is not None
+        return SimpleNamespace(
+            x=np.asarray(problem.start),
+            fun=np.ones(workflow.engine.plan.retained_observation_count),
+            status=0,
+            success=False,
+            message="qualified non-convergence",
+            nfev=1,
+            njev=0,
+            cost=1.0,
+            optimality=1.0,
+            active_mask=np.zeros(len(problem.start), dtype=np.int64),
+        )
+
+    with patch("chemex.optimize.direct_trf.least_squares", unsuccessful):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.FAILED
+    assert outcome.accepted_result is None
+    assert outcome.commit_operation is None
+
+
+def test_requested_uncertainty_runs_only_after_commit_and_cannot_mutate_central_values() -> (
+    None
+):
+    session, base = _direct_workflow(stabilize_data=True)
+    request = _uncertainty_request(base)
+    assert base.problem is not None
+    assert base.decomposition is not None
+    assert base.invocation is not None
+    workflow = MethodStepWorkflow.for_optimization(
+        starting_snapshot=base.starting_snapshot,
+        parameter_model=base.parameter_model,
+        parameterization=base.parameterization,
+        engine=base.engine,
+        method=base.method,
+        problem=base.problem,
+        decomposition=base.decomposition,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=base.invocation,
+        derivations=(request,),
+    )
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert len(outcome.derivations) == 1
+    assert outcome.derivations[0].stage == "uncertainty"
+    assert outcome.derivations[0].disposition in {
+        DerivationDisposition.COMPLETED,
+        DerivationDisposition.FAILED,
+    }
+    assert outcome.commit_operation is not None
+    assert (
+        outcome.commit_operation.committed_snapshot
+        == session.analysis_values.snapshot()
+    )
+
+
+def test_cancellation_after_commit_stops_requested_derivations_without_rollback() -> (
+    None
+):
+    session, base = _direct_workflow()
+    request = _uncertainty_request(base)
+    assert base.problem is not None
+    assert base.decomposition is not None
+    assert base.invocation is not None
+    workflow = MethodStepWorkflow.for_optimization(
+        starting_snapshot=base.starting_snapshot,
+        parameter_model=base.parameter_model,
+        parameterization=base.parameterization,
+        engine=base.engine,
+        method=base.method,
+        problem=base.problem,
+        decomposition=base.decomposition,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=base.invocation,
+        derivations=(request,),
+    )
+    cancellation = CancellationToken()
+
+    def cancel_after_commit(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is MethodStepCheckpoint.COMMIT_COMPLETED:
+            cancellation.cancel()
+
+    outcome = execute_method_step(
+        workflow,
+        analysis_values=session.analysis_values,
+        cancellation=cancellation,
+        checkpoint_observer=cancel_after_commit,
+    )
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert outcome.commit_operation is not None
+    assert outcome.commit_operation.receipt is not None
+    assert outcome.derivations[0].disposition is (
+        DerivationDisposition.NOT_STARTED_BY_WORKFLOW_STOP
+    )
+    assert require_successor_state(outcome, session.analysis_values).revision == 1
+
+
+def test_cancellation_after_acceptance_blocks_commit_and_all_derivations() -> None:
+    session, base = _direct_workflow()
+    request = _uncertainty_request(base)
+    workflow = dataclasses.replace(base, derivations=(request,))
+    cancellation = CancellationToken()
+
+    def cancel_at_acceptance(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is MethodStepCheckpoint.AGGREGATE_ACCEPTED:
+            cancellation.cancel()
+
+    outcome = execute_method_step(
+        workflow,
+        analysis_values=session.analysis_values,
+        cancellation=cancellation,
+        checkpoint_observer=cancel_at_acceptance,
+    )
+
+    assert outcome.lifecycle is MethodStepLifecycle.CANCELLED
+    assert outcome.accepted_result is not None
+    assert outcome.commit_operation is None
+    assert session.analysis_values.snapshot().revision == 0
+    assert outcome.derivations[0].disposition is (
+        DerivationDisposition.NOT_STARTED_BY_WORKFLOW_STOP
+    )
+    with pytest.raises(ValueError, match="successor authority"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_independent_resampling_runs_after_uncertainty_branch_failure() -> None:
+    session, base = _direct_workflow(stabilize_data=True)
+    valid_uncertainty = _uncertainty_request(base)
+    incompatible_policy = dataclasses.replace(
+        valid_uncertainty.policy,
+        coordinate_scales=(("__FOREIGN", 1.0),),
+        coordinate_units=(("__FOREIGN", ParameterUnit.RATE_PER_SECOND),),
+    )
+    uncertainty = dataclasses.replace(
+        valid_uncertainty,
+        policy=incompatible_policy,
+    )
+    resampling = _resampling_request(base)
+    assert base.problem is not None
+    assert base.decomposition is not None
+    assert base.invocation is not None
+    workflow = MethodStepWorkflow.for_optimization(
+        starting_snapshot=base.starting_snapshot,
+        parameter_model=base.parameter_model,
+        parameterization=base.parameterization,
+        engine=base.engine,
+        method=base.method,
+        problem=base.problem,
+        decomposition=base.decomposition,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=base.invocation,
+        derivations=(uncertainty, resampling),
+    )
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert [item.stage for item in outcome.derivations] == [
+        "uncertainty",
+        "resampling",
+    ]
+    assert outcome.derivations[0].disposition is DerivationDisposition.FAILED
+    assert outcome.derivations[1].disposition is DerivationDisposition.COMPLETED
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+
+
+def test_interrupted_derivation_stops_later_requested_stages() -> None:
+    session, base = _direct_workflow(stabilize_data=True)
+    resampling = _resampling_request(base)
+    assert base.problem is not None
+    assert base.decomposition is not None
+    assert base.invocation is not None
+    policy = ExpertMcmcPolicy(
+        burn_steps=1,
+        retained_steps=2,
+        walkers=max(6, 2 * len(base.problem.controlled_ids)),
+        expert_provenance="issue-641-interruption",
+    ).resolve(dimension=len(base.problem.controlled_ids), root_seed=641)
+    mcmc = McmcDerivationRequest(
+        policy,
+        tuple(
+            (param_id, ParameterUnit.DIMENSIONLESS)
+            for param_id in base.problem.controlled_ids
+        ),
+        tuple(
+            (param_id, ParameterUnit.DIMENSIONLESS)
+            for param_id in base.problem.commit_scope
+        ),
+    )
+    workflow = MethodStepWorkflow.for_optimization(
+        starting_snapshot=base.starting_snapshot,
+        parameter_model=base.parameter_model,
+        parameterization=base.parameterization,
+        engine=base.engine,
+        method=base.method,
+        problem=base.problem,
+        decomposition=base.decomposition,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=base.invocation,
+        derivations=(resampling, mcmc),
+    )
+    interrupted = SimpleNamespace(
+        terminal=ResamplingOperationTerminal.INTERRUPTED,
+        identity="qualified-resampling-interruption",
+        evidence=None,
+    )
+
+    with (
+        patch(
+            "chemex.optimize.method_step.execute_resampling_evidence",
+            return_value=interrupted,
+        ),
+        patch("chemex.optimize.method_step.execute_mcmc_evidence") as execute_mcmc,
+    ):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    assert [item.disposition for item in outcome.derivations] == [
+        DerivationDisposition.INTERRUPTED,
+        DerivationDisposition.NOT_STARTED_BY_WORKFLOW_STOP,
+    ]
+    execute_mcmc.assert_not_called()
+
+
+def test_committed_publication_retains_partial_derivation_evidence(
+    tmp_path: Path,
+) -> None:
+    session, base = _direct_workflow(stabilize_data=True)
+    request = _resampling_request(base)
+    output = tmp_path / "partial"
+    workflow = dataclasses.replace(
+        base,
+        derivations=(request,),
+        publication=_publication_request(output),
+    )
+
+    def cancel_resampling(
+        accepted: AcceptedFitResult,
+        plan: ResamplingPlan,
+        **_kwargs: object,
+    ) -> ResamplingOperation:
+        return execute_resampling_evidence(
+            accepted,
+            plan,
+            cancellation_probe=lambda: True,
+        )
+
+    with patch(
+        "chemex.optimize.method_step.execute_resampling_evidence",
+        side_effect=cancel_resampling,
+    ):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED, (
+        outcome.publication_failure
+    )
+    assert outcome.derivations[0].disposition is DerivationDisposition.CANCELLED
+    assert outcome.publication is not None
+    assert (
+        output / "PartialEvidence" / "Resampling" / "MC" / "evidence.json"
+    ).is_file()
+    assert (output / "Parameters" / "restart.toml").is_file()
+
+
+def test_resampling_summary_failure_is_preserved_and_published(
+    tmp_path: Path,
+) -> None:
+    session, base = _direct_workflow(stabilize_data=True)
+    request = _resampling_request(base)
+    output = tmp_path / "summary-failure"
+    workflow = dataclasses.replace(
+        base,
+        derivations=(request,),
+        publication=_publication_request(output),
+    )
+    captured_failure: SummaryFailure | None = None
+
+    def fail_summary(
+        evidence: ResamplingEvidence,
+        _policy: ResamplingSummaryPolicy,
+    ) -> ResamplingSummaryOutcome:
+        nonlocal captured_failure
+        captured_failure = SummaryFailure(
+            evidence.identity,
+            "qualification_summary_failure",
+            "Qualification forced the derived summary to fail",
+        )
+        return ResamplingSummaryOutcome(
+            SummaryTerminal.INSUFFICIENT_COVERAGE,
+            failure=captured_failure,
+        )
+
+    with patch(
+        "chemex.optimize.method_step.summarize_resampling_evidence",
+        side_effect=fail_summary,
+    ) as summarize:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    assert captured_failure is not None
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED, (
+        outcome.publication_failure
+    )
+    assert outcome.derivations[0].disposition is DerivationDisposition.FAILED
+    assert captured_failure.identity in outcome.derivations[0].artifact_identities
+    assert summarize.call_count == 1
+    assert (
+        output / "PartialEvidence" / "Resampling" / "MC" / "summary-failure.json"
+    ).is_file()
+
+
+@pytest.mark.parametrize(
+    ("posterior_error", "expected_disposition"),
+    [
+        (
+            ValueError("qualification posterior failure"),
+            DerivationDisposition.FAILED,
+        ),
+        (KeyboardInterrupt(), DerivationDisposition.INTERRUPTED),
+    ],
+)
+def test_mcmc_posterior_stop_retains_completed_primary_evidence(
+    tmp_path: Path,
+    posterior_error: BaseException,
+    expected_disposition: DerivationDisposition,
+) -> None:
+    session, inputs = _optimization_inputs(
+        method=Method(fit=["PB"], fix=["R1A_A", "KEX_AB"]),
+        stabilize_data=True,
+    )
+    problem = inputs["problem"]
+    decomposition = inputs["decomposition"]
+    assert isinstance(problem, OptimizationProblem)
+    assert isinstance(decomposition, FitDecomposition)
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(80,) * len(decomposition.components),
+    )
+    policy = ExpertMcmcPolicy(
+        burn_steps=1,
+        retained_steps=2,
+        walkers=max(6, 2 * len(problem.controlled_ids)),
+        expert_provenance="issue-641-posterior-failure",
+    ).resolve(dimension=len(problem.controlled_ids), root_seed=641)
+    request = McmcDerivationRequest(
+        policy,
+        tuple(
+            (param_id, ParameterUnit.DIMENSIONLESS)
+            for param_id in problem.controlled_ids
+        ),
+        tuple(
+            (param_id, ParameterUnit.DIMENSIONLESS) for param_id in problem.commit_scope
+        ),
+    )
+    output = tmp_path / "mcmc-posterior-failure"
+    workflow = MethodStepWorkflow.for_optimization(
+        **inputs,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=invocation,
+        derivations=(request,),
+        publication=_publication_request(output),
+    )
+
+    with patch(
+        "chemex.optimize.method_step.derive_retained_sample_view",
+        side_effect=posterior_error,
+    ):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    derivation = outcome.derivations[0]
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED, (
+        outcome.publication_failure
+    )
+    assert derivation.disposition is expected_disposition
+    assert isinstance(derivation.artifacts[0], McmcEvidence)
+    assert type(posterior_error).__name__ in derivation.message
+    assert (output / "PartialEvidence" / "MCMC" / "evidence.json").is_file()
+
+
+def test_requested_mcmc_retains_exact_committed_fit_lineage() -> None:
+    session, inputs = _optimization_inputs(
+        method=Method(fit=["PB"], fix=["R1A_A", "KEX_AB"]),
+        stabilize_data=True,
+    )
+    problem = inputs["problem"]
+    decomposition = inputs["decomposition"]
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(80,) * len(decomposition.components),
+    )
+    policy = ExpertMcmcPolicy(
+        burn_steps=1,
+        retained_steps=2,
+        walkers=6,
+        expert_provenance="issue-641-explicit-mcmc",
+    ).resolve(dimension=len(problem.controlled_ids), root_seed=641)
+    mcmc = McmcDerivationRequest(
+        policy,
+        tuple(
+            (param_id, ParameterUnit.DIMENSIONLESS)
+            for param_id in problem.controlled_ids
+        ),
+        tuple(
+            (param_id, ParameterUnit.DIMENSIONLESS) for param_id in problem.commit_scope
+        ),
+    )
+    workflow = MethodStepWorkflow.for_optimization(
+        **inputs,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=invocation,
+        derivations=(mcmc,),
+    )
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert outcome.derivations[0].stage == "mcmc"
+    assert outcome.derivations[0].disposition is DerivationDisposition.COMPLETED
+    assert len(outcome.derivations[0].artifact_identities) == 3
+
+
+def test_successful_method_step_publication_uses_atomic_native_step_root(
+    tmp_path: Path,
+) -> None:
+    session, base = _direct_workflow()
+    assert base.problem is not None
+    assert base.decomposition is not None
+    assert base.invocation is not None
+    output = tmp_path / "step-0001"
+    workflow = MethodStepWorkflow.for_optimization(
+        starting_snapshot=base.starting_snapshot,
+        parameter_model=base.parameter_model,
+        parameterization=base.parameterization,
+        engine=base.engine,
+        method=base.method,
+        problem=base.problem,
+        decomposition=base.decomposition,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=base.invocation,
+        publication=_publication_request(output),
+    )
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert outcome.publication is not None, outcome.publication_failure
+    outcome.publication.require_exact_live_publication()
+    assert outcome.publication.path == output
+    assert (output / "fit-manifest.toml").is_file()
+    assert (output / "Parameters" / "fitted.toml").is_file()
+    assert (output / "Parameters" / "restart.toml").is_file()
+
+
+def test_publication_failure_never_rolls_back_committed_fit(tmp_path: Path) -> None:
+    session, base = _direct_workflow()
+    assert base.problem is not None
+    assert base.decomposition is not None
+    assert base.invocation is not None
+    output = tmp_path / "occupied"
+    output.mkdir()
+    workflow = MethodStepWorkflow.for_optimization(
+        starting_snapshot=base.starting_snapshot,
+        parameter_model=base.parameter_model,
+        parameterization=base.parameterization,
+        engine=base.engine,
+        method=base.method,
+        problem=base.problem,
+        decomposition=base.decomposition,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=base.invocation,
+        publication=_publication_request(output),
+    )
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.PUBLICATION_FAILED
+    assert outcome.commit_operation is not None
+    assert outcome.commit_operation.receipt is not None
+    assert session.analysis_values.snapshot().revision == 1
+    assert "FileExistsError" in outcome.publication_failure
+    with pytest.raises(ValueError, match="successor authority"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_evaluation_only_publication_uses_existing_native_reporting(
+    tmp_path: Path,
+) -> None:
+    session, base = _evaluation_workflow()
+    output = tmp_path / "evaluation"
+    workflow = dataclasses.replace(base, publication=_publication_request(output))
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE, (
+        outcome.publication_failure
+    )
+    assert outcome.publication is not None, outcome.publication_failure
+    assert (output / "fit-manifest.toml").is_file()
+    assert not (output / "Parameters" / "restart.toml").exists()
+    assert require_successor_state(outcome, session.analysis_values).revision == 0
+
+
+def test_failed_primary_publishes_diagnostics_only(tmp_path: Path) -> None:
+    session, base = _direct_workflow()
+    output = tmp_path / "failed"
+    workflow = dataclasses.replace(base, publication=_publication_request(output))
+
+    with patch.object(workflow.engine, "project_profiles", side_effect=RuntimeError):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.FAILED
+    assert outcome.publication is not None, outcome.publication_failure
+    assert (output / "Diagnostics" / "outcome.json").is_file()
+    assert not (output / "Parameters").exists()
+    assert not (output / "Statistics").exists()
+
+
+def test_stale_commit_publication_suppresses_fitted_and_restart_output(
+    tmp_path: Path,
+) -> None:
+    session, base = _direct_workflow()
+    output = tmp_path / "stale"
+    workflow = dataclasses.replace(base, publication=_publication_request(output))
+
+    def make_stale(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is MethodStepCheckpoint.AGGREGATE_ACCEPTED:
+            current = session.analysis_values.snapshot()
+            session.analysis_values.commit(
+                dict(current.items()),
+                expected=current,
+                scope=tuple(current),
+            )
+
+    outcome = execute_method_step(
+        workflow,
+        analysis_values=session.analysis_values,
+        checkpoint_observer=make_stale,
+    )
+
+    assert outcome.lifecycle is MethodStepLifecycle.ACCEPTED_UNCOMMITTED
+    assert outcome.publication is not None, outcome.publication_failure
+    assert (output / "Diagnostics" / "outcome.json").is_file()
+    assert not (output / "Parameters").exists()
+
+
+def test_interruption_during_primary_starts_no_later_stage() -> None:
+    session, workflow = _direct_workflow()
+
+    with patch.object(
+        workflow.engine, "project_profiles", side_effect=KeyboardInterrupt
+    ):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.INTERRUPTED
+    assert outcome.accepted_result is None
+    assert outcome.commit_operation is None
+
+
+def test_aggregate_materialization_failure_never_accepts_or_commits() -> None:
+    session, workflow = _direct_workflow()
+    calls = 0
+
+    def fail_aggregate(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return RootMaterializationFailure(
+            MaterializationTerminal.FAILURE,
+            1,
+            workflow.engine.compatibility_identity,
+            0,
+            1,
+            TerminalFailure("qualified_aggregate_failure"),
+        )
+
+    with patch(
+        "chemex.optimize.grouped_direct_trf.direct_trf_owner.materialize_root_candidate",
+        fail_aggregate,
+    ):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    assert calls == 1
+    assert outcome.lifecycle is MethodStepLifecycle.FAILED
+    assert outcome.accepted_result is None
+    assert outcome.commit_operation is None
+
+
+def test_two_steps_compile_second_from_exact_committed_successor() -> None:
+    session, first = _direct_workflow(stabilize_data=True)
+    first_outcome = execute_method_step(
+        first,
+        analysis_values=session.analysis_values,
+    )
+    successor = require_successor_state(first_outcome, session.analysis_values)
+    parameterization = session.compile_parameterization(
+        first.method,
+        set(first.parameterization.scope_ids),
+    )
+    engine = first.engine.rebind_parameterization(parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert configuration is not None
+    assert parameter_model is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        successor,
+    )
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    second = MethodStepWorkflow.for_optimization(
+        starting_snapshot=successor,
+        parameter_model=parameter_model,
+        parameterization=parameterization,
+        engine=engine,
+        method=first.method,
+        problem=problem,
+        decomposition=decomposition,
+        strategy=MethodStepStrategy.DIRECT_TRF,
+        invocation=GroupedDirectTrfInvocation.for_decomposition(
+            decomposition,
+            objective_request_budgets=(80,) * len(decomposition.components),
+        ),
+    )
+
+    second_outcome = execute_method_step(
+        second,
+        analysis_values=session.analysis_values,
+    )
+
+    assert second.starting_snapshot is successor
+    assert second_outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert (
+        require_successor_state(second_outcome, session.analysis_values).revision == 2
+    )
+
+
+def test_method_step_publication_can_write_existing_run_information(
+    tmp_path: Path,
+) -> None:
+    session, base = _direct_workflow()
+    output = tmp_path / "Output"
+    captured = capture_native_inputs(
+        Namespace(
+            experiments=[EXPERIMENT],
+            parameters=[PARAMETERS],
+            method=[METHOD],
+            output=output,
+        ),
+        working_directory=ROOT,
+    )
+    run_request = MethodStepRunProvenanceRequest(
+        output,
+        "issue-641-native-method-step",
+        captured,
+        base.starting_snapshot,
+        working_directory=ROOT,
+    )
+    publication = dataclasses.replace(
+        _publication_request(output / "STEP-0001"),
+        run_provenance=run_request,
+    )
+    workflow = dataclasses.replace(base, publication=publication)
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED, (
+        outcome.publication_failure
+    )
+    assert outcome.run_provenance is not None
+    assert outcome.publication is not None
+    outcome.publication.require_exact_live_publication()
+    assert outcome.run_provenance_identity == (
+        outcome.run_provenance.execution_occurrence_identity
+    )
+    assert (output / "run_info" / "run.toml").is_file()
+
+
+def test_run_information_failure_retains_successful_step_publication(
+    tmp_path: Path,
+) -> None:
+    session, base = _direct_workflow()
+    output = tmp_path / "Output"
+    (output / "run_info").mkdir(parents=True)
+    captured = capture_native_inputs(
+        Namespace(
+            experiments=[EXPERIMENT],
+            parameters=[PARAMETERS],
+            method=[METHOD],
+            output=output,
+        ),
+        working_directory=ROOT,
+    )
+    run_request = MethodStepRunProvenanceRequest(
+        output,
+        "issue-641-run-info-failure",
+        captured,
+        base.starting_snapshot,
+        working_directory=ROOT,
+    )
+    workflow = dataclasses.replace(
+        base,
+        publication=dataclasses.replace(
+            _publication_request(output / "STEP-0001"),
+            run_provenance=run_request,
+        ),
+    )
+
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert outcome.lifecycle is MethodStepLifecycle.PUBLICATION_FAILED
+    assert outcome.publication is not None
+    assert outcome.publication_identity == outcome.publication.identity
+    outcome.publication.require_exact_live_publication()
+    assert (output / "STEP-0001" / "fit-manifest.toml").is_file()
+    assert "FileExistsError" in outcome.publication_failure
+
+
+def test_semantic_identity_excludes_publication_occurrence_facts(
+    tmp_path: Path,
+) -> None:
+    _session, base = _direct_workflow()
+    first = dataclasses.replace(
+        base,
+        publication=_publication_request(tmp_path / "one"),
+    )
+    second = dataclasses.replace(
+        base,
+        publication=_publication_request(tmp_path / "two"),
+    )
+
+    assert first.semantic_identity == second.semantic_identity
+    assert first.binding_identity != second.binding_identity
+
+
+def test_semantic_identity_includes_strategy_and_derivation_choices() -> None:
+    _session, direct = _direct_workflow()
+    problem = direct.problem
+    assert problem is not None
+    grid = dataclasses.replace(
+        direct,
+        strategy=MethodStepStrategy.GRID_DIRECT_TRF,
+        invocation=GridDirectTrfInvocation.for_problem(
+            problem,
+            axes=((problem.controlled_ids[0], (problem.start[0],)),),
+            objective_request_budget=80,
+        ),
+    )
+    with_uncertainty = dataclasses.replace(
+        direct,
+        derivations=(_uncertainty_request(direct),),
+    )
+
+    assert direct.semantic_identity != grid.semantic_identity
+    assert direct.semantic_identity != with_uncertainty.semantic_identity
+
+
+def test_historical_outcome_rejects_lifecycle_tampering() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    record = outcome.to_record()
+    record["lifecycle"] = MethodStepLifecycle.FAILED.value
+
+    with pytest.raises(ValueError, match="identity differs"):
+        type(outcome).from_record(record)
+
+
+def test_native_method_step_never_calls_legacy_run_methods() -> None:
+    session, workflow = _direct_workflow()
+
+    with patch(
+        "chemex.optimize.fitting.run_methods",
+        side_effect=AssertionError("legacy execution was called"),
+    ) as legacy:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    legacy.assert_not_called()

--- a/tests/test_native_method_step.py
+++ b/tests/test_native_method_step.py
@@ -13,12 +13,13 @@ import json
 from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TypedDict
+from typing import Any, TypedDict
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+import chemex.optimize.method_step as method_step_module
 from chemex.baselines import (
     LegacyObservationImplementation,
     Occurrence,
@@ -53,6 +54,7 @@ from chemex.optimize.direct_trf import (
     OptimizationProblem,
     RootMaterializationFailure,
     TerminalFailure,
+    fit_commit_authority_is_authoritative,
 )
 from chemex.optimize.grid_direct_trf import GridDirectTrfInvocation
 from chemex.optimize.grouped_direct_trf import (
@@ -939,7 +941,7 @@ def test_cancellation_before_primary_starts_blocks_commit_and_successor() -> Non
         require_successor_state(outcome, session.analysis_values)
 
 
-def test_stale_commit_retains_accepted_diagnostics_and_blocks_successor() -> None:
+def test_stale_observer_state_retains_diagnostics_without_commit_attempt() -> None:
     session, workflow = _direct_workflow()
 
     def make_stale(checkpoint: MethodStepCheckpoint) -> None:
@@ -958,13 +960,208 @@ def test_stale_commit_retains_accepted_diagnostics_and_blocks_successor() -> Non
         checkpoint_observer=make_stale,
     )
 
-    assert outcome.lifecycle is MethodStepLifecycle.ACCEPTED_UNCOMMITTED
-    assert outcome.accepted_result is not None
-    assert outcome.commit_operation is not None
-    assert outcome.commit_operation.failure is not None
-    assert outcome.commit_operation.failure.category.value == "stale_revision"
+    assert outcome.lifecycle is MethodStepLifecycle.FAILED
+    assert outcome.accepted_result_identity is not None
+    assert outcome.accepted_result is None
+    assert outcome.commit_operation is None
+    assert session.analysis_values.snapshot().revision == 1
     with pytest.raises(ValueError, match="successor authority"):
         require_successor_state(outcome, session.analysis_values)
+
+
+def test_acceptance_observer_cannot_retarget_invocation_before_commit(
+    tmp_path: Path,
+) -> None:
+    session, base = _direct_workflow(stabilize_data=True)
+    request = _uncertainty_request(base)
+    workflow = dataclasses.replace(
+        base,
+        derivations=(request,),
+        publication=_publication_request(tmp_path / "retargeted"),
+    )
+    decomposition = workflow.decomposition
+    assert decomposition is not None
+    primary_executions: list[GroupedDirectTrfOutcome] = []
+    execute_primary = method_step_module.execute_grouped_direct_trf
+
+    def capture_primary(*args: Any, **kwargs: Any) -> GroupedDirectTrfOutcome:
+        execution = execute_primary(*args, **kwargs)
+        primary_executions.append(execution)
+        return execution
+
+    def retarget(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is MethodStepCheckpoint.AGGREGATE_ACCEPTED:
+            object.__setattr__(
+                workflow,
+                "invocation",
+                GroupedDirectTrfInvocation.for_decomposition(
+                    decomposition,
+                    objective_request_budgets=(81,) * len(decomposition.components),
+                ),
+            )
+
+    with (
+        patch(
+            "chemex.optimize.method_step.execute_grouped_direct_trf",
+            side_effect=capture_primary,
+        ),
+        patch("chemex.optimize.method_step.execute_fit_commit") as commit,
+        patch("chemex.optimize.method_step._execute_derivations") as derivations,
+        patch(
+            "chemex.optimize.method_step._publish_committed_method_step"
+        ) as publication,
+    ):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            checkpoint_observer=retarget,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.FAILED
+    assert outcome.accepted_result_identity is not None
+    assert outcome.commit_operation is None
+    assert session.analysis_values.snapshot().revision == 0
+    commit.assert_not_called()
+    derivations.assert_not_called()
+    publication.assert_not_called()
+    assert not (tmp_path / "retargeted").exists()
+    assert len(primary_executions) == 1
+    primary = primary_executions[0]
+    assert primary.accepted_result is not None
+    assert primary.commit_authority is not None
+    assert workflow.problem is not None
+    assert fit_commit_authority_is_authoritative(
+        primary.accepted_result,
+        primary.commit_authority,
+        workflow.problem,
+    )
+    with pytest.raises(ValueError, match="successor authority"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_acceptance_observer_cannot_retarget_and_rehash_workflow() -> None:
+    session, workflow = _direct_workflow()
+    decomposition = workflow.decomposition
+    assert decomposition is not None
+
+    def retarget_and_rehash(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is not MethodStepCheckpoint.AGGREGATE_ACCEPTED:
+            return
+        replacement = GroupedDirectTrfInvocation.for_decomposition(
+            decomposition,
+            objective_request_budgets=(81,) * len(decomposition.components),
+        )
+        repaired = dataclasses.replace(workflow, invocation=replacement)
+        object.__setattr__(workflow, "invocation", replacement)
+        object.__setattr__(workflow, "semantic_identity", repaired.semantic_identity)
+        object.__setattr__(workflow, "binding_identity", repaired.binding_identity)
+
+    with patch("chemex.optimize.method_step.execute_fit_commit") as commit:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            checkpoint_observer=retarget_and_rehash,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.FAILED
+    assert session.analysis_values.snapshot().revision == 0
+    commit.assert_not_called()
+
+
+@pytest.mark.parametrize("mutation", ["problem", "strategy", "starting_snapshot"])
+def test_acceptance_observer_cannot_mutate_pinned_primary_context(
+    mutation: str,
+) -> None:
+    session, workflow = _direct_workflow()
+    _foreign_session, foreign = _direct_workflow()
+    assert foreign.problem is not None
+
+    def mutate(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is not MethodStepCheckpoint.AGGREGATE_ACCEPTED:
+            return
+        if mutation == "problem":
+            object.__setattr__(workflow, "problem", foreign.problem)
+        elif mutation == "strategy":
+            object.__setattr__(workflow, "strategy", MethodStepStrategy.GRID_DIRECT_TRF)
+        else:
+            object.__setattr__(
+                workflow.starting_snapshot,
+                "revision",
+                workflow.starting_snapshot.revision + 1,
+            )
+
+    with patch("chemex.optimize.method_step.execute_fit_commit") as commit:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            checkpoint_observer=mutate,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.FAILED
+    assert session.analysis_values.snapshot().revision == 0
+    commit.assert_not_called()
+
+
+@pytest.mark.parametrize("observe", [False, True])
+def test_valid_acceptance_observer_preserves_exactly_one_commit(observe: bool) -> None:
+    session, workflow = _direct_workflow()
+    observed: list[MethodStepCheckpoint] = []
+
+    def record(checkpoint: MethodStepCheckpoint) -> None:
+        observed.append(checkpoint)
+
+    with patch(
+        "chemex.optimize.method_step.execute_fit_commit",
+        wraps=method_step_module.execute_fit_commit,
+    ) as commit:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            checkpoint_observer=record if observe else None,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert session.analysis_values.snapshot().revision == 1
+    commit.assert_called_once()
+    assert observed == (
+        [
+            MethodStepCheckpoint.AGGREGATE_ACCEPTED,
+            MethodStepCheckpoint.COMMIT_COMPLETED,
+        ]
+        if observe
+        else []
+    )
+
+
+@pytest.mark.parametrize(
+    ("failure", "lifecycle"),
+    [
+        (RuntimeError("observer failed"), MethodStepLifecycle.FAILED),
+        (KeyboardInterrupt(), MethodStepLifecycle.INTERRUPTED),
+    ],
+)
+def test_acceptance_observer_failure_is_typed_before_commit(
+    failure: BaseException,
+    lifecycle: MethodStepLifecycle,
+) -> None:
+    session, workflow = _direct_workflow()
+
+    def fail(checkpoint: MethodStepCheckpoint) -> None:
+        if checkpoint is MethodStepCheckpoint.AGGREGATE_ACCEPTED:
+            raise failure
+
+    with patch("chemex.optimize.method_step.execute_fit_commit") as commit:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            checkpoint_observer=fail,
+        )
+
+    assert outcome.lifecycle is lifecycle
+    assert outcome.accepted_result_identity is not None
+    assert outcome.commit_operation is None
+    assert session.analysis_values.snapshot().revision == 0
+    commit.assert_not_called()
 
 
 def test_stale_first_step_cannot_compile_a_required_second_step() -> None:
@@ -1559,9 +1756,9 @@ def test_stale_commit_publication_suppresses_fitted_and_restart_output(
         checkpoint_observer=make_stale,
     )
 
-    assert outcome.lifecycle is MethodStepLifecycle.ACCEPTED_UNCOMMITTED
-    assert outcome.publication is not None, outcome.publication_failure
-    assert (output / "Diagnostics" / "outcome.json").is_file()
+    assert outcome.lifecycle is MethodStepLifecycle.FAILED
+    assert outcome.publication is None
+    assert not output.exists()
     assert not (output / "Parameters").exists()
 
 

--- a/tests/test_native_method_step.py
+++ b/tests/test_native_method_step.py
@@ -8,6 +8,8 @@ outcome and the explicit successor-state gate.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import json
 from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
@@ -23,11 +25,21 @@ from chemex.baselines import (
     ResultBundle,
     ResultMember,
 )
-from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.methods import (
+    McmcSettings,
+    Method,
+    Selection,
+    Statistics,
+    read_methods,
+)
 from chemex.configuration.parameters import read_defaults
 from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
 from chemex.experiments.builder import build_experiments
-from chemex.native_provenance import BaselineReference, ProvenanceEnvironment
+from chemex.native_provenance import (
+    BaselineReference,
+    ProvenanceEnvironment,
+    WorkflowProvenance,
+)
 from chemex.optimize.de_direct_trf import (
     DeCoordinateSemantics,
     DeDirectTrfInvocation,
@@ -55,6 +67,7 @@ from chemex.optimize.method_step import (
     McmcDerivationRequest,
     MethodStepCheckpoint,
     MethodStepLifecycle,
+    MethodStepOutcome,
     MethodStepPublicationRequest,
     MethodStepRunProvenanceRequest,
     MethodStepStrategy,
@@ -93,7 +106,7 @@ from chemex.parameters.parameterization import (
 from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.values import AnalysisValuesSnapshot
 from chemex.run_info import capture_native_inputs
-from chemex.runtime import AnalysisSession
+from chemex.runtime import AnalysisSession, ExecutionSettings
 
 ROOT = Path(__file__).parent.parent
 EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
@@ -392,6 +405,34 @@ def test_evaluation_only_retains_objective_without_fit_acceptance_or_commit() ->
     )
 
 
+def test_pre_cancelled_evaluation_never_creates_an_evaluator() -> None:
+    session, workflow = _evaluation_workflow()
+    starting = session.analysis_values.snapshot()
+    cancellation = CancellationToken()
+    cancellation.cancel()
+
+    with patch.object(
+        workflow.engine,
+        "new_evaluator",
+        side_effect=AssertionError("evaluate-only cancellation gate was crossed"),
+    ) as evaluator_factory:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            cancellation=cancellation,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.CANCELLED
+    assert outcome.primary_terminal == "cancelled"
+    assert outcome.evaluation_result is None
+    assert outcome.accepted_result is None
+    assert outcome.commit_operation is None
+    assert session.analysis_values.snapshot() == starting
+    evaluator_factory.assert_not_called()
+    with pytest.raises(ValueError, match="successor authority"):
+        require_successor_state(outcome, session.analysis_values)
+
+
 def test_no_objective_data_is_typed_and_does_not_evaluate_or_continue() -> None:
     session, workflow = _evaluation_workflow(
         purpose=EvaluationPurpose.NO_OBJECTIVE_DATA
@@ -476,6 +517,337 @@ def test_one_component_direct_trf_uses_decomposition_aggregate_and_one_commit() 
     assert outcome.commit_operation.receipt.new_revision == 1
     successor = require_successor_state(outcome, session.analysis_values)
     assert successor.revision == 1
+
+
+def test_mutated_different_budget_invocation_cannot_execute() -> None:
+    session, workflow = _direct_workflow()
+    decomposition = workflow.decomposition
+    assert decomposition is not None
+    replacement = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(81,) * len(decomposition.components),
+    )
+    original_identity = workflow.semantic_identity
+    object.__setattr__(workflow, "invocation", replacement)
+
+    with pytest.raises(ValueError, match="integrity"):
+        execute_method_step(workflow, analysis_values=session.analysis_values)
+
+    assert workflow.semantic_identity == original_identity
+    assert session.analysis_values.snapshot().revision == 0
+
+
+def test_recomputed_workflow_hash_cannot_repair_stale_invocation_child() -> None:
+    session, workflow = _direct_workflow()
+    invocation = workflow.invocation
+    assert isinstance(invocation, GroupedDirectTrfInvocation)
+    stale_child = invocation.component_invocations[0]
+    object.__setattr__(
+        stale_child,
+        "objective_request_budget",
+        stale_child.objective_request_budget + 1,
+    )
+    repaired_child = dataclasses.replace(stale_child)
+    repaired_invocation = dataclasses.replace(
+        invocation,
+        component_invocations=(
+            repaired_child,
+            *invocation.component_invocations[1:],
+        ),
+    )
+    repaired_workflow = dataclasses.replace(workflow, invocation=repaired_invocation)
+    object.__setattr__(
+        workflow,
+        "semantic_identity",
+        repaired_workflow.semantic_identity,
+    )
+    object.__setattr__(
+        workflow,
+        "binding_identity",
+        repaired_workflow.binding_identity,
+    )
+
+    with pytest.raises(ValueError, match="child integrity"):
+        execute_method_step(workflow, analysis_values=session.analysis_values)
+    assert session.analysis_values.snapshot().revision == 0
+
+
+def test_dataclass_replacement_rederives_invocation_identity() -> None:
+    session, workflow = _direct_workflow()
+    decomposition = workflow.decomposition
+    assert decomposition is not None
+    replacement = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(81,) * len(decomposition.components),
+    )
+
+    replaced = dataclasses.replace(workflow, invocation=replacement)
+
+    assert replaced.semantic_identity != workflow.semantic_identity
+    assert replaced.binding_identity != workflow.binding_identity
+    outcome = execute_method_step(replaced, analysis_values=session.analysis_values)
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+
+
+def test_stale_caller_supplied_semantic_identity_cannot_execute() -> None:
+    session, original = _direct_workflow()
+    decomposition = original.decomposition
+    assert decomposition is not None
+    replacement = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(81,) * len(decomposition.components),
+    )
+    reconstructed = dataclasses.replace(original, invocation=replacement)
+    object.__setattr__(
+        reconstructed,
+        "semantic_identity",
+        original.semantic_identity,
+    )
+
+    with pytest.raises(ValueError, match="workflow integrity"):
+        execute_method_step(reconstructed, analysis_values=session.analysis_values)
+    assert session.analysis_values.snapshot().revision == 0
+
+
+def test_mutated_committed_lifecycle_cannot_grant_successor() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    object.__setattr__(outcome, "lifecycle", MethodStepLifecycle.FAILED)
+
+    with pytest.raises(ValueError, match="integrity"):
+        require_successor_state(outcome, session.analysis_values)
+
+    with pytest.raises(ValueError, match="integrity"):
+        outcome.to_record()
+
+
+def _recompute_outcome_record_identity(record: dict[str, object]) -> str:
+    payload = dict(record)
+    payload.pop("identity", None)
+    return hashlib.sha256(
+        json.dumps(
+            ("native-method-step-outcome-v1", payload),
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+    ).hexdigest()
+
+
+def _repair_live_outcome_record_identity(outcome: MethodStepOutcome) -> None:
+    payload = outcome._record_payload()
+    object.__setattr__(
+        outcome,
+        "record_identity",
+        hashlib.sha256(
+            json.dumps(
+                ("native-method-step-outcome-v1", payload),
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("ascii")
+        ).hexdigest(),
+    )
+
+
+def test_serialized_lifecycle_tampering_survives_no_rehashed_envelope() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    record = outcome.to_record()
+    record["lifecycle"] = MethodStepLifecycle.FAILED.value
+    record["identity"] = _recompute_outcome_record_identity(record)
+
+    with pytest.raises(ValueError, match="lifecycle integrity"):
+        type(outcome).from_record(record)
+
+
+def test_mutated_commit_operation_cannot_grant_successor() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    operation = outcome.commit_operation
+    assert operation is not None
+    tampered = dataclasses.replace(
+        operation,
+        occurrence_identity="tampered-commit-occurrence",
+        _occurrence_witness=None,
+    )
+    object.__setattr__(outcome, "commit_operation", tampered)
+    object.__setattr__(outcome, "commit_operation_identity", tampered.identity)
+    _repair_live_outcome_record_identity(outcome)
+
+    with pytest.raises(ValueError, match="integrity"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_mutated_successor_revision_cannot_grant_successor() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    operation = outcome.commit_operation
+    assert operation is not None
+    successor = operation.committed_snapshot
+    assert successor is not None
+    object.__setattr__(successor, "revision", successor.revision + 1)
+
+    with pytest.raises(ValueError, match="integrity"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_mutated_source_workflow_cannot_grant_successor() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    _foreign_session, foreign = _direct_workflow()
+    object.__setattr__(outcome, "source_workflow", foreign)
+
+    with pytest.raises(ValueError, match="integrity"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_mutated_outcome_starting_state_cannot_grant_successor() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    object.__setattr__(outcome, "starting_state_identity", "stale-starting-state")
+    _repair_live_outcome_record_identity(outcome)
+
+    with pytest.raises(ValueError, match="integrity"):
+        require_successor_state(outcome, session.analysis_values)
+
+
+def test_operational_worker_and_thread_settings_are_not_semantic(
+    tmp_path: Path,
+) -> None:
+    _session, base = _evaluation_workflow(purpose=EvaluationPurpose.EVALUATE_ONLY)
+    mcmc_one = McmcSettings(steps=8, burn=2, walkers=6, seed=641, workers=1)
+    mcmc_four = mcmc_one.model_copy(update={"workers": 4})
+    one = dataclasses.replace(
+        base,
+        method=base.method.model_copy(update={"statistics": Statistics(mcmc=mcmc_one)}),
+    )
+    four = dataclasses.replace(
+        base,
+        method=base.method.model_copy(
+            update={"statistics": Statistics(mcmc=mcmc_four)}
+        ),
+    )
+
+    assert one.semantic_identity == four.semantic_identity
+    assert one.binding_identity != four.binding_identity
+    request = _publication_request(tmp_path / "unused")
+    common = {
+        "parameterization": one.parameterization,
+        "plan": one.engine.plan,
+        "semantic_workflow_identity": one.semantic_identity,
+        "grouping_topology": (("aggregate", one.parameterization.independent_ids),),
+        "policies": (),
+        "budgets": (),
+        "seeds": (),
+        "execution": ExecutionSettings(),
+        "environment": request.environment,
+        "baseline_references": request.baseline_references,
+    }
+    provenance_one = WorkflowProvenance.create_method_step(method=one.method, **common)
+    provenance_four = WorkflowProvenance.create_method_step(
+        method=four.method, **common
+    )
+    assert provenance_one.execution_identity != provenance_four.execution_identity
+    assert provenance_one.identity != provenance_four.identity
+
+    _direct_session, direct = _direct_workflow()
+    invocation = direct.invocation
+    assert isinstance(invocation, GroupedDirectTrfInvocation)
+    with_one_thread = GroupedDirectTrfInvocation(
+        invocation.root_problem_identity,
+        invocation.decomposition_identity,
+        tuple(
+            dataclasses.replace(
+                item,
+                execution_settings=ExecutionSettings(native_threads=1),
+            )
+            for item in invocation.component_invocations
+        ),
+    )
+    with_four_threads = GroupedDirectTrfInvocation(
+        invocation.root_problem_identity,
+        invocation.decomposition_identity,
+        tuple(
+            dataclasses.replace(
+                item,
+                execution_settings=ExecutionSettings(native_threads=4),
+            )
+            for item in invocation.component_invocations
+        ),
+    )
+    thread_one = dataclasses.replace(direct, invocation=with_one_thread)
+    thread_four = dataclasses.replace(direct, invocation=with_four_threads)
+    assert thread_one.semantic_identity == thread_four.semantic_identity
+    assert thread_one.binding_identity != thread_four.binding_identity
+    decomposition = direct.decomposition
+    assert decomposition is not None
+    thread_grouping = tuple(
+        (component.identity, component.controlled_ids)
+        for component in decomposition.components
+    )
+    thread_common = {
+        "parameterization": direct.parameterization,
+        "plan": direct.engine.plan,
+        "method": direct.method,
+        "semantic_workflow_identity": thread_one.semantic_identity,
+        "grouping_topology": thread_grouping,
+        "policies": (),
+        "budgets": (),
+        "seeds": (),
+        "environment": request.environment,
+        "baseline_references": request.baseline_references,
+    }
+    thread_provenance_one = WorkflowProvenance.create_method_step(
+        execution=ExecutionSettings(native_threads=1),
+        **thread_common,
+    )
+    thread_provenance_four = WorkflowProvenance.create_method_step(
+        execution=ExecutionSettings(native_threads=4),
+        **thread_common,
+    )
+    assert (
+        thread_provenance_one.execution_identity
+        != thread_provenance_four.execution_identity
+    )
+
+
+def test_scientific_mcmc_setting_remains_semantic() -> None:
+    _session, base = _evaluation_workflow(purpose=EvaluationPurpose.EVALUATE_ONLY)
+    first = dataclasses.replace(
+        base,
+        method=base.method.model_copy(
+            update={
+                "statistics": Statistics(
+                    mcmc=McmcSettings(
+                        steps=8,
+                        burn=2,
+                        walkers=6,
+                        seed=641,
+                        workers=1,
+                    )
+                )
+            }
+        ),
+    )
+    changed = dataclasses.replace(
+        first,
+        method=first.method.model_copy(
+            update={
+                "statistics": Statistics(
+                    mcmc=McmcSettings(
+                        steps=10,
+                        burn=2,
+                        walkers=6,
+                        seed=641,
+                        workers=1,
+                    )
+                )
+            }
+        ),
+    )
+
+    assert first.semantic_identity != changed.semantic_identity
 
 
 def test_optimization_workflow_rejects_foreign_or_zero_component_decomposition() -> (
@@ -1416,7 +1788,7 @@ def test_historical_outcome_rejects_lifecycle_tampering() -> None:
     record = outcome.to_record()
     record["lifecycle"] = MethodStepLifecycle.FAILED.value
 
-    with pytest.raises(ValueError, match="identity differs"):
+    with pytest.raises(ValueError, match="integrity"):
         type(outcome).from_record(record)
 
 


### PR DESCRIPTION
Closes #641.

## Summary

Implements the qualification-only native method-step composer already specified by
#576.

The composer coordinates:

- evaluation-only execution;
- Direct and grouped TRF;
- GRID → TRF, including grouped GRID;
- DE → TRF;
- aggregate acceptance and one atomic commit attempt;
- covariance, constrained uncertainty, resampling, and MCMC derivations;
- aggregate reporting;
- restart and run provenance;
- exact successor-state transitions.

## Key guarantees

- All numerical and evidence stages reuse the existing native implementations.
- Components remain non-authoritative.
- Ordinary derivations, fitted publication, committed restart state, and dependent
  method steps require the exact successful commit.
- Failed or stale commits preserve diagnostics but block downstream work.
- Derivation failures do not roll back an already committed fit.
- Evaluation-only execution performs no fit acceptance or commit.
- Pre-existing cancellation prevents evaluate-only execution from starting.
- Workflow and outcome integrity are revalidated from current fields before
  irreversible transitions and successor-state access.
- Observer callbacks cannot retarget a running workflow before commit.
- Operational settings such as worker and native-thread counts remain outside semantic
  workflow identity while remaining in execution provenance.
- No native occurrence invokes or falls back to legacy execution.
- Production CLI dispatch remains unchanged.

## Validation

- Full suite: green on final HEAD
- Final callback-boundary cases: 7 passed
- Focused method-step/commit/reporting/provenance tests: 179 passed
- `ty`: passed
- Ruff lint and format: passed
- `git diff --check`: passed
- Independent review: MERGE
- Standards: 0 Blocking/Important findings
- Spec: 0 Blocking/Important findings