### PR TITLE
Route product MCMC through native production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,14 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   refits with stable ordered seeds across serial and worker execution. Existing
   STATISTICS syntax and output directories are preserved; incomplete analyses
   retain explicit samples/failures diagnostics without publishing complete
-  summaries or plots. MCMC-bearing steps and explicit legacy optimizer
-  spellings without native statistics remain on the legacy path pending their
-  dedicated migrations.
+  summaries or plots. MCMC now also starts from the single committed native
+  deterministic fit and samples ChemEx weighted residuals through the native
+  evaluation engine, with seeded serial/worker replay and the existing compact
+  and nested method forms. Native MCMC requires finite, strictly ordered bounds
+  and rejects `UPDATE_PARAMETERS = true`; failed or interrupted chains publish
+  incomplete diagnostics without summary, sample, correlation, or plot files.
+  Explicit legacy optimizer spellings without native statistics remain on their
+  compatibility path.
 
 ### Infrastructure
 - Removed the unused `B1FieldConfig` model and its `default_distribution_config`

--- a/src/chemex/configuration/methods.py
+++ b/src/chemex/configuration/methods.py
@@ -50,6 +50,12 @@ class McmcSettings(BaseModel):
 
     @model_validator(mode="after")
     def validate_sample_window(self) -> Self:
+        if self.update_parameters:
+            msg = "MCMC posterior sampling cannot mutate the committed central fit"
+            raise ValueError(msg)
+        if self.seed is not None and not 0 <= self.seed < 1 << 64:
+            msg = "MCMC seed must be an unsigned 64-bit integer"
+            raise ValueError(msg)
         burn = 0 if self.burn == "auto" else self.burn
         if burn >= self.steps:
             msg = "MCMC burn must be smaller than steps"

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -9,11 +9,11 @@ from chemex.messages import (
     print_fitmethod,
     print_grid_statistic_warning,
     print_group_name,
+    print_mcmc_no_vary_warning,
     print_minimizing,
     print_no_data,
     print_running_statistics,
     print_step_name,
-    print_value_error,
 )
 from chemex.optimize.gridding import run_grid
 from chemex.optimize.grouping import create_groups
@@ -21,7 +21,7 @@ from chemex.optimize.helper import (
     execute_post_fit,
     execute_post_fit_groups,
 )
-from chemex.optimize.mcmc import run_mcmc
+from chemex.optimize.mcmc import run_native_mcmc
 from chemex.optimize.minimizer import (
     minimize_with_report,
 )
@@ -55,25 +55,6 @@ def _run_statistics(
         statistics,
         execution=execution,
     )
-    parameter_store = experiments.parameter_store
-
-    if statistics.mcmc is None:
-        return
-
-    print_running_statistics("MCMC")
-    try:
-        params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
-        run_mcmc(
-            experiments,
-            params_lf,
-            statistics.mcmc,
-            path,
-            execution=execution,
-        )
-    except KeyboardInterrupt:
-        print_calculation_stopped_error()
-    except ValueError:
-        print_value_error()
 
 
 def _fit_groups(
@@ -144,9 +125,51 @@ def _run_native_statistics(
             fit,
             execution=session.execution,
         )
+        if statistics.mcmc is not None:
+            print_running_statistics("MCMC")
+            run_native_mcmc(
+                experiments,
+                fit,
+                statistics.mcmc,
+                path,
+                execution=session.execution,
+            )
     finally:
         if session.analysis_values.snapshot() != committed:
             raise RuntimeError("Native statistics mutated the committed central fit")
+
+
+def _requests_only_mcmc(statistics: Statistics) -> bool:
+    return (
+        statistics.mcmc is not None
+        and statistics.mc is None
+        and statistics.bs is None
+        and statistics.bsn is None
+    )
+
+
+def _run_requested_native_statistics(
+    experiments: Experiments,
+    path: Path,
+    statistics: Statistics | None,
+    fit: NativeDeterministicFit | None,
+    *,
+    session: AnalysisSession,
+) -> None:
+    if statistics is None:
+        return
+    if fit is None:
+        if _requests_only_mcmc(statistics):
+            print_mcmc_no_vary_warning()
+            return
+        raise RuntimeError("Native resampling requires a committed deterministic fit")
+    _run_native_statistics(
+        experiments,
+        path,
+        statistics,
+        fit,
+        session=session,
+    )
 
 
 def run_methods(
@@ -190,18 +213,13 @@ def run_methods(
                 plot_level,
                 session=session,
             )
-            if method.statistics is not None:
-                if fit is None:
-                    raise RuntimeError(
-                        "Native resampling requires a committed deterministic fit"
-                    )
-                _run_native_statistics(
-                    experiments,
-                    path_sect,
-                    method.statistics,
-                    fit,
-                    session=session,
-                )
+            _run_requested_native_statistics(
+                experiments,
+                path_sect,
+                method.statistics,
+                fit,
+                session=session,
+            )
             continue
 
         if method.grid:

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -27,7 +28,18 @@ from chemex.optimize.mcmc_engine import (
     McmcProblem,
     run_emcee_sampler,
 )
+from chemex.optimize.native_deterministic import NativeDeterministicFit
+from chemex.optimize.native_mcmc import (
+    ExpertMcmcPolicy,
+    McmcDiagnosticStatus,
+    McmcEvidence,
+    McmcOperationTerminal,
+    McmcPlan,
+    derive_mcmc_diagnostics,
+    execute_mcmc_evidence,
+)
 from chemex.optimize.statistics_plot import write_mcmc_plots
+from chemex.optimize.uncertainty import ParameterUnit
 from chemex.parameters.database import ParameterStore
 from chemex.runtime import ExecutionSettings
 from chemex.runtime.execution import native_thread_env, native_thread_environment
@@ -143,6 +155,10 @@ _TIMING_KEYS = (
     "output_total_seconds",
     "total_seconds",
 )
+
+
+class NativeMcmcIncompleteError(RuntimeError):
+    """Raised when native product MCMC cannot publish a complete chain."""
 
 
 def resolve_mcmc_settings(
@@ -691,6 +707,9 @@ def _write_diagnostics(
     parameter_store: ParameterStore,
     unbounded_parameter_ids: tuple[str, ...],
     timings: Mapping[str, float],
+    *,
+    engine: str,
+    root_seed: int | None = None,
 ) -> None:
     acceptance = result.acceptance_fraction
     unbounded_parameters = list(
@@ -698,8 +717,9 @@ def _write_diagnostics(
     )
     requested_burn = '"auto"' if settings.burn == "auto" else str(settings.burn)
     lines = [
+        'status = "complete"',
+        f"engine = {_quote_toml_string(engine)}",
         'sampler = "emcee via ChemEx direct EnsembleSampler"',
-        f"lmfit_version = {_quote_toml_string(_package_version('lmfit'))}",
         f"emcee_version = {_quote_toml_string(_package_version('emcee'))}",
         'credible_interval = "95% equal-tailed"',
         'convergence_diagnostic = "integrated_autocorrelation_time"',
@@ -722,6 +742,8 @@ def _write_diagnostics(
         f"acceptance_fraction_max = {_format_toml_float(float(np.max(acceptance)))}",
         f"unbounded_parameters = {_format_toml_string_list(unbounded_parameters)}",
     ]
+    if root_seed is not None:
+        lines.append(f"root_seed = {root_seed}")
     if result.burn_in_warning is not None:
         lines.append(f"burn_in_warning = {_quote_toml_string(result.burn_in_warning)}")
     _extend_autocorrelation_diagnostics(lines, result, settings)
@@ -741,6 +763,9 @@ def write_mcmc_outputs(
     parameter_store: ParameterStore,
     unbounded_parameter_ids: tuple[str, ...] = (),
     timings: dict[str, float] | None = None,
+    *,
+    engine: str = "legacy MCMC",
+    root_seed: int | None = None,
 ) -> None:
     timings = {} if timings is None else timings
     output_start = perf_counter()
@@ -781,7 +806,266 @@ def write_mcmc_outputs(
         parameter_store,
         unbounded_parameter_ids,
         timings,
+        engine=engine,
+        root_seed=root_seed,
     )
+
+
+def _clear_mcmc_artifacts(path: Path) -> None:
+    for name in (
+        "summary.toml",
+        "samples.tsv",
+        "correlations.tsv",
+        "diagnostics.toml",
+        "plots.pdf",
+    ):
+        (path / name).unlink(missing_ok=True)
+
+
+def _write_native_mcmc_state_diagnostics(
+    path: Path,
+    *,
+    settings: EffectiveMcmcSettings,
+    root_seed: int,
+    parameter_ids: tuple[str, ...],
+    status: str,
+    terminal: str | None = None,
+    completed_steps: int | None = None,
+    failure: BaseException | None = None,
+) -> None:
+    requested_burn = '"auto"' if settings.burn == "auto" else str(settings.burn)
+    lines = [
+        f"status = {_quote_toml_string(status)}",
+        'engine = "native MCMC"',
+        'sampler = "emcee via ChemEx direct EnsembleSampler"',
+        f"steps = {settings.steps}",
+        f"requested_burn = {requested_burn}",
+        f"thin = {settings.thin}",
+        f"walkers = {settings.walkers}",
+        f"workers = {settings.workers}",
+        f"root_seed = {root_seed}",
+        f"parameters = {_format_toml_string_list(list(parameter_ids))}",
+    ]
+    if terminal is not None:
+        lines.append(f"terminal = {_quote_toml_string(terminal)}")
+    if completed_steps is not None:
+        lines.append(f"completed_steps = {completed_steps}")
+    if failure is not None:
+        message = str(failure).replace("\n", " ")
+        lines.extend(
+            (
+                f"failure_type = {_quote_toml_string(type(failure).__name__)}",
+                f"failure_message = {_quote_toml_string(message)}",
+            )
+        )
+    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _native_result_from_evidence(
+    evidence: McmcEvidence,
+    settings: EffectiveMcmcSettings,
+) -> McmcResult:
+    raw_chain = np.asarray(
+        [state.positions for state in evidence.states[1:]],
+        dtype=float,
+    )
+    raw_lnprob = np.asarray(
+        [state.log_densities for state in evidence.states[1:]],
+        dtype=float,
+    )
+    diagnostics = derive_mcmc_diagnostics(evidence)
+    if (
+        diagnostics.status is not McmcDiagnosticStatus.AVAILABLE
+        or diagnostics.acceptance_fractions is None
+    ):
+        msg = "Native MCMC completed without authoritative acceptance diagnostics"
+        raise NativeMcmcIncompleteError(msg)
+    autocorrelation_time, tentative_autocorrelation_time, autocorrelation_warning = (
+        _estimate_autocorrelation_time(raw_chain)
+    )
+    burn_autocorrelation_time = (
+        autocorrelation_time
+        if autocorrelation_time is not None
+        else tentative_autocorrelation_time
+    )
+    retained_chain, retained_lnprob, discarded_steps, burn_in_warning = (
+        _apply_sample_window(
+            raw_chain,
+            raw_lnprob,
+            burn=settings.burn,
+            thin=settings.thin,
+            autocorrelation_time=burn_autocorrelation_time,
+            autocorrelation_time_reliable=autocorrelation_time is not None,
+        )
+    )
+    samples = retained_chain.reshape((-1, len(evidence.coordinate_ids)))
+    return McmcResult(
+        var_names=evidence.coordinate_ids,
+        chain=retained_chain,
+        lnprob=retained_lnprob,
+        summary=_summarize_chain(
+            evidence.coordinate_ids,
+            samples,
+            autocorrelation_time,
+            settings.thin,
+        ),
+        correlations=_correlation_matrix(samples),
+        acceptance_fraction=np.asarray(
+            diagnostics.acceptance_fractions,
+            dtype=float,
+        ),
+        autocorrelation_time=autocorrelation_time,
+        discarded_steps=discarded_steps,
+        burn_in_warning=burn_in_warning,
+        tentative_autocorrelation_time=tentative_autocorrelation_time,
+        autocorrelation_warning=autocorrelation_warning,
+        raw_chain=raw_chain,
+        raw_lnprob=raw_lnprob,
+    )
+
+
+def run_native_mcmc(
+    experiments: Experiments,
+    fit: NativeDeterministicFit,
+    settings: McmcSettings,
+    path: Path,
+    *,
+    execution: ExecutionSettings | None = None,
+) -> McmcResult:
+    """Run product MCMC directly from one committed native deterministic fit."""
+    effective = resolve_mcmc_settings(
+        settings,
+        nvarys=len(fit.problem.controlled_ids),
+        execution=execution,
+    )
+    root_seed = secrets.randbits(64) if effective.seed is None else effective.seed
+    statistic_path = path / "Statistics" / "MCMC"
+    statistic_path.mkdir(parents=True, exist_ok=True)
+    _clear_mcmc_artifacts(statistic_path)
+    _write_native_mcmc_state_diagnostics(
+        statistic_path,
+        settings=effective,
+        root_seed=root_seed,
+        parameter_ids=fit.problem.controlled_ids,
+        status="running",
+    )
+    lower = np.asarray(fit.problem.lower_bounds, dtype=float)
+    upper = np.asarray(fit.problem.upper_bounds, dtype=float)
+    invalid_bounds = ~np.isfinite(lower) | ~np.isfinite(upper) | (lower >= upper)
+    if np.any(invalid_bounds):
+        parameter_names = _format_parameter_ids(
+            tuple(
+                param_id
+                for param_id, invalid in zip(
+                    fit.problem.controlled_ids,
+                    invalid_bounds,
+                    strict=True,
+                )
+                if invalid
+            ),
+            experiments.parameter_store,
+        )
+        error = ValueError(
+            "Native MCMC requires finite lower and upper bounds with lower < upper "
+            f"for every fitted parameter; affected: {', '.join(parameter_names)}"
+        )
+        _write_native_mcmc_state_diagnostics(
+            statistic_path,
+            settings=effective,
+            root_seed=root_seed,
+            parameter_ids=fit.problem.controlled_ids,
+            status="incomplete",
+            terminal="failed",
+            completed_steps=0,
+            failure=error,
+        )
+        raise error
+
+    timings: dict[str, float] = {}
+    try:
+        policy = ExpertMcmcPolicy(
+            burn_steps=0,
+            retained_steps=effective.steps,
+            walkers=effective.walkers,
+            expert_provenance="chemex-product-method-v1",
+        ).resolve(
+            dimension=len(fit.problem.controlled_ids),
+            root_seed=root_seed,
+        )
+        plan = McmcPlan.for_accepted(
+            fit.accepted,
+            source_problem=fit.problem,
+            parameterization=fit.parameterization,
+            source_engine=fit.engine,
+            policy=policy,
+            coordinate_units=tuple(
+                (param_id, ParameterUnit.DIMENSIONLESS)
+                for param_id in fit.problem.controlled_ids
+            ),
+        )
+        phase_start = perf_counter()
+        operation = execute_mcmc_evidence(
+            fit.accepted,
+            plan,
+            execution=ExecutionSettings(
+                workers=effective.workers,
+                native_threads=effective.native_threads,
+            ),
+        )
+        timings["sampling_seconds"] = perf_counter() - phase_start
+        if (
+            operation.terminal is not McmcOperationTerminal.COMPLETED
+            or operation.evidence is None
+        ):
+            error = NativeMcmcIncompleteError(
+                f"Native MCMC {operation.terminal.value}: {operation.failure_message}"
+            )
+            completed_steps = (
+                0
+                if operation.evidence is None
+                else operation.evidence.completed_transition_count
+            )
+            _write_native_mcmc_state_diagnostics(
+                statistic_path,
+                settings=effective,
+                root_seed=root_seed,
+                parameter_ids=fit.problem.controlled_ids,
+                status="incomplete",
+                terminal=operation.terminal.value,
+                completed_steps=completed_steps,
+                failure=error,
+            )
+            raise error
+        phase_start = perf_counter()
+        result = _native_result_from_evidence(operation.evidence, effective)
+        timings["result_processing_seconds"] = perf_counter() - phase_start
+        write_mcmc_outputs(
+            result,
+            effective,
+            path,
+            experiments.parameter_store,
+            timings=timings,
+            engine="native MCMC",
+            root_seed=root_seed,
+        )
+    except (Exception, KeyboardInterrupt) as error:
+        if not isinstance(error, NativeMcmcIncompleteError):
+            _clear_mcmc_artifacts(statistic_path)
+            _write_native_mcmc_state_diagnostics(
+                statistic_path,
+                settings=effective,
+                root_seed=root_seed,
+                parameter_ids=fit.problem.controlled_ids,
+                status="incomplete",
+                terminal=(
+                    "interrupted" if isinstance(error, KeyboardInterrupt) else "failed"
+                ),
+                completed_steps=0,
+                failure=error,
+            )
+        raise
+    else:
+        return result
 
 
 def run_mcmc(

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -30,13 +30,13 @@ from chemex.optimize.mcmc_engine import (
 )
 from chemex.optimize.native_deterministic import NativeDeterministicFit
 from chemex.optimize.native_mcmc import (
-    ExpertMcmcPolicy,
     McmcDiagnosticStatus,
     McmcEvidence,
     McmcOperationTerminal,
     McmcPlan,
     derive_mcmc_diagnostics,
     execute_mcmc_evidence,
+    resolve_product_mcmc_policy,
 )
 from chemex.optimize.statistics_plot import write_mcmc_plots
 from chemex.optimize.uncertainty import ParameterUnit
@@ -160,6 +160,17 @@ _TIMING_KEYS = (
 class NativeMcmcIncompleteError(RuntimeError):
     """Raised when native product MCMC cannot publish a complete chain."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        terminal: str = "failed",
+        completed_steps: int = 0,
+    ) -> None:
+        super().__init__(message)
+        self.terminal = terminal
+        self.completed_steps = completed_steps
+
 
 def resolve_mcmc_settings(
     settings: McmcSettings,
@@ -205,6 +216,35 @@ def _format_parameter_ids(
 ) -> tuple[str, ...]:
     parameters = parameter_store.get_parameters(parameter_ids)
     return tuple(str(parameters[param_id].param_name) for param_id in parameter_ids)
+
+
+def _native_coordinate_units(
+    parameter_ids: tuple[str, ...],
+    parameter_store: ParameterStore,
+) -> tuple[tuple[str, ParameterUnit], ...]:
+    """Project established ChemEx parameter families to evidence units."""
+    parameters = parameter_store.get_parameters(parameter_ids)
+    units: list[tuple[str, ParameterUnit]] = []
+    for param_id in parameter_ids:
+        name = parameters[param_id].param_name.name
+        if name.startswith(("R1", "R2", "ETA", "SIGMA", "MU", "KEX")) or (
+            len(name) == 3 and name[0] == "K" and name[1:].isalpha()
+        ):
+            unit = ParameterUnit.RATE_PER_SECOND
+        elif name.startswith(("CS_", "DW_", "DWM_", "DWP_")):
+            unit = ParameterUnit.CHEMICAL_SHIFT_PPM
+        elif name.startswith("J_"):
+            unit = ParameterUnit.FREQUENCY_HZ
+        elif name in {"PA", "PB", "PC", "PD", "PE", "PF", "D2O"}:
+            unit = ParameterUnit.FRACTION
+        elif name.startswith("DH_"):
+            unit = ParameterUnit.ENERGY_PER_MOLE
+        elif name.startswith("DS_"):
+            unit = ParameterUnit.ENTROPY_PER_MOLE_KELVIN
+        else:
+            unit = ParameterUnit.DIMENSIONLESS
+        units.append((param_id, unit))
+    return tuple(units)
 
 
 def _find_unbounded_parameter_ids(
@@ -983,13 +1023,10 @@ def run_native_mcmc(
 
     timings: dict[str, float] = {}
     try:
-        policy = ExpertMcmcPolicy(
-            burn_steps=0,
-            retained_steps=effective.steps,
-            walkers=effective.walkers,
-            expert_provenance="chemex-product-method-v1",
-        ).resolve(
+        policy = resolve_product_mcmc_policy(
             dimension=len(fit.problem.controlled_ids),
+            walkers=effective.walkers,
+            steps=effective.steps,
             root_seed=root_seed,
         )
         plan = McmcPlan.for_accepted(
@@ -998,9 +1035,9 @@ def run_native_mcmc(
             parameterization=fit.parameterization,
             source_engine=fit.engine,
             policy=policy,
-            coordinate_units=tuple(
-                (param_id, ParameterUnit.DIMENSIONLESS)
-                for param_id in fit.problem.controlled_ids
+            coordinate_units=_native_coordinate_units(
+                fit.problem.controlled_ids,
+                experiments.parameter_store,
             ),
         )
         phase_start = perf_counter()
@@ -1018,22 +1055,13 @@ def run_native_mcmc(
             or operation.evidence is None
         ):
             error = NativeMcmcIncompleteError(
-                f"Native MCMC {operation.terminal.value}: {operation.failure_message}"
-            )
-            completed_steps = (
-                0
-                if operation.evidence is None
-                else operation.evidence.completed_transition_count
-            )
-            _write_native_mcmc_state_diagnostics(
-                statistic_path,
-                settings=effective,
-                root_seed=root_seed,
-                parameter_ids=fit.problem.controlled_ids,
-                status="incomplete",
+                f"Native MCMC {operation.terminal.value}: {operation.failure_message}",
                 terminal=operation.terminal.value,
-                completed_steps=completed_steps,
-                failure=error,
+                completed_steps=(
+                    0
+                    if operation.evidence is None
+                    else operation.evidence.completed_transition_count
+                ),
             )
             raise error
         phase_start = perf_counter()
@@ -1049,20 +1077,27 @@ def run_native_mcmc(
             root_seed=root_seed,
         )
     except (Exception, KeyboardInterrupt) as error:
-        if not isinstance(error, NativeMcmcIncompleteError):
-            _clear_mcmc_artifacts(statistic_path)
-            _write_native_mcmc_state_diagnostics(
-                statistic_path,
-                settings=effective,
-                root_seed=root_seed,
-                parameter_ids=fit.problem.controlled_ids,
-                status="incomplete",
-                terminal=(
-                    "interrupted" if isinstance(error, KeyboardInterrupt) else "failed"
-                ),
-                completed_steps=0,
-                failure=error,
-            )
+        _clear_mcmc_artifacts(statistic_path)
+        terminal = (
+            error.terminal
+            if isinstance(error, NativeMcmcIncompleteError)
+            else "interrupted"
+            if isinstance(error, KeyboardInterrupt)
+            else "failed"
+        )
+        completed_steps = (
+            error.completed_steps if isinstance(error, NativeMcmcIncompleteError) else 0
+        )
+        _write_native_mcmc_state_diagnostics(
+            statistic_path,
+            settings=effective,
+            root_seed=root_seed,
+            parameter_ids=fit.problem.controlled_ids,
+            status="incomplete",
+            terminal=terminal,
+            completed_steps=completed_steps,
+            failure=error,
+        )
         raise
     else:
         return result

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -218,35 +218,6 @@ def _format_parameter_ids(
     return tuple(str(parameters[param_id].param_name) for param_id in parameter_ids)
 
 
-def _native_coordinate_units(
-    parameter_ids: tuple[str, ...],
-    parameter_store: ParameterStore,
-) -> tuple[tuple[str, ParameterUnit], ...]:
-    """Project established ChemEx parameter families to evidence units."""
-    parameters = parameter_store.get_parameters(parameter_ids)
-    units: list[tuple[str, ParameterUnit]] = []
-    for param_id in parameter_ids:
-        name = parameters[param_id].param_name.name
-        if name.startswith(("R1", "R2", "ETA", "SIGMA", "MU", "KEX")) or (
-            len(name) == 3 and name[0] == "K" and name[1:].isalpha()
-        ):
-            unit = ParameterUnit.RATE_PER_SECOND
-        elif name.startswith(("CS_", "DW_", "DWM_", "DWP_")):
-            unit = ParameterUnit.CHEMICAL_SHIFT_PPM
-        elif name.startswith("J_"):
-            unit = ParameterUnit.FREQUENCY_HZ
-        elif name in {"PA", "PB", "PC", "PD", "PE", "PF", "D2O"}:
-            unit = ParameterUnit.FRACTION
-        elif name.startswith("DH_"):
-            unit = ParameterUnit.ENERGY_PER_MOLE
-        elif name.startswith("DS_"):
-            unit = ParameterUnit.ENTROPY_PER_MOLE_KELVIN
-        else:
-            unit = ParameterUnit.DIMENSIONLESS
-        units.append((param_id, unit))
-    return tuple(units)
-
-
 def _find_unbounded_parameter_ids(
     params: Parameters,
     var_names: tuple[str, ...],
@@ -919,7 +890,10 @@ def _native_result_from_evidence(
         or diagnostics.acceptance_fractions is None
     ):
         msg = "Native MCMC completed without authoritative acceptance diagnostics"
-        raise NativeMcmcIncompleteError(msg)
+        raise NativeMcmcIncompleteError(
+            msg,
+            completed_steps=evidence.completed_transition_count,
+        )
     autocorrelation_time, tentative_autocorrelation_time, autocorrelation_warning = (
         _estimate_autocorrelation_time(raw_chain)
     )
@@ -1022,6 +996,7 @@ def run_native_mcmc(
         raise error
 
     timings: dict[str, float] = {}
+    completed_steps = 0
     try:
         policy = resolve_product_mcmc_policy(
             dimension=len(fit.problem.controlled_ids),
@@ -1035,9 +1010,9 @@ def run_native_mcmc(
             parameterization=fit.parameterization,
             source_engine=fit.engine,
             policy=policy,
-            coordinate_units=_native_coordinate_units(
-                fit.problem.controlled_ids,
-                experiments.parameter_store,
+            coordinate_units=tuple(
+                (param_id, ParameterUnit.UNSPECIFIED)
+                for param_id in fit.problem.controlled_ids
             ),
         )
         phase_start = perf_counter()
@@ -1050,6 +1025,11 @@ def run_native_mcmc(
             ),
         )
         timings["sampling_seconds"] = perf_counter() - phase_start
+        completed_steps = (
+            0
+            if operation.evidence is None
+            else operation.evidence.completed_transition_count
+        )
         if (
             operation.terminal is not McmcOperationTerminal.COMPLETED
             or operation.evidence is None
@@ -1057,11 +1037,7 @@ def run_native_mcmc(
             error = NativeMcmcIncompleteError(
                 f"Native MCMC {operation.terminal.value}: {operation.failure_message}",
                 terminal=operation.terminal.value,
-                completed_steps=(
-                    0
-                    if operation.evidence is None
-                    else operation.evidence.completed_transition_count
-                ),
+                completed_steps=completed_steps,
             )
             raise error
         phase_start = perf_counter()
@@ -1085,8 +1061,10 @@ def run_native_mcmc(
             if isinstance(error, KeyboardInterrupt)
             else "failed"
         )
-        completed_steps = (
-            error.completed_steps if isinstance(error, NativeMcmcIncompleteError) else 0
+        failure_completed_steps = (
+            max(error.completed_steps, completed_steps)
+            if isinstance(error, NativeMcmcIncompleteError)
+            else completed_steps
         )
         _write_native_mcmc_state_diagnostics(
             statistic_path,
@@ -1095,7 +1073,7 @@ def run_native_mcmc(
             parameter_ids=fit.problem.controlled_ids,
             status="incomplete",
             terminal=terminal,
-            completed_steps=completed_steps,
+            completed_steps=failure_completed_steps,
             failure=error,
         )
         raise

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -65,7 +65,7 @@ class NativeDeterministicFit:
 def uses_native_deterministic(method: Method) -> bool:
     """Return whether one whole method occurrence uses native TRF."""
     if method.statistics is not None and method.statistics.mcmc is not None:
-        return False
+        return not method.grid
     if method.statistics is not None:
         return not method.grid
     if "fitmethod" not in method.model_fields_set:

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -1,8 +1,8 @@
-"""Prospective native fixed-topology MCMC evidence qualification (#600).
+"""Native fixed-topology MCMC execution and evidence from #600.
 
-This module is an isolated qualification seam. Production method parsing,
-workflow orchestration, reporting, and parameter-state mutation do not consume
-these artifacts yet.
+Qualification policy and evidence types remain isolated from the public method
+surface. The production adapter consumes the accepted-fit execution evidence
+without exposing calibrated or expert product modes or mutating fit state.
 """
 
 from __future__ import annotations
@@ -13,9 +13,11 @@ import math
 import secrets
 import warnings
 from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
 from dataclasses import dataclass, field
 from enum import StrEnum
-from threading import RLock
+from threading import Lock, RLock, local
 from typing import SupportsIndex, cast
 from weakref import WeakKeyDictionary
 
@@ -37,6 +39,8 @@ from chemex.optimize.direct_trf import (
 )
 from chemex.optimize.uncertainty import ParameterUnit
 from chemex.parameters.parameterization import ActiveParameterization
+from chemex.runtime import ExecutionSettings
+from chemex.runtime.execution import native_thread_environment
 from chemex.typing import Array
 
 _SCHEMA_VERSION = 1
@@ -3600,14 +3604,26 @@ def summarize_posterior_evidence(
 class _LogDensityEvaluator:
     def __init__(self, plan: McmcPlan) -> None:
         self.plan = plan
-        self.evaluator = plan.source_engine.new_evaluator()
+        self._worker_state = local()
+        self._count_lock = Lock()
         self.objective_request_count = 0
         self.evaluation_request_count = 0
 
+    def _evaluator(self) -> BoundEvaluator:
+        evaluator = getattr(self._worker_state, "evaluator", None)
+        if evaluator is None:
+            evaluator = self.plan.source_engine.new_evaluator()
+            self._worker_state.evaluator = evaluator
+        return cast("BoundEvaluator", evaluator)
+
     def __call__(self, vector: Array) -> float:
-        if self.objective_request_count >= self.plan.policy.objective_request_budget:
-            raise McmcExecutionError("MCMC objective-request budget exhausted")
-        self.objective_request_count += 1
+        with self._count_lock:
+            if (
+                self.objective_request_count
+                >= self.plan.policy.objective_request_budget
+            ):
+                raise McmcExecutionError("MCMC objective-request budget exhausted")
+            self.objective_request_count += 1
         candidate = np.asarray(vector, dtype=np.float64)
         if (
             candidate.shape != (self.plan.policy.dimension,)
@@ -3629,8 +3645,9 @@ class _LogDensityEvaluator:
             raise McmcExecutionError(
                 f"MCMC candidate frame failed: {type(error).__name__}: {error}"
             ) from error
-        outcome = self.evaluator.evaluate(frame)
-        self.evaluation_request_count += 1
+        outcome = self._evaluator().evaluate(frame)
+        with self._count_lock:
+            self.evaluation_request_count += 1
         if isinstance(outcome, EvaluationFailure):
             if outcome.validity == "INVALID_TRIAL":
                 return -np.inf
@@ -3678,6 +3695,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     state_observer: Callable[[EnsembleState], None] | None = None,
     cancellation: CancellationToken | None = None,
     checkpoint_observer: Callable[[McmcExecutionStage, int], None] | None = None,
+    execution: ExecutionSettings | None = None,
 ) -> McmcOperation:
     """Execute one fixed run while preserving only complete ensemble states."""
     plan.validate_integrity(accepted)
@@ -3690,6 +3708,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     states: list[EnsembleState] = []
     stage = McmcExecutionStage.BEFORE_INITIALIZATION
     initialization_outcome = McmcInitializationOutcome.NOT_STARTED
+    execution_settings = ExecutionSettings() if execution is None else execution
 
     def checkpoint(next_stage: McmcExecutionStage) -> None:
         nonlocal stage
@@ -3700,60 +3719,78 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
             raise _McmcCancelled(f"MCMC cancelled at {stage.value}")
 
     try:
-        checkpoint(McmcExecutionStage.BEFORE_INITIALIZATION)
-        initial = np.asarray(plan.initial_ensemble, dtype=np.float64)
-        initial_values: list[float] = []
-        for row in initial:
-            checkpoint(McmcExecutionStage.INITIALIZING)
-            initial_values.append(log_density(row))
-        initial_log_density = np.asarray(initial_values, dtype=np.float64)
-        if not np.all(np.isfinite(initial_log_density)):
-            raise McmcExecutionError(
-                "MCMC initial ensemble has unavailable native log density"
-            )
-        initialization_outcome = McmcInitializationOutcome.COMPLETED
-        states.append(_ensemble_state(0, initial, initial_log_density))
-        checkpoint(McmcExecutionStage.AFTER_INITIALIZATION)
-        checkpoint(McmcExecutionStage.AFTER_COMPLETE_STATE)
-        move = _RecordingStretchMove(scale=plan.policy.proposal_scale)
-        sampler = emcee.EnsembleSampler(
-            plan.policy.walkers,
-            plan.policy.dimension,
-            log_density,
-            moves=move,
-        )
-        sampler.random_state = _legacy_sampler_random_state(plan.policy.sampler_seed)
-        emcee_state = emcee.State(initial, log_prob=initial_log_density)
-        iterator = sampler.sample(
-            emcee_state,
-            iterations=plan.policy.total_steps,
-            tune=False,
-            skip_initial_state_check=True,
-            store=False,
-        )
-        for ordinal in range(1, plan.policy.total_steps + 1):
-            checkpoint(McmcExecutionStage.BEFORE_TRANSITION)
-            checkpoint(McmcExecutionStage.DURING_TRANSITION)
-            sampled = next(iterator)
-            if move.last_accepted is None:
-                raise McmcExecutionError(
-                    "MCMC backend omitted its transition diagnostic mask"
+        with ExitStack() as stack:
+            stack.enter_context(
+                native_thread_environment(
+                    execution_settings.native_thread_env(
+                        parallel=execution_settings.is_parallel,
+                    )
                 )
-            state = _ensemble_state(
-                ordinal,
-                sampled.coords,
-                sampled.log_prob,
             )
-            _record_backend_execution_transition(
-                backend_observation,
-                states[-1],
-                state,
-                tuple(bool(value) for value in move.last_accepted),
+            pool = (
+                stack.enter_context(
+                    ThreadPoolExecutor(max_workers=execution_settings.workers)
+                )
+                if execution_settings.is_parallel
+                else None
             )
-            states.append(state)
-            if state_observer is not None:
-                state_observer(state)
+            checkpoint(McmcExecutionStage.BEFORE_INITIALIZATION)
+            initial = np.asarray(plan.initial_ensemble, dtype=np.float64)
+            initial_values: list[float] = []
+            for row in initial:
+                checkpoint(McmcExecutionStage.INITIALIZING)
+                initial_values.append(log_density(row))
+            initial_log_density = np.asarray(initial_values, dtype=np.float64)
+            if not np.all(np.isfinite(initial_log_density)):
+                raise McmcExecutionError(
+                    "MCMC initial ensemble has unavailable native log density"
+                )
+            initialization_outcome = McmcInitializationOutcome.COMPLETED
+            states.append(_ensemble_state(0, initial, initial_log_density))
+            checkpoint(McmcExecutionStage.AFTER_INITIALIZATION)
             checkpoint(McmcExecutionStage.AFTER_COMPLETE_STATE)
+            move = _RecordingStretchMove(scale=plan.policy.proposal_scale)
+            sampler = emcee.EnsembleSampler(
+                plan.policy.walkers,
+                plan.policy.dimension,
+                log_density,
+                moves=move,
+                pool=pool,
+            )
+            sampler.random_state = _legacy_sampler_random_state(
+                plan.policy.sampler_seed
+            )
+            emcee_state = emcee.State(initial, log_prob=initial_log_density)
+            iterator = sampler.sample(
+                emcee_state,
+                iterations=plan.policy.total_steps,
+                tune=False,
+                skip_initial_state_check=True,
+                store=False,
+            )
+            for ordinal in range(1, plan.policy.total_steps + 1):
+                checkpoint(McmcExecutionStage.BEFORE_TRANSITION)
+                checkpoint(McmcExecutionStage.DURING_TRANSITION)
+                sampled = next(iterator)
+                if move.last_accepted is None:
+                    raise McmcExecutionError(
+                        "MCMC backend omitted its transition diagnostic mask"
+                    )
+                state = _ensemble_state(
+                    ordinal,
+                    sampled.coords,
+                    sampled.log_prob,
+                )
+                _record_backend_execution_transition(
+                    backend_observation,
+                    states[-1],
+                    state,
+                    tuple(bool(value) for value in move.last_accepted),
+                )
+                states.append(state)
+                if state_observer is not None:
+                    state_observer(state)
+                checkpoint(McmcExecutionStage.AFTER_COMPLETE_STATE)
         if log_density.objective_request_count != plan.policy.objective_request_budget:
             raise McmcExecutionError(
                 "MCMC backend request count differs from the frozen budget"

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -46,8 +46,10 @@ from chemex.typing import Array
 _SCHEMA_VERSION = 1
 _SEED_POLICY_VERSION = "sha256-structural-u64-v1"
 _RNG_ALGORITHM = "numpy-pcg64-lhs+seedsequence-mt19937-emcee-v1"
+_PRODUCT_RNG_ALGORITHM = "numpy-pcg64-accepted-jitter+seedsequence-mt19937-emcee-v1"
 _SAMPLER_VERSION = "chemex-emcee-ensemble-v1"
 _INITIALIZATION_VERSION = "bounded-latin-hypercube-v1"
+_PRODUCT_INITIALIZATION_VERSION = "accepted-point-jitter-v1"
 _PROPOSAL_VERSION = "emcee-stretch-v1"
 _MAX_U64 = (1 << 64) - 1
 
@@ -62,12 +64,14 @@ class McmcPolicyKind(StrEnum):
     CALIBRATED = "calibrated"
     CALIBRATION_CANDIDATE = "calibration_candidate"
     EXPERT = "expert"
+    PRODUCT = "product"
 
 
 class InitializationKind(StrEnum):
     """Closed native ensemble initialization constructions."""
 
     BOUNDED_LATIN_HYPERCUBE = "bounded_latin_hypercube"
+    ACCEPTED_POINT_JITTER = "accepted_point_jitter"
 
 
 class ProposalKind(StrEnum):
@@ -514,6 +518,60 @@ def build_bounded_latin_hypercube(
     return tuple(tuple(float(value) for value in row) for row in positions)
 
 
+def build_accepted_point_ensemble(
+    accepted: Sequence[float],
+    lower_bounds: Sequence[float],
+    upper_bounds: Sequence[float],
+    *,
+    walkers: int,
+    seed: int,
+) -> tuple[tuple[float, ...], ...]:
+    """Reproduce the product contract of jittering the committed central fit."""
+    walker_count = _positive_integer(walkers, name="MCMC walker count")
+    rng_seed = _unsigned_seed(seed, name="MCMC initialization seed")
+    center = np.asarray(tuple(accepted), dtype=np.float64)
+    lower = np.asarray(tuple(lower_bounds), dtype=np.float64)
+    upper = np.asarray(tuple(upper_bounds), dtype=np.float64)
+    if (
+        center.ndim != 1
+        or lower.ndim != 1
+        or upper.ndim != 1
+        or center.shape != lower.shape
+        or center.shape != upper.shape
+        or center.size < 1
+        or not np.all(np.isfinite(center))
+        or not np.all(np.isfinite(lower))
+        or not np.all(np.isfinite(upper))
+        or not np.all(lower < upper)
+        or not np.all((center >= lower) & (center <= upper))
+    ):
+        raise McmcConstructionError(
+            "Accepted-point MCMC initialization requires a finite accepted vector "
+            "inside finite strictly ordered bounds"
+        )
+    interior_lower = np.nextafter(lower, upper)
+    interior_upper = np.nextafter(upper, lower)
+    if not np.all(interior_lower < interior_upper):
+        raise McmcConstructionError(
+            "Accepted-point MCMC initialization has no representable open interval"
+        )
+    scale = np.maximum.reduce(
+        (
+            np.abs(center) * 1.0e-4,
+            (upper - lower) * 1.0e-4,
+            np.full_like(center, 1.0e-8),
+        )
+    )
+    rng = np.random.Generator(np.random.PCG64(rng_seed))
+    positions = center + rng.standard_normal((walker_count, center.size)) * scale
+    positions = np.clip(positions, interior_lower, interior_upper)
+    if not np.all((positions > lower) & (positions < upper)):
+        raise McmcConstructionError(
+            "Accepted-point MCMC initialization reached a closed bound"
+        )
+    return tuple(tuple(float(value) for value in row) for row in positions)
+
+
 @dataclass(frozen=True, slots=True)
 class ResolvedMcmcPolicy:
     """Complete immutable MCMC topology and work allocation fixed pre-run."""
@@ -572,9 +630,11 @@ class ResolvedMcmcPolicy:
                 "No repository-frozen calibration reference is available for "
                 "native MCMC"
             )
-        if self.kind is McmcPolicyKind.EXPERT and qualification_range is not None:
+        if self.kind in {McmcPolicyKind.EXPERT, McmcPolicyKind.PRODUCT} and (
+            qualification_range is not None
+        ):
             raise McmcConstructionError(
-                "Expert MCMC policy cannot inherit calibrated qualification"
+                "Non-calibrated MCMC policy cannot inherit calibrated qualification"
             )
         proposal_scale = _finite_positive(
             self.proposal_scale,
@@ -825,6 +885,29 @@ class ExpertMcmcPolicy:
         )
 
 
+def resolve_product_mcmc_policy(
+    *,
+    dimension: int,
+    walkers: int,
+    steps: int,
+    root_seed: int,
+) -> ResolvedMcmcPolicy:
+    """Resolve the frozen v1 product method without qualification policy modes."""
+    return ResolvedMcmcPolicy(
+        kind=McmcPolicyKind.PRODUCT,
+        policy_version="product-method-v1",
+        dimension=dimension,
+        walkers=walkers,
+        burn_steps=0,
+        retained_steps=steps,
+        root_seed=root_seed,
+        provenance_identity="chemex-product-method-v1",
+        initialization=InitializationKind.ACCEPTED_POINT_JITTER,
+        initialization_version=_PRODUCT_INITIALIZATION_VERSION,
+        rng_algorithm=_PRODUCT_RNG_ALGORITHM,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class McmcAcceptedAnchor:
     """Exact occurrence-owned scientific context for one MCMC request."""
@@ -1028,12 +1111,21 @@ class McmcPlan:
             )
         lower = tuple(problem.lower_bounds)
         upper = tuple(problem.upper_bounds)
-        initial = build_bounded_latin_hypercube(
-            lower,
-            upper,
-            walkers=self.policy.walkers,
-            seed=self.policy.initialization_seed,
-        )
+        if self.policy.initialization is InitializationKind.ACCEPTED_POINT_JITTER:
+            initial = build_accepted_point_ensemble(
+                accepted.vector,
+                lower,
+                upper,
+                walkers=self.policy.walkers,
+                seed=self.policy.initialization_seed,
+            )
+        else:
+            initial = build_bounded_latin_hypercube(
+                lower,
+                upper,
+                walkers=self.policy.walkers,
+                seed=self.policy.initialization_seed,
+            )
         anchor = McmcAcceptedAnchor(
             accepted.identity,
             accepted.occurrence_identity,

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -642,9 +642,14 @@ class ResolvedMcmcPolicy:
         )
         if proposal_scale <= 1.0:
             raise McmcConstructionError("MCMC stretch proposal scale must exceed one")
-        if walkers < max(4, 2 * dimension):
+        minimum_walkers = (
+            2 * dimension
+            if self.kind is McmcPolicyKind.PRODUCT
+            else max(4, 2 * dimension)
+        )
+        if walkers < minimum_walkers:
             raise McmcConstructionError(
-                "MCMC walker count must be at least max(4, 2 * dimension)"
+                f"MCMC walker count must be at least {minimum_walkers}"
             )
         if self.thin != 1:
             raise McmcConstructionError(

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -128,6 +128,7 @@ class OperationTerminal(StrEnum):
 class ParameterUnit(StrEnum):
     """Closed unit vocabulary carried by uncertainty evidence."""
 
+    UNSPECIFIED = "unspecified"
     DIMENSIONLESS = "dimensionless"
     FRACTION = "fraction"
     RATE_PER_SECOND = "s^-1"

--- a/tests/configuration/test_methods.py
+++ b/tests/configuration/test_methods.py
@@ -54,3 +54,10 @@ def test_statistics_parse_mcmc_auto_burn_case_insensitive() -> None:
 
     assert statistics.mcmc is not None
     assert statistics.mcmc.burn == "auto"
+
+
+def test_statistics_rejects_mcmc_update_parameters_state_mutation() -> None:
+    with pytest.raises(
+        ValidationError, match="cannot mutate the committed central fit"
+    ):
+        Statistics.model_validate({"MCMC": {"STEPS": 100, "UPDATE_PARAMETERS": True}})

--- a/tests/configuration/test_methods.py
+++ b/tests/configuration/test_methods.py
@@ -61,3 +61,17 @@ def test_statistics_rejects_mcmc_update_parameters_state_mutation() -> None:
         ValidationError, match="cannot mutate the committed central fit"
     ):
         Statistics.model_validate({"MCMC": {"STEPS": 100, "UPDATE_PARAMETERS": True}})
+
+
+@pytest.mark.parametrize("seed", (0, (1 << 64) - 1))
+def test_statistics_accepts_unsigned_64_bit_mcmc_seed_boundaries(seed: int) -> None:
+    statistics = Statistics.model_validate({"MCMC": {"STEPS": 100, "SEED": seed}})
+
+    assert statistics.mcmc is not None
+    assert statistics.mcmc.seed == seed
+
+
+@pytest.mark.parametrize("seed", (-1, 1 << 64))
+def test_statistics_rejects_out_of_range_mcmc_seed(seed: int) -> None:
+    with pytest.raises(ValidationError, match="unsigned 64-bit integer"):
+        Statistics.model_validate({"MCMC": {"STEPS": 100, "SEED": seed}})

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -747,56 +747,6 @@ def test_resampling_statistics_use_execution_workers(
     assert samples.count("\n") == 3
 
 
-def test_run_statistics_dispatches_mcmc_without_resampling(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    recorded: dict[str, object] = {}
-    execution = ExecutionSettings(workers=4)
-    experiments = SimpleNamespace(
-        param_ids=["__PB"],
-        parameter_store=StatisticsParameterStore(),
-    )
-
-    def fail_generate_exp_for_statistics(*_args, **_kwargs) -> None:
-        pytest.fail("MCMC should not generate resampled experiments")
-
-    def fake_run_mcmc(
-        experiments_arg: object,
-        params_arg: object,
-        settings_arg: object,
-        path_arg: Path,
-        *,
-        execution: object | None = None,
-    ) -> None:
-        recorded["experiments"] = experiments_arg
-        recorded["params"] = params_arg
-        recorded["settings"] = settings_arg
-        recorded["path"] = path_arg
-        recorded["execution"] = execution
-
-    monkeypatch.setattr(
-        resampling_module,
-        "generate_exp_for_statistics",
-        fail_generate_exp_for_statistics,
-    )
-    monkeypatch.setattr(fitting_module, "run_mcmc", fake_run_mcmc)
-
-    fitting_module._run_statistics(
-        experiments,
-        tmp_path,
-        "leastsq",
-        fitting_module.Statistics(mcmc=100),
-        execution=execution,
-    )
-
-    np.testing.assert_equal(recorded["experiments"], experiments)
-    assert "__PB" in recorded["params"]
-    assert recorded["settings"].steps == 100
-    np.testing.assert_equal(recorded["path"], tmp_path)
-    np.testing.assert_equal(recorded["execution"], execution)
-
-
 def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None:
     store = WriterParameterStore(
         {

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 import numpy as np
 import pytest
 from pydantic import BaseModel
+from scipy.stats import truncnorm
 
 import chemex.optimize.native_mcmc as native_mcmc
 from chemex.containers.data import Data
@@ -46,6 +47,7 @@ from chemex.optimize.native_mcmc import (
     PosteriorSampleDisposition,
     ProposalKind,
     ResolvedMcmcPolicy,
+    build_accepted_point_ensemble,
     build_bounded_latin_hypercube,
     derive_mcmc_diagnostics,
     derive_mcmc_operation_diagnostics,
@@ -53,6 +55,7 @@ from chemex.optimize.native_mcmc import (
     derive_posterior_summary,
     derive_retained_sample_view,
     execute_mcmc_evidence,
+    resolve_product_mcmc_policy,
     validate_raw_mcmc_capture,
 )
 from chemex.optimize.uncertainty import ParameterUnit
@@ -446,6 +449,62 @@ def test_initial_ensemble_rejects_transposed_or_unrepresentably_narrow_bounds() 
         build_bounded_latin_hypercube((lower,), (upper,), walkers=4, seed=1)
 
 
+def test_product_initial_ensemble_is_seeded_accepted_point_jitter() -> None:
+    first = build_accepted_point_ensemble(
+        (1.0, 2.0),
+        (0.0, 1.0),
+        (2.0, 3.0),
+        walkers=8,
+        seed=612,
+    )
+    second = build_accepted_point_ensemble(
+        (1.0, 2.0),
+        (0.0, 1.0),
+        (2.0, 3.0),
+        walkers=8,
+        seed=612,
+    )
+    positions = np.asarray(first)
+
+    assert first == second
+    assert np.all(positions > np.asarray((0.0, 1.0)))
+    assert np.all(positions < np.asarray((2.0, 3.0)))
+    np.testing.assert_allclose(
+        positions.mean(axis=0),
+        (1.0, 2.0),
+        atol=2.0e-4,
+    )
+
+
+def test_product_policy_initializes_from_exact_accepted_fit() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    policy = resolve_product_mcmc_policy(
+        dimension=2,
+        walkers=8,
+        steps=3,
+        root_seed=612,
+    )
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=policy,
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+
+    assert policy.kind is McmcPolicyKind.PRODUCT
+    assert policy.initialization is InitializationKind.ACCEPTED_POINT_JITTER
+    np.testing.assert_allclose(
+        np.asarray(plan.initial_ensemble).mean(axis=0),
+        accepted.vector,
+        atol=2.0e-4,
+    )
+
+
 def test_plan_binds_initial_ensemble_to_exact_accepted_native_lineage() -> None:
     accepted, problem, parameterization, engine = _native_context()
 
@@ -633,6 +692,49 @@ def test_complete_chain_is_primary_and_flat_samples_are_derived_views() -> None:
         1.0,
     )
     assert diagnostics.mean_acceptance_fraction == 0.625
+
+
+def test_seeded_native_chain_recovers_known_truncated_normal_posterior() -> None:
+    accepted, problem, parameterization, engine = _native_context(fit_b=False)
+    policy = resolve_product_mcmc_policy(
+        dimension=1,
+        walkers=8,
+        steps=6000,
+        root_seed=657,
+    )
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=policy,
+        coordinate_units=(("A", ParameterUnit.DIMENSIONLESS),),
+    )
+
+    operation = execute_mcmc_evidence(accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    samples = np.asarray(
+        [
+            position[0]
+            for state in operation.evidence.states[1001:]
+            for position in state.positions
+        ]
+    )
+    # With B fixed at 1.5, the three unit-error residuals are
+    # A - (1.0, 1.5, 2.0), hence N(1.5, 1/3) truncated to [0, 2].
+    mean = 1.5
+    standard_deviation = 1.0 / np.sqrt(3.0)
+    distribution = truncnorm(
+        (0.0 - mean) / standard_deviation,
+        (2.0 - mean) / standard_deviation,
+        loc=mean,
+        scale=standard_deviation,
+    )
+
+    assert samples.mean() == pytest.approx(distribution.mean(), abs=0.04)
+    assert samples.std(ddof=1) == pytest.approx(distribution.std(), abs=0.025)
 
 
 def test_interruption_preserves_only_a_contiguous_complete_state_prefix() -> None:

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import copy
 import dataclasses
 import pickle
+import threading
+import time
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, cast
@@ -63,6 +65,7 @@ from chemex.parameters.parameterization import (
 from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.values import AnalysisValuesSnapshot
 from chemex.printers.data import Printer
+from chemex.runtime import ExecutionSettings
 from chemex.typing import Array
 
 
@@ -232,6 +235,48 @@ def _same_semantics_foreign_occurrence(
         commit_items=accepted.commit_items,
         origin_context_identity=accepted.origin_context_identity,
     )
+
+
+def test_seeded_native_mcmc_workers_execute_in_parallel_without_changing_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accepted, plan = _plan_context()
+    main_thread = threading.get_ident()
+    worker_threads: set[int] = set()
+    worker_lock = threading.Lock()
+    original_calculate = _LinearPulseSequence.calculate
+
+    def record_worker(
+        pulse_sequence: _LinearPulseSequence,
+        spectrometer: _LinearSpectrometer,
+        data: Data,
+    ) -> Array:
+        thread_id = threading.get_ident()
+        if thread_id != main_thread:
+            with worker_lock:
+                worker_threads.add(thread_id)
+            time.sleep(0.002)
+        return original_calculate(pulse_sequence, spectrometer, data)
+
+    monkeypatch.setattr(_LinearPulseSequence, "calculate", record_worker)
+
+    parallel = execute_mcmc_evidence(
+        accepted,
+        plan,
+        execution=ExecutionSettings(workers=2),
+    )
+    serial = execute_mcmc_evidence(
+        accepted,
+        plan,
+        execution=ExecutionSettings(workers=1),
+    )
+
+    assert parallel.terminal is McmcOperationTerminal.COMPLETED
+    assert serial.terminal is McmcOperationTerminal.COMPLETED
+    assert parallel.evidence is not None
+    assert serial.evidence is not None
+    assert len(worker_threads) == 2
+    assert parallel.evidence.states == serial.evidence.states
 
 
 def test_arbitrary_settings_cannot_mint_calibrated_authority() -> None:

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -505,6 +505,20 @@ def test_product_policy_initializes_from_exact_accepted_fit() -> None:
     )
 
 
+@pytest.mark.parametrize("walkers", (2, 3))
+def test_one_dimensional_product_policy_preserves_two_walker_minimum(
+    walkers: int,
+) -> None:
+    policy = resolve_product_mcmc_policy(
+        dimension=1,
+        walkers=walkers,
+        steps=2,
+        root_seed=612,
+    )
+
+    assert policy.walkers == walkers
+
+
 def test_plan_binds_initial_ensemble_to_exact_accepted_native_lineage() -> None:
     accepted, problem, parameterization, engine = _native_context()
 

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -8,9 +8,12 @@ from unittest.mock import patch
 import pytest
 
 import chemex.optimize.direct_trf as direct_trf_module
+import chemex.optimize.fitting as fitting_module
+import chemex.optimize.native_mcmc as native_mcmc_module
 import chemex.optimize.native_resampling as native_resampling_module
 from chemex.chemex import run
 from chemex.cli import build_parser
+from chemex.optimize.mcmc import NativeMcmcIncompleteError
 from chemex.optimize.resampling import NativeResamplingIncompleteError
 from chemex.runtime import AnalysisSession
 
@@ -25,6 +28,7 @@ def _fit_arguments(
     output: Path,
     method: Path = METHOD,
     *,
+    parameters: Path = PARAMETERS,
     include: tuple[str, ...] = ("G2N-HN",),
     plot_level: str = "nothing",
     workers: int = 1,
@@ -35,7 +39,7 @@ def _fit_arguments(
             "-e",
             str(EXPERIMENT),
             "-p",
-            str(PARAMETERS),
+            str(parameters),
             "-m",
             str(method),
             "-o",
@@ -136,6 +140,271 @@ STATISTICS = {{ {statistics} }}
         encoding="utf-8",
     )
     return path
+
+
+def _bounded_parameters(path: Path) -> Path:
+    path.write_text(
+        PARAMETERS.read_text(encoding="utf-8")
+        + """
+
+[R1A_A]
+G2N-HN = [1.5, 0.1, 5.0]
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _nested_mcmc_method(path: Path, *, workers: int) -> Path:
+    path.write_text(
+        f"""[DEFAULT]
+FIX = ["PB", "KEX_AB"]
+
+[DEFAULT.STATISTICS.MCMC]
+STEPS = 5
+BURN = 1
+THIN = 2
+WALKERS = 4
+SEED = 612
+WORKERS = {workers}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MCMC" = 2')
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy evaluation was called"),
+        ),
+        patch(
+            "chemex.optimize.mcmc_engine.run_emcee_sampler",
+            side_effect=AssertionError("legacy MCMC wrapper was called"),
+        ),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=session,
+        )
+
+    assert session.analysis_values.snapshot().revision == 1
+    statistics = output / "Statistics" / "MCMC"
+    assert (statistics / "summary.toml").is_file()
+    assert (statistics / "samples.tsv").is_file()
+    assert (statistics / "correlations.tsv").is_file()
+    assert (statistics / "plots.pdf").stat().st_size > 0
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "complete"
+    assert diagnostics["engine"] == "native MCMC"
+    assert diagnostics["steps"] == 2
+    assert diagnostics["walkers"] == 32
+    assert "lmfit_version" not in diagnostics
+
+
+def test_seeded_nested_native_mcmc_replays_across_worker_counts(
+    tmp_path: Path,
+) -> None:
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    serial_method = _nested_mcmc_method(tmp_path / "serial.toml", workers=1)
+    parallel_method = _nested_mcmc_method(tmp_path / "parallel.toml", workers=2)
+    serial = tmp_path / "Serial"
+    parallel = tmp_path / "Parallel"
+
+    run(
+        _fit_arguments(serial, serial_method, parameters=parameters),
+        session=AnalysisSession.create(),
+    )
+    run(
+        _fit_arguments(parallel, parallel_method, parameters=parameters),
+        session=AnalysisSession.create(),
+    )
+
+    serial_samples = (serial / "Statistics" / "MCMC" / "samples.tsv").read_text(
+        encoding="utf-8"
+    )
+    parallel_samples = (parallel / "Statistics" / "MCMC" / "samples.tsv").read_text(
+        encoding="utf-8"
+    )
+    assert serial_samples == parallel_samples
+    diagnostics = tomllib.loads(
+        (parallel / "Statistics" / "MCMC" / "diagnostics.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert diagnostics["root_seed"] == 612
+    assert diagnostics["workers"] == 2
+    assert diagnostics["requested_burn"] == 1
+    assert diagnostics["thin"] == 2
+    assert diagnostics["retained_steps"] == 2
+    assert diagnostics["retained_samples"] == 8
+    summary = tomllib.loads(
+        (parallel / "Statistics" / "MCMC" / "summary.toml").read_text(encoding="utf-8")
+    )
+    posterior = next(iter(summary.values()))
+    assert posterior["prior_lower"] == pytest.approx(0.1)
+    assert posterior["prior_upper"] == pytest.approx(5.0)
+    assert 0.1 < posterior["median"] < 5.0
+    assert posterior["standard_deviation"] > 0.0
+
+
+def test_native_mcmc_preserves_committed_central_fit(tmp_path: Path) -> None:
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    central_session = AnalysisSession.create()
+    mcmc_session = AnalysisSession.create()
+
+    run(
+        _fit_arguments(tmp_path / "Central", parameters=parameters),
+        session=central_session,
+    )
+    run(
+        _fit_arguments(tmp_path / "Mcmc", method, parameters=parameters),
+        session=mcmc_session,
+    )
+
+    central = central_session.analysis_values.snapshot()
+    sampled = mcmc_session.analysis_values.snapshot()
+    assert central.revision == sampled.revision == 1
+    assert central.items() == sampled.items()
+
+
+def test_unbounded_native_mcmc_fails_closed_after_committing_central_fit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MCMC" = 2')
+    session = AnalysisSession.create()
+
+    with pytest.raises(ValueError, match="finite lower and upper bounds"):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "incomplete"
+    assert diagnostics["terminal"] == "failed"
+    assert "finite lower and upper bounds" in diagnostics["failure_message"]
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "samples.tsv").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+
+
+def test_interrupted_native_mcmc_publishes_only_incomplete_diagnostics(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    session = AnalysisSession.create()
+
+    with (
+        patch.object(
+            native_mcmc_module._RecordingStretchMove,
+            "propose",
+            side_effect=KeyboardInterrupt,
+        ),
+        pytest.raises(NativeMcmcIncompleteError, match="interrupted"),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=session,
+        )
+
+    assert session.analysis_values.snapshot().revision == 1
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "incomplete"
+    assert diagnostics["terminal"] == "interrupted"
+    assert diagnostics["completed_steps"] == 0
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "samples.tsv").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+
+
+def test_mixed_mc_and_mcmc_use_one_native_central_fit_without_legacy_fallback(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(
+        tmp_path / "method.toml",
+        '"MC" = 1, "MCMC" = {STEPS = 2, BURN = 0, WALKERS = 4, SEED = 612}',
+    )
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    session = AnalysisSession.create()
+
+    with (
+        patch.object(
+            fitting_module,
+            "run_native_deterministic",
+            wraps=fitting_module.run_native_deterministic,
+        ) as native_central,
+        patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy evaluation was called"),
+        ),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=session,
+        )
+
+    native_central.assert_called_once()
+    assert session.analysis_values.snapshot().revision == 1
+    assert (output / "Statistics" / "MonteCarlo" / "summary.toml").is_file()
+    assert (output / "Statistics" / "MCMC" / "summary.toml").is_file()
+
+
+def test_native_mcmc_without_fitted_parameters_keeps_documented_skip_behavior(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+FIX = ["R1A_A", "PB", "KEX_AB"]
+STATISTICS = {"MCMC" = 2}
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 0
+    assert not (output / "Statistics" / "MCMC").exists()
 
 
 def test_real_mc_fit_is_wholly_native_and_writes_product_statistics(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 from unittest.mock import patch
@@ -9,12 +11,14 @@ import pytest
 
 import chemex.optimize.direct_trf as direct_trf_module
 import chemex.optimize.fitting as fitting_module
+import chemex.optimize.mcmc as mcmc_module
 import chemex.optimize.native_mcmc as native_mcmc_module
 import chemex.optimize.native_resampling as native_resampling_module
 from chemex.chemex import run
 from chemex.cli import build_parser
 from chemex.optimize.mcmc import NativeMcmcIncompleteError
 from chemex.optimize.resampling import NativeResamplingIncompleteError
+from chemex.optimize.uncertainty import ParameterUnit
 from chemex.runtime import AnalysisSession
 
 ROOT = Path(__file__).parent.parent
@@ -51,6 +55,36 @@ def _fit_arguments(
             "--workers",
             str(workers),
         ]
+    )
+
+
+def _run_real_fit_cli(output: Path, method: Path, parameters: Path) -> None:
+    subprocess.run(  # noqa: S603 - fixed local CLI and repository-owned fixtures
+        [
+            sys.executable,
+            "-m",
+            "chemex",
+            "fit",
+            "-e",
+            str(EXPERIMENT),
+            "-p",
+            str(parameters),
+            "-m",
+            str(method),
+            "-o",
+            str(output),
+            "--include",
+            "G2N-HN",
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
     )
 
 
@@ -198,6 +232,11 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
             "chemex.optimize.mcmc_engine.run_emcee_sampler",
             side_effect=AssertionError("legacy MCMC wrapper was called"),
         ),
+        patch.object(
+            mcmc_module,
+            "execute_mcmc_evidence",
+            wraps=mcmc_module.execute_mcmc_evidence,
+        ) as native_sampler,
     ):
         run(
             _fit_arguments(output, method, parameters=parameters),
@@ -218,6 +257,47 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     assert diagnostics["steps"] == 2
     assert diagnostics["walkers"] == 32
     assert "lmfit_version" not in diagnostics
+    plan = native_sampler.call_args.args[1]
+    assert plan.coordinate_units[0][1] is ParameterUnit.RATE_PER_SECOND
+
+
+def test_compact_mcmc_form_runs_through_real_chemex_cli(tmp_path: Path) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MCMC" = 2')
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+
+    _run_real_fit_cli(output, method, parameters)
+
+    diagnostics = tomllib.loads(
+        (output / "Statistics" / "MCMC" / "diagnostics.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert diagnostics["status"] == "complete"
+    assert diagnostics["engine"] == "native MCMC"
+    assert diagnostics["steps"] == 2
+
+
+def test_seeded_nested_mcmc_settings_run_through_real_chemex_cli(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+
+    _run_real_fit_cli(output, method, parameters)
+
+    diagnostics = tomllib.loads(
+        (output / "Statistics" / "MCMC" / "diagnostics.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert diagnostics["status"] == "complete"
+    assert diagnostics["root_seed"] == 612
+    assert diagnostics["requested_burn"] == 1
+    assert diagnostics["thin"] == 2
+    assert diagnostics["walkers"] == 4
+    assert diagnostics["workers"] == 1
 
 
 def test_seeded_nested_native_mcmc_replays_across_worker_counts(
@@ -340,6 +420,42 @@ def test_interrupted_native_mcmc_publishes_only_incomplete_diagnostics(
     assert diagnostics["status"] == "incomplete"
     assert diagnostics["terminal"] == "interrupted"
     assert diagnostics["completed_steps"] == 0
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "samples.tsv").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+
+
+def test_native_mcmc_postprocessing_failure_replaces_running_diagnostics(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    session = AnalysisSession.create()
+
+    with (
+        patch.object(
+            mcmc_module,
+            "_native_result_from_evidence",
+            side_effect=NativeMcmcIncompleteError("missing acceptance diagnostics"),
+        ),
+        pytest.raises(NativeMcmcIncompleteError, match="acceptance diagnostics"),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=session,
+        )
+
+    assert session.analysis_values.snapshot().revision == 1
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "incomplete"
+    assert diagnostics["terminal"] == "failed"
+    assert diagnostics["completed_steps"] == 0
+    assert "acceptance diagnostics" in diagnostics["failure_message"]
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "samples.tsv").exists()
     assert not (statistics / "correlations.tsv").exists()

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -258,7 +258,7 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     assert diagnostics["walkers"] == 32
     assert "lmfit_version" not in diagnostics
     plan = native_sampler.call_args.args[1]
-    assert plan.coordinate_units[0][1] is ParameterUnit.RATE_PER_SECOND
+    assert plan.coordinate_units[0][1] is ParameterUnit.UNSPECIFIED
 
 
 def test_compact_mcmc_form_runs_through_real_chemex_cli(tmp_path: Path) -> None:
@@ -438,9 +438,9 @@ def test_native_mcmc_postprocessing_failure_replaces_running_diagnostics(
         patch.object(
             mcmc_module,
             "_native_result_from_evidence",
-            side_effect=NativeMcmcIncompleteError("missing acceptance diagnostics"),
+            side_effect=RuntimeError("missing acceptance diagnostics"),
         ),
-        pytest.raises(NativeMcmcIncompleteError, match="acceptance diagnostics"),
+        pytest.raises(RuntimeError, match="acceptance diagnostics"),
     ):
         run(
             _fit_arguments(output, method, parameters=parameters),
@@ -454,7 +454,7 @@ def test_native_mcmc_postprocessing_failure_replaces_running_diagnostics(
     )
     assert diagnostics["status"] == "incomplete"
     assert diagnostics["terminal"] == "failed"
-    assert diagnostics["completed_steps"] == 0
+    assert diagnostics["completed_steps"] == 5
     assert "acceptance diagnostics" in diagnostics["failure_message"]
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "samples.tsv").exists()

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -195,8 +195,8 @@ MCMC analysis samples the posterior distribution after the native deterministic
 fit has converged and committed. It consumes that accepted native problem and
 evaluation engine directly, uses ChemEx's weighted residuals as the likelihood,
 and uses the fitted-parameter bounds as uniform priors. Initial walkers are
-placed reproducibly inside those bounds with a seeded bounded Latin-hypercube
-construction.
+placed reproducibly by applying small seeded perturbations to the committed
+fitted values and clipping them into the open bounded intervals.
 
 Every fitted parameter sampled by MCMC must have finite lower and upper bounds,
 with the lower bound strictly smaller than the upper bound. ChemEx rejects an

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -191,9 +191,17 @@ Nucleus-specific bootstrap can create datasets of varying sizes, unlike standard
 
 ### MCMC Analysis
 
-MCMC analysis samples the posterior distribution after the normal fit has converged. It uses the fitted parameters as the starting point, ChemEx's weighted residuals as the likelihood, and the parameter bounds as uniform priors.
+MCMC analysis samples the posterior distribution after the native deterministic
+fit has converged and committed. It consumes that accepted native problem and
+evaluation engine directly, uses ChemEx's weighted residuals as the likelihood,
+and uses the fitted-parameter bounds as uniform priors. Initial walkers are
+placed reproducibly inside those bounds with a seeded bounded Latin-hypercube
+construction.
 
-For meaningful MCMC results, set finite lower and upper bounds for the fitted parameters in the parameter file. Parameters without finite bounds are still accepted, but ChemEx will print a warning because the implied prior is weakly constrained.
+Every fitted parameter sampled by MCMC must have finite lower and upper bounds,
+with the lower bound strictly smaller than the upper bound. ChemEx rejects an
+unbounded or empty interval before sampling, writes an incomplete diagnostic,
+and leaves the committed central fit unchanged.
 
 ### Syntax
 
@@ -268,6 +276,10 @@ is `auto`. Set `WORKERS` in the method file only when this MCMC step needs a
 specific positive worker count. Command-line `--workers 0` means all available
 CPUs, but method-file `WORKERS` must be a positive integer.
 
+`UPDATE_PARAMETERS = true` is rejected. Posterior summaries are evidence about
+the committed central fit and never replace its authoritative parameter values
+or generic fitted-parameter errors.
+
 See [Multicore Execution](multicore_execution.md) for performance guidance and
 the interaction between `--workers` and `--native-threads`.
 
@@ -304,3 +316,8 @@ Statistics/
 For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`. Their `plots.pdf` reports provide a summary page, one-dimensional sample distributions, a χ² distribution, and two-dimensional sample distributions for parameter pairs with `|r| >= 0.5`.
 
 For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when the autocorrelation estimate passes emcee's reliability threshold. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, reliable or tentative autocorrelation time, recommended chain lengths, and burn-in decisions. The `plots.pdf` report provides a summary page, one-dimensional posterior distributions, walker traces, the log-probability trace, an autocorrelation monitor, and two-dimensional posterior distributions for parameter pairs with `|r| >= 0.5`.
+
+If MCMC setup, sampling, processing, or output fails or is interrupted,
+`diagnostics.toml` records an explicit incomplete terminal state. ChemEx does not
+publish `summary.toml`, `samples.tsv`, `correlations.tsv`, or `plots.pdf` for an
+incomplete chain.

--- a/website/docs/user_guide/fitting/multicore_execution.md
+++ b/website/docs/user_guide/fitting/multicore_execution.md
@@ -35,9 +35,8 @@ simulation runs, plotting, and output writing are not controlled by
 `--workers`.
 
 Workers are active only while the parallel statistics task is running. Native
-MC, BS, and BSN refits use worker threads; MCMC may show multiple Python
-processes. The earlier deterministic fit and later output-writing phase remain
-serial.
+MC, BS, BSN, and MCMC use worker threads with isolated native evaluators. The
+earlier deterministic fit and later output-writing phase remain serial.
 
 ## Command-Line Controls
 
@@ -49,7 +48,7 @@ Controls the number of ChemEx worker slots used by fit statistics.
 | ---- | ------- |
 | `auto` | Conservative default, capped at 8 workers. |
 | `1` | Serial execution. Useful for debugging and reproducibility checks. |
-| `N` | Use `N` worker slots (threads for native MC/BS/BSN; processes may be used for MCMC). |
+| `N` | Use `N` worker slots for native statistics. |
 | `0` | Use all CPUs visible to the current process. |
 
 For long MCMC runs on a dedicated machine, it can be reasonable to set an
@@ -127,6 +126,8 @@ settings:
 
 ```toml
 sampler = "emcee via ChemEx direct EnsembleSampler"
+engine = "native MCMC"
 workers = 8
+root_seed = 1234
 sampling_seconds = 120.42
 ```

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -156,7 +156,9 @@ BS, and BSN diagnostics include the native Direct TRF engine, root seed, and
 effective worker count. An incomplete analysis instead writes the successful
 sample rows, `failures.tsv`, and an explicit incomplete diagnostic; complete
 summary, correlation, and plot files are suppressed. MCMC diagnostics also
-include the direct emcee sampler engine, timing information, acceptance
-fractions, burn-in decisions, and autocorrelation estimates. These diagnostics
-are the best place to confirm that [`--workers`](multicore_execution.md) was
-applied as intended.
+include the direct emcee sampler engine, timing information, effective worker
+count and root seed, acceptance fractions, burn-in decisions, and
+autocorrelation estimates. Failed or interrupted MCMC suppresses every
+complete-chain product and leaves only an explicit incomplete diagnostic. These
+diagnostics are the best place to confirm that
+[`--workers`](multicore_execution.md) was applied as intended.


### PR DESCRIPTION
## Summary

- route every supported MCMC-bearing statistics occurrence through the committed `NativeDeterministicFit`, native evaluation engine, and direct emcee sampler
- preserve compact and nested v1 method forms, accepted-fit-centered initialization, weighted-residual likelihood, bounded priors, seed replay, worker behavior, summaries, correlations, diagnostics, and plots
- keep the authoritative central fit immutable and publish truthful incomplete diagnostics without complete-chain artifacts on failures or interruption
- keep mixed MC/BS/BSN + MCMC on one native central occurrence without lmfit fallback

Refs #657 and #612.

## Scope

This is the final supported statistics product-integration slice described by #612 under the frozen #657 scope. It does not add calibrated/expert product modes, FORMAT_VERSION 2, DE, GRID + STATISTICS redesign, or #613 output/restart/provenance redesign.

After merge, all #612 statistics workflows in the supported #657 scope are product-integrated; the remaining release frontier is #657's final no-lmfit verification/removal matrix and #613's broader output contract.

## Validation

- Python 3.14 focused real MCMC product tests: 10 passed
- Python 3.13 native MCMC/resampling/product tests: 142 passed
- Python 3.13 full pytest: 1150 passed, 1 existing emcee short-chain warning
- `ty check`
- `ruff check .`
- `ruff format --check .`
- `git diff --check main...HEAD`
- `uv build`
- two-axis standards/spec review against `main`, followed by a clean final audit
