### PR TITLE
Make statistical summaries and restart contract truthful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 ## [Unreleased]
 
 ### Changed
+- Renamed misleading statistical summary fields without changing sampling or
+  fitted values. MC, BS, and BSN now use `percentile_68_lower`,
+  `percentile_68_upper`, and `half_percentile_68_width` instead of
+  `lower_1sigma`, `upper_1sigma`, and `stderr`. MCMC now uses
+  `credible_interval_68_lower`, `credible_interval_68_upper`, and
+  `half_credible_interval_68_width`; genuine `mcse_mean` remains the Monte Carlo
+  standard error of the posterior mean. Native deterministic fitted-parameter
+  reports continue to state `(error not calculated)`. Clarified that
+  `run_info/parameters_used.toml` is the bound-preserving restart input, while
+  the fitted/fixed/constrained parameter files are result reports.
 - Fit output now has a success-last `run_info/outcome.toml` lifecycle marker.
   Reruns eagerly invalidate only known ChemEx result locations for every planned
   method step, preventing earlier deterministic or later statistics-family

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -111,9 +111,9 @@ class McmcSummary:
     median: float
     eti_95_lower: float
     eti_95_upper: float
-    lower_1sigma: float
-    upper_1sigma: float
-    stderr: float
+    credible_interval_68_lower: float
+    credible_interval_68_upper: float
+    half_credible_interval_68_width: float
     effective_sample_size: float | None = None
     mcse_mean: float | None = None
 
@@ -320,7 +320,7 @@ def _summarize_chain(
     quantiles = np.percentile(samples, [2.5, 15.87, 50.0, 84.13, 97.5], axis=0)
     summaries: list[McmcSummary] = []
     for index, name in enumerate(var_names):
-        lower_95, lower, median, upper, upper_95 = quantiles[:, index]
+        lower_95, lower_68, median, upper_68, upper_95 = quantiles[:, index]
         values = samples[:, index]
         standard_deviation = float(np.std(values, ddof=1)) if len(values) > 1 else 0.0
         effective_sample_size = None
@@ -339,9 +339,9 @@ def _summarize_chain(
                 median=float(median),
                 eti_95_lower=float(lower_95),
                 eti_95_upper=float(upper_95),
-                lower_1sigma=float(lower),
-                upper_1sigma=float(upper),
-                stderr=0.5 * float(upper - lower),
+                credible_interval_68_lower=float(lower_68),
+                credible_interval_68_upper=float(upper_68),
+                half_credible_interval_68_width=0.5 * float(upper_68 - lower_68),
                 effective_sample_size=effective_sample_size,
                 mcse_mean=mcse_mean,
             ),
@@ -664,9 +664,18 @@ def _write_summary(
                 f"median = {_format_toml_float(summary.median)}",
                 f"eti_95_lower = {_format_toml_float(summary.eti_95_lower)}",
                 f"eti_95_upper = {_format_toml_float(summary.eti_95_upper)}",
-                f"lower_1sigma = {_format_toml_float(summary.lower_1sigma)}",
-                f"upper_1sigma = {_format_toml_float(summary.upper_1sigma)}",
-                f"stderr = {_format_toml_float(summary.stderr)}",
+                (
+                    "credible_interval_68_lower = "
+                    f"{_format_toml_float(summary.credible_interval_68_lower)}"
+                ),
+                (
+                    "credible_interval_68_upper = "
+                    f"{_format_toml_float(summary.credible_interval_68_upper)}"
+                ),
+                (
+                    "half_credible_interval_68_width = "
+                    f"{_format_toml_float(summary.half_credible_interval_68_width)}"
+                ),
             ],
         )
         if summary.effective_sample_size is not None:
@@ -1151,7 +1160,6 @@ def run_mcmc(
         updated_params = params.copy()
         for summary in result.summary:
             updated_params[summary.parameter_id].value = summary.median
-            updated_params[summary.parameter_id].stderr = summary.stderr
         updated_params.update_constraints()
         parameter_store.update_from_parameters(updated_params)
     return result

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -212,7 +212,7 @@ def _write_resampling_summary(
             ],
         )
         if len(values) > 0:
-            lower_95, lower, median, upper, upper_95 = np.percentile(
+            lower_95, lower_68, median, upper_68, upper_95 = np.percentile(
                 values,
                 [2.5, 15.87, 50.0, 84.13, 97.5],
             )
@@ -226,9 +226,12 @@ def _write_resampling_summary(
                     f"median = {_format_toml_float(float(median))}",
                     f"percentile_95_lower = {_format_toml_float(float(lower_95))}",
                     f"percentile_95_upper = {_format_toml_float(float(upper_95))}",
-                    f"lower_1sigma = {_format_toml_float(float(lower))}",
-                    f"upper_1sigma = {_format_toml_float(float(upper))}",
-                    f"stderr = {_format_toml_float(0.5 * float(upper - lower))}",
+                    f"percentile_68_lower = {_format_toml_float(float(lower_68))}",
+                    f"percentile_68_upper = {_format_toml_float(float(upper_68))}",
+                    (
+                        "half_percentile_68_width = "
+                        f"{_format_toml_float(0.5 * float(upper_68 - lower_68))}"
+                    ),
                 ],
             )
         lines.append("")

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -413,9 +413,9 @@ def test_run_mcmc_passes_execution_workers_to_direct_sampler(
                 median=0.15,
                 eti_95_lower=0.10,
                 eti_95_upper=0.20,
-                lower_1sigma=0.10,
-                upper_1sigma=0.20,
-                stderr=0.05,
+                credible_interval_68_lower=0.10,
+                credible_interval_68_upper=0.20,
+                half_credible_interval_68_width=0.05,
             ),
         ),
         correlations=np.array([[1.0]]),
@@ -594,9 +594,9 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
                 median=0.25,
                 eti_95_lower=0.11,
                 eti_95_upper=0.39,
-                lower_1sigma=0.12,
-                upper_1sigma=0.38,
-                stderr=0.13,
+                credible_interval_68_lower=0.12,
+                credible_interval_68_upper=0.38,
+                half_credible_interval_68_width=0.13,
                 effective_sample_size=2.0,
                 mcse_mean=0.09,
             ),
@@ -607,9 +607,9 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
                 median=275.0,
                 eti_95_lower=205.0,
                 eti_95_upper=345.0,
-                lower_1sigma=210.0,
-                upper_1sigma=340.0,
-                stderr=65.0,
+                credible_interval_68_lower=210.0,
+                credible_interval_68_upper=340.0,
+                half_credible_interval_68_width=65.0,
                 effective_sample_size=1.3333333333,
                 mcse_mean=56.2916512459,
             ),
@@ -646,7 +646,12 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
     assert 'credible_interval = "95% equal-tailed"' in summary
     assert "median = 2.50000e-01" in summary
     assert "eti_95_lower = 1.10000e-01" in summary
+    assert "credible_interval_68_lower = 1.20000e-01" in summary
+    assert "credible_interval_68_upper = 3.80000e-01" in summary
+    assert "half_credible_interval_68_width = 1.30000e-01" in summary
     assert "effective_sample_size = 2.00000e+00" in summary
+    assert "mcse_mean = 9.00000e-02" in summary
+    assert "stderr" not in summary
     assert "[PB]\t[KEX_AB]\tlnprob" in samples
     assert "2.00000e-01\t2.50000e+02\t-2.00000e+00" in samples
     assert "[PB]" in correlations
@@ -702,9 +707,9 @@ def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
                 median=0.45,
                 eti_95_lower=0.31,
                 eti_95_upper=0.59,
-                lower_1sigma=0.32,
-                upper_1sigma=0.58,
-                stderr=0.13,
+                credible_interval_68_lower=0.32,
+                credible_interval_68_upper=0.58,
+                half_credible_interval_68_width=0.13,
             ),
         ),
         correlations=np.array([[1.0]]),

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -96,6 +96,20 @@ def _read_outcome(output: Path) -> dict[str, object]:
     )
 
 
+def _assert_truthful_resampling_summary(path: Path) -> None:
+    summary = tomllib.loads(path.read_text(encoding="utf-8"))
+    distribution = next(iter(summary.values()))
+    assert {
+        "percentile_68_lower",
+        "percentile_68_upper",
+        "half_percentile_68_width",
+    } <= distribution.keys()
+    assert distribution["percentile_68_lower"] <= distribution["median"]
+    assert distribution["percentile_68_upper"] >= distribution["median"]
+    assert distribution["half_percentile_68_width"] >= 0.0
+    assert "stderr" not in distribution
+
+
 def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     tmp_path: Path,
 ) -> None:
@@ -139,6 +153,27 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     time_2, intensity_2 = curve[-1]
     fitted_curve_rate = -math.log(intensity_2 / intensity_1) / (time_2 - time_1)
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
+
+
+def test_parameters_used_supports_real_cli_restart_round_trip(tmp_path: Path) -> None:
+    first_output = tmp_path / "First"
+    restarted_output = tmp_path / "Restarted"
+
+    _run_real_fit_cli(first_output, METHOD, PARAMETERS)
+    restart_parameters = first_output / "run_info" / "parameters_used.toml"
+    _run_real_fit_cli(restarted_output, METHOD, restart_parameters)
+
+    def fitted_value(output: Path) -> float:
+        fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+        record = next(line for line in fitted.splitlines() if "=" in line)
+        return float(record.split("=", 1)[1].split()[0])
+
+    first_value = fitted_value(first_output)
+    restarted_value = fitted_value(restarted_output)
+    # fitted.toml is rendered to 5 decimal places in scientific notation; this
+    # allows roughly one final rendered digit of solver/platform variation.
+    assert first_value == pytest.approx(2.34742, rel=5.0e-6)
+    assert restarted_value == pytest.approx(first_value, rel=5.0e-6)
 
 
 def test_failed_deterministic_rerun_invalidates_prior_results_and_is_incomplete(
@@ -364,6 +399,9 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     assert diagnostics["steps"] == 2
     assert diagnostics["walkers"] == 32
     assert "lmfit_version" not in diagnostics
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    assert "(error not calculated)" in fitted
+    assert "±" not in fitted
     plan = native_sampler.call_args.args[1]
     assert plan.coordinate_units[0][1] is ParameterUnit.UNSPECIFIED
 
@@ -451,6 +489,10 @@ def test_seeded_nested_native_mcmc_replays_across_worker_counts(
     assert posterior["prior_upper"] == pytest.approx(5.0)
     assert 0.1 < posterior["median"] < 5.0
     assert posterior["standard_deviation"] > 0.0
+    assert posterior["credible_interval_68_lower"] <= posterior["median"]
+    assert posterior["credible_interval_68_upper"] >= posterior["median"]
+    assert posterior["half_credible_interval_68_width"] >= 0.0
+    assert "stderr" not in posterior
 
 
 def test_native_mcmc_preserves_committed_central_fit(tmp_path: Path) -> None:
@@ -704,6 +746,7 @@ def test_real_mc_fit_is_wholly_native_and_writes_product_statistics(
     assert (statistics / "summary.toml").is_file()
     assert (statistics / "correlations.tsv").is_file()
     assert (statistics / "plots.pdf").stat().st_size > 0
+    _assert_truthful_resampling_summary(statistics / "summary.toml")
     samples = (statistics / "samples.tsv").read_text(encoding="utf-8")
     assert len(samples.splitlines()) == 3
     diagnostics = (statistics / "diagnostics.toml").read_text(encoding="utf-8")
@@ -769,6 +812,7 @@ def test_real_bs_fit_uses_native_refits_and_writes_bootstrap_products(
     assert (statistics / "correlations.tsv").is_file()
     assert (statistics / "diagnostics.toml").is_file()
     assert (statistics / "plots.pdf").stat().st_size > 0
+    _assert_truthful_resampling_summary(statistics / "summary.toml")
 
 
 def test_real_bsn_fit_uses_native_nucleus_resampling_products(tmp_path: Path) -> None:
@@ -801,6 +845,7 @@ def test_real_bsn_fit_uses_native_nucleus_resampling_products(tmp_path: Path) ->
     assert (statistics / "correlations.tsv").is_file()
     assert (statistics / "diagnostics.toml").is_file()
     assert (statistics / "plots.pdf").stat().st_size > 0
+    _assert_truthful_resampling_summary(statistics / "summary.toml")
 
 
 def test_seeded_native_mc_products_are_ordered_across_worker_counts(

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -148,6 +148,61 @@ def test_write_run_info_captures_inputs_parameters_and_runtime(
     assert "PA" not in parameters["GLOBAL"]
 
 
+def test_archived_tomls_are_immutable_byte_copies_alongside_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    original_bytes = {
+        "experiments": b'[experiment]\r\nname = "relaxation_hznz"\r\n',
+        "parameters": b"[GLOBAL]\r\nPB = 0.1\r\n",
+        "methods": b'[DEFAULT]\r\nFITMETHOD = "trf"\r\n',
+    }
+    sources = {category: tmp_path / f"{category}.toml" for category in original_bytes}
+    for category, source in sources.items():
+        source.write_bytes(original_bytes[category])
+    output = tmp_path / "Output"
+    experiments = SimpleNamespace(
+        param_ids=set(),
+        parameter_store=ParameterStore({}),
+    )
+    monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
+
+    run_info_module.write_run_info(
+        Namespace(
+            experiments=[sources["experiments"]],
+            parameters=[sources["parameters"]],
+            method=[sources["methods"]],
+            output=output,
+        ),
+        experiments,
+        argv=["chemex", "fit"],
+        working_directory=tmp_path,
+    )
+
+    run_info = output / "run_info"
+    run_path = run_info / "run.toml"
+    run_bytes = run_path.read_bytes()
+    run = tomllib.loads(run_bytes.decode())
+    archived = {
+        category: run_info / run["inputs"][category][0]["copied_path"]
+        for category in original_bytes
+    }
+    for category, path in archived.items():
+        assert path.read_bytes() == original_bytes[category]
+
+    for source in sources.values():
+        source.write_bytes(b"[changed]\nvalue = true\n")
+    run_info_module.write_run_outcome(output, "complete")
+
+    assert run_path.read_bytes() == run_bytes
+    assert tomllib.loads((run_info / "outcome.toml").read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "status": "complete",
+    }
+    for category, path in archived.items():
+        assert path.read_bytes() == original_bytes[category]
+
+
 def test_run_info_uses_chemex_path_semantics_for_literal_tilde(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -313,9 +313,13 @@ Statistics/
     plots.pdf
 ```
 
-For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ², `summary.toml` reports percentile-based parameter summaries, and `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`. Their `plots.pdf` reports provide a summary page, one-dimensional sample distributions, a χ² distribution, and two-dimensional sample distributions for parameter pairs with `|r| >= 0.5`.
+For Monte Carlo and bootstrap methods, `samples.tsv` contains one fitted-parameter row per synthetic dataset plus χ². `summary.toml` reports empirical-distribution quantities: mean, median, standard deviation, 95% percentile bounds, 68% percentile bounds, and `half_percentile_68_width`. `correlations.tsv` reports parameter correlations across the fitted synthetic datasets. Missing values are written as `nan`. Their `plots.pdf` reports provide a summary page, one-dimensional sample distributions, a χ² distribution, and two-dimensional sample distributions for parameter pairs with `|r| >= 0.5`.
 
-For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, a 95% equal-tailed credible interval, the 68.26% interval used for `stderr`, and effective sample size/Monte Carlo standard error when the autocorrelation estimate passes emcee's reliability threshold. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, reliable or tentative autocorrelation time, recommended chain lengths, and burn-in decisions. The `plots.pdf` report provides a summary page, one-dimensional posterior distributions, walker traces, the log-probability trace, an autocorrelation monitor, and two-dimensional posterior distributions for parameter pairs with `|r| >= 0.5`.
+For MCMC, `summary.toml` reports the uniform prior implied by each parameter's bounds, posterior mean, median, standard deviation, 95% equal-tailed and 68% credible-interval bounds, and `half_credible_interval_68_width`. Effective sample size and `mcse_mean` are included when the autocorrelation estimate passes emcee's reliability threshold; `mcse_mean` is the Monte Carlo standard error of the estimated posterior mean, not a posterior interval width. MCMC diagnostics include sampler versions, retained samples, acceptance fractions, reliable or tentative autocorrelation time, recommended chain lengths, and burn-in decisions. The `plots.pdf` report provides a summary page, one-dimensional posterior distributions, walker traces, the log-probability trace, an autocorrelation monitor, and two-dimensional posterior distributions for parameter pairs with `|r| >= 0.5`.
+
+MC, BS, BSN, and MCMC summaries remain separate statistical results. They do not
+mutate the committed central fit or populate a generic error in
+`Parameters/fitted.toml`.
 
 If MCMC setup, sampling, processing, or output fails or is interrupted,
 `diagnostics.toml` records an explicit incomplete terminal state. ChemEx does not

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -47,11 +47,12 @@ The output directory typically includes the following files and subdirectories:
 Records how the fit was started. `run.toml` contains runtime and command-line
 metadata grouped into run, ChemEx, Python, command, inputs, and optional Git
 sections. `parameters_used.toml` contains the parsed independent starting
-parameters needed to restart the fit, including values and bounds. Parameters
+parameters needed to restart or re-run the fit, including values and bounds. Use
+this file as the parameter input for a subsequent `chemex fit`. Parameters
 calculated from expressions are not written separately because ChemEx
 reconstructs them from the independent parameters and model. `inputs/` contains
-lightweight copies of the user-provided experiment, parameter, and method TOML
-files. Raw experimental data files are not copied.
+byte copies of the user-provided experiment, parameter, and method TOML files as
+captured for the run. Raw experimental data files are not copied.
 
 `outcome.toml` is the lifecycle marker for the current invocation. It has
 `schema_version = 1` and a `status` of `running`, `complete`, or `incomplete`.
@@ -69,7 +70,11 @@ report that invocation as complete.
 
 ### `Parameters/`
 
-Contains results of the fitting as three files: `fitted.toml`, `fixed.toml`, and `constrained.toml`, which list parameters that were fitted, fixed, and constrained, respectively.
+Contains result reports as three files: `fitted.toml`, `fixed.toml`, and
+`constrained.toml`, which list parameters that were fitted, fixed, and
+constrained, respectively. These reports are not promised to form a complete,
+bound-preserving restart bundle; use `run_info/parameters_used.toml` when
+restarting or re-running a fit.
 
 #### Example Files
 
@@ -80,16 +85,19 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
 ```toml
 [GLOBAL]
-KEX_AB =  3.81511e+02 # ±8.90870e+00
-PB     =  7.02971e-02 # ±1.14784e-03
+KEX_AB =  3.81511e+02 # (error not calculated)
+PB     =  7.02971e-02 # (error not calculated)
 
 [DW_AB]
-15N =  2.00075e+00 # ±2.30817e-02
-31N =  1.98968e+00 # ±1.90842e-02
+15N =  2.00075e+00 # (error not calculated)
+31N =  1.98968e+00 # (error not calculated)
 ```
 
 :::note
-Uncertainties (if calculated) are shown as comments preceded by "±", based on the covariance matrix from the Levenberg-Marquardt optimization.
+Native deterministic fits do not automatically assign a generic standard error.
+When no family-qualified uncertainty is rendered here, fitted values are marked
+`(error not calculated)`. Resampling and MCMC uncertainty summaries are reported
+separately under `Statistics/` and are not copied into this generic comment.
 :::
 
 </TabItem>
@@ -106,12 +114,13 @@ Uncertainties (if calculated) are shown as comments preceded by "±", based on t
 
 ```toml
 [GLOBAL]
-KAB =  2.68192e+01 # ±3.06068e-01 ([KEX_AB] * [PB])
-KBA =  3.54692e+02 # ±8.28245e+00 ([KEX_AB] * [PA])
+KAB =  2.68192e+01 # ([KEX_AB] * [PB])
+KBA =  3.54692e+02 # ([KEX_AB] * [PA])
 ```
 
 :::note
-Propagated uncertainties and applied constraints are provided in comments.
+Applied constraints are provided in comments. Statistical interval widths are
+not attached as generic constrained-parameter errors.
 :::
 
 </TabItem>
@@ -179,3 +188,12 @@ autocorrelation estimates. Failed or interrupted MCMC suppresses every
 complete-chain product and leaves only an explicit incomplete diagnostic. These
 diagnostics are the best place to confirm that
 [`--workers`](multicore_execution.md) was applied as intended.
+
+MC, BS, and BSN `summary.toml` files describe their empirical fitted-sample
+distributions with the mean, median, standard deviation, 95% percentile bounds,
+68% percentile bounds, and `half_percentile_68_width`. MCMC summaries describe
+the posterior with the mean, median, standard deviation, 95% equal-tailed and
+68% credible-interval bounds, and `half_credible_interval_68_width`.
+`mcse_mean`, when available, is the Monte Carlo standard error of the estimated
+posterior mean; it is distinct from posterior interval width. None of these
+statistical summaries mutates the committed central fit.


### PR DESCRIPTION
## Summary

- replace misleading MC/BS/BSN interval fields with explicit 68% percentile names
- replace misleading MCMC interval fields with explicit 68% credible-interval names while retaining genuine `mcse_mean`
- keep native deterministic `Parameters/fitted.toml` errors unpopulated
- prove the existing schema-v1 restart and archived-input contracts through product tests
- correct output and method-file documentation and record the deliberate schema change

## Schema changes

MC, BS, and BSN:

- `lower_1sigma` -> `percentile_68_lower`
- `upper_1sigma` -> `percentile_68_upper`
- `stderr` -> `half_percentile_68_width`

MCMC:

- `lower_1sigma` -> `credible_interval_68_lower`
- `upper_1sigma` -> `credible_interval_68_upper`
- `stderr` -> `half_credible_interval_68_width`

`mcse_mean` remains the Monte Carlo standard error of the estimated posterior mean.

## Product contracts

- A real RELAXATION_HZNZ CLI fit was restarted using `run_info/parameters_used.toml`; the restarted fitted rate reproduced the original within the existing 5e-6 relative product tolerance.
- Experiment, parameter, and method TOMLs are tested as immutable byte copies after source mutation.
- Same-basename collision behavior remains deterministic, and `outcome.toml` coexists with the archive without changing schema-v1 `run.toml` semantics.
- Raw experimental data remain outside the archive.

## Validation

- Python 3.13 focused production/run-info/resampling/MCMC: 186 passed, one existing emcee warning
- Python 3.14 focused production/run-info: 55 passed, one dependency SyntaxWarning
- Python 3.14 final full suite: 1163 passed, one existing emcee warning
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `uv build`
- two-axis Standards/Spec review; all code findings addressed

## Scope

No output-path redesign, new restart/provenance schema, FORMAT_VERSION 2, `restart.toml`, generalized uncertainty object, or scientific fitting/sampling change is introduced.

Refs #613 and #657.

After merge, no frozen #613 removal blocker remains. The next frontier is the final #657 representative/no-lmfit removal matrix.
