### PR TITLE
Route MC, BS, and BSN through native production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   ordered role inheritance, profile selection, calculated-data files, and
   output paths are preserved. Native deterministic fits do not populate the
   legacy generic `stderr` field; family-qualified uncertainty output remains
-  part of the dedicated output-contract migration;
-  statistics-bearing steps and explicit legacy optimizer spellings remain on
-  the legacy path pending their dedicated migration.
+  part of the dedicated output-contract migration. MC, BS, and BSN statistics
+  now start from that committed native fit and run wholly native Direct TRF
+  refits with stable ordered seeds across serial and worker execution. Existing
+  STATISTICS syntax and output directories are preserved; incomplete analyses
+  retain explicit samples/failures diagnostics without publishing complete
+  summaries or plots. MCMC-bearing steps and explicit legacy optimizer
+  spellings without native statistics remain on the legacy path pending their
+  dedicated migrations.
 
 ### Infrastructure
 - Removed the unused `B1FieldConfig` model and its `default_distribution_config`

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -42,20 +42,17 @@ def run_fit(
     else:
         methods = {"": Method()}
 
-    # Native occurrences must fail closed before any lmfit value carrier can be
-    # constructed by the compatibility filter path.
-    native_occurrence = any(
-        uses_native_deterministic(method) for method in methods.values()
+    # Native statistics occurrences must fail closed before any lmfit value
+    # carrier can be constructed by the compatibility filter path.
+    native_statistics = any(
+        method.statistics is not None and uses_native_deterministic(method)
+        for method in methods.values()
     )
-    resolved_values = (
-        session.resolve_current_values(experiments.param_ids)
-        if native_occurrence
-        else session.try_resolve_current_values(experiments.param_ids)
-    )
-    if resolved_values is None:
-        experiments.filter()
-    else:
+    if native_statistics:
+        resolved_values = session.resolve_current_values(experiments.param_ids)
         experiments.filter_from_values(resolved_values)
+    else:
+        experiments.filter()
 
     write_run_info(args, experiments, argv=argv)
 

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -20,6 +20,7 @@ from chemex.messages import (
 )
 from chemex.optimize.fitting import run_methods
 from chemex.optimize.helper import execute_simulation
+from chemex.optimize.native_deterministic import uses_native_deterministic
 from chemex.run_info import write_run_info
 from chemex.runtime import (
     AnalysisSession,
@@ -35,18 +36,27 @@ def run_fit(
     *,
     argv: Sequence[str] | None = None,
 ) -> None:
-    # Filter datapoints out if necessary (e.g., on-resonance filter CEST)
-    resolved_values = session.try_resolve_current_values(experiments.param_ids)
-    if resolved_values is None:
-        experiments.filter()
-    else:
-        experiments.filter_from_values(resolved_values)
-
     if args.method is not None:
         print_reading_methods()
         methods = read_methods(args.method)
     else:
         methods = {"": Method()}
+
+    # Native statistics occurrences must fail closed before any lmfit value carrier
+    # can be constructed by the compatibility filter path.
+    native_statistics = any(
+        method.statistics is not None and uses_native_deterministic(method)
+        for method in methods.values()
+    )
+    resolved_values = (
+        session.resolve_current_values(experiments.param_ids)
+        if native_statistics
+        else session.try_resolve_current_values(experiments.param_ids)
+    )
+    if resolved_values is None:
+        experiments.filter()
+    else:
+        experiments.filter_from_values(resolved_values)
 
     write_run_info(args, experiments, argv=argv)
 

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -42,15 +42,14 @@ def run_fit(
     else:
         methods = {"": Method()}
 
-    # Native statistics occurrences must fail closed before any lmfit value carrier
-    # can be constructed by the compatibility filter path.
-    native_statistics = any(
-        method.statistics is not None and uses_native_deterministic(method)
-        for method in methods.values()
+    # Native occurrences must fail closed before any lmfit value carrier can be
+    # constructed by the compatibility filter path.
+    native_occurrence = any(
+        uses_native_deterministic(method) for method in methods.values()
     )
     resolved_values = (
         session.resolve_current_values(experiments.param_ids)
-        if native_statistics
+        if native_occurrence
         else session.try_resolve_current_values(experiments.param_ids)
     )
     if resolved_values is None:

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -36,7 +36,11 @@ def run_fit(
     argv: Sequence[str] | None = None,
 ) -> None:
     # Filter datapoints out if necessary (e.g., on-resonance filter CEST)
-    experiments.filter()
+    resolved_values = session.try_resolve_current_values(experiments.param_ids)
+    if resolved_values is None:
+        experiments.filter()
+    else:
+        experiments.filter_from_values(resolved_values)
 
     if args.method is not None:
         print_reading_methods()

--- a/src/chemex/containers/experiment.py
+++ b/src/chemex/containers/experiment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Self
@@ -88,6 +88,11 @@ class Experiment:
     def filter(self, params: ParametersLF) -> None:
         for profile in self.profiles:
             profile.filter(params)
+
+    def filter_from_values(self, parameter_values: Mapping[str, float]) -> None:
+        """Apply profile filters from resolved native parameter values."""
+        for profile in self.profiles:
+            profile.filter_from_values(parameter_values)
 
     def _any_duplicate(self) -> bool:
         return any(profile.any_duplicate() for profile in self.profiles)

--- a/src/chemex/containers/experiments.py
+++ b/src/chemex/containers/experiments.py
@@ -4,7 +4,7 @@ This module contains the Experiments class and functions for generating differen
 types of simulated experiment datasets for statistical analysis.
 """
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from hashlib import blake2b
 from itertools import chain
 from pathlib import Path
@@ -255,6 +255,11 @@ class Experiments:
         params = self.parameter_store.build_lmfit_params(self.param_ids)
         for experiment in self:
             experiment.filter(params)
+
+    def filter_from_values(self, parameter_values: Mapping[str, float]) -> None:
+        """Apply all data filters from resolved native parameter values."""
+        for experiment in self:
+            experiment.filter_from_values(parameter_values)
 
     def get_relevant_subset(self, param_ids: set[str]) -> Self:
         """Get a subset of experiments relevant to specified parameter IDs.

--- a/src/chemex/containers/profile.py
+++ b/src/chemex/containers/profile.py
@@ -90,6 +90,13 @@ class Profile:
         parameter_values = self._get_parameter_values(params)
         self.spectrometer.update(parameter_values)
 
+    def update_spectrometer_from_values(
+        self,
+        parameter_values: Mapping[str, float],
+    ) -> None:
+        """Update the spectrometer directly from stable native parameter values."""
+        self.spectrometer.update(self._local_parameter_values(parameter_values))
+
     def calculate_unscaled(self, parameter_values: Mapping[str, float]) -> Array:
         """Run only this profile's scientific calculation.
 
@@ -138,6 +145,14 @@ class Profile:
         """Apply a filter to the data, if a filterer is available."""
         if self.filterer is not None:
             self.update_spectrometer(params)
+            self.filterer.filter(self.data)
+            self.data.mark_dirty()
+            self.clear_cache()
+
+    def filter_from_values(self, parameter_values: Mapping[str, float]) -> None:
+        """Apply the configured filter using resolved native parameter values."""
+        if self.filterer is not None:
+            self.update_spectrometer_from_values(parameter_values)
             self.filterer.filter(self.data)
             self.data.mark_dirty()
             self.clear_cache()

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -26,10 +26,14 @@ from chemex.optimize.minimizer import (
     minimize_with_report,
 )
 from chemex.optimize.native_deterministic import (
+    NativeDeterministicFit,
     run_native_deterministic,
     uses_native_deterministic,
 )
-from chemex.optimize.resampling import run_resampling_statistics
+from chemex.optimize.resampling import (
+    run_native_resampling_statistics,
+    run_resampling_statistics,
+)
 from chemex.runtime import AnalysisSession, ExecutionSettings
 
 
@@ -123,6 +127,28 @@ def _fit_groups(
         execute_post_fit_groups(experiments, path, plot)
 
 
+def _run_native_statistics(
+    experiments: Experiments,
+    path: Path,
+    statistics: Statistics,
+    fit: NativeDeterministicFit,
+    *,
+    session: AnalysisSession,
+) -> None:
+    committed = session.analysis_values.snapshot()
+    try:
+        run_native_resampling_statistics(
+            experiments,
+            path,
+            statistics,
+            fit,
+            execution=session.execution,
+        )
+    finally:
+        if session.analysis_values.snapshot() != committed:
+            raise RuntimeError("Native statistics mutated the committed central fit")
+
+
 def run_methods(
     experiments: Experiments,
     methods: Methods,
@@ -157,13 +183,25 @@ def run_methods(
         path_sect = path / section if len(methods) > 1 else path
 
         if use_native_deterministic:
-            run_native_deterministic(
+            fit = run_native_deterministic(
                 experiments,
                 method,
                 path_sect,
                 plot_level,
                 session=session,
             )
+            if method.statistics is not None:
+                if fit is None:
+                    raise RuntimeError(
+                        "Native resampling requires a committed deterministic fit"
+                    )
+                _run_native_statistics(
+                    experiments,
+                    path_sect,
+                    method.statistics,
+                    fit,
+                    session=session,
+                )
             continue
 
         if method.grid:

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -1,5 +1,6 @@
 """Production composition for native deterministic method steps."""
 
+from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
 from typing import cast
@@ -10,7 +11,7 @@ from chemex.configuration.methods import Method
 from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import EvaluationEngine, EvaluationResult
 from chemex.messages import print_group_name, print_minimizing
-from chemex.optimize.direct_trf import OptimizationProblem
+from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
 from chemex.optimize.grid_direct_trf import GridDirectTrfInvocation
 from chemex.optimize.gridding import (
     GridResult,
@@ -46,10 +47,27 @@ from chemex.typing import Array
 _TRF_EVALUATIONS_PER_COORDINATE = 100
 
 
+@dataclass(frozen=True, slots=True)
+class NativeDeterministicFit:
+    """Accepted production fit context available to native successor analyses."""
+
+    accepted: AcceptedFitResult
+    problem: OptimizationProblem
+    parameterization: ActiveParameterization
+    engine: EvaluationEngine
+
+    @property
+    def objective_request_budget(self) -> int:
+        """Return the accepted occurrence's native Direct TRF request budget."""
+        return _objective_request_budget(self.problem)
+
+
 def uses_native_deterministic(method: Method) -> bool:
     """Return whether one whole method occurrence uses native TRF."""
-    if method.statistics is not None:
+    if method.statistics is not None and method.statistics.mcmc is not None:
         return False
+    if method.statistics is not None:
+        return not method.grid
     if "fitmethod" not in method.model_fields_set:
         return True
     return method.fitmethod in {"trf", "least_squares"}
@@ -272,7 +290,7 @@ def run_native_deterministic(
     plot: str,
     *,
     session: AnalysisSession,
-) -> None:
+) -> NativeDeterministicFit | None:
     """Execute one complete deterministic method occurrence natively."""
     parameter_model = session.parameter_factory.sealed_parameter_model
     configuration = session.parameter_factory.sealed_configuration
@@ -311,7 +329,7 @@ def run_native_deterministic(
             residuals=result.residuals,
             nvarys=0,
         )
-        return
+        return None
 
     problem = OptimizationProblem.from_native(
         engine.plan,
@@ -366,6 +384,7 @@ def run_native_deterministic(
     if accepted is None:
         raise RuntimeError("Committed native fit lacks its accepted result")
     result = accepted.evaluation_result
+    fit = NativeDeterministicFit(accepted, problem, parameterization, engine)
     session.sync_parameter_store_from_analysis_values(
         dict(result.resolved_values.ordered_items())
     )
@@ -395,7 +414,7 @@ def run_native_deterministic(
                 residuals=result.residuals,
                 nvarys=variable_count,
             )
-        return
+        return fit
 
     _write_direct_output(
         experiments,
@@ -407,3 +426,4 @@ def run_native_deterministic(
         variable_count,
         aggregate_output=aggregate_output,
     )
+    return fit

--- a/src/chemex/optimize/native_resampling.py
+++ b/src/chemex/optimize/native_resampling.py
@@ -1,11 +1,12 @@
 """Deterministic native resampling evidence qualification (#599).
 
-This module is an isolated qualification seam.  It plans identity-derived
-Monte Carlo, bootstrap, and nucleus-bootstrap replicates; delegates each draw
-to an internally bound evidence-only native optimizer; freshly evaluates every
-eligible candidate in a separate replicate-local workspace; freezes every
-terminal outcome; and derives summaries from one common complete-scope sample
-set.  Production fitting and reporting do not consume these artifacts yet.
+This module plans identity-derived Monte Carlo, bootstrap, and
+nucleus-bootstrap replicates; delegates each draw to an internally bound
+evidence-only native optimizer; freshly evaluates every eligible candidate in a
+separate replicate-local workspace; freezes every terminal outcome; and derives
+summaries from one common complete-scope sample set. The production adapter
+consumes the execution artifacts without exposing qualification policy objects
+through the method-file surface.
 """
 
 from __future__ import annotations
@@ -48,7 +49,7 @@ from chemex.runtime.execution import native_thread_environment
 from chemex.typing import Array
 
 _SCHEMA_VERSION = 1
-_SEED_POLICY_VERSION = "sha256-structural-u64-v1"
+_SEED_POLICY_VERSION = "sha256-product-stable-structural-u64-v2"
 _RNG_ALGORITHM = "numpy-pcg64-v1"
 _GENERATION_POLICY_VERSION = "chemex-mc-bs-bsn-v1"
 _SUMMARY_POLICY_VERSION = "complete-scope-percentile-v1"
@@ -317,6 +318,7 @@ class ResamplingPlan:
 
     accepted_result_identity: str
     accepted_occurrence_identity: str
+    accepted_vector: tuple[float, ...]
     dataset: ResamplingDatasetManifest = field(repr=False, compare=False)
     source_problem: OptimizationProblem = field(repr=False, compare=False)
     parameterization: ActiveParameterization = field(repr=False, compare=False)
@@ -341,6 +343,14 @@ class ResamplingPlan:
 
     def __post_init__(self) -> None:  # noqa: C901 - complete plan invariant
         count = _positive_integer(self.replicate_count, name="replicate count")
+        accepted_vector = tuple(
+            _finite(value, name=f"accepted vector[{index}]")
+            for index, value in enumerate(self.accepted_vector)
+        )
+        if len(accepted_vector) != len(self.source_problem.controlled_ids):
+            raise ResamplingConstructionError(
+                "Accepted resampling vector must cover the controlled coordinates"
+            )
         minimum = _positive_integer(
             self.minimum_successful_count,
             name="minimum successful replicate count",
@@ -438,6 +448,7 @@ class ResamplingPlan:
             (
                 self.accepted_result_identity,
                 self.accepted_occurrence_identity,
+                tuple(_float_token(value) for value in accepted_vector),
                 self.scheme.value,
                 count,
                 structural_identities,
@@ -457,13 +468,22 @@ class ResamplingPlan:
                 self.generation_policy_version,
             ),
         )
+        seed_stage_identity = _identity(
+            "native-resampling-seed-stage",
+            (
+                self.scheme.value,
+                self.seed_policy_version,
+                self.rng_algorithm,
+                self.generation_policy_version,
+            ),
+        )
         requests: list[ReplicateRequest] = []
         for ordinal, (structural_identity, components) in enumerate(
             zip(structural_identities, component_identities, strict=True)
         ):
             seed = _derive_seed(
                 root_seed=root_seed,
-                stage_identity=identity,
+                stage_identity=seed_stage_identity,
                 work_unit_kind="resampling-replicate",
                 structural_identity=structural_identity,
             )
@@ -486,6 +506,7 @@ class ResamplingPlan:
                 "Distinct resampling work units produced a derived-seed collision"
             )
         object.__setattr__(self, "replicate_count", count)
+        object.__setattr__(self, "accepted_vector", accepted_vector)
         object.__setattr__(
             self,
             "replicate_structural_identities",
@@ -546,6 +567,7 @@ class ResamplingPlan:
         return cls(
             accepted.identity,
             accepted.occurrence_identity,
+            accepted.vector,
             dataset,
             source_problem,
             parameterization,
@@ -585,7 +607,6 @@ def _validate_accepted_source(
         )
         != dataset.calculated
         or accepted.controlled_ids != source_problem.controlled_ids
-        or accepted.vector != source_problem.start
         or accepted.commit_scope != source_problem.commit_scope
         or accepted.commit_items
         != accepted.evaluation_result.resolved_values.ordered_items()
@@ -1154,7 +1175,7 @@ class ReplicateExecutionPlan:
         )
         problem = plan.source_problem.derive_child(
             controlled_ids=plan.source_problem.controlled_ids,
-            start=plan.source_problem.start,
+            start=plan.accepted_vector,
             derivation=derivation,
         )
         if plan.strategy is not OptimizationStrategy.DIRECT_TRF:
@@ -2688,6 +2709,7 @@ def execute_resampling_evidence(
         not accepted_occurrence_is_authoritative(accepted)
         or accepted.identity != plan.accepted_result_identity
         or accepted.occurrence_identity != plan.accepted_occurrence_identity
+        or accepted.vector != plan.accepted_vector
     ):
         raise ResamplingConstructionError(
             "Resampling execution requires the plan's exact authoritative anchor"

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import multiprocessing
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -22,6 +22,15 @@ from chemex.optimize.helper import (
     calculate_statistics,
 )
 from chemex.optimize.minimizer import minimize
+from chemex.optimize.native_deterministic import NativeDeterministicFit
+from chemex.optimize.native_resampling import (
+    OperationTerminal,
+    ReplicateOutcome,
+    ResamplingDatasetManifest,
+    ResamplingPlan,
+    ResamplingScheme,
+    execute_resampling_evidence,
+)
 from chemex.optimize.statistics_plot import write_resampling_plots
 from chemex.runtime import ExecutionSettings
 from chemex.runtime.execution import native_thread_environment
@@ -55,6 +64,30 @@ class _WorkerState:
 
 
 _WORKER_STATE = _WorkerState()
+
+
+class NativeResamplingIncompleteError(RuntimeError):
+    """Raised after truthful incomplete native statistics have been published."""
+
+
+def _resampling_methods(statistics: Statistics) -> tuple[_ResamplingMethod, ...]:
+    methods: list[_ResamplingMethod] = []
+    if statistics.mc is not None:
+        methods.append(
+            _ResamplingMethod("mc", "Monte Carlo", "MonteCarlo", statistics.mc)
+        )
+    if statistics.bs is not None:
+        methods.append(_ResamplingMethod("bs", "bootstrap", "Bootstrap", statistics.bs))
+    if statistics.bsn is not None:
+        methods.append(
+            _ResamplingMethod(
+                "bsn",
+                "nucleus-based bootstrap",
+                "BootstrapNS",
+                statistics.bsn,
+            )
+        )
+    return tuple(methods)
 
 
 def _initialize_worker(context: _ResamplingContext) -> None:
@@ -243,6 +276,9 @@ def _write_resampling_diagnostics(
     completed_samples: int,
     workers: int,
     parameter_ids: list[str],
+    engine: str | None = None,
+    root_seed: int | None = None,
+    status: str | None = None,
 ) -> None:
     lines = [
         f"method = {_quote_toml_string(method)}",
@@ -256,6 +292,12 @@ def _write_resampling_diagnostics(
         'correlations_file = "correlations.tsv"',
         'plots_file = "plots.pdf"',
     ]
+    if engine is not None:
+        lines.append(f"engine = {_quote_toml_string(engine)}")
+    if root_seed is not None:
+        lines.append(f"root_seed = {root_seed}")
+    if status is not None:
+        lines.append(f"status = {_quote_toml_string(status)}")
     (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -359,34 +401,7 @@ def run_resampling_statistics(
         return
 
     execution = ExecutionSettings() if execution is None else execution
-    methods: list[_ResamplingMethod] = []
-    if statistics.mc is not None:
-        methods.append(
-            _ResamplingMethod(
-                statistic_name="mc",
-                message="Monte Carlo",
-                directory="MonteCarlo",
-                iterations=statistics.mc,
-            ),
-        )
-    if statistics.bs is not None:
-        methods.append(
-            _ResamplingMethod(
-                statistic_name="bs",
-                message="bootstrap",
-                directory="Bootstrap",
-                iterations=statistics.bs,
-            ),
-        )
-    if statistics.bsn is not None:
-        methods.append(
-            _ResamplingMethod(
-                statistic_name="bsn",
-                message="nucleus-based bootstrap",
-                directory="BootstrapNS",
-                iterations=statistics.bsn,
-            ),
-        )
+    methods = _resampling_methods(statistics)
 
     parameter_store = experiments.parameter_store
     params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
@@ -401,4 +416,278 @@ def run_resampling_statistics(
             method,
             parameter_ids,
             execution=execution,
+        )
+
+
+def _native_dataset(
+    experiments: Experiments,
+    fit: NativeDeterministicFit,
+) -> ResamplingDatasetManifest:
+    profiles = tuple(profile for experiment in experiments for profile in experiment)
+    if len(profiles) != len(fit.engine.plan.profiles):
+        raise NativeResamplingIncompleteError(
+            "Native resampling profile population differs from the accepted fit"
+        )
+    references: list[bool] = []
+    nucleus_groups: list[str] = []
+    descriptors: list[str] = []
+    for profile, profile_plan in zip(profiles, fit.engine.plan.profiles, strict=True):
+        if profile.data.size != profile_plan.observation_count:
+            raise NativeResamplingIncompleteError(
+                "Native resampling profile shape differs from the accepted fit"
+            )
+        references.extend(bool(value) for value in profile.data.refs)
+        nucleus_group = str(profile.spin_system.groups["i"])
+        nucleus_groups.extend([nucleus_group] * profile.data.size)
+        descriptors.extend(
+            f"{profile_plan.identity}:{index}"
+            for index in range(profile_plan.observation_count)
+        )
+    return ResamplingDatasetManifest(
+        fit.engine.plan,
+        tuple(
+            float(value)
+            for value in fit.accepted.evaluation_result.normalized_calculations
+        ),
+        tuple(references),
+        tuple(nucleus_groups),
+        tuple(descriptors),
+    )
+
+
+def _write_native_failures(path: Path, outcomes: Sequence[ReplicateOutcome]) -> None:
+    failed = tuple(outcome for outcome in outcomes if outcome.failure is not None)
+    if not failed:
+        return
+    with (path / "failures.tsv").open("w", encoding="utf-8") as output:
+        output.write("ordinal\tdisposition\tcategory\tmessage\n")
+        for outcome in failed:
+            failure = outcome.failure
+            if failure is None:
+                continue
+            message = failure.message.replace("\t", " ").replace("\n", " ")
+            output.write(
+                f"{outcome.ordinal}\t{outcome.disposition.value}\t"
+                f"{failure.category}\t{message}\n"
+            )
+
+
+def _write_incomplete_native_diagnostics(
+    path: Path,
+    *,
+    method: _ResamplingMethod,
+    successful_samples: int,
+    failed_samples: int,
+    workers: int,
+    terminal: str,
+    parameter_ids: tuple[str, ...],
+    root_seed: int,
+) -> None:
+    lines = [
+        f"method = {_quote_toml_string(method.message)}",
+        'fitmethod = "trf"',
+        'engine = "native direct TRF"',
+        'status = "incomplete"',
+        f"terminal = {_quote_toml_string(terminal)}",
+        f"requested_samples = {method.iterations}",
+        f"completed_samples = {successful_samples}",
+        f"failed_samples = {failed_samples}",
+        f"workers = {workers}",
+        f"parameters = {_format_toml_string_list(list(parameter_ids))}",
+        f"root_seed = {root_seed}",
+        'samples_file = "samples.tsv"',
+        'failures_file = "failures.tsv"',
+    ]
+    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_running_native_diagnostics(
+    path: Path,
+    *,
+    method: _ResamplingMethod,
+    workers: int,
+    parameter_ids: tuple[str, ...],
+    root_seed: int,
+) -> None:
+    lines = [
+        f"method = {_quote_toml_string(method.message)}",
+        'fitmethod = "trf"',
+        'engine = "native direct TRF"',
+        'status = "running"',
+        f"requested_samples = {method.iterations}",
+        f"workers = {workers}",
+        f"parameters = {_format_toml_string_list(list(parameter_ids))}",
+        f"root_seed = {root_seed}",
+    ]
+    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _clear_native_statistics_artifacts(path: Path) -> None:
+    for name in (
+        "summary.toml",
+        "samples.tsv",
+        "correlations.tsv",
+        "diagnostics.toml",
+        "plots.pdf",
+        "failures.tsv",
+    ):
+        (path / name).unlink(missing_ok=True)
+
+
+def _run_native_resampling_method(
+    experiments: Experiments,
+    path: Path,
+    method: _ResamplingMethod,
+    fit: NativeDeterministicFit,
+    *,
+    execution: ExecutionSettings,
+    root_seed: int,
+) -> None:
+    statistic_path = path / "Statistics" / method.directory
+    statistic_path.mkdir(parents=True, exist_ok=True)
+    _clear_native_statistics_artifacts(statistic_path)
+    parameter_ids = fit.accepted.controlled_ids
+    parameter_names = _format_parameter_names(
+        list(parameter_ids), experiments.parameter_store
+    )
+    worker_count = min(execution.workers, method.iterations)
+    _write_running_native_diagnostics(
+        statistic_path,
+        method=method,
+        workers=worker_count,
+        parameter_ids=parameter_ids,
+        root_seed=root_seed,
+    )
+    dataset = _native_dataset(experiments, fit)
+    width = max(6, len(str(method.iterations)))
+    plan = ResamplingPlan.for_accepted(
+        fit.accepted,
+        dataset=dataset,
+        source_problem=fit.problem,
+        parameterization=fit.parameterization,
+        source_engine=fit.engine,
+        scheme=ResamplingScheme(method.statistic_name),
+        replicate_count=method.iterations,
+        replicate_structural_identities=tuple(
+            f"production-replicate-{index:0{width}d}"
+            for index in range(method.iterations)
+        ),
+        replicate_component_identities=tuple(
+            (f"production-direct-trf-{index:0{width}d}",)
+            for index in range(method.iterations)
+        ),
+        root_seed=root_seed,
+        output_scope=fit.problem.commit_scope,
+        output_units=("native",) * len(fit.problem.commit_scope),
+        minimum_successful_count=method.iterations,
+        strategy_settings=(
+            (
+                "objective_request_budget",
+                str(fit.objective_request_budget),
+            ),
+        ),
+    )
+    operation = execute_resampling_evidence(
+        fit.accepted,
+        plan,
+        execution=execution,
+    )
+    evidence = operation.evidence
+    if evidence is None:
+        raise NativeResamplingIncompleteError(
+            f"Native {method.message} produced no replicate evidence"
+        )
+    successful = tuple(
+        outcome.success for outcome in evidence.outcomes if outcome.success is not None
+    )
+    sample_rows = [
+        [dict(success.resolved_items)[param_id] for param_id in parameter_ids]
+        for success in successful
+    ]
+    chisqr_rows = [success.chi_square for success in successful]
+    samples = _as_sample_array(sample_rows, len(parameter_ids))
+    with (statistic_path / "samples.tsv").open("w", encoding="utf-8") as output:
+        output.write("\t".join((*parameter_names, "chisqr")) + "\n")
+        for values, chisqr in zip(sample_rows, chisqr_rows, strict=True):
+            output.write(
+                "\t".join(
+                    _format_tsv_float(value) for value in (*values, float(chisqr))
+                )
+                + "\n"
+            )
+    complete = (
+        operation.terminal is OperationTerminal.COMPLETED
+        and evidence.successful_count == method.iterations
+    )
+    if not complete:
+        _write_native_failures(statistic_path, evidence.outcomes)
+        _write_incomplete_native_diagnostics(
+            statistic_path,
+            method=method,
+            successful_samples=evidence.successful_count,
+            failed_samples=method.iterations - evidence.successful_count,
+            workers=worker_count,
+            terminal=operation.terminal.value,
+            parameter_ids=parameter_ids,
+            root_seed=root_seed,
+        )
+        raise NativeResamplingIncompleteError(
+            f"Native {method.message} completed {evidence.successful_count} of "
+            f"{method.iterations} requested replicates"
+        )
+    _write_resampling_summary(
+        statistic_path,
+        parameter_names=parameter_names,
+        samples=samples,
+    )
+    correlations = _write_resampling_correlations(
+        statistic_path,
+        parameter_names=parameter_names,
+        samples=samples,
+    )
+    write_resampling_plots(
+        statistic_path,
+        method=method.message,
+        fitmethod="trf",
+        parameter_names=parameter_names,
+        samples=samples,
+        chisqr_values=np.asarray(chisqr_rows, dtype=float),
+        correlations=correlations,
+        requested_samples=method.iterations,
+        completed_samples=evidence.successful_count,
+    )
+    _write_resampling_diagnostics(
+        statistic_path,
+        method=method.message,
+        fitmethod="trf",
+        requested_samples=method.iterations,
+        completed_samples=evidence.successful_count,
+        workers=worker_count,
+        parameter_ids=list(parameter_ids),
+        engine="native direct TRF",
+        root_seed=root_seed,
+        status="complete",
+    )
+
+
+def run_native_resampling_statistics(
+    experiments: Experiments,
+    path: Path,
+    statistics: Statistics,
+    fit: NativeDeterministicFit,
+    *,
+    execution: ExecutionSettings | None = None,
+    root_seed: int = 0,
+) -> None:
+    """Run existing MC/BS/BSN product analyses from one committed native fit."""
+    settings = ExecutionSettings() if execution is None else execution
+    for method in _resampling_methods(statistics):
+        print_running_statistics(method.message)
+        _run_native_resampling_method(
+            experiments,
+            path,
+            method,
+            fit,
+            execution=settings,
+            root_seed=root_seed,
         )

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -502,7 +502,12 @@ def _write_native_state_diagnostics(
     if failed_samples is not None:
         lines.append(f"failed_samples = {failed_samples}")
     if status == "incomplete":
-        lines.extend(('samples_file = "samples.tsv"', 'failures_file = "failures.tsv"'))
+        accounted = (successful_samples or 0) + (failed_samples or 0)
+        lines.append(f"unstarted_samples = {method.iterations - accounted}")
+        if (path / "samples.tsv").is_file():
+            lines.append('samples_file = "samples.tsv"')
+        if (path / "failures.tsv").is_file():
+            lines.append('failures_file = "failures.tsv"')
     if failure is not None:
         message = str(failure).replace("\n", " ")
         lines.extend(

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import multiprocessing
+from collections import Counter
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,6 +26,7 @@ from chemex.optimize.minimizer import minimize
 from chemex.optimize.native_deterministic import NativeDeterministicFit
 from chemex.optimize.native_resampling import (
     OperationTerminal,
+    ReplicateDisposition,
     ReplicateOutcome,
     ResamplingDatasetManifest,
     ResamplingPlan,
@@ -482,6 +484,9 @@ def _write_native_state_diagnostics(
     status: str,
     successful_samples: int | None = None,
     failed_samples: int | None = None,
+    cancelled_samples: int | None = None,
+    interrupted_samples: int | None = None,
+    unstarted_samples: int | None = None,
     terminal: str | None = None,
     failure: BaseException | None = None,
 ) -> None:
@@ -497,13 +502,17 @@ def _write_native_state_diagnostics(
     ]
     if terminal is not None:
         lines.append(f"terminal = {_quote_toml_string(terminal)}")
-    if successful_samples is not None:
-        lines.append(f"completed_samples = {successful_samples}")
-    if failed_samples is not None:
-        lines.append(f"failed_samples = {failed_samples}")
+    sample_counts = (
+        ("completed_samples", successful_samples),
+        ("failed_samples", failed_samples),
+        ("cancelled_samples", cancelled_samples),
+        ("interrupted_samples", interrupted_samples),
+        ("unstarted_samples", unstarted_samples),
+    )
+    lines.extend(
+        f"{name} = {count}" for name, count in sample_counts if count is not None
+    )
     if status == "incomplete":
-        accounted = (successful_samples or 0) + (failed_samples or 0)
-        lines.append(f"unstarted_samples = {method.iterations - accounted}")
         if (path / "samples.tsv").is_file():
             lines.append('samples_file = "samples.tsv"')
         if (path / "failures.tsv").is_file():
@@ -602,6 +611,9 @@ def _run_native_resampling_method(
             status="incomplete",
             successful_samples=0,
             failed_samples=0,
+            cancelled_samples=0,
+            interrupted_samples=0,
+            unstarted_samples=method.iterations,
             terminal=terminal,
             failure=error,
         )
@@ -620,6 +632,9 @@ def _run_native_resampling_method(
             status="incomplete",
             successful_samples=0,
             failed_samples=0,
+            cancelled_samples=0,
+            interrupted_samples=0,
+            unstarted_samples=method.iterations,
             terminal=operation.terminal.value,
             failure=error,
         )
@@ -648,6 +663,9 @@ def _run_native_resampling_method(
     )
     if not complete:
         _write_native_failures(statistic_path, evidence.outcomes)
+        disposition_counts = Counter(
+            outcome.disposition for outcome in evidence.outcomes
+        )
         _write_native_state_diagnostics(
             statistic_path,
             method=method,
@@ -655,8 +673,11 @@ def _run_native_resampling_method(
             parameter_ids=parameter_ids,
             root_seed=root_seed,
             status="incomplete",
-            successful_samples=evidence.successful_count,
-            failed_samples=method.iterations - evidence.successful_count,
+            successful_samples=disposition_counts[ReplicateDisposition.SUCCEEDED],
+            failed_samples=disposition_counts[ReplicateDisposition.FAILED],
+            cancelled_samples=disposition_counts[ReplicateDisposition.CANCELLED],
+            interrupted_samples=disposition_counts[ReplicateDisposition.INTERRUPTED],
+            unstarted_samples=disposition_counts[ReplicateDisposition.NOT_STARTED],
             terminal=operation.terminal.value,
         )
         raise NativeResamplingIncompleteError(

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -472,53 +472,45 @@ def _write_native_failures(path: Path, outcomes: Sequence[ReplicateOutcome]) -> 
             )
 
 
-def _write_incomplete_native_diagnostics(
-    path: Path,
-    *,
-    method: _ResamplingMethod,
-    successful_samples: int,
-    failed_samples: int,
-    workers: int,
-    terminal: str,
-    parameter_ids: tuple[str, ...],
-    root_seed: int,
-) -> None:
-    lines = [
-        f"method = {_quote_toml_string(method.message)}",
-        'fitmethod = "trf"',
-        'engine = "native direct TRF"',
-        'status = "incomplete"',
-        f"terminal = {_quote_toml_string(terminal)}",
-        f"requested_samples = {method.iterations}",
-        f"completed_samples = {successful_samples}",
-        f"failed_samples = {failed_samples}",
-        f"workers = {workers}",
-        f"parameters = {_format_toml_string_list(list(parameter_ids))}",
-        f"root_seed = {root_seed}",
-        'samples_file = "samples.tsv"',
-        'failures_file = "failures.tsv"',
-    ]
-    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def _write_running_native_diagnostics(
+def _write_native_state_diagnostics(
     path: Path,
     *,
     method: _ResamplingMethod,
     workers: int,
     parameter_ids: tuple[str, ...],
     root_seed: int,
+    status: str,
+    successful_samples: int | None = None,
+    failed_samples: int | None = None,
+    terminal: str | None = None,
+    failure: BaseException | None = None,
 ) -> None:
     lines = [
         f"method = {_quote_toml_string(method.message)}",
         'fitmethod = "trf"',
         'engine = "native direct TRF"',
-        'status = "running"',
+        f"status = {_quote_toml_string(status)}",
         f"requested_samples = {method.iterations}",
         f"workers = {workers}",
         f"parameters = {_format_toml_string_list(list(parameter_ids))}",
         f"root_seed = {root_seed}",
     ]
+    if terminal is not None:
+        lines.append(f"terminal = {_quote_toml_string(terminal)}")
+    if successful_samples is not None:
+        lines.append(f"completed_samples = {successful_samples}")
+    if failed_samples is not None:
+        lines.append(f"failed_samples = {failed_samples}")
+    if status == "incomplete":
+        lines.extend(('samples_file = "samples.tsv"', 'failures_file = "failures.tsv"'))
+    if failure is not None:
+        message = str(failure).replace("\n", " ")
+        lines.extend(
+            (
+                f"failure_type = {_quote_toml_string(type(failure).__name__)}",
+                f"failure_message = {_quote_toml_string(message)}",
+            )
+        )
     (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -551,52 +543,82 @@ def _run_native_resampling_method(
         list(parameter_ids), experiments.parameter_store
     )
     worker_count = min(execution.workers, method.iterations)
-    _write_running_native_diagnostics(
+    _write_native_state_diagnostics(
         statistic_path,
         method=method,
         workers=worker_count,
         parameter_ids=parameter_ids,
         root_seed=root_seed,
+        status="running",
     )
-    dataset = _native_dataset(experiments, fit)
-    width = max(6, len(str(method.iterations)))
-    plan = ResamplingPlan.for_accepted(
-        fit.accepted,
-        dataset=dataset,
-        source_problem=fit.problem,
-        parameterization=fit.parameterization,
-        source_engine=fit.engine,
-        scheme=ResamplingScheme(method.statistic_name),
-        replicate_count=method.iterations,
-        replicate_structural_identities=tuple(
-            f"production-replicate-{index:0{width}d}"
-            for index in range(method.iterations)
-        ),
-        replicate_component_identities=tuple(
-            (f"production-direct-trf-{index:0{width}d}",)
-            for index in range(method.iterations)
-        ),
-        root_seed=root_seed,
-        output_scope=fit.problem.commit_scope,
-        output_units=("native",) * len(fit.problem.commit_scope),
-        minimum_successful_count=method.iterations,
-        strategy_settings=(
-            (
-                "objective_request_budget",
-                str(fit.objective_request_budget),
+    try:
+        dataset = _native_dataset(experiments, fit)
+        width = max(6, len(str(method.iterations)))
+        plan = ResamplingPlan.for_accepted(
+            fit.accepted,
+            dataset=dataset,
+            source_problem=fit.problem,
+            parameterization=fit.parameterization,
+            source_engine=fit.engine,
+            scheme=ResamplingScheme(method.statistic_name),
+            replicate_count=method.iterations,
+            replicate_structural_identities=tuple(
+                f"production-replicate-{index:0{width}d}"
+                for index in range(method.iterations)
             ),
-        ),
-    )
-    operation = execute_resampling_evidence(
-        fit.accepted,
-        plan,
-        execution=execution,
-    )
+            replicate_component_identities=tuple(
+                (f"production-direct-trf-{index:0{width}d}",)
+                for index in range(method.iterations)
+            ),
+            root_seed=root_seed,
+            output_scope=fit.problem.commit_scope,
+            output_units=("native",) * len(fit.problem.commit_scope),
+            minimum_successful_count=method.iterations,
+            strategy_settings=(
+                (
+                    "objective_request_budget",
+                    str(fit.objective_request_budget),
+                ),
+            ),
+        )
+        operation = execute_resampling_evidence(
+            fit.accepted,
+            plan,
+            execution=execution,
+        )
+    except (Exception, KeyboardInterrupt) as error:
+        terminal = "interrupted" if isinstance(error, KeyboardInterrupt) else "failed"
+        _write_native_state_diagnostics(
+            statistic_path,
+            method=method,
+            workers=worker_count,
+            parameter_ids=parameter_ids,
+            root_seed=root_seed,
+            status="incomplete",
+            successful_samples=0,
+            failed_samples=0,
+            terminal=terminal,
+            failure=error,
+        )
+        raise
     evidence = operation.evidence
     if evidence is None:
-        raise NativeResamplingIncompleteError(
+        error = NativeResamplingIncompleteError(
             f"Native {method.message} produced no replicate evidence"
         )
+        _write_native_state_diagnostics(
+            statistic_path,
+            method=method,
+            workers=worker_count,
+            parameter_ids=parameter_ids,
+            root_seed=root_seed,
+            status="incomplete",
+            successful_samples=0,
+            failed_samples=0,
+            terminal=operation.terminal.value,
+            failure=error,
+        )
+        raise error
     successful = tuple(
         outcome.success for outcome in evidence.outcomes if outcome.success is not None
     )
@@ -621,15 +643,16 @@ def _run_native_resampling_method(
     )
     if not complete:
         _write_native_failures(statistic_path, evidence.outcomes)
-        _write_incomplete_native_diagnostics(
+        _write_native_state_diagnostics(
             statistic_path,
             method=method,
-            successful_samples=evidence.successful_count,
-            failed_samples=method.iterations - evidence.successful_count,
             workers=worker_count,
-            terminal=operation.terminal.value,
             parameter_ids=parameter_ids,
             root_seed=root_seed,
+            status="incomplete",
+            successful_samples=evidence.successful_count,
+            failed_samples=method.iterations - evidence.successful_count,
+            terminal=operation.terminal.value,
         )
         raise NativeResamplingIncompleteError(
             f"Native {method.message} completed {evidence.successful_count} of "

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -196,15 +196,20 @@ class AnalysisSession:
         self,
         required_ids: set[str],
     ) -> Mapping[str, float] | None:
-        """Resolve current stable values without constructing lmfit Parameters."""
+        """Best-effort current-value resolution for legacy-compatible paths."""
         try:
-            parameterization = self.compile_current_parameterization(required_ids)
-            frame = parameterization.frame_from_snapshot(
-                self.analysis_values.snapshot()
-            )
-            return parameterization.resolve(frame)
+            return self.resolve_current_values(required_ids)
         except Exception:  # noqa: BLE001 - legacy filtering remains the fallback
             return None
+
+    def resolve_current_values(
+        self,
+        required_ids: set[str],
+    ) -> Mapping[str, float]:
+        """Resolve current stable values without an lmfit fallback."""
+        parameterization = self.compile_current_parameterization(required_ids)
+        frame = parameterization.frame_from_snapshot(self.analysis_values.snapshot())
+        return parameterization.resolve(frame)
 
     def sync_parameter_store_from_analysis_values(
         self,

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Protocol
 
 from chemex.configuration.methods import Method
@@ -190,6 +191,20 @@ class AnalysisSession:
         except Exception:  # noqa: BLE001 - checkpoint-1 isolation boundary
             return None
         return candidate
+
+    def try_resolve_current_values(
+        self,
+        required_ids: set[str],
+    ) -> Mapping[str, float] | None:
+        """Resolve current stable values without constructing lmfit Parameters."""
+        try:
+            parameterization = self.compile_current_parameterization(required_ids)
+            frame = parameterization.frame_from_snapshot(
+                self.analysis_values.snapshot()
+            )
+            return parameterization.resolve(frame)
+        except Exception:  # noqa: BLE001 - legacy filtering remains the fallback
+            return None
 
     def sync_parameter_store_from_analysis_values(
         self,

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -192,16 +192,6 @@ class AnalysisSession:
             return None
         return candidate
 
-    def try_resolve_current_values(
-        self,
-        required_ids: set[str],
-    ) -> Mapping[str, float] | None:
-        """Best-effort current-value resolution for legacy-compatible paths."""
-        try:
-            return self.resolve_current_values(required_ids)
-        except Exception:  # noqa: BLE001 - legacy filtering remains the fallback
-            return None
-
     def resolve_current_values(
         self,
         required_ids: set[str],

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -103,9 +103,6 @@ class StubSession:
     ) -> None:
         return None
 
-    def try_resolve_current_values(self, _required_ids: set[str]) -> None:
-        return None
-
 
 class WriterParameterStore:
     def __init__(self, parameters: dict[str, ParamSetting]) -> None:

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -103,6 +103,9 @@ class StubSession:
     ) -> None:
         return None
 
+    def try_resolve_current_values(self, _required_ids: set[str]) -> None:
+        return None
+
 
 class WriterParameterStore:
     def __init__(self, parameters: dict[str, ParamSetting]) -> None:
@@ -138,6 +141,7 @@ class FakeExperiments:
         self.filtered = 0
         self.selections: list[Selection] = []
         self.parameter_store = parameter_store
+        self.param_ids: set[str] = set()
 
     def filter(self) -> None:
         self.filtered += 1

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -56,10 +56,6 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
 
     with (
         patch(
-            "chemex.parameters.database.ParameterStore.build_lmfit_params",
-            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
-        ),
-        patch(
             "lmfit.Minimizer.minimize",
             side_effect=AssertionError("legacy lmfit optimizer was called"),
         ),

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -184,6 +184,27 @@ def test_real_mc_fit_is_wholly_native_and_writes_product_statistics(
     assert "(error not calculated)" in fitted
 
 
+def test_native_statistics_filter_resolution_fails_closed_before_lmfit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 1')
+    session = AnalysisSession.create()
+
+    with (
+        patch.object(
+            session,
+            "resolve_current_values",
+            side_effect=RuntimeError("native values unavailable"),
+        ),
+        patch("chemex.containers.experiments.Experiments.filter") as legacy_filter,
+        pytest.raises(RuntimeError, match="native values unavailable"),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    legacy_filter.assert_not_called()
+
+
 def test_real_bs_fit_uses_native_refits_and_writes_bootstrap_products(
     tmp_path: Path,
 ) -> None:
@@ -337,6 +358,36 @@ def test_failed_native_replicate_keeps_central_fit_and_suppresses_complete_produ
     assert "requested_samples = 2" in diagnostics
     assert "completed_samples = 1" in diagnostics
     assert "failed_samples = 1" in diagnostics
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+
+
+def test_native_statistics_setup_failure_publishes_incomplete_diagnostics(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 2')
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "chemex.optimize.resampling._native_dataset",
+            side_effect=RuntimeError("manifest unavailable"),
+        ),
+        pytest.raises(RuntimeError, match="manifest unavailable"),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    statistics = output / "Statistics" / "MonteCarlo"
+    diagnostics = (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    assert 'status = "incomplete"' in diagnostics
+    assert 'terminal = "failed"' in diagnostics
+    assert "completed_samples = 0" in diagnostics
+    assert "failed_samples = 0" in diagnostics
+    assert 'failure_type = "RuntimeError"' in diagnostics
+    assert 'failure_message = "manifest unavailable"' in diagnostics
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -6,8 +6,10 @@ from unittest.mock import patch
 
 import pytest
 
+import chemex.optimize.direct_trf as direct_trf_module
 from chemex.chemex import run
 from chemex.cli import build_parser
+from chemex.optimize.resampling import NativeResamplingIncompleteError
 from chemex.runtime import AnalysisSession
 
 ROOT = Path(__file__).parent.parent
@@ -23,6 +25,7 @@ def _fit_arguments(
     *,
     include: tuple[str, ...] = ("G2N-HN",),
     plot_level: str = "nothing",
+    workers: int = 1,
 ):
     return build_parser().parse_args(
         [
@@ -40,7 +43,7 @@ def _fit_arguments(
             "--plot",
             plot_level,
             "--workers",
-            "1",
+            str(workers),
         ]
     )
 
@@ -52,6 +55,10 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     session = AnalysisSession.create()
 
     with (
+        patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
         patch(
             "lmfit.Minimizer.minimize",
             side_effect=AssertionError("legacy lmfit optimizer was called"),
@@ -120,6 +127,219 @@ GRID = ["[R1A_A] = (1.0, 3.0)"]
         encoding="utf-8",
     )
     return path
+
+
+def _statistics_method(path: Path, statistics: str) -> Path:
+    path.write_text(
+        f"""[DEFAULT]
+FIX = ["PB", "KEX_AB"]
+STATISTICS = {{ {statistics} }}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_real_mc_fit_is_wholly_native_and_writes_product_statistics(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 2')
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy evaluation was called"),
+        ),
+        patch(
+            "chemex.optimize.fitting.run_resampling_statistics",
+            side_effect=AssertionError("legacy resampling was called"),
+        ),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    statistics = output / "Statistics" / "MonteCarlo"
+    assert (statistics / "summary.toml").is_file()
+    assert (statistics / "correlations.tsv").is_file()
+    assert (statistics / "plots.pdf").stat().st_size > 0
+    samples = (statistics / "samples.tsv").read_text(encoding="utf-8")
+    assert len(samples.splitlines()) == 3
+    diagnostics = (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    assert "requested_samples = 2" in diagnostics
+    assert "completed_samples = 2" in diagnostics
+    assert 'engine = "native direct TRF"' in diagnostics
+    assert "root_seed = 0" in diagnostics
+    assert 'status = "complete"' in diagnostics
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    assert "(error not calculated)" in fitted
+
+
+def test_real_bs_fit_uses_native_refits_and_writes_bootstrap_products(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"BS" = 2')
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy evaluation was called"),
+        ),
+        patch(
+            "chemex.optimize.fitting.run_resampling_statistics",
+            side_effect=AssertionError("legacy resampling was called"),
+        ),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    statistics = output / "Statistics" / "Bootstrap"
+    assert (
+        len((statistics / "samples.tsv").read_text(encoding="utf-8").splitlines()) == 3
+    )
+    assert (statistics / "summary.toml").is_file()
+    assert (statistics / "correlations.tsv").is_file()
+    assert (statistics / "diagnostics.toml").is_file()
+    assert (statistics / "plots.pdf").stat().st_size > 0
+
+
+def test_real_bsn_fit_uses_native_nucleus_resampling_products(tmp_path: Path) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"BSN" = 2')
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy evaluation was called"),
+        ),
+        patch(
+            "chemex.optimize.fitting.run_resampling_statistics",
+            side_effect=AssertionError("legacy resampling was called"),
+        ),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    statistics = output / "Statistics" / "BootstrapNS"
+    assert (
+        len((statistics / "samples.tsv").read_text(encoding="utf-8").splitlines()) == 3
+    )
+    assert (statistics / "summary.toml").is_file()
+    assert (statistics / "correlations.tsv").is_file()
+    assert (statistics / "diagnostics.toml").is_file()
+    assert (statistics / "plots.pdf").stat().st_size > 0
+
+
+def test_seeded_native_mc_products_are_ordered_across_worker_counts(
+    tmp_path: Path,
+) -> None:
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 3')
+    serial = tmp_path / "Serial"
+    parallel = tmp_path / "Parallel"
+
+    run(_fit_arguments(serial, method, workers=1), session=AnalysisSession.create())
+    run(_fit_arguments(parallel, method, workers=2), session=AnalysisSession.create())
+
+    serial_samples = (serial / "Statistics" / "MonteCarlo" / "samples.tsv").read_text(
+        encoding="utf-8"
+    )
+    parallel_samples = (
+        parallel / "Statistics" / "MonteCarlo" / "samples.tsv"
+    ).read_text(encoding="utf-8")
+    assert serial_samples == parallel_samples
+    parallel_diagnostics = (
+        parallel / "Statistics" / "MonteCarlo" / "diagnostics.toml"
+    ).read_text(encoding="utf-8")
+    assert "workers = 2" in parallel_diagnostics
+    assert "root_seed = 0" in parallel_diagnostics
+
+
+def test_native_statistics_do_not_mutate_committed_central_values(
+    tmp_path: Path,
+) -> None:
+    central_session = AnalysisSession.create()
+    statistics_session = AnalysisSession.create()
+    statistics_method = _statistics_method(
+        tmp_path / "method.toml",
+        '"MC" = 1, "BS" = 1, "BSN" = 1',
+    )
+
+    run(_fit_arguments(tmp_path / "Central"), session=central_session)
+    run(
+        _fit_arguments(tmp_path / "Statistics", statistics_method),
+        session=statistics_session,
+    )
+
+    central = central_session.analysis_values.snapshot()
+    after_statistics = statistics_session.analysis_values.snapshot()
+    assert central.revision == after_statistics.revision == 1
+    assert central.items() == after_statistics.items()
+
+
+def test_failed_native_replicate_keeps_central_fit_and_suppresses_complete_products(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 2')
+    session = AnalysisSession.create()
+    real_least_squares = direct_trf_module.least_squares
+    call_count = 0
+
+    def fail_first_replicate(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise RuntimeError("invalid replicate backend")
+        return real_least_squares(*args, **kwargs)
+
+    with (
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            side_effect=fail_first_replicate,
+        ),
+        pytest.raises(NativeResamplingIncompleteError, match="1 of 2"),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    fitted_record = next(line for line in fitted.splitlines() if "=" in line)
+    fitted_value = float(fitted_record.split("=", 1)[1].split()[0])
+    assert fitted_value == pytest.approx(2.34742, rel=5.0e-6)
+    statistics = output / "Statistics" / "MonteCarlo"
+    assert (
+        len((statistics / "samples.tsv").read_text(encoding="utf-8").splitlines()) == 2
+    )
+    failures = (statistics / "failures.tsv").read_text(encoding="utf-8")
+    assert "direct_trf_solver_unsuccessful" in failures
+    diagnostics = (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    assert 'status = "incomplete"' in diagnostics
+    assert "requested_samples = 2" in diagnostics
+    assert "completed_samples = 1" in diagnostics
+    assert "failed_samples = 1" in diagnostics
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
 
 
 def test_real_grid_fit_uses_native_cartesian_trf_and_writes_grid_output(
@@ -314,7 +534,7 @@ FIX = ["R1A_A", "PB", "KEX_AB"]
     assert "1.00000000e+32" not in data
 
 
-def test_statistics_fallback_maps_explicit_trf_to_legacy_least_squares(
+def test_explicit_trf_with_statistics_uses_native_production_dispatch(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -328,31 +548,14 @@ STATISTICS = { "MC" = 1 }
     )
     session = AnalysisSession.create()
 
-    with patch("chemex.optimize.fitting._fit_groups") as fit_groups:
+    with patch(
+        "chemex.optimize.fitting._fit_groups",
+        side_effect=AssertionError("legacy grouped fit was called"),
+    ):
         run(_fit_arguments(output, method), session=session)
 
-    fit_groups.assert_called_once()
-    assert fit_groups.call_args.args[3] == "least_squares"
-
-
-def test_statistics_fallback_preserves_omitted_legacy_fitmethod(
-    tmp_path: Path,
-) -> None:
-    output = tmp_path / "Output"
-    method = tmp_path / "method.toml"
-    method.write_text(
-        """[DEFAULT]
-STATISTICS = { "MC" = 1 }
-""",
-        encoding="utf-8",
-    )
-    session = AnalysisSession.create()
-
-    with patch("chemex.optimize.fitting._fit_groups") as fit_groups:
-        run(_fit_arguments(output, method), session=session)
-
-    fit_groups.assert_called_once()
-    assert fit_groups.call_args.args[3] == "leastsq"
+    assert session.analysis_values.snapshot().revision == 1
+    assert (output / "Statistics" / "MonteCarlo" / "samples.tsv").is_file()
 
 
 def test_grid_with_statistics_remains_wholly_on_legacy_dispatch(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -354,6 +354,9 @@ def test_failed_native_replicate_keeps_central_fit_and_suppresses_complete_produ
     assert "requested_samples = 2" in diagnostics
     assert "completed_samples = 1" in diagnostics
     assert "failed_samples = 1" in diagnostics
+    assert "unstarted_samples = 0" in diagnostics
+    assert 'samples_file = "samples.tsv"' in diagnostics
+    assert 'failures_file = "failures.tsv"' in diagnostics
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()
@@ -382,8 +385,11 @@ def test_native_statistics_setup_failure_publishes_incomplete_diagnostics(
     assert 'terminal = "failed"' in diagnostics
     assert "completed_samples = 0" in diagnostics
     assert "failed_samples = 0" in diagnostics
+    assert "unstarted_samples = 2" in diagnostics
     assert 'failure_type = "RuntimeError"' in diagnostics
     assert 'failure_message = "manifest unavailable"' in diagnostics
+    assert "samples_file" not in diagnostics
+    assert "failures_file" not in diagnostics
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import math
+import tomllib
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 import chemex.optimize.direct_trf as direct_trf_module
+import chemex.optimize.native_resampling as native_resampling_module
 from chemex.chemex import run
 from chemex.cli import build_parser
 from chemex.optimize.resampling import NativeResamplingIncompleteError
@@ -357,6 +359,55 @@ def test_failed_native_replicate_keeps_central_fit_and_suppresses_complete_produ
     assert "unstarted_samples = 0" in diagnostics
     assert 'samples_file = "samples.tsv"' in diagnostics
     assert 'failures_file = "failures.tsv"' in diagnostics
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+
+
+def test_interrupted_native_statistics_report_truthful_disposition_counts(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 3')
+    session = AnalysisSession.create()
+    real_generate = native_resampling_module.generate_resampling_draw
+
+    def interrupt_second_draw(dataset, request):
+        if request.ordinal == 1:
+            raise KeyboardInterrupt
+        return real_generate(dataset, request)
+
+    with (
+        patch(
+            "chemex.optimize.native_resampling.generate_resampling_draw",
+            side_effect=interrupt_second_draw,
+        ),
+        pytest.raises(NativeResamplingIncompleteError, match="1 of 3"),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    statistics = output / "Statistics" / "MonteCarlo"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    disposition_counts = {
+        "completed": diagnostics["completed_samples"],
+        "failed": diagnostics["failed_samples"],
+        "cancelled": diagnostics["cancelled_samples"],
+        "interrupted": diagnostics["interrupted_samples"],
+        "unstarted": diagnostics["unstarted_samples"],
+    }
+    assert disposition_counts == {
+        "completed": 1,
+        "failed": 0,
+        "cancelled": 0,
+        "interrupted": 1,
+        "unstarted": 1,
+    }
+    assert sum(disposition_counts.values()) == diagnostics["requested_samples"]
+    failures = (statistics / "failures.tsv").read_text(encoding="utf-8")
+    assert "\tinterrupted\t" in failures
+    assert "\tnot_started\t" in failures
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -286,7 +286,6 @@ def test_run_fit_creates_run_info(
         SimpleNamespace(
             execution=None,
             try_compile_parameterization=lambda *_args: None,
-            try_resolve_current_values=lambda *_args: None,
         ),
         argv=["chemex", "fit"],
     )

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -286,6 +286,7 @@ def test_run_fit_creates_run_info(
         SimpleNamespace(
             execution=None,
             try_compile_parameterization=lambda *_args: None,
+            try_resolve_current_values=lambda *_args: None,
         ),
         argv=["chemex", "fit"],
     )

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -169,6 +169,10 @@ Results are stored in the `grid.toml` file, with 1D and 2D plots generated. If m
 
 ChemEx offers additional methods for estimating uncertainty, including Monte Carlo, bootstrap, nucleus-specific bootstrap, and MCMC analyses.
 
+MC, BS, and BSN start from the accepted native Direct TRF fit. Their refits are
+evaluation-only successors: they cannot update the committed central parameter
+values or populate the generic fitted-parameter error field.
+
 ### Monte Carlo Simulations
 
 In Monte Carlo simulations, the fit is run once, Gaussian noise is added to generated profiles, and fitting is repeated. After N simulations, the distribution of fitted parameters provides an uncertainty estimate.
@@ -213,6 +217,13 @@ To perform multiple analyses:
 [STEP1]
 STATISTICS = {"MC"= 100, "BS"= 100}
 ```
+
+ChemEx runs every requested MC, BS, and BSN replicate. A failed or interrupted
+replicate makes that analysis incomplete: successful rows and failure
+diagnostics remain available, but ChemEx does not publish a complete summary,
+correlation matrix, or plots. The native root seed is recorded in
+`diagnostics.toml`; serial and worker execution preserve the same ordered
+results.
 
 For MCMC, the compact form sets the number of sampler steps:
 

--- a/website/docs/user_guide/fitting/multicore_execution.md
+++ b/website/docs/user_guide/fitting/multicore_execution.md
@@ -17,10 +17,10 @@ chemex fit -e Experiments/*.toml \
            -o Output
 ```
 
-By default, `--workers auto` chooses a conservative number of worker processes,
-up to 8 CPUs. This gives typical workstations useful parallelism without
-starting an unexpectedly large number of Python processes. Use `--workers 1` for
-serial execution, or `--workers 0` to explicitly use all CPUs visible to ChemEx.
+By default, `--workers auto` chooses a conservative number of worker slots, up
+to 8 CPUs. This gives typical workstations useful parallelism without starting
+an unexpectedly large worker pool. Use `--workers 1` for serial execution, or
+`--workers 0` to explicitly use all CPUs visible to ChemEx.
 
 ## What Runs in Parallel
 
@@ -34,16 +34,16 @@ The normal deterministic fit still runs as one optimization task. Grid searches,
 simulation runs, plotting, and output writing are not controlled by
 `--workers`.
 
-Worker processes are created only while the parallel statistics task is running.
-For example, Activity Monitor or `top` should show multiple Python processes
-during MCMC sampling, but not necessarily during the earlier deterministic fit
-or the later output-writing phase.
+Workers are active only while the parallel statistics task is running. Native
+MC, BS, and BSN refits use worker threads; MCMC may show multiple Python
+processes. The earlier deterministic fit and later output-writing phase remain
+serial.
 
 ## Command-Line Controls
 
 ### `--workers N|auto`
 
-Controls the number of ChemEx worker processes used by fit statistics.
+Controls the number of ChemEx worker slots used by fit statistics.
 
 | Value | Meaning |
 | ---- | ------- |
@@ -68,9 +68,9 @@ chemex fit -e Experiments/*.toml \
 Controls native numerical library threads, such as BLAS or OpenMP threads.
 
 The default, `--native-threads auto`, leaves native thread settings untouched for
-serial runs. When ChemEx starts multiple worker processes, it sets native
+serial runs. When ChemEx starts multiple workers, it sets native numerical
 threads to 1 inside the worker-pool context. This avoids oversubscription, where
-each Python worker also starts many native threads.
+each ChemEx worker also starts many BLAS or OpenMP threads.
 
 Most users should keep the default. Use an explicit value only when you are
 benchmarking a specific machine:

--- a/website/docs/user_guide/fitting/multicore_execution.md
+++ b/website/docs/user_guide/fitting/multicore_execution.md
@@ -49,7 +49,7 @@ Controls the number of ChemEx worker slots used by fit statistics.
 | ---- | ------- |
 | `auto` | Conservative default, capped at 8 workers. |
 | `1` | Serial execution. Useful for debugging and reproducibility checks. |
-| `N` | Use `N` worker processes. |
+| `N` | Use `N` worker slots (threads for native MC/BS/BSN; processes may be used for MCMC). |
 | `0` | Use all CPUs visible to the current process. |
 
 For long MCMC runs on a dedicated machine, it can be reasonable to set an

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -145,15 +145,18 @@ Contains goodness-of-fit statistics, such as χ<sup>2</sup>.
 
 Contains optional uncertainty-analysis outputs requested with the `STATISTICS`
 method-file key. Monte Carlo and bootstrap methods write `summary.toml`,
-`samples.tsv`, `correlations.tsv`, and `diagnostics.toml` under
+`samples.tsv`, `correlations.tsv`, `diagnostics.toml`, and `plots.pdf` under
 `Statistics/MonteCarlo/`, `Statistics/Bootstrap/`, and `Statistics/BootstrapNS/`.
 MCMC writes the same file set under `Statistics/MCMC/`, plus a `plots.pdf`
 report with posterior distributions, walker traces, log-probability traces, and
 autocorrelation diagnostics.
 
-The `diagnostics.toml` files record execution details for reproducibility. For
-parallel statistics, they include the effective worker count. MCMC diagnostics
-also include the direct emcee sampler engine, timing information, acceptance
+The `diagnostics.toml` files record execution details for reproducibility. MC,
+BS, and BSN diagnostics include the native Direct TRF engine, root seed, and
+effective worker count. An incomplete analysis instead writes the successful
+sample rows, `failures.tsv`, and an explicit incomplete diagnostic; complete
+summary, correlation, and plot files are suppressed. MCMC diagnostics also
+include the direct emcee sampler engine, timing information, acceptance
 fractions, burn-in decisions, and autocorrelation estimates. These diagnostics
 are the best place to confirm that [`--workers`](multicore_execution.md) was
 applied as intended.


### PR DESCRIPTION
## Summary

- route supported MC, BS, and BSN `STATISTICS` occurrences through the native deterministic fit and native resampling execution path
- carry the committed accepted native fit into every replicate without constructing lmfit parameters or entering legacy residual/minimizer/resampling code
- preserve existing statistics TOML, worker behavior, stable ordered seeded products, output directories, summaries, samples, correlations, diagnostics, and plots
- fail closed before legacy filtering for native MC/BS/BSN occurrences and publish explicit incomplete diagnostics without mutating the committed central fit

Refs #657 and #612. This does not close #612; MCMC remains the next slice.

## Scope and compatibility

- MC keeps generated-profile plus Gaussian-noise semantics
- BS keeps within-profile bootstrap semantics
- BSN keeps nucleus-specific resampling semantics
- GRID + STATISTICS retains the existing warning/compatibility path
- MCMC-bearing occurrences remain on the existing legacy path
- no new method syntax, format version, calibration, GatePlan, or generic uncertainty/provenance framework
- native resampling does not populate generic parameter stderr

## Validation

- real RELAXATION_HZNZ product coverage for MC, BS, BSN, workers, seeded ordering, central-state immutability, lmfit exclusion, failed replicates, and setup failures
- focused product workflow: Python 3.13 and 3.14 (`19 passed` on each finalized product run)
- full pytest: `1129 passed`, with one existing emcee autocorrelation warning
- native resampling suite: `48 passed`
- `uv run ty check`
- `uvx ruff check .`
- `uvx ruff format --check .`
- `git diff --check main...HEAD`
- `uv build`
