### PR TITLE
Fail closed across fit output reruns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 ## [Unreleased]
 
 ### Changed
+- Fit output now has a success-last `run_info/outcome.toml` lifecycle marker.
+  Reruns eagerly invalidate only known ChemEx result locations for every planned
+  method step, preventing earlier deterministic or later statistics-family
+  results from surviving as current after a failure. MC, BS, and BSN publication
+  failures now retain truthful completed samples while removing complete-only
+  summaries, correlations, and plots and publishing incomplete diagnostics.
 - Routed Direct TRF, grouped Direct, GRID, and grouped GRID method steps through
   the native parameterization, evaluation, aggregate acceptance, and atomic
   commit stack in the production `chemex fit` path. Existing v1 method TOML,

--- a/src/chemex/atomic.py
+++ b/src/chemex/atomic.py
@@ -6,11 +6,29 @@ import ctypes
 import errno
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 _AT_FDCWD = -100
 _RENAME_NOREPLACE = 1
 _RENAME_EXCL = 4
+
+
+def write_text_atomic(destination: Path, content: str) -> None:
+    """Replace one text file atomically from a same-directory temporary file."""
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=f".{destination.name}-",
+        text=True,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            output.write(content)
+        temporary.replace(destination)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
 
 
 def publish_directory_noreplace(staging: Path, destination: Path) -> None:

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -18,10 +18,10 @@ from chemex.messages import (
     print_running_simulations,
     print_start_fit,
 )
-from chemex.optimize.fitting import run_methods
+from chemex.optimize.fitting import invalidate_planned_outputs, run_methods
 from chemex.optimize.helper import execute_simulation
 from chemex.optimize.native_deterministic import uses_native_deterministic
-from chemex.run_info import write_run_info
+from chemex.run_info import write_run_info, write_run_outcome
 from chemex.runtime import (
     AnalysisSession,
     ExecutionSettings,
@@ -42,28 +42,40 @@ def run_fit(
     else:
         methods = {"": Method()}
 
-    # Native statistics occurrences must fail closed before any lmfit value
-    # carrier can be constructed by the compatibility filter path.
-    native_statistics = any(
-        method.statistics is not None and uses_native_deterministic(method)
-        for method in methods.values()
-    )
-    if native_statistics:
-        resolved_values = session.resolve_current_values(experiments.param_ids)
-        experiments.filter_from_values(resolved_values)
-    else:
-        experiments.filter()
-
     write_run_info(args, experiments, argv=argv)
 
-    print_start_fit()
-    run_methods(
-        experiments,
-        methods,
-        args.output,
-        args.plot,
-        session=session,
-    )
+    try:
+        invalidate_planned_outputs(methods, args.output)
+
+        # Native statistics occurrences must fail closed before any lmfit value
+        # carrier can be constructed by the compatibility filter path.
+        native_statistics = any(
+            method.statistics is not None and uses_native_deterministic(method)
+            for method in methods.values()
+        )
+        if native_statistics:
+            resolved_values = session.resolve_current_values(experiments.param_ids)
+            experiments.filter_from_values(resolved_values)
+        else:
+            experiments.filter()
+
+        print_start_fit()
+        run_methods(
+            experiments,
+            methods,
+            args.output,
+            args.plot,
+            session=session,
+        )
+        write_run_outcome(args.output, "complete")
+    except (Exception, KeyboardInterrupt) as error:
+        try:
+            write_run_outcome(args.output, "incomplete", failure=error)
+        except (Exception, KeyboardInterrupt) as outcome_error:  # noqa: BLE001
+            error.add_note(
+                f"ChemEx could not publish the incomplete run outcome: {outcome_error}"
+            )
+        raise
 
 
 def run_sim(

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -1,5 +1,6 @@
 """The fitting module contains the code for fitting the experimental data."""
 
+import shutil
 from pathlib import Path
 
 from chemex.configuration.methods import Methods, Statistics
@@ -35,6 +36,39 @@ from chemex.optimize.resampling import (
     run_resampling_statistics,
 )
 from chemex.runtime import AnalysisSession, ExecutionSettings
+
+_CHEMEX_RESULT_PATHS = (
+    "Parameters",
+    "Data",
+    "Plots",
+    "Grid",
+    "Groups",
+    "All",
+    "Statistics",
+    "statistics.toml",
+)
+
+
+def invalidate_planned_outputs(methods: Methods, path: Path) -> None:
+    """Remove only ChemEx-owned results for every method step planned now."""
+    if len(methods) > 1:
+        output_root = path.resolve()
+        step_roots = tuple(path / section for section in methods)
+        if any(
+            not step_root.resolve().is_relative_to(output_root)
+            for step_root in step_roots
+        ):
+            msg = "A planned method step root is outside the output directory"
+            raise ValueError(msg)
+    else:
+        step_roots = (path,)
+    for step_root in step_roots:
+        for name in _CHEMEX_RESULT_PATHS:
+            result_path = step_root / name
+            if result_path.is_symlink() or result_path.is_file():
+                result_path.unlink()
+            elif result_path.is_dir():
+                shutil.rmtree(result_path)
 
 
 def _run_statistics(
@@ -233,6 +267,7 @@ def run_methods(
                 )
             except KeyboardInterrupt:
                 print_calculation_stopped_error()
+                raise
         else:
             legacy_fitmethod = (
                 "least_squares" if method.fitmethod == "trf" else method.fitmethod

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -128,6 +128,7 @@ def _write_plots(experiments: Experiments, path: Path) -> None:
         experiments.plot(path=path_)
     except KeyboardInterrupt:
         print_plotting_canceled()
+        raise
 
 
 def _write_simulation_plots(experiments: Experiments, path: Path) -> None:

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as np
 from rich.progress import track
 
+from chemex.atomic import write_text_atomic
 from chemex.configuration.methods import Statistics
 from chemex.containers.experiments import Experiments, generate_exp_for_statistics
 from chemex.messages import (
@@ -300,7 +301,7 @@ def _write_resampling_diagnostics(
         lines.append(f"root_seed = {root_seed}")
     if status is not None:
         lines.append(f"status = {_quote_toml_string(status)}")
-    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_text_atomic(path / "diagnostics.toml", "\n".join(lines) + "\n")
 
 
 def _run_resampling_method(
@@ -525,7 +526,7 @@ def _write_native_state_diagnostics(
                 f"failure_message = {_quote_toml_string(message)}",
             )
         )
-    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_text_atomic(path / "diagnostics.toml", "\n".join(lines) + "\n")
 
 
 def _clear_native_statistics_artifacts(path: Path) -> None:
@@ -538,6 +539,18 @@ def _clear_native_statistics_artifacts(path: Path) -> None:
         "failures.tsv",
     ):
         (path / name).unlink(missing_ok=True)
+
+
+def _remove_failed_publication_artifacts(
+    path: Path,
+    names: Sequence[str],
+    failure: BaseException,
+) -> None:
+    for name in names:
+        try:
+            (path / name).unlink(missing_ok=True)
+        except (Exception, KeyboardInterrupt) as cleanup_error:  # noqa: BLE001
+            failure.add_note(f"ChemEx could not remove {name}: {cleanup_error}")
 
 
 def _run_native_resampling_method(
@@ -639,84 +652,134 @@ def _run_native_resampling_method(
             failure=error,
         )
         raise error
-    successful = tuple(
-        outcome.success for outcome in evidence.outcomes if outcome.success is not None
-    )
-    sample_rows = [
-        [dict(success.resolved_items)[param_id] for param_id in parameter_ids]
-        for success in successful
-    ]
-    chisqr_rows = [success.chi_square for success in successful]
-    samples = _as_sample_array(sample_rows, len(parameter_ids))
-    with (statistic_path / "samples.tsv").open("w", encoding="utf-8") as output:
-        output.write("\t".join((*parameter_names, "chisqr")) + "\n")
-        for values, chisqr in zip(sample_rows, chisqr_rows, strict=True):
-            output.write(
-                "\t".join(
-                    _format_tsv_float(value) for value in (*values, float(chisqr))
+    disposition_counts = Counter(outcome.disposition for outcome in evidence.outcomes)
+    samples_published = False
+    failures_published = False
+    try:
+        complete = (
+            operation.terminal is OperationTerminal.COMPLETED
+            and evidence.successful_count == method.iterations
+        )
+        successful = tuple(
+            outcome.success
+            for outcome in evidence.outcomes
+            if outcome.success is not None
+        )
+        sample_rows = [
+            [dict(success.resolved_items)[param_id] for param_id in parameter_ids]
+            for success in successful
+        ]
+        chisqr_rows = [success.chi_square for success in successful]
+        samples = _as_sample_array(sample_rows, len(parameter_ids))
+        with (statistic_path / "samples.tsv").open("w", encoding="utf-8") as output:
+            output.write("\t".join((*parameter_names, "chisqr")) + "\n")
+            for values, chisqr in zip(sample_rows, chisqr_rows, strict=True):
+                output.write(
+                    "\t".join(
+                        _format_tsv_float(value) for value in (*values, float(chisqr))
+                    )
+                    + "\n"
                 )
-                + "\n"
+        samples_published = True
+        if not complete:
+            _write_native_failures(statistic_path, evidence.outcomes)
+            failures_published = True
+            _write_native_state_diagnostics(
+                statistic_path,
+                method=method,
+                workers=worker_count,
+                parameter_ids=parameter_ids,
+                root_seed=root_seed,
+                status="incomplete",
+                successful_samples=disposition_counts[ReplicateDisposition.SUCCEEDED],
+                failed_samples=disposition_counts[ReplicateDisposition.FAILED],
+                cancelled_samples=disposition_counts[ReplicateDisposition.CANCELLED],
+                interrupted_samples=disposition_counts[
+                    ReplicateDisposition.INTERRUPTED
+                ],
+                unstarted_samples=disposition_counts[ReplicateDisposition.NOT_STARTED],
+                terminal=operation.terminal.value,
             )
-    complete = (
-        operation.terminal is OperationTerminal.COMPLETED
-        and evidence.successful_count == method.iterations
-    )
-    if not complete:
-        _write_native_failures(statistic_path, evidence.outcomes)
-        disposition_counts = Counter(
-            outcome.disposition for outcome in evidence.outcomes
-        )
-        _write_native_state_diagnostics(
+        else:
+            _write_resampling_summary(
+                statistic_path,
+                parameter_names=parameter_names,
+                samples=samples,
+            )
+            correlations = _write_resampling_correlations(
+                statistic_path,
+                parameter_names=parameter_names,
+                samples=samples,
+            )
+            write_resampling_plots(
+                statistic_path,
+                method=method.message,
+                fitmethod="trf",
+                parameter_names=parameter_names,
+                samples=samples,
+                chisqr_values=np.asarray(chisqr_rows, dtype=float),
+                correlations=correlations,
+                requested_samples=method.iterations,
+                completed_samples=evidence.successful_count,
+            )
+            _write_resampling_diagnostics(
+                statistic_path,
+                method=method.message,
+                fitmethod="trf",
+                requested_samples=method.iterations,
+                completed_samples=evidence.successful_count,
+                workers=worker_count,
+                parameter_ids=list(parameter_ids),
+                engine="native direct TRF",
+                root_seed=root_seed,
+                status="complete",
+            )
+    except (Exception, KeyboardInterrupt) as error:
+        artifacts_to_remove = ["summary.toml", "correlations.tsv", "plots.pdf"]
+        if not samples_published:
+            artifacts_to_remove.append("samples.tsv")
+        if not failures_published:
+            artifacts_to_remove.append("failures.tsv")
+        _remove_failed_publication_artifacts(
             statistic_path,
-            method=method,
-            workers=worker_count,
-            parameter_ids=parameter_ids,
-            root_seed=root_seed,
-            status="incomplete",
-            successful_samples=disposition_counts[ReplicateDisposition.SUCCEEDED],
-            failed_samples=disposition_counts[ReplicateDisposition.FAILED],
-            cancelled_samples=disposition_counts[ReplicateDisposition.CANCELLED],
-            interrupted_samples=disposition_counts[ReplicateDisposition.INTERRUPTED],
-            unstarted_samples=disposition_counts[ReplicateDisposition.NOT_STARTED],
-            terminal=operation.terminal.value,
+            artifacts_to_remove,
+            error,
         )
+        terminal = "interrupted" if isinstance(error, KeyboardInterrupt) else "failed"
+        try:
+            _write_native_state_diagnostics(
+                statistic_path,
+                method=method,
+                workers=worker_count,
+                parameter_ids=parameter_ids,
+                root_seed=root_seed,
+                status="incomplete",
+                successful_samples=disposition_counts[ReplicateDisposition.SUCCEEDED],
+                failed_samples=disposition_counts[ReplicateDisposition.FAILED],
+                cancelled_samples=disposition_counts[ReplicateDisposition.CANCELLED],
+                interrupted_samples=disposition_counts[
+                    ReplicateDisposition.INTERRUPTED
+                ],
+                unstarted_samples=disposition_counts[ReplicateDisposition.NOT_STARTED],
+                terminal=terminal,
+                failure=error,
+            )
+        except (Exception, KeyboardInterrupt) as diagnostics_error:  # noqa: BLE001
+            error.add_note(
+                "ChemEx could not publish incomplete resampling diagnostics: "
+                f"{diagnostics_error}"
+            )
+            _remove_failed_publication_artifacts(
+                statistic_path,
+                ("diagnostics.toml",),
+                error,
+            )
+        raise
+    if not complete:
         raise NativeResamplingIncompleteError(
             f"Native {method.message} completed {evidence.successful_count} of "
             f"{method.iterations} requested replicates"
         )
-    _write_resampling_summary(
-        statistic_path,
-        parameter_names=parameter_names,
-        samples=samples,
-    )
-    correlations = _write_resampling_correlations(
-        statistic_path,
-        parameter_names=parameter_names,
-        samples=samples,
-    )
-    write_resampling_plots(
-        statistic_path,
-        method=method.message,
-        fitmethod="trf",
-        parameter_names=parameter_names,
-        samples=samples,
-        chisqr_values=np.asarray(chisqr_rows, dtype=float),
-        correlations=correlations,
-        requested_samples=method.iterations,
-        completed_samples=evidence.successful_count,
-    )
-    _write_resampling_diagnostics(
-        statistic_path,
-        method=method.message,
-        fitmethod="trf",
-        requested_samples=method.iterations,
-        completed_samples=evidence.successful_count,
-        workers=worker_count,
-        parameter_ids=list(parameter_ids),
-        engine="native direct TRF",
-        root_seed=root_seed,
-        status="complete",
-    )
 
 
 def run_native_resampling_statistics(

--- a/src/chemex/run_info.py
+++ b/src/chemex/run_info.py
@@ -16,10 +16,10 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from hashlib import blake2b, sha256
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 from chemex import __version__
-from chemex.atomic import publish_directory_noreplace
+from chemex.atomic import publish_directory_noreplace, write_text_atomic
 from chemex.containers.experiments import Experiments
 from chemex.native_provenance import (
     ArtifactReference,
@@ -39,6 +39,7 @@ from chemex.parameters.values import AnalysisValuesSnapshot
 
 SCHEMA_VERSION = 1
 _INPUT_CATEGORIES = ("experiments", "parameters", "methods")
+RunOutcomeStatus = Literal["running", "complete", "incomplete"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -592,6 +593,45 @@ def _serialize_run(
     return "\n".join(lines)
 
 
+def _serialize_outcome(
+    status: RunOutcomeStatus,
+    failure: BaseException | None = None,
+) -> str:
+    lines = [
+        f"schema_version = {SCHEMA_VERSION}",
+        f"status = {_quote_string(status)}",
+    ]
+    if failure is not None:
+        reported_terminal = getattr(failure, "terminal", None)
+        terminal = (
+            str(reported_terminal)
+            if reported_terminal in {"failed", "interrupted"}
+            else "interrupted"
+            if isinstance(failure, KeyboardInterrupt)
+            else "failed"
+        )
+        message = str(failure).replace("\n", " ")
+        lines.extend(
+            (
+                f"terminal = {_quote_string(terminal)}",
+                f"failure_type = {_quote_string(type(failure).__name__)}",
+                f"failure_message = {_quote_string(message)}",
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_run_outcome(
+    output_directory: Path,
+    status: RunOutcomeStatus,
+    *,
+    failure: BaseException | None = None,
+) -> None:
+    """Atomically replace the lifecycle marker for the current fit invocation."""
+    outcome_path = Path(output_directory) / "run_info" / "outcome.toml"
+    write_text_atomic(outcome_path, _serialize_outcome(status, failure))
+
+
 def write_run_info(
     args: Namespace,
     experiments: Experiments,
@@ -636,6 +676,10 @@ def write_run_info(
             git_metadata=git_metadata,
         )
         (staging_path / "run.toml").write_text(run_text, encoding="utf-8")
+        (staging_path / "outcome.toml").write_text(
+            _serialize_outcome("running"),
+            encoding="utf-8",
+        )
 
         _replace_run_info(staging_path, run_info_path)
 

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -373,6 +373,11 @@ def test_run_uses_explicit_session_for_fit_flow(
         "write_run_info",
         lambda *_args, **_kwargs: recorded.setdefault("run_info", True),
     )
+    monkeypatch.setattr(
+        chemex_module,
+        "write_run_outcome",
+        lambda _path, status, **_kwargs: recorded.setdefault("outcome", status),
+    )
     monkeypatch.setattr(chemex_module.os, "environ", recorded_env)
 
     args = make_args("fit")
@@ -393,6 +398,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     np.testing.assert_equal(recorded["build"][2], session)
     assert recorded["run_methods"][4] is session
     assert recorded["run_info"] is True
+    assert recorded["outcome"] == "complete"
 
 
 def test_run_continues_when_native_configuration_is_unavailable(
@@ -415,6 +421,11 @@ def test_run_continues_when_native_configuration_is_unavailable(
         lambda *_args, **_kwargs: fit_ran.append(True),
     )
     monkeypatch.setattr(chemex_module, "write_run_info", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        chemex_module,
+        "write_run_outcome",
+        lambda *_args, **_kwargs: None,
+    )
 
     chemex_module.run(make_args("fit"), session=session)
 

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -14,6 +14,8 @@ import chemex.optimize.fitting as fitting_module
 import chemex.optimize.mcmc as mcmc_module
 import chemex.optimize.native_mcmc as native_mcmc_module
 import chemex.optimize.native_resampling as native_resampling_module
+import chemex.optimize.resampling as resampling_module
+import chemex.run_info as run_info_module
 from chemex.chemex import run
 from chemex.cli import build_parser
 from chemex.optimize.mcmc import NativeMcmcIncompleteError
@@ -88,6 +90,12 @@ def _run_real_fit_cli(output: Path, method: Path, parameters: Path) -> None:
     )
 
 
+def _read_outcome(output: Path) -> dict[str, object]:
+    return tomllib.loads(
+        (output / "run_info" / "outcome.toml").read_text(encoding="utf-8")
+    )
+
+
 def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     tmp_path: Path,
 ) -> None:
@@ -131,6 +139,105 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     time_2, intensity_2 = curve[-1]
     fitted_curve_rate = -math.log(intensity_2 / intensity_1) / (time_2 - time_1)
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
+
+
+def test_failed_deterministic_rerun_invalidates_prior_results_and_is_incomplete(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    run(
+        _fit_arguments(output, plot_level="normal"),
+        session=AnalysisSession.create(),
+    )
+    user_file = output / "notes.txt"
+    user_file.write_text("keep me\n", encoding="utf-8")
+
+    with (
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            side_effect=RuntimeError("rerun backend failed"),
+        ),
+        pytest.raises(RuntimeError, match="did not commit"),
+    ):
+        run(_fit_arguments(output), session=AnalysisSession.create())
+
+    outcome = _read_outcome(output)
+    assert outcome["schema_version"] == 1
+    assert outcome["status"] == "incomplete"
+    assert outcome["terminal"] == "failed"
+    assert outcome["failure_type"] == "RuntimeError"
+    assert not (output / "Parameters").exists()
+    assert not (output / "Data").exists()
+    assert not (output / "Plots").exists()
+    assert not (output / "statistics.toml").exists()
+    assert user_file.read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_data_writer_failure_after_commit_cannot_complete_or_retain_stale_results(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    run(_fit_arguments(output), session=AnalysisSession.create())
+    stale_parameter = output / "Parameters" / "stale.toml"
+    stale_data = output / "Data" / "stale.dat"
+    stale_parameter.write_text("old parameter\n", encoding="utf-8")
+    stale_data.write_text("old data\n", encoding="utf-8")
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "chemex.containers.experiments.Experiments.write",
+            side_effect=RuntimeError("data writer failed"),
+        ),
+        pytest.raises(RuntimeError, match="data writer failed"),
+    ):
+        run(_fit_arguments(output), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    assert _read_outcome(output) == {
+        "schema_version": 1,
+        "status": "incomplete",
+        "terminal": "failed",
+        "failure_type": "RuntimeError",
+        "failure_message": "data writer failed",
+    }
+    assert (output / "Parameters" / "fitted.toml").is_file()
+    assert not stale_parameter.exists()
+    assert not stale_data.exists()
+    assert not (output / "statistics.toml").exists()
+
+
+def test_final_complete_outcome_write_failure_is_terminal_and_propagates(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    real_atomic_write = run_info_module.write_text_atomic
+
+    def fail_complete_outcome(destination: Path, content: str) -> None:
+        if 'status = "complete"' in content:
+            raise OSError("complete outcome publication failed")
+        real_atomic_write(destination, content)
+
+    session = AnalysisSession.create()
+    with (
+        patch.object(
+            run_info_module,
+            "write_text_atomic",
+            side_effect=fail_complete_outcome,
+        ),
+        pytest.raises(OSError, match="complete outcome publication failed"),
+    ):
+        run(_fit_arguments(output), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    assert (output / "Parameters" / "fitted.toml").is_file()
+    assert _read_outcome(output) == {
+        "schema_version": 1,
+        "status": "incomplete",
+        "terminal": "failed",
+        "failure_type": "OSError",
+        "failure_message": "complete outcome publication failed",
+    }
 
 
 def test_real_grouped_direct_fit_uses_native_aggregate_commit(
@@ -424,6 +531,7 @@ def test_interrupted_native_mcmc_publishes_only_incomplete_diagnostics(
     assert not (statistics / "samples.tsv").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()
+    assert _read_outcome(output)["terminal"] == "interrupted"
 
 
 def test_native_mcmc_postprocessing_failure_replaces_running_diagnostics(
@@ -501,6 +609,47 @@ def test_mixed_mc_and_mcmc_use_one_native_central_fit_without_legacy_fallback(
     assert session.analysis_values.snapshot().revision == 1
     assert (output / "Statistics" / "MonteCarlo" / "summary.toml").is_file()
     assert (output / "Statistics" / "MCMC" / "summary.toml").is_file()
+
+
+def test_failed_mixed_statistics_rerun_removes_later_family_outputs_eagerly(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(
+        tmp_path / "method.toml",
+        '"MC" = 1, "BS" = 1, "MCMC" = {STEPS = 2, BURN = 0, WALKERS = 4, SEED = 612}',
+    )
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    run(
+        _fit_arguments(output, method, parameters=parameters),
+        session=AnalysisSession.create(),
+    )
+    assert _read_outcome(output) == {"schema_version": 1, "status": "complete"}
+    assert (output / "Statistics" / "Bootstrap" / "diagnostics.toml").is_file()
+    assert (output / "Statistics" / "MCMC" / "diagnostics.toml").is_file()
+
+    with (
+        patch(
+            "chemex.optimize.resampling._native_dataset",
+            side_effect=RuntimeError("MC setup failed"),
+        ),
+        pytest.raises(RuntimeError, match="MC setup failed"),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    monte_carlo = output / "Statistics" / "MonteCarlo"
+    assert (
+        tomllib.loads((monte_carlo / "diagnostics.toml").read_text(encoding="utf-8"))[
+            "status"
+        ]
+        == "incomplete"
+    )
+    assert not (output / "Statistics" / "Bootstrap").exists()
+    assert not (output / "Statistics" / "MCMC").exists()
+    assert _read_outcome(output)["status"] == "incomplete"
 
 
 def test_native_mcmc_without_fitted_parameters_keeps_documented_skip_behavior(
@@ -831,6 +980,126 @@ def test_native_statistics_setup_failure_publishes_incomplete_diagnostics(
     assert not (statistics / "plots.pdf").exists()
 
 
+@pytest.mark.parametrize(
+    ("family", "directory"),
+    (
+        ("MC", "MonteCarlo"),
+        ("BS", "Bootstrap"),
+        ("BSN", "BootstrapNS"),
+    ),
+)
+def test_native_resampling_publication_failure_is_terminal_and_fail_closed(
+    tmp_path: Path,
+    family: str,
+    directory: str,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(
+        tmp_path / "method.toml",
+        f'"{family}" = 1',
+    )
+
+    with (
+        patch(
+            "chemex.optimize.resampling._write_resampling_correlations",
+            side_effect=RuntimeError("correlation publication failed"),
+        ),
+        pytest.raises(RuntimeError, match="correlation publication failed"),
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    statistics = output / "Statistics" / directory
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "incomplete"
+    assert diagnostics["terminal"] == "failed"
+    assert diagnostics["completed_samples"] == 1
+    assert diagnostics["failed_samples"] == 0
+    assert diagnostics["cancelled_samples"] == 0
+    assert diagnostics["interrupted_samples"] == 0
+    assert diagnostics["unstarted_samples"] == 0
+    assert diagnostics["failure_type"] == "RuntimeError"
+    assert diagnostics["failure_message"] == "correlation publication failed"
+    assert (
+        len((statistics / "samples.tsv").read_text(encoding="utf-8").splitlines()) == 2
+    )
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+    assert _read_outcome(output)["status"] == "incomplete"
+
+
+def test_native_resampling_materialization_failure_replaces_running_diagnostics(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 1')
+
+    with (
+        patch.object(
+            resampling_module,
+            "_as_sample_array",
+            side_effect=RuntimeError("sample materialization failed"),
+        ),
+        pytest.raises(RuntimeError, match="sample materialization failed"),
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    statistics = output / "Statistics" / "MonteCarlo"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "incomplete"
+    assert diagnostics["completed_samples"] == 1
+    assert diagnostics["failure_message"] == "sample materialization failed"
+    assert not (statistics / "samples.tsv").exists()
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+    assert _read_outcome(output)["status"] == "incomplete"
+
+
+def test_resampling_diagnostics_failure_preserves_original_publication_error(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 1')
+    real_atomic_write = resampling_module.write_text_atomic
+
+    def fail_incomplete_diagnostics(destination: Path, content: str) -> None:
+        if (
+            destination.name == "diagnostics.toml"
+            and 'status = "incomplete"' in content
+        ):
+            raise OSError("incomplete diagnostics publication failed")
+        real_atomic_write(destination, content)
+
+    with (
+        patch.object(
+            resampling_module,
+            "_write_resampling_correlations",
+            side_effect=RuntimeError("correlation publication failed"),
+        ),
+        patch.object(
+            resampling_module,
+            "write_text_atomic",
+            side_effect=fail_incomplete_diagnostics,
+        ),
+        pytest.raises(RuntimeError, match="correlation publication failed"),
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    statistics = output / "Statistics" / "MonteCarlo"
+    assert not (statistics / "diagnostics.toml").exists()
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+    outcome = _read_outcome(output)
+    assert outcome["status"] == "incomplete"
+    assert outcome["failure_message"] == "correlation publication failed"
+
+
 def test_real_grid_fit_uses_native_cartesian_trf_and_writes_grid_output(
     tmp_path: Path,
 ) -> None:
@@ -908,6 +1177,79 @@ FIX = ["PB", "KEX_AB"]
         )
         assert "PB" in fixed
         assert "KEX_AB" in fixed
+
+
+def test_failed_second_step_rerun_eagerly_invalidates_every_planned_step(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[STEP1]
+FIX = ["PB", "KEX_AB"]
+
+[STEP2]
+""",
+        encoding="utf-8",
+    )
+    run(_fit_arguments(output, method), session=AnalysisSession.create())
+    stale_step1 = output / "STEP1" / "Parameters" / "stale.toml"
+    stale_step2 = output / "STEP2" / "Parameters" / "stale.toml"
+    user_file = output / "STEP2" / "notes.txt"
+    stale_step1.write_text("old step 1\n", encoding="utf-8")
+    stale_step2.write_text("old step 2\n", encoding="utf-8")
+    user_file.write_text("keep me\n", encoding="utf-8")
+    real_least_squares = direct_trf_module.least_squares
+    call_count = 0
+
+    def fail_second_step(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise RuntimeError("step 2 backend failed")
+        return real_least_squares(*args, **kwargs)
+
+    session = AnalysisSession.create()
+    with (
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            side_effect=fail_second_step,
+        ),
+        pytest.raises(RuntimeError, match="did not commit"),
+    ):
+        run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    assert (output / "STEP1" / "Parameters" / "fitted.toml").is_file()
+    assert not stale_step1.exists()
+    assert not (output / "STEP2" / "Parameters").exists()
+    assert not stale_step2.exists()
+    assert user_file.read_text(encoding="utf-8") == "keep me\n"
+    assert _read_outcome(output)["status"] == "incomplete"
+
+
+def test_planned_invalidation_rejects_a_step_root_outside_the_output(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    external_result = tmp_path / "external" / "Parameters" / "keep.toml"
+    external_result.parent.mkdir(parents=True)
+    external_result.write_text("keep me\n", encoding="utf-8")
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """["../external"]
+FIX = ["PB", "KEX_AB"]
+
+[SAFE]
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="outside the output directory"):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    assert external_result.read_text(encoding="utf-8") == "keep me\n"
+    assert _read_outcome(output)["status"] == "incomplete"
 
 
 def test_native_step_clears_generic_error_from_preceding_legacy_step(

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -272,12 +272,24 @@ def test_run_fit_creates_run_info(
 
     monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
     monkeypatch.setattr(chemex_module, "print_start_fit", lambda: None)
+
+    def observe_running_outcome(
+        _experiments: object,
+        _methods: object,
+        path: Path,
+        _plot: object,
+        **_kwargs: object,
+    ) -> None:
+        outcome = tomllib.loads(
+            (path / "run_info" / "outcome.toml").read_text(encoding="utf-8")
+        )
+        assert outcome == {"schema_version": 1, "status": "running"}
+        run_methods_calls.append(path)
+
     monkeypatch.setattr(
         chemex_module,
         "run_methods",
-        lambda _experiments, _methods, path, _plot, **_kwargs: run_methods_calls.append(
-            path
-        ),
+        observe_running_outcome,
     )
 
     chemex_module.run_fit(
@@ -294,6 +306,10 @@ def test_run_fit_creates_run_info(
     assert run_methods_calls == [output]
     assert (output / "run_info" / "run.toml").exists()
     assert (output / "run_info" / "parameters_used.toml").exists()
+    outcome = tomllib.loads(
+        (output / "run_info" / "outcome.toml").read_text(encoding="utf-8")
+    )
+    assert outcome == {"schema_version": 1, "status": "complete"}
 
 
 def test_git_metadata_is_optional_when_git_is_unavailable(

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -53,6 +53,20 @@ reconstructs them from the independent parameters and model. `inputs/` contains
 lightweight copies of the user-provided experiment, parameter, and method TOML
 files. Raw experimental data files are not copied.
 
+`outcome.toml` is the lifecycle marker for the current invocation. It has
+`schema_version = 1` and a `status` of `running`, `complete`, or `incomplete`.
+ChemEx writes `complete` only after every requested method step and statistics
+analysis succeeds. Incomplete outcomes also identify the failure or interruption
+when available. A process kill may leave `running`, which is not a successful
+outcome.
+
+When reusing an output directory, ChemEx clears its known result locations for
+every currently planned method step before the first step starts. This includes
+`Parameters/`, `Data/`, `Plots/`, `Grid/`, `Groups/`, `All/`, `Statistics/`, and
+`statistics.toml`; `run_info/` and unknown user-created paths are not cleared.
+Partial new output can remain after a writer failure, but `outcome.toml` will not
+report that invocation as complete.
+
 ### `Parameters/`
 
 Contains results of the fitting as three files: `fitted.toml`, `fixed.toml`, and `constrained.toml`, which list parameters that were fitted, fixed, and constrained, respectively.
@@ -155,7 +169,10 @@ The `diagnostics.toml` files record execution details for reproducibility. MC,
 BS, and BSN diagnostics include the native Direct TRF engine, root seed, and
 effective worker count. An incomplete analysis instead writes the successful
 sample rows, `failures.tsv`, and an explicit incomplete diagnostic; complete
-summary, correlation, and plot files are suppressed. MCMC diagnostics also
+summary, correlation, and plot files are suppressed. A failure while publishing
+an MC, BS, or BSN summary, correlation table, plot, or final diagnostic likewise
+retains only truthful completed sample/failure rows and atomically terminalizes
+the diagnostic as incomplete. MCMC diagnostics also
 include the direct emcee sampler engine, timing information, effective worker
 count and root seed, acceptance fractions, burn-in decisions, and
 autocorrelation estimates. Failed or interrupted MCMC suppresses every


### PR DESCRIPTION
## Summary

- add run_info/outcome.toml as a success-last lifecycle marker for the current invocation
- eagerly invalidate ChemEx-owned result paths for every planned method occurrence before fitting
- terminalize MC/BS/BSN publication failures without leaving complete-only artifacts or running diagnostics
- add product-path regressions for deterministic, multistep, mixed-statistics, and output-publication failures

This implements PR 1 of the frozen lmfit-removal scope in #613 and follows the lifecycle requirements in #657.

## Validation

- Python 3.14 full suite: 1161 passed, 1 existing emcee warning
- Python 3.13 focused product/resampling/MCMC/run_info suite: 165 passed
- ty check
- Ruff check and format check
- git diff --check
- uv build

## Deliberately deferred

The truthful summary-field and restart/archive round-trip slice remains for PR 2 of #613. This PR does not change scientific calculations, supported method syntax, output-tree structure, or run_info/run.toml semantics.