### PR TITLE
Test spawned evaluation process boundary (#593)

### DIFF
--- a/tests/qualification/native_evaluation_process.py
+++ b/tests/qualification/native_evaluation_process.py
@@ -1,0 +1,243 @@
+"""One-shot process-boundary qualification helper for issue #593."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import multiprocessing
+import os
+from collections.abc import Mapping, Sequence
+from multiprocessing.connection import Connection
+from multiprocessing.process import BaseProcess
+from pathlib import Path
+from typing import Literal, cast
+
+from chemex.configuration.methods import Method, Selection
+from chemex.configuration.parameters import read_defaults
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationPlan,
+    EvaluationResult,
+)
+from chemex.experiments.builder import build_experiments
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+
+_SCHEMA_VERSION = 1
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        value, allow_nan=False, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("ascii")
+
+
+def _identity(value: object) -> str:
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _selection_value(value: object) -> list[str] | str | None:
+    if value is None or value == "*":
+        return cast("str | None", value)
+    return [str(item) for item in cast("Sequence[SpinSystem]", value)]
+
+
+def evaluation_request(
+    *,
+    model: str,
+    experiment_files: Sequence[Path],
+    parameter_files: Sequence[Path],
+    selection: Selection,
+    method: Method,
+    plan: EvaluationPlan,
+    frame: EvaluationFrame,
+) -> bytes:
+    payload: dict[str, object] = {
+        "schema_version": _SCHEMA_VERSION,
+        "model": model,
+        "experiment_files": [str(path.resolve()) for path in experiment_files],
+        "parameter_files": [str(path.resolve()) for path in parameter_files],
+        "selection": {
+            "include": _selection_value(selection.include),
+            "exclude": _selection_value(selection.exclude),
+        },
+        "method": method.model_dump(mode="json", exclude_none=True),
+        "plan": plan.to_record(),
+        "frame": frame.to_record(),
+    }
+    payload["identity"] = _identity(payload)
+    return _canonical_bytes(payload)
+
+
+def _mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Evaluation-process {name} must be a record")
+    return cast("Mapping[str, object]", value)
+
+
+def _selection(value: object) -> Selection:
+    record = _mapping(value, "selection")
+    if set(record) != {"include", "exclude"}:
+        raise ValueError("Malformed evaluation-process selection")
+
+    def restore(item: object) -> list[SpinSystem] | Literal["*"] | None:
+        if item is None or item == "*":
+            return cast('Literal["*"] | None', item)
+        if not isinstance(item, list) or not all(
+            isinstance(name, str) for name in item
+        ):
+            raise TypeError("Evaluation-process selection names must be strings")
+        names = cast("list[str]", item)
+        return [SpinSystem.from_name(name) for name in names]
+
+    return Selection(restore(record["include"]), restore(record["exclude"]))
+
+
+def _execute_request(
+    content: bytes,
+    barrier: Connection | None = None,
+) -> bytes:
+    worker_pid = os.getpid()
+    request_identity = ""
+    try:
+        record = json.loads(content)
+        if not isinstance(record, dict) or set(record) != {
+            "schema_version",
+            "model",
+            "experiment_files",
+            "parameter_files",
+            "selection",
+            "method",
+            "plan",
+            "frame",
+            "identity",
+        }:
+            raise ValueError("Malformed evaluation-process request")
+        if not isinstance(record["identity"], str) or not isinstance(
+            record["model"], str
+        ):
+            raise TypeError("Evaluation-process identity and model must be strings")
+        request_identity = record["identity"]
+        model = record["model"]
+        unsigned = {key: value for key, value in record.items() if key != "identity"}
+        if record["schema_version"] != _SCHEMA_VERSION or request_identity != _identity(
+            unsigned
+        ):
+            raise ValueError(
+                "Evaluation-process request identity does not match payload"
+            )
+        experiment_files = _absolute_paths(record["experiment_files"], "experiment")
+        parameter_files = _absolute_paths(record["parameter_files"], "parameter")
+        method = Method.model_validate(_mapping(record["method"], "method"))
+        plan = EvaluationPlan.from_record(_mapping(record["plan"], "plan"))
+        frame = EvaluationFrame.from_record(_mapping(record["frame"], "frame"))
+        if frame.parameterization_identity != plan.parameterization_identity:
+            raise ValueError("Evaluation frame belongs to another plan")
+
+        session = AnalysisSession.create()
+        session.set_model(model)
+        experiments = build_experiments(
+            experiment_files, _selection(record["selection"]), session=session
+        )
+        session.parameters.set_defaults(read_defaults(parameter_files))
+        if not session.try_build_analysis_values():
+            raise ValueError("Fresh evaluation parameter state is unavailable")
+        parameterization = session.compile_parameterization(
+            method, experiments.param_ids
+        )
+        if (
+            parameterization.evaluator_identity != plan.parameterization_identity
+            or parameterization.program.fingerprint != plan.constraint_program_identity
+        ):
+            raise ValueError("Fresh evaluation plan does not match serialized plan")
+        evaluator = EvaluationEngine.bind(
+            plan, parameterization, experiments
+        ).new_evaluator()
+        if barrier is not None:
+            barrier.send_bytes(str(evaluator._owner_pid).encode("ascii"))
+            barrier.recv_bytes()
+        outcome = evaluator.evaluate(frame)
+        kind = "result" if isinstance(outcome, EvaluationResult) else "failure"
+        if not isinstance(outcome, (EvaluationResult, EvaluationFailure)):
+            raise TypeError("Native evaluation returned an unknown outcome")
+        receipt = {
+            "schema_version": _SCHEMA_VERSION,
+            "request_identity": request_identity,
+            "status": "completed",
+            "worker_pid": worker_pid,
+            "evaluator_owner_pid": evaluator._owner_pid,
+            "outcome_kind": kind,
+            "outcome": outcome.to_record(),
+            "rejection": None,
+        }
+    except Exception as error:  # noqa: BLE001 - qualification rejection fence
+        receipt = {
+            "schema_version": _SCHEMA_VERSION,
+            "request_identity": request_identity,
+            "status": "rejected",
+            "worker_pid": worker_pid,
+            "evaluator_owner_pid": None,
+            "outcome_kind": None,
+            "outcome": None,
+            "rejection": f"{type(error).__name__}: {error}",
+        }
+    return _canonical_bytes(receipt)
+
+
+def _absolute_paths(value: object, name: str) -> list[Path]:
+    if not isinstance(value, list) or not value:
+        raise TypeError(f"Evaluation-process {name} files must be a non-empty list")
+    paths = [Path(item) for item in value if isinstance(item, str)]
+    if len(paths) != len(value) or any(not path.is_absolute() for path in paths):
+        raise ValueError(f"Evaluation-process {name} files must be absolute paths")
+    return paths
+
+
+def run_serial_request(content: bytes) -> bytes:
+    return _execute_request(content)
+
+
+def _spawn_worker(connection: Connection, content: bytes) -> None:
+    connection.send_bytes(_execute_request(content))
+    connection.close()
+
+
+def run_spawned_requests(contents: Sequence[bytes]) -> tuple[bytes, ...]:
+    """Start exactly one fresh spawn process per request, with no persistent pool."""
+    context = multiprocessing.get_context("spawn")
+    workers: list[tuple[BaseProcess, Connection]] = []
+    for content in contents:
+        receiving, sending = context.Pipe(duplex=False)
+        process = context.Process(target=_spawn_worker, args=(sending, content))
+        process.start()
+        sending.close()
+        workers.append((process, receiving))
+    receipts: list[bytes] = []
+    for process, connection in workers:
+        if not connection.poll(60.0):
+            process.terminate()
+            process.join()
+            raise TimeoutError("Spawned evaluation process did not respond")
+        receipts.append(connection.recv_bytes())
+        connection.close()
+        process.join()
+        if process.exitcode != 0:
+            raise RuntimeError("Spawned evaluation process exited unsuccessfully")
+    return tuple(receipts)
+
+
+def start_interruptible_spawned_request(
+    content: bytes,
+) -> tuple[BaseProcess, Connection]:
+    """Start a worker paused after local binding and before evaluation."""
+    context = multiprocessing.get_context("spawn")
+    barrier, child_barrier = context.Pipe()
+    process = context.Process(
+        target=_execute_request,
+        args=(content, child_barrier),
+    )
+    process.start()
+    child_barrier.close()
+    return process, barrier

--- a/tests/test_native_evaluation_process.py
+++ b/tests/test_native_evaluation_process.py
@@ -1,0 +1,203 @@
+"""Real spawn-boundary qualification for the native evaluation records (#593)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from chemex.configuration.methods import Method, Selection
+from chemex.configuration.parameters import read_defaults
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationResult,
+)
+from chemex.experiments.builder import build_experiments
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+from tests.qualification.native_evaluation_process import (
+    evaluation_request,
+    run_serial_request,
+    run_spawned_requests,
+    start_interruptible_spawned_request,
+)
+
+ROOT = Path(__file__).parent.parent
+EXPERIMENT = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Experiments/3hz.toml"
+PARAMETERS = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Parameters/parameters.toml"
+
+
+class EvaluationReceipt(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1]
+    request_identity: str
+    status: Literal["completed", "rejected"]
+    worker_pid: int
+    evaluator_owner_pid: int | None
+    outcome_kind: Literal["result", "failure"] | None
+    outcome: dict[str, object] | None
+    rejection: str | None
+
+
+def _receipt(content: bytes) -> EvaluationReceipt:
+    return EvaluationReceipt.model_validate_json(content)
+
+
+def _selected_evaluation(
+    name: str = "1N",
+    parameter_file: Path = PARAMETERS,
+) -> tuple[EvaluationEngine, EvaluationFrame, bytes]:
+    method = Method()
+    selection = Selection(include=[SpinSystem.from_name(name)], exclude=None)
+    session = AnalysisSession.create()
+    session.set_model("2st_hd")
+    experiments = build_experiments([EXPERIMENT], selection, session=session)
+    session.parameters.set_defaults(read_defaults([parameter_file]))
+    assert session.try_build_analysis_values()
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
+    )
+    request = evaluation_request(
+        model="2st_hd",
+        experiment_files=[EXPERIMENT],
+        parameter_files=[parameter_file],
+        selection=selection,
+        method=method,
+        plan=engine.plan,
+        frame=frame,
+    )
+    return engine, frame, request
+
+
+def test_serial_and_fresh_spawn_replay_the_same_selected_evaluation() -> None:
+    engine, frame, request = _selected_evaluation()
+    expected = engine.new_evaluator().evaluate(frame)
+    assert isinstance(expected, EvaluationResult)
+
+    serial = _receipt(run_serial_request(request))
+    spawned, replay = map(_receipt, run_spawned_requests((request, request)))
+
+    assert serial.status == spawned.status == replay.status == "completed"
+    assert (
+        serial.outcome_kind == spawned.outcome_kind == replay.outcome_kind == "result"
+    )
+    assert serial.outcome == spawned.outcome == replay.outcome == expected.to_record()
+    assert spawned.outcome is not None
+    assert EvaluationResult.from_record(spawned.outcome, engine.plan).identity == (
+        expected.identity
+    )
+    assert serial.worker_pid == serial.evaluator_owner_pid == os.getpid()
+    assert spawned.worker_pid != replay.worker_pid
+    assert {spawned.worker_pid, replay.worker_pid}.isdisjoint({os.getpid()})
+    assert spawned.worker_pid == spawned.evaluator_owner_pid
+    assert replay.worker_pid == replay.evaluator_owner_pid
+
+
+def test_two_fresh_workers_are_independent_of_request_order() -> None:
+    first_engine, _first_frame, first_request = _selected_evaluation("1N")
+    second_engine, _second_frame, second_request = _selected_evaluation("2N")
+
+    forward = tuple(
+        map(_receipt, run_spawned_requests((first_request, second_request)))
+    )
+    reverse = tuple(
+        map(_receipt, run_spawned_requests((second_request, first_request)))
+    )
+
+    assert len({receipt.worker_pid for receipt in forward}) == 2
+    assert len({receipt.worker_pid for receipt in reverse}) == 2
+    forward_records = {receipt.request_identity: receipt.outcome for receipt in forward}
+    reverse_records = {receipt.request_identity: receipt.outcome for receipt in reverse}
+    assert forward_records == reverse_records
+    assert {
+        receipt.outcome["plan_identity"]
+        for receipt in forward
+        if receipt.outcome is not None
+    } == {first_engine.plan.identity, second_engine.plan.identity}
+
+
+def test_interrupted_fresh_worker_returns_no_result_and_terminates() -> None:
+    engine, frame, request = _selected_evaluation()
+    parent_evaluator = engine.new_evaluator()
+    expected = parent_evaluator.evaluate(frame)
+    assert isinstance(expected, EvaluationResult)
+    process, boundary = start_interruptible_spawned_request(request)
+    started = boundary.poll(60.0)
+    if not started:
+        process.terminate()
+        process.join()
+    assert started
+    owner_pid = int(boundary.recv_bytes())
+    process.terminate()
+    process.join(60.0)
+    assert not process.is_alive()
+    try:
+        outcome = boundary.recv_bytes()
+    except EOFError:
+        outcome = None
+    boundary.close()
+
+    assert outcome is None
+    assert process.exitcode is not None and process.exitcode != 0
+    assert process.pid == owner_pid != parent_evaluator._owner_pid == os.getpid()
+    assert parent_evaluator.evaluate(frame).to_record() == expected.to_record()
+
+
+def test_evaluation_failure_crosses_the_spawn_boundary_unchanged() -> None:
+    engine, frame, _request = _selected_evaluation()
+    reversed_frame = EvaluationFrame(
+        frame.parameterization_identity, tuple(reversed(frame._items))
+    )
+    expected = engine.new_evaluator().evaluate(reversed_frame)
+    assert isinstance(expected, EvaluationFailure)
+    request = evaluation_request(
+        model="2st_hd",
+        experiment_files=[EXPERIMENT],
+        parameter_files=[PARAMETERS],
+        selection=Selection(include=[SpinSystem.from_name("1N")], exclude=None),
+        method=Method(),
+        plan=engine.plan,
+        frame=reversed_frame,
+    )
+
+    receipt = _receipt(run_spawned_requests((request,))[0])
+
+    assert receipt.status == "completed"
+    assert receipt.outcome_kind == "failure"
+    assert receipt.outcome == expected.to_record()
+    assert receipt.outcome is not None
+    assert EvaluationFailure.from_record(receipt.outcome, engine.plan) == expected
+
+
+def test_malformed_and_stale_requests_fail_closed(tmp_path: Path) -> None:
+    _engine, _frame, valid_request = _selected_evaluation()
+    malformed_record = json.loads(valid_request)
+    malformed_record["unknown"] = True
+    malformed = json.dumps(malformed_record).encode()
+
+    copied_parameters = tmp_path / "parameters.toml"
+    copied_parameters.write_bytes(PARAMETERS.read_bytes())
+    _engine, _frame, stale = _selected_evaluation(parameter_file=copied_parameters)
+    copied_parameters.write_text(
+        copied_parameters.read_text().replace("KDH = 10.0", "KDH = 11.0")
+    )
+
+    malformed_receipt, stale_receipt = map(
+        _receipt, run_spawned_requests((malformed, stale))
+    )
+
+    assert malformed_receipt.status == stale_receipt.status == "rejected"
+    assert malformed_receipt.outcome is stale_receipt.outcome is None
+    assert malformed_receipt.rejection is not None
+    assert stale_receipt.rejection is not None
+    assert "Malformed evaluation-process request" in malformed_receipt.rejection
+    assert "does not match serialized plan" in stale_receipt.rejection


### PR DESCRIPTION
Closes #593.

Adds a test-only native process-boundary qualification for evaluation.

- Uses Python `spawn` with fresh worker-owned evaluators.
- Reuses existing EvaluationPlan / EvaluationFrame / EvaluationResult /
  EvaluationFailure serialization.
- Proves serial/spawn equivalence, deterministic replay, two-worker ordering
  independence, stale-input rejection, failure transport, and clean interruption.
- No optimizer integration, scheduler, multiprocessing framework, or production code
  changes.