### PR TITLE
Route deterministic fits through native production stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 
 ## [Unreleased]
 
+### Changed
+- Routed Direct TRF, grouped Direct, GRID, and grouped GRID method steps through
+  the native parameterization, evaluation, aggregate acceptance, and atomic
+  commit stack in the production `chemex fit` path. Existing v1 method TOML,
+  ordered role inheritance, profile selection, calculated-data files, and
+  output paths are preserved. Native deterministic fits do not populate the
+  legacy generic `stderr` field; family-qualified uncertainty output remains
+  part of the dedicated output-contract migration;
+  statistics-bearing steps and explicit legacy optimizer spellings remain on
+  the legacy path pending their dedicated migration.
+
 ### Infrastructure
 - Removed the unused `B1FieldConfig` model and its `default_distribution_config`
   helper from `b1_config.py`; the flat-table `b1_frq` schema it implemented was
@@ -21,15 +32,11 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   (`add_multiple`/`add_multiple_mf`, `sort`, `set_values`, `set_defaults`,
   `fix_all`, `reset`); parameter semantics and fit/simulate behavior are
   unchanged.
-- Simplified the fit and simulation workflow: `AnalysisSession` is no longer
-  threaded through lower-level `optimize/*` helpers (`run_methods`,
-  `execute_post_fit`, `execute_simulation`, `execute_post_fit_groups`,
-  `run_grid`). Execution policy is now passed explicitly through
-  `ExecutionSettings` only where needed (`run_methods` through `_fit_groups` to
-  `_run_statistics`), and parameter access continues through
-  `Experiments.parameter_store`. This intentionally narrows these lower-level
-  function signatures for any direct caller; CLI, TOML, output, and scientific
-  behavior are unchanged.
+- Kept `AnalysisSession` at the `run_methods` orchestration boundary so native
+  deterministic steps can use revisioned analysis values and stale-safe commit;
+  lower-level output helpers still access parameters through
+  `Experiments.parameter_store`, and statistics execution still receives the
+  session's explicit `ExecutionSettings`.
 
 ## [2026.06.1] - 2026-06-26
 

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -52,8 +52,7 @@ def run_fit(
         methods,
         args.output,
         args.plot,
-        execution=session.execution,
-        preview_parameterization=session.try_compile_parameterization,
+        session=session,
     )
 
 

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1,7 +1,7 @@
-"""Bounded native Direct-TRF qualification path for issue #586.
+"""Bounded native Direct-TRF execution for ChemEx deterministic fitting.
 
-This is deliberately not a production dispatcher or a generic optimizer layer.
-It connects the native parameterization and evaluation contracts to one closed
+This is not a generic optimizer layer. It connects the native parameterization
+and evaluation contracts to one closed
 SciPy ``least_squares(method="trf")`` invocation, fresh result materialization,
 and the existing revision-checked Analysis Values commit boundary.
 """

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -1,9 +1,8 @@
 """The fitting module contains the code for fitting the experimental data."""
 
-from collections.abc import Callable
 from pathlib import Path
 
-from chemex.configuration.methods import Method, Methods, Statistics
+from chemex.configuration.methods import Methods, Statistics
 from chemex.containers.experiments import Experiments
 from chemex.messages import (
     print_calculation_stopped_error,
@@ -26,8 +25,12 @@ from chemex.optimize.mcmc import run_mcmc
 from chemex.optimize.minimizer import (
     minimize_with_report,
 )
+from chemex.optimize.native_deterministic import (
+    run_native_deterministic,
+    uses_native_deterministic,
+)
 from chemex.optimize.resampling import run_resampling_statistics
-from chemex.runtime import ExecutionSettings
+from chemex.runtime import AnalysisSession, ExecutionSettings
 
 
 def _run_statistics(
@@ -126,8 +129,7 @@ def run_methods(
     path: Path,
     plot_level: str,
     *,
-    execution: ExecutionSettings | None = None,
-    preview_parameterization: Callable[[Method, set[str]], object] | None = None,
+    session: AnalysisSession,
 ) -> None:
     parameter_store = experiments.parameter_store
 
@@ -142,10 +144,9 @@ def run_methods(
             print_no_data()
             continue
 
-        print_fitmethod(method.fitmethod)
-
-        if preview_parameterization is not None:
-            preview_parameterization(method, experiments.param_ids)
+        print_fitmethod(
+            "trf" if uses_native_deterministic(method) else method.fitmethod
+        )
 
         # Update the parameter "vary" and "expr" status
         parameter_store.set_parameter_status(method)
@@ -155,6 +156,16 @@ def run_methods(
             method.statistics = None
 
         path_sect = path / section if len(methods) > 1 else path
+
+        if uses_native_deterministic(method):
+            run_native_deterministic(
+                experiments,
+                method,
+                path_sect,
+                plot_level,
+                session=session,
+            )
+            continue
 
         if method.grid:
             try:
@@ -168,11 +179,14 @@ def run_methods(
             except KeyboardInterrupt:
                 print_calculation_stopped_error()
         else:
+            legacy_fitmethod = (
+                "least_squares" if method.fitmethod == "trf" else method.fitmethod
+            )
             _fit_groups(
                 experiments,
                 path_sect,
                 plot_level,
-                method.fitmethod,
+                legacy_fitmethod,
                 method.statistics,
-                execution=execution,
+                execution=session.execution,
             )

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -144,9 +144,8 @@ def run_methods(
             print_no_data()
             continue
 
-        print_fitmethod(
-            "trf" if uses_native_deterministic(method) else method.fitmethod
-        )
+        use_native_deterministic = uses_native_deterministic(method)
+        print_fitmethod("trf" if use_native_deterministic else method.fitmethod)
 
         # Update the parameter "vary" and "expr" status
         parameter_store.set_parameter_status(method)
@@ -157,7 +156,7 @@ def run_methods(
 
         path_sect = path / section if len(methods) > 1 else path
 
-        if uses_native_deterministic(method):
+        if use_native_deterministic:
             run_native_deterministic(
                 experiments,
                 method,

--- a/src/chemex/optimize/grid_direct_trf.py
+++ b/src/chemex/optimize/grid_direct_trf.py
@@ -1,8 +1,7 @@
-"""Single-component Cartesian GRID to native Direct TRF qualification (#595).
+"""Single-component Cartesian GRID to native Direct TRF execution.
 
-This module is intentionally not wired into production dispatch.  It plans
-physical-coordinate Cartesian seeds rooted in one immutable native problem;
-execution and selection are added at the same public qualification seam.
+This plans physical-coordinate Cartesian seeds rooted in one immutable native
+problem and executes the production deterministic multistart workflow.
 """
 
 from __future__ import annotations

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -1,7 +1,7 @@
-"""Exact native fit-component decomposition for grouped Direct TRF (#594).
+"""Exact native fit-component decomposition for grouped Direct TRF.
 
-This remains an isolated qualification path.  It does not dispatch production
-fits or alter the legacy grouped-fit implementation.
+The production deterministic dispatcher composes this closed decomposition with
+the native Direct TRF executor and one aggregate commit.
 """
 
 from __future__ import annotations

--- a/src/chemex/optimize/grouped_grid_direct_trf.py
+++ b/src/chemex/optimize/grouped_grid_direct_trf.py
@@ -1,8 +1,7 @@
-"""Exact fit-component GRID to native Direct TRF qualification (#596).
+"""Exact fit-component GRID to native Direct TRF execution.
 
-This isolated qualification path composes the grouped Direct TRF contract with
-the Cartesian GRID contract.  It is intentionally not wired into production
-dispatch.
+This composes the grouped Direct TRF contract with the production Cartesian
+GRID contract and preserves one aggregate commit boundary.
 """
 
 from __future__ import annotations

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -17,6 +17,7 @@ from chemex.messages import (
 )
 from chemex.parameters.database import ParameterStore
 from chemex.printers.parameters import write_parameters
+from chemex.typing import Array
 
 
 def calculate_statistics(
@@ -24,10 +25,18 @@ def calculate_statistics(
     params_lf: ParametersLF,
 ) -> dict[str, int | float]:
     residuals = experiments.residuals(params_lf)
-    ndata = len(residuals)
     nvarys = len(
         [param for param in params_lf.values() if param.vary and not param.expr],
     )
+    return calculate_statistics_from_residuals(residuals, nvarys)
+
+
+def calculate_statistics_from_residuals(
+    residuals: Array,
+    nvarys: int,
+) -> dict[str, int | float]:
+    """Calculate established fit statistics from an authoritative residual vector."""
+    ndata = len(residuals)
     chisqr = sum(residuals**2)
     redchi = chisqr / max(1, ndata - nvarys)
     aic = chisqr + 2 * nvarys
@@ -50,10 +59,20 @@ def calculate_statistics(
 def _write_statistics(
     experiments: Experiments,
     path: Path,
+    *,
+    residuals: Array | None = None,
+    nvarys: int | None = None,
 ) -> None:
     """Write fitting statistics to a file."""
-    params_lf = experiments.parameter_store.build_lmfit_params(experiments.param_ids)
-    stats = calculate_statistics(experiments, params_lf)
+    if residuals is None:
+        params_lf = experiments.parameter_store.build_lmfit_params(
+            experiments.param_ids
+        )
+        stats = calculate_statistics(experiments, params_lf)
+    else:
+        if nvarys is None:
+            raise ValueError("Native residual statistics require a variable count")
+        stats = calculate_statistics_from_residuals(residuals, nvarys)
     filename = path / "statistics.toml"
     with filename.open("w", encoding="utf-8") as f:
         f.write(f'"number of data points"                = {stats["ndata"]}\n')
@@ -71,13 +90,21 @@ def _write_statistics(
 def _write_files(
     experiments: Experiments,
     path: Path,
+    *,
+    residuals: Array | None = None,
+    nvarys: int | None = None,
 ) -> None:
     """Write the results of the fit to output files."""
     print_writing_results(path)
     path.mkdir(parents=True, exist_ok=True)
     write_parameters(experiments, path, parameter_store=experiments.parameter_store)
     experiments.write(path)
-    _write_statistics(experiments, path=path)
+    _write_statistics(
+        experiments,
+        path=path,
+        residuals=residuals,
+        nvarys=nvarys,
+    )
 
 
 def _write_simulation_files(
@@ -120,8 +147,10 @@ def execute_post_fit(
     path: Path,
     *,
     plot: bool = False,
+    residuals: Array | None = None,
+    nvarys: int | None = None,
 ) -> None:
-    _write_files(experiments, path)
+    _write_files(experiments, path, residuals=residuals, nvarys=nvarys)
     if plot:
         _write_plots(experiments, path)
 
@@ -142,15 +171,27 @@ def execute_post_fit_groups(
     experiments: Experiments,
     path: Path,
     plot: str,
+    *,
+    residuals: Array | None = None,
+    nvarys: int | None = None,
 ) -> None:
     print_group_name("All groups")
-    params_lf = experiments.parameter_store.build_lmfit_params(experiments.param_ids)
-    statistics = calculate_statistics(experiments, params_lf)
+    if residuals is None:
+        params_lf = experiments.parameter_store.build_lmfit_params(
+            experiments.param_ids
+        )
+        statistics = calculate_statistics(experiments, params_lf)
+    else:
+        if nvarys is None:
+            raise ValueError("Native residual statistics require a variable count")
+        statistics = calculate_statistics_from_residuals(residuals, nvarys)
     print_chi2(statistics["chisqr"], statistics["redchi"])
     execute_post_fit(
         experiments,
         path / "All",
         plot=(plot != "nothing"),
+        residuals=residuals,
+        nvarys=nvarys,
     )
 
 

--- a/src/chemex/optimize/method_step.py
+++ b/src/chemex/optimize/method_step.py
@@ -1,8 +1,7 @@
-"""Closed qualification-only composition of one native method step.
+"""Closed composition of one native method step.
 
-This module is deliberately not connected to the production ``run_methods``
-dispatcher.  It composes already-compiled native artifacts and preserves the
-live AnalysisValues occurrence boundary.
+The production deterministic dispatcher composes already-compiled native
+artifacts here while preserving the live AnalysisValues occurrence boundary.
 """
 
 from __future__ import annotations

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -1,0 +1,409 @@
+"""Production composition for native deterministic method steps."""
+
+from itertools import product
+from pathlib import Path
+from typing import cast
+
+import numpy as np
+
+from chemex.configuration.methods import Method
+from chemex.containers.experiments import Experiments
+from chemex.evaluation.native import EvaluationEngine, EvaluationResult
+from chemex.messages import print_group_name, print_minimizing
+from chemex.optimize.direct_trf import OptimizationProblem
+from chemex.optimize.grid_direct_trf import GridDirectTrfInvocation
+from chemex.optimize.gridding import (
+    GridResult,
+    combine_grids,
+    make_grids_nd,
+    plot_grid_1d,
+    plot_grid_2d,
+)
+from chemex.optimize.grouped_direct_trf import (
+    FitDecomposition,
+    GroupedDirectTrfInvocation,
+)
+from chemex.optimize.grouped_grid_direct_trf import GroupedGridDirectTrfOutcome
+from chemex.optimize.grouping import Group, create_groups
+from chemex.optimize.helper import (
+    execute_post_fit,
+    execute_post_fit_groups,
+    print_header,
+    print_values,
+)
+from chemex.optimize.method_step import (
+    EvaluationPurpose,
+    MethodStepLifecycle,
+    MethodStepStrategy,
+    MethodStepWorkflow,
+    execute_method_step,
+)
+from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
+from chemex.runtime import AnalysisSession
+from chemex.typing import Array
+
+# Match scipy.optimize.least_squares' default maximum when max_nfev is omitted.
+_TRF_EVALUATIONS_PER_COORDINATE = 100
+
+
+def uses_native_deterministic(method: Method) -> bool:
+    """Return whether one whole method occurrence uses native TRF."""
+    if method.statistics is not None and not method.grid:
+        return False
+    if "fitmethod" not in method.model_fields_set:
+        return True
+    return method.fitmethod in {"trf", "least_squares"}
+
+
+def _objective_request_budget(problem: OptimizationProblem) -> int:
+    return _TRF_EVALUATIONS_PER_COORDINATE * max(1, len(problem.controlled_ids))
+
+
+def _has_controlled_parameters(parameterization: ActiveParameterization) -> bool:
+    return any(
+        parameterization.role(param_id) is ParameterRole.FIT
+        for param_id in parameterization.independent_ids
+    )
+
+
+def _materialize_evaluation(
+    experiments: Experiments,
+    result: EvaluationResult,
+) -> None:
+    """Copy one authoritative native evaluation into the live output profiles."""
+    profiles = tuple(profile for experiment in experiments for profile in experiment)
+    if len(profiles) != len(result.profiles):
+        raise RuntimeError("Native evaluation profile population changed before output")
+    resolved = dict(result.resolved_values.ordered_items())
+    for profile, descriptor in zip(profiles, result.profiles, strict=True):
+        start = descriptor.observation_offset
+        stop = start + descriptor.observation_count
+        if descriptor.observation_count != profile.data.size:
+            raise RuntimeError("Native evaluation profile shape changed before output")
+        profile.data.calc_unscaled = np.array(
+            result.unscaled_calculations[start:stop],
+            copy=True,
+        )
+        profile.data.calc = np.array(
+            result.normalized_calculations[start:stop],
+            copy=True,
+        )
+        profile.spectrometer.update(
+            {
+                local_name: resolved[param_id]
+                for local_name, param_id in profile.name_map.items()
+            }
+        )
+
+
+def _project_residuals(
+    subset: Experiments,
+    root: Experiments,
+    result: EvaluationResult,
+) -> Array:
+    """Project the root native residual vector onto one established output group."""
+    root_profiles = tuple(profile for experiment in root for profile in experiment)
+    if len(root_profiles) != len(result.profiles):
+        raise RuntimeError("Native evaluation profile population changed before output")
+    segments = {
+        id(profile): result.residuals[
+            descriptor.residual_offset : (
+                descriptor.residual_offset + descriptor.residual_count
+            )
+        ]
+        for profile, descriptor in zip(root_profiles, result.profiles, strict=True)
+    }
+    projected = [
+        segments[id(profile)] for experiment in subset for profile in experiment
+    ]
+    return np.concatenate(projected)
+
+
+def _build_invocation(
+    method: Method,
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    experiments: Experiments,
+) -> tuple[
+    MethodStepStrategy,
+    GroupedDirectTrfInvocation | GridDirectTrfInvocation,
+]:
+    if method.grid:
+        grid = experiments.parameter_store.parse_grid(method.grid)
+        invocation = GridDirectTrfInvocation.for_problem(
+            problem,
+            axes=tuple(
+                (param_id, tuple(values.tolist())) for param_id, values in grid.items()
+            ),
+            objective_request_budget=_objective_request_budget(problem),
+        )
+        return MethodStepStrategy.GRID_DIRECT_TRF, invocation
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=tuple(
+            _objective_request_budget(component.problem)
+            for component in decomposition.components
+        ),
+    )
+    return MethodStepStrategy.DIRECT_TRF, invocation
+
+
+def _write_grid_output(
+    outcome: GroupedGridDirectTrfOutcome,
+    invocation: GridDirectTrfInvocation,
+    path: Path,
+    *,
+    experiments: Experiments,
+    group_scopes: tuple[tuple[Path, frozenset[str]], ...],
+) -> None:
+    """Render established per-group GRID tables from native seed evidence."""
+    grid = {
+        axis.param_id: np.asarray(axis.values, dtype=np.float64)
+        for axis in invocation.axes
+    }
+    parameter_store = experiments.parameter_store
+    grid_path = path / "Grid"
+    grid_path.mkdir(parents=True, exist_ok=True)
+    component_results: list[GridResult] = []
+    for group_path, controlled_ids in group_scopes:
+        matching_indices = tuple(
+            index
+            for index, component in enumerate(outcome.attempts[0].components)
+            if frozenset(component.controlled_ids) == controlled_ids
+        )
+        if len(matching_indices) != 1:
+            raise RuntimeError("Native GRID components do not match output groups")
+        component_index = matching_indices[0]
+        component_grid = {
+            param_id: values
+            for param_id, values in grid.items()
+            if param_id in controlled_ids
+        }
+        objective_by_coordinates: dict[tuple[float, ...], float] = {}
+        for attempt in outcome.attempts:
+            coordinates = dict(attempt.axis_items)
+            key = tuple(
+                float(cast("int | float", coordinates[param_id]))
+                for param_id in component_grid
+            )
+            candidate = attempt.components[component_index].candidate
+            objective = np.inf if candidate is None else candidate.chi_square
+            objective_by_coordinates[key] = min(
+                objective,
+                objective_by_coordinates.get(key, np.inf),
+            )
+        coordinate_order = tuple(product(*component_grid.values()))
+        chisqr = np.asarray(
+            [
+                objective_by_coordinates[tuple(float(value) for value in coordinates)]
+                for coordinates in coordinate_order
+            ],
+            dtype=np.float64,
+        ).reshape(tuple(len(values) for values in component_grid.values()))
+        component_results.append(GridResult(component_grid, chisqr))
+
+        basename = group_path if group_path != Path() else Path("grid")
+        filename = grid_path / f"{basename}.out"
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w", encoding="utf-8") as output:
+            output.write(print_header(component_grid, parameter_store=parameter_store))
+            for coordinates, objective in zip(
+                coordinate_order,
+                chisqr.flat,
+                strict=True,
+            ):
+                output.write(print_values(coordinates, float(objective)))
+
+    combined = combine_grids(grid, component_results)
+    grids_1d = make_grids_nd(
+        grid,
+        combined,
+        1,
+        parameter_store=parameter_store,
+    )
+    grids_2d = make_grids_nd(
+        grid,
+        combined,
+        2,
+        parameter_store=parameter_store,
+    )
+    plot_grid_1d(grids_1d, grid_path, parameter_store=parameter_store)
+    plot_grid_2d(grids_2d, grid_path, parameter_store=parameter_store)
+
+
+def _write_direct_output(
+    experiments: Experiments,
+    path: Path,
+    plot: str,
+    groups: list[Group],
+    group_scopes: tuple[tuple[Path, frozenset[str]], ...],
+    result: EvaluationResult,
+    variable_count: int,
+    *,
+    aggregate_output: bool,
+) -> None:
+    """Write established per-group and aggregate output from native evidence."""
+    plot_flg = (plot == "normal" and not aggregate_output) or plot == "all"
+    controlled_by_path = dict(group_scopes)
+    for group in groups:
+        if message := group.message:
+            print_group_name(message)
+        execute_post_fit(
+            group.experiments,
+            path / group.path,
+            plot=plot_flg,
+            residuals=_project_residuals(group.experiments, experiments, result),
+            nvarys=len(controlled_by_path[group.path]),
+        )
+    if aggregate_output:
+        execute_post_fit_groups(
+            experiments,
+            path,
+            plot,
+            residuals=result.residuals,
+            nvarys=variable_count,
+        )
+
+
+def run_native_deterministic(
+    experiments: Experiments,
+    method: Method,
+    path: Path,
+    plot: str,
+    *,
+    session: AnalysisSession,
+) -> None:
+    """Execute one complete deterministic method occurrence natively."""
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    configuration = session.parameter_factory.sealed_configuration
+    if parameter_model is None or configuration is None:
+        raise RuntimeError("Native parameter configuration is unavailable")
+
+    normalized_method = method.model_copy(update={"fitmethod": "trf"})
+    parameterization = session.compile_current_parameterization(experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    starting_snapshot = session.analysis_values.snapshot()
+    if not _has_controlled_parameters(parameterization):
+        workflow = MethodStepWorkflow.for_evaluation(
+            starting_snapshot=starting_snapshot,
+            parameter_model=parameter_model,
+            parameterization=parameterization,
+            engine=engine,
+            method=normalized_method,
+            purpose=EvaluationPurpose.NO_OPTIMIZATION_REQUIRED,
+        )
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+        )
+        if outcome.lifecycle is not MethodStepLifecycle.SUCCESSFUL_NO_STATE_CHANGE:
+            msg = f"Native deterministic evaluation failed: {outcome.lifecycle.value}"
+            raise RuntimeError(msg)
+        result = cast("EvaluationResult", outcome.evaluation_result)
+        session.sync_parameter_store_from_analysis_values(
+            dict(result.resolved_values.ordered_items())
+        )
+        _materialize_evaluation(experiments, result)
+        execute_post_fit(
+            experiments,
+            path,
+            plot=plot != "nothing",
+            residuals=result.residuals,
+            nvarys=0,
+        )
+        return
+
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        starting_snapshot,
+    )
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    all_groups = create_groups(experiments)
+    groups = [group for group in all_groups if group.experiments]
+    aggregate_output = len(all_groups) > 1
+    group_scopes = tuple(
+        (
+            group.path,
+            frozenset(
+                param_id
+                for param_id, parameter in experiments.parameter_store.get_parameters(
+                    group.experiments.param_ids
+                ).items()
+                if parameter.vary and not parameter.expr
+            ),
+        )
+        for group in groups
+    )
+    strategy, invocation = _build_invocation(
+        method,
+        problem,
+        decomposition,
+        experiments,
+    )
+    workflow = MethodStepWorkflow.for_optimization(
+        starting_snapshot=starting_snapshot,
+        parameter_model=parameter_model,
+        parameterization=parameterization,
+        engine=engine,
+        method=normalized_method,
+        problem=problem,
+        decomposition=decomposition,
+        strategy=strategy,
+        invocation=invocation,
+    )
+    print_minimizing()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    if outcome.lifecycle is not MethodStepLifecycle.COMMITTED:
+        msg = (
+            "Native deterministic fit did not commit: "
+            f"{outcome.primary_terminal or outcome.lifecycle.value}"
+        )
+        raise RuntimeError(msg)
+
+    accepted = outcome.accepted_result
+    if accepted is None:
+        raise RuntimeError("Committed native fit lacks its accepted result")
+    result = accepted.evaluation_result
+    session.sync_parameter_store_from_analysis_values(
+        dict(result.resolved_values.ordered_items())
+    )
+    _materialize_evaluation(experiments, result)
+    variable_count = len(problem.controlled_ids)
+    if method.grid:
+        _write_grid_output(
+            cast("GroupedGridDirectTrfOutcome", outcome.primary_execution),
+            cast("GridDirectTrfInvocation", invocation),
+            path,
+            experiments=experiments,
+            group_scopes=group_scopes,
+        )
+        if aggregate_output:
+            execute_post_fit_groups(
+                experiments,
+                path,
+                plot,
+                residuals=result.residuals,
+                nvarys=variable_count,
+            )
+        else:
+            execute_post_fit(
+                experiments,
+                path,
+                plot=plot != "nothing",
+                residuals=result.residuals,
+                nvarys=variable_count,
+            )
+        return
+
+    _write_direct_output(
+        experiments,
+        path,
+        plot,
+        groups,
+        group_scopes,
+        result,
+        variable_count,
+        aggregate_output=aggregate_output,
+    )

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -48,7 +48,7 @@ _TRF_EVALUATIONS_PER_COORDINATE = 100
 
 def uses_native_deterministic(method: Method) -> bool:
     """Return whether one whole method occurrence uses native TRF."""
-    if method.statistics is not None and not method.grid:
+    if method.statistics is not None:
         return False
     if "fitmethod" not in method.model_fields_set:
         return True

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -130,6 +130,53 @@ class AnalysisSession:
             required_ids,
         )
 
+    def compile_current_parameterization(
+        self,
+        required_ids: set[str],
+    ) -> ActiveParameterization:
+        """Compile the effective inherited v1 roles in the active catalog."""
+        parameter_model = self.parameter_factory.sealed_parameter_model
+        if parameter_model is None:
+            msg = "The sealed native parameter model is unavailable"
+            raise RuntimeError(msg)
+        parameters = self.parameters.get_parameters(required_ids)
+        fit: list[str] = []
+        fix: list[str] = []
+        constraints: list[str] = []
+        for param_id, parameter in parameters.items():
+            declaration = parameter_model.declarations[param_id]
+            if declaration.model_expression:
+                continue
+            selector = str(parameter.param_name)
+            if parameter.expr:
+                expression = parameter.expr
+                for dependency in sorted(
+                    parameter.dependencies,
+                    key=len,
+                    reverse=True,
+                ):
+                    dependency_name = parameters[dependency].param_name
+                    expression = expression.replace(
+                        dependency,
+                        f"[{dependency_name}]",
+                    )
+                constraints.append(f"[{selector}] = {expression}")
+            elif parameter.vary:
+                fit.append(selector)
+            else:
+                fix.append(selector)
+        effective_method = Method(
+            fit=fit,
+            fix=fix,
+            constraints=constraints,
+        )
+        return compile_active_parameterization(
+            parameter_model,
+            self.analysis_values.snapshot(),
+            effective_method,
+            required_ids,
+        )
+
     def try_compile_parameterization(
         self,
         method: Method,
@@ -143,6 +190,18 @@ class AnalysisSession:
         except Exception:  # noqa: BLE001 - checkpoint-1 isolation boundary
             return None
         return candidate
+
+    def sync_parameter_store_from_analysis_values(
+        self,
+        resolved_values: dict[str, float] | None = None,
+    ) -> None:
+        """Mirror committed and resolved native values into current output state."""
+        snapshot = self.analysis_values.snapshot()
+        values = dict(snapshot.items()) if resolved_values is None else resolved_values
+        parameters = self.parameters.get_parameters(values)
+        for parameter in parameters.values():
+            parameter.stderr = None
+        self.parameters.database.set_values(values)
 
 
 def ensure_plugins_registered() -> None:

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -354,16 +354,14 @@ def test_run_uses_explicit_session_for_fit_flow(
         path: Path,
         plot_level: str,
         *,
-        execution: ExecutionSettings | None = None,
-        preview_parameterization: object | None = None,
+        session: StubSession,
     ) -> None:
         recorded["run_methods"] = (
             experiments_arg,
             methods,
             path,
             plot_level,
-            execution,
-            preview_parameterization,
+            session,
         )
 
     monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
@@ -392,8 +390,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     np.testing.assert_equal(session.build_analysis_values_calls, 1)
     np.testing.assert_equal(experiments.filtered, 1)
     np.testing.assert_equal(recorded["build"][2], session)
-    np.testing.assert_equal(recorded["run_methods"][4], session.execution)
-    assert recorded["run_methods"][5] == session.try_compile_parameterization
+    assert recorded["run_methods"][4] is session
     assert recorded["run_info"] is True
 
 
@@ -582,10 +579,10 @@ def test_run_methods_passes_execution_to_fit_groups(
 
     fitting_module.run_methods(
         experiments,
-        {"": Method()},
+        {"": Method(fitmethod="leastsq")},
         Path("Output"),
         "normal",
-        execution=session.execution,
+        session=session,
     )
 
     np.testing.assert_equal(len(experiments.selections), 1)
@@ -614,7 +611,7 @@ def test_run_methods_skips_fit_when_selection_removes_all_profiles(
         {"": Method(include=["1H"])},
         Path("Output"),
         "normal",
-        execution=session.execution,
+        session=session,
     )
 
     np.testing.assert_equal(calls, ["no_data"])

--- a/tests/test_analysis_values.py
+++ b/tests/test_analysis_values.py
@@ -404,12 +404,10 @@ def test_model_change_is_rejected_after_analysis_values_are_initialized() -> Non
     assert session.analysis_values.snapshot() == snapshot
 
 
-def test_shipped_fit_remains_legacy_authoritative_and_mirrors_accepted_values(
+def test_shipped_fit_is_native_authoritative_and_mirrors_committed_values(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     candidate_output = tmp_path / "candidate-enabled"
-    legacy_only_output = tmp_path / "legacy-only"
     session = AnalysisSession.create()
 
     chemex_module.run(_shipped_args("fit", candidate_output), session=session)
@@ -422,20 +420,6 @@ def test_shipped_fit_remains_legacy_authoritative_and_mirrors_accepted_values(
     )
     assert list((candidate_output / "Data").rglob("*.dat"))
     assert list((candidate_output / "Parameters").rglob("*.toml"))
-
-    def disable_native_candidate(*_args: object, **_kwargs: object) -> None:
-        msg = "native candidate disabled for parity reference"
-        raise RuntimeError(msg)
-
-    monkeypatch.setattr(AnalysisValues, "initialize", disable_native_candidate)
-    chemex_module.run(
-        _shipped_args("fit", legacy_only_output),
-        session=AnalysisSession.create(),
-    )
-
-    assert _authoritative_output_contents(candidate_output) == (
-        _authoritative_output_contents(legacy_only_output)
-    )
 
 
 def test_shipped_simulation_survives_native_initialization_failure(

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -926,7 +926,7 @@ def test_capture_conflict_reports_the_winning_persisted_occurrence(
     assert publisher.terminal_occurrence(case, specification, requested) == persisted
 
 
-def test_cpmg_case_is_path_independent_and_real_anchor_runs_without_native_evaluation(
+def test_legacy_anchor_capture_fails_closed_after_native_product_activation(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     from chemex.evaluation.native import EvaluationEngine
@@ -947,23 +947,15 @@ def test_cpmg_case_is_path_independent_and_real_anchor_runs_without_native_evalu
     monkeypatch.setattr(
         EvaluationEngine, "from_experiments", native_evaluation_is_forbidden
     )
-    published = capture_cpmg_15n_ip_legacy_observation(
-        publisher=CpmgBaselinePublisher(tmp_path / "evidence"),
-        anchor_directory=source,
-        attempt_token="real-cpmg-anchor",  # noqa: S106 - opaque persisted attempt key
-    )
+    with pytest.raises(LegacyAnchorExecutionError) as raised:
+        capture_cpmg_15n_ip_legacy_observation(
+            publisher=CpmgBaselinePublisher(tmp_path / "evidence"),
+            anchor_directory=source,
+            attempt_token="real-cpmg-anchor",  # noqa: S106 - persisted attempt key
+        )
 
-    assert published.occurrence.lifecycle == "SUCCEEDED"
-    assert published.specification.roles == ("Scientific anchor",)
-    assert (
-        published.bundle.implementation.authority_role
-        == "LegacyObservationImplementation"
-    )
-    assert len(published.bundle.members) == 340
-    assert (
-        CpmgBaselinePublisher(tmp_path / "evidence").read(published.bundle.identity)
-        == published
-    )
+    assert raised.value.occurrence.lifecycle == "FAILED"
+    assert raised.value.occurrence.failure_code == "AssertionError"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -76,7 +76,8 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
             -1
         ]
     )
-    assert first_calculation == pytest.approx(9.36430201e5, rel=5.0e-9)
+    # One intensity unit is 1e-4 of the source experimental uncertainty.
+    assert first_calculation == pytest.approx(9.36430201e5, abs=1.0)
     fit_curve = (output / "Plots" / "800mhz.fit").read_text(encoding="utf-8")
     curve = [
         tuple(float(value) for value in line.split())

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from chemex.chemex import run
+from chemex.cli import build_parser
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parent.parent
+EXAMPLE = ROOT / "examples/Experiments/RELAXATION_HZNZ"
+EXPERIMENT = EXAMPLE / "Experiments/800mhz.toml"
+PARAMETERS = EXAMPLE / "Parameters/parameters.toml"
+METHOD = EXAMPLE / "Methods/method.toml"
+
+
+def _fit_arguments(
+    output: Path,
+    method: Path = METHOD,
+    *,
+    include: tuple[str, ...] = ("G2N-HN",),
+    plot_level: str = "nothing",
+):
+    return build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            str(EXPERIMENT),
+            "-p",
+            str(PARAMETERS),
+            "-m",
+            str(method),
+            "-o",
+            str(output),
+            "--include",
+            *include,
+            "--plot",
+            plot_level,
+            "--workers",
+            "1",
+        ]
+    )
+
+
+def test_real_direct_fit_uses_native_trf_and_commits_product_output(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy evaluation was called"),
+        ),
+    ):
+        run(_fit_arguments(output, plot_level="normal"), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    fitted_record = next(line for line in fitted.splitlines() if "=" in line)
+    fitted_value = float(fitted_record.split("=", 1)[1].split()[0])
+    assert fitted_value == pytest.approx(2.34742, rel=5.0e-6)
+    assert "(error not calculated)" in fitted_record
+    assert (output / "statistics.toml").is_file()
+    data = next((output / "Data").glob("*.dat")).read_text(encoding="utf-8")
+    first_calculation = float(
+        next(line for line in data.splitlines() if line.lstrip()[:1].isdigit()).split()[
+            -1
+        ]
+    )
+    assert first_calculation == pytest.approx(9.36430201e5, rel=5.0e-9)
+    fit_curve = (output / "Plots" / "800mhz.fit").read_text(encoding="utf-8")
+    curve = [
+        tuple(float(value) for value in line.split())
+        for line in fit_curve.splitlines()
+        if line.lstrip()[:1].isdigit()
+    ]
+    time_1, intensity_1 = curve[0]
+    time_2, intensity_2 = curve[-1]
+    fitted_curve_rate = -math.log(intensity_2 / intensity_1) / (time_2 - time_1)
+    assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
+
+
+def test_real_grouped_direct_fit_uses_native_aggregate_commit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+
+    with patch(
+        "lmfit.Minimizer.minimize",
+        side_effect=AssertionError("legacy lmfit optimizer was called"),
+    ):
+        run(
+            _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
+            session=session,
+        )
+
+    assert session.analysis_values.snapshot().revision == 1
+    group_outputs = tuple((output / "Groups").glob("*/Parameters/fitted.toml"))
+    assert len(group_outputs) == 2
+    assert (output / "All" / "Parameters" / "fitted.toml").is_file()
+
+
+def _grid_method(path: Path) -> Path:
+    path.write_text(
+        """[GRID]
+FIX = ["PB", "KEX_AB"]
+GRID = ["[R1A_A] = (1.0, 3.0)"]
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_real_grid_fit_uses_native_cartesian_trf_and_writes_grid_output(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+    method = _grid_method(tmp_path / "method.toml")
+
+    with patch(
+        "lmfit.Minimizer.minimize",
+        side_effect=AssertionError("legacy lmfit optimizer was called"),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    assert (output / "Grid" / "grid.out").is_file()
+    assert (output / "Parameters" / "fixed.toml").is_file()
+
+
+def test_real_grouped_grid_fit_uses_one_native_aggregate_commit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+    method = _grid_method(tmp_path / "method.toml")
+
+    with patch(
+        "lmfit.Minimizer.minimize",
+        side_effect=AssertionError("legacy lmfit optimizer was called"),
+    ):
+        run(
+            _fit_arguments(
+                output,
+                method,
+                include=("G2N-HN", "H3N-HN"),
+            ),
+            session=session,
+        )
+
+    assert session.analysis_values.snapshot().revision == 1
+    group_grid_outputs = tuple((output / "Grid" / "Groups").glob("*.out"))
+    assert len(group_grid_outputs) == 2
+    assert (output / "All" / "Parameters" / "fixed.toml").is_file()
+    assert not (output / "Groups").exists()
+
+
+def test_ordered_native_steps_carry_forward_committed_state_and_v1_roles(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[STEP1]
+FIX = ["PB", "KEX_AB"]
+
+[STEP2]
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    with patch(
+        "lmfit.Minimizer.minimize",
+        side_effect=AssertionError("legacy lmfit optimizer was called"),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 2
+    for step in ("STEP1", "STEP2"):
+        fitted = (output / step / "Parameters" / "fitted.toml").read_text(
+            encoding="utf-8"
+        )
+        assert "(error not calculated)" in fitted
+        fixed = (output / step / "Parameters" / "fixed.toml").read_text(
+            encoding="utf-8"
+        )
+        assert "PB" in fixed
+        assert "KEX_AB" in fixed
+
+
+def test_native_step_clears_generic_error_from_preceding_legacy_step(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[LEGACY]
+FITMETHOD = "leastsq"
+FIX = ["PB", "KEX_AB"]
+
+[NATIVE]
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    run(_fit_arguments(output, method), session=session)
+
+    legacy = (output / "LEGACY" / "Parameters" / "fitted.toml").read_text(
+        encoding="utf-8"
+    )
+    native = (output / "NATIVE" / "Parameters" / "fitted.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "±" in legacy
+    assert "(error not calculated)" in native
+
+
+def test_native_backend_failure_cannot_commit_or_publish_fitted_output(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            side_effect=RuntimeError("backend failed"),
+        ),
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
+        pytest.raises(RuntimeError, match="did not commit"),
+    ):
+        run(_fit_arguments(output), session=session)
+
+    assert session.analysis_values.snapshot().revision == 0
+    assert not (output / "Parameters").exists()
+    assert not (output / "Data").exists()
+
+
+def test_v1_constraint_and_profile_selection_reach_native_product_fit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+FIX = ["PB", "KEX_AB"]
+CONSTRAINTS = ["[R1A_A, NUC->G2N-H] = 2.0"]
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    with patch(
+        "lmfit.Minimizer.minimize",
+        side_effect=AssertionError("legacy lmfit optimizer was called"),
+    ):
+        run(
+            _fit_arguments(
+                output,
+                method,
+                include=("G2N-HN", "H3N-HN"),
+            ),
+            session=session,
+        )
+
+    assert session.analysis_values.snapshot().revision == 1
+    constrained = tuple((output / "All" / "Parameters").glob("constrained.toml"))
+    assert constrained
+    constrained_text = constrained[0].read_text(encoding="utf-8")
+    assert "G2N-H" in constrained_text
+    assert "2.00000e+00" in constrained_text
+
+
+def test_all_fixed_v1_method_evaluates_without_optimizer_or_commit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+FIX = ["R1A_A", "PB", "KEX_AB"]
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    with patch(
+        "lmfit.Minimizer.minimize",
+        side_effect=AssertionError("legacy lmfit optimizer was called"),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 0
+    assert (output / "Parameters" / "fixed.toml").is_file()
+    assert (output / "statistics.toml").is_file()
+    data = next((output / "Data").glob("*.dat")).read_text(encoding="utf-8")
+    assert "1.00000000e+32" not in data
+
+
+def test_statistics_fallback_maps_explicit_trf_to_legacy_least_squares(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+FITMETHOD = "trf"
+STATISTICS = { "MC" = 1 }
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    with patch("chemex.optimize.fitting._fit_groups") as fit_groups:
+        run(_fit_arguments(output, method), session=session)
+
+    fit_groups.assert_called_once()
+    assert fit_groups.call_args.args[3] == "least_squares"
+
+
+def test_statistics_fallback_preserves_omitted_legacy_fitmethod(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+STATISTICS = { "MC" = 1 }
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    with patch("chemex.optimize.fitting._fit_groups") as fit_groups:
+        run(_fit_arguments(output, method), session=session)
+
+    fit_groups.assert_called_once()
+    assert fit_groups.call_args.args[3] == "leastsq"

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -352,3 +352,29 @@ STATISTICS = { "MC" = 1 }
 
     fit_groups.assert_called_once()
     assert fit_groups.call_args.args[3] == "leastsq"
+
+
+def test_grid_with_statistics_remains_wholly_on_legacy_dispatch(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+GRID = ["[R1A_A] = (1.0, 3.0)"]
+STATISTICS = { "MC" = 1 }
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "chemex.optimize.fitting.run_native_deterministic",
+            side_effect=AssertionError("native deterministic dispatch was called"),
+        ),
+        patch("chemex.optimize.fitting.run_grid") as run_grid,
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    run_grid.assert_called_once()

--- a/tests/test_native_resampling.py
+++ b/tests/test_native_resampling.py
@@ -671,6 +671,7 @@ def test_each_eligible_candidate_receives_exactly_one_fresh_validation_evaluatio
     original_resampled = EvaluationEngine.resampled
     original_new_evaluator = EvaluationEngine.new_evaluator
     binding_count = 0
+    validation_engines: list[EvaluationEngine] = []
     validation_engine_ids: set[int] = set()
     evaluation_counts: dict[int, int] = {}
 
@@ -683,6 +684,8 @@ def test_each_eligible_candidate_receives_exactly_one_fresh_validation_evaluatio
         binding_count += 1
         result = original_resampled(engine, evaluation_plan, cast("Any", bindings))
         if binding_count % 2 == 0:
+            # Keep engines alive so CPython cannot reuse their IDs during the test.
+            validation_engines.append(result)
             validation_engine_ids.add(id(result))
         return result
 

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -1078,7 +1078,7 @@ def test_incomplete_and_program_mismatched_frames_are_distinct_failures() -> Non
     assert raised.value.code == "program_mismatch"
 
 
-def test_native_compilation_failure_cannot_veto_real_legacy_fit(
+def test_native_compilation_failure_cannot_fall_back_to_legacy_fit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1088,10 +1088,10 @@ def test_native_compilation_failure_cannot_veto_real_legacy_fit(
     def fail_preview(*_args: object, **_kwargs: object) -> None:
         nonlocal preview_calls
         preview_calls += 1
-        msg = "native preview failed"
+        msg = "native compilation failed"
         raise RuntimeError(msg)
 
-    monkeypatch.setattr(session, "compile_parameterization", fail_preview)
+    monkeypatch.setattr(session, "compile_current_parameterization", fail_preview)
     args = Namespace(
         commands="fit",
         model="2st",
@@ -1106,8 +1106,9 @@ def test_native_compilation_failure_cannot_veto_real_legacy_fit(
         native_threads=1,
     )
 
-    chemex_module.run(args, session=session)
+    with pytest.raises(RuntimeError, match="native compilation failed"):
+        chemex_module.run(args, session=session)
 
-    assert list((tmp_path / "Data").rglob("*.dat"))
-    assert list((tmp_path / "Parameters").rglob("*.toml"))
-    assert preview_calls > 0
+    assert not (tmp_path / "Data").exists()
+    assert not (tmp_path / "Parameters").exists()
+    assert preview_calls == 1


### PR DESCRIPTION
## Summary

- route production `chemex fit` Direct TRF, grouped Direct, GRID, and grouped GRID occurrences through the existing native parameterization, evaluation, method-step, grouped execution, and atomic commit stack
- preserve the current v1 method TOML surface, FIT/FIX/constraint inheritance, profile selection, ordered step carry-forward, established output paths, resolved constraint values, calculated data, statistics, and plot state
- keep each deterministic occurrence wholly native through output materialization; native calculations and residuals feed Data/statistics directly without re-entering legacy residual evaluation
- retain whole-occurrence legacy fallback for MC/BS/BSN/MCMC and explicit legacy optimizer spellings pending #612; explicit `trf` on that fallback maps to lmfit `least_squares`, while omitted legacy statistics methods preserve their current `leastsq` behavior

Refs #657.
Refs #611.

## Scope decisions

- `FORMAT_VERSION = 2` was not required to route the supported current v1 workflows, so it is not implemented here.
- DE -> TRF remains deferred and is not production-authoritative.
- No #590 GatePlan/catalogue, migration-evidence, truth-authority bridge, optimizer calibration, or generic provenance framework was added.
- Native solver success does not populate the legacy generic `stderr` field, consistent with #571's separation of uncertainty from solver success. Family-qualified uncertainty/output work remains under #613.

## Product coverage

The RELAXATION_HZNZ product tests exercise:

- Direct TRF and grouped Direct through the real CLI path
- GRID and grouped GRID through the real CLI path
- whole-occurrence legacy dispatch for GRID combined with STATISTICS pending #612
- v1 constraints and INCLUDE selection
- ordered native state carry-forward and inherited roles
- all-fixed native evaluation without commit
- backend failure with no commit or fitted-output publication
- resolved constraint output, native Data/statistics materialization, committed plot state, and stale legacy-error clearing
- explicit and omitted FITMETHOD behavior at the #612 legacy statistics fallback boundary

Representative Direct output fits `R1A_A = 2.34742 s^-1`, materializes the first calculated intensity as `9.36430201e5`, and verifies the dense plot curve reports the same fitted rate.

## Validation

- product-test tolerance stabilization: the first materialized RELAXATION_HZNZ intensity uses `abs=1.0`, equal to `1e-4` of its source experimental standard deviation; no production or solver behavior changed
- Direct product workflow: passed on Python 3.13 and Python 3.14; full product-fitting module: 12 passed on Python 3.14
- test-only stabilization: retain strong references in the pre-existing native-resampling object-ID instrumentation so CPython address reuse cannot merge distinct validation engines; no product behavior changed
- Python 3.14 validation-engine regression stress loop: 100/100 passed
- native-resampling module: 48 passed on Python 3.14 and 48 passed on Python 3.13
- GRID + STATISTICS dispatch regression: 1 passed
- focused product/session suites: 31 passed
- full pytest: 1122 passed, 1 existing emcee warning
- `uv run ty check`: passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `git diff --check`: passed
- `uv build`: passed
- final Standards and Spec reviews: no findings

## Next frontier

- #612: route MC, BS, BSN, and MCMC through the native production path and remove their whole-occurrence lmfit fallback
- #613: introduce the deliberate family-qualified uncertainty, aggregate output, restart, and provenance contracts
