### PR TITLE
Complete native product paths before lmfit dependency removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,13 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   and nested method forms. Native MCMC requires finite, strictly ordered bounds
   and rejects `UPDATE_PARAMETERS = true`; failed or interrupted chains publish
   incomplete diagnostics without summary, sample, correlation, or plot files.
-  Explicit legacy optimizer spellings without native statistics remain on their
-  compatibility path.
+  The public `FITMETHOD` surface is now closed to `trf`; omitted values default
+  to `trf`, and `least_squares` remains a temporary canonicalized alias. Legacy
+  and arbitrary optimizer spellings fail during method validation. Ordinary
+  filtering, revision-zero model/default resolution, simulation
+  back-calculation, and native fit publication no longer construct lmfit
+  parameter containers. `GRID` with `STATISTICS` keeps its warning and native
+  GRID-only compatibility behavior.
 
 ### Infrastructure
 - Removed the unused `B1FieldConfig` model and its `default_distribution_config`

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -6,7 +6,7 @@ from argparse import Namespace
 from collections.abc import Sequence
 
 from chemex.cli import build_parser
-from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.methods import Method, Methods, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
 from chemex.experiments.builder import build_experiments
@@ -20,7 +20,6 @@ from chemex.messages import (
 )
 from chemex.optimize.fitting import invalidate_planned_outputs, run_methods
 from chemex.optimize.helper import execute_simulation
-from chemex.optimize.native_deterministic import uses_native_deterministic
 from chemex.run_info import write_run_info, write_run_outcome
 from chemex.runtime import (
     AnalysisSession,
@@ -35,29 +34,18 @@ def run_fit(
     session: AnalysisSession,
     *,
     argv: Sequence[str] | None = None,
+    methods: Methods | None = None,
 ) -> None:
-    if args.method is not None:
-        print_reading_methods()
-        methods = read_methods(args.method)
-    else:
-        methods = {"": Method()}
+    if methods is None:
+        methods = _read_fit_methods(args)
 
     write_run_info(args, experiments, argv=argv)
 
     try:
         invalidate_planned_outputs(methods, args.output)
 
-        # Native statistics occurrences must fail closed before any lmfit value
-        # carrier can be constructed by the compatibility filter path.
-        native_statistics = any(
-            method.statistics is not None and uses_native_deterministic(method)
-            for method in methods.values()
-        )
-        if native_statistics:
-            resolved_values = session.resolve_current_values(experiments.param_ids)
-            experiments.filter_from_values(resolved_values)
-        else:
-            experiments.filter()
+        resolved_values = session.resolve_current_values(experiments.param_ids)
+        experiments.filter_from_values(resolved_values)
 
         print_start_fit()
         run_methods(
@@ -89,8 +77,21 @@ def run_sim(
     plot = args.plot == "normal"
 
     session.parameters.fix_all()
+    resolved_values = session.resolve_current_values(experiments.param_ids)
 
-    execute_simulation(experiments, path, plot=plot)
+    execute_simulation(
+        experiments,
+        path,
+        parameter_values=resolved_values,
+        plot=plot,
+    )
+
+
+def _read_fit_methods(args: Namespace) -> Methods:
+    if args.method is None:
+        return {"": Method()}
+    print_reading_methods()
+    return read_methods(args.method)
 
 
 def run(
@@ -124,16 +125,27 @@ def run(
         msg = "Experiments parameter store does not match the active session"
         raise ValueError(msg)
 
+    methods = _read_fit_methods(args) if args.commands == "fit" else None
+
     # Read initial values of fitting/fixed parameters
     print_reading_defaults()
     defaults = read_defaults(args.parameters)
     session.parameters.set_defaults(defaults)
-    session.try_build_analysis_values()
+    if not session.try_build_analysis_values():
+        construction_error = getattr(
+            session.parameter_factory,
+            "native_construction_error",
+            None,
+        )
+        msg = "Native parameter initialization failed"
+        if construction_error is None:
+            raise RuntimeError(msg)
+        raise RuntimeError(f"{msg}: {construction_error}") from construction_error
 
     if args.commands == "simulate":
         run_sim(args, experiments, session)
     else:
-        run_fit(args, experiments, session, argv=argv)
+        run_fit(args, experiments, session, argv=argv, methods=methods)
 
 
 def main() -> None:

--- a/src/chemex/configuration/methods.py
+++ b/src/chemex/configuration/methods.py
@@ -91,7 +91,7 @@ class Selection:
 
 class Method(BaseModel):
     model_config = ConfigDict(str_to_lower=True, extra="forbid")
-    fitmethod: str = "leastsq"
+    fitmethod: Literal["trf"] = "trf"
     include: SelectionType = None
     exclude: SelectionType = None
     fit: list[str] = Field(default_factory=list)
@@ -101,6 +101,21 @@ class Method(BaseModel):
     statistics: Statistics | None = None
 
     _key_to_lower = model_validator(mode="before")(key_to_lower)
+
+    @field_validator("fitmethod", mode="before")
+    @classmethod
+    def canonicalize_fitmethod(cls, value: object) -> object:
+        if isinstance(value, str):
+            normalized = value.lower()
+            if normalized == "least_squares":
+                return "trf"
+            if normalized == "trf":
+                return normalized
+        msg = (
+            "FITMETHOD supports only 'trf'; 'least_squares' is accepted as a "
+            "temporary alias"
+        )
+        raise ValueError(msg)
 
     @field_validator("include", "exclude", mode="before")
     @classmethod
@@ -136,6 +151,6 @@ def read_methods(filenames: Iterable[Path]) -> Methods:
             except ValidationError as error:
                 options = {option for err in error.errors() for option in err["loc"]}
                 print_method_error(filename, section, options)
-                sys.exit()
+                sys.exit(1)
             methods[section] = method
     return methods

--- a/src/chemex/containers/experiment.py
+++ b/src/chemex/containers/experiment.py
@@ -56,6 +56,14 @@ class Experiment:
     def residuals(self, params: ParametersLF) -> Array:
         return np.concatenate([profile.residuals(params) for profile in self.profiles])
 
+    def back_calculate_from_values(
+        self,
+        parameter_values: Mapping[str, float],
+    ) -> None:
+        """Publish calculated profile values from a native resolved mapping."""
+        for profile in self.profiles:
+            profile.calculate_from_values(parameter_values)
+
     def plot(self, output_stem: Path) -> None:
         self.plotter.plot(output_stem, self.profiles)
 

--- a/src/chemex/containers/experiments.py
+++ b/src/chemex/containers/experiments.py
@@ -162,9 +162,20 @@ class Experiments:
         params_lf = self.parameter_store.build_lmfit_params(self.param_ids)
         self.residuals(params_lf)
 
-    def prepare_for_simulation(self) -> None:
+    def back_calculate_from_values(
+        self,
+        parameter_values: Mapping[str, float],
+    ) -> None:
+        """Back calculate every selected profile from native resolved values."""
+        for experiment in self:
+            experiment.back_calculate_from_values(parameter_values)
+
+    def prepare_for_simulation(
+        self,
+        parameter_values: Mapping[str, float],
+    ) -> None:
         """Prepare each experiment in the collection for simulation."""
-        self.back_calculate()
+        self.back_calculate_from_values(parameter_values)
         for experiment in self:
             experiment.prepare_for_simulation()
 

--- a/src/chemex/containers/profile.py
+++ b/src/chemex/containers/profile.py
@@ -120,9 +120,16 @@ class Profile:
 
     def calculate(self, params: ParametersLF) -> Array:
         """Calculate and return the Array."""
-        self.data.calc_unscaled = self.calculate_unscaled(
+        return self.calculate_from_values(
             {param_id: params[param_id].value for param_id in self.param_ids}
         )
+
+    def calculate_from_values(
+        self,
+        parameter_values: Mapping[str, float],
+    ) -> Array:
+        """Calculate and publish data from resolved native parameter values."""
+        self.data.calc_unscaled = self.calculate_unscaled(parameter_values)
         if self.is_scaled:
             self.data.calc = self.data.scale * self.data.calc_unscaled
         else:

--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -217,32 +217,38 @@ def _identity(kind: str, record: object) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _semantic_value(value: object) -> object:
+def _semantic_value(value: object, *, allow_infinity: bool = False) -> object:
     """Encode finite scientific values without repr or runtime identity."""
     if value is None or isinstance(value, (bool, str)):
         return value
     if isinstance(value, Real):
         if isinstance(value, bool):
             return value
-        return {"binary64": _canonical_float(float(value))}
+        scalar = float(value)
+        if allow_infinity and math.isinf(scalar):
+            return {"infinity": "positive" if scalar > 0.0 else "negative"}
+        return {"binary64": _canonical_float(scalar)}
     if isinstance(value, np.ndarray):
         raw_values = cast("Any", value).tolist()
-        return _semantic_value(raw_values)
+        return _semantic_value(raw_values, allow_infinity=allow_infinity)
     if isinstance(value, Mapping):
         return {
-            str(key): _semantic_value(item)
+            str(key): _semantic_value(item, allow_infinity=allow_infinity)
             for key, item in sorted(value.items(), key=lambda item: str(item[0]))
         }
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-        return [_semantic_value(item) for item in value]
+        return [_semantic_value(item, allow_infinity=allow_infinity) for item in value]
     raise TypeError(
         f"Unsupported native scientific descriptor value: {type(value).__name__}"
     )
 
 
-def _semantic_json(value: object) -> str:
+def _semantic_json(value: object, *, allow_infinity: bool = False) -> str:
     return json.dumps(
-        _semantic_value(value), ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        _semantic_value(value, allow_infinity=allow_infinity),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
     )
 
 
@@ -250,7 +256,13 @@ def _kernel_configuration(profile: Profile) -> str:
     settings = getattr(profile.pulse_sequence, "settings", None)
     if not hasattr(settings, "model_dump"):
         raise ValueError("Native profile kernels must expose immutable settings")
-    return _semantic_json(settings.model_dump(mode="json"))
+    # Pulse settings may use infinity as an explicit configuration sentinel
+    # (for example, CEST's unbounded sweep width).  It is fingerprinted as a
+    # stable token here; evaluated values and observations remain finite-only.
+    return _semantic_json(
+        settings.model_dump(mode="json"),
+        allow_infinity=True,
+    )
 
 
 def _observation_metadata(profile: Profile) -> str:
@@ -878,7 +890,12 @@ def _validate_result_relationships(
             item.normalization_factor
         ) != _canonical_float(expected_factor):
             raise ValueError("Evaluation result has inconsistent normalization")
-        with np.errstate(all="raise"):
+        with np.errstate(
+            divide="raise",
+            over="raise",
+            under="ignore",
+            invalid="raise",
+        ):
             expected_normalized = item.normalization_factor * unscaled[start:stop]
             expected_residuals = (
                 normalized[start:stop][retained]
@@ -1787,7 +1804,12 @@ class BoundEvaluator:
         else:
             scale = 1.0
         try:
-            with np.errstate(all="raise"):
+            with np.errstate(
+                divide="raise",
+                over="raise",
+                under="ignore",
+                invalid="raise",
+            ):
                 normalized = _readonly(scale * unscaled)
                 residuals = _readonly(
                     (normalized[retained] - exp[retained]) / err[retained]
@@ -1972,7 +1994,12 @@ class BoundEvaluator:
             )
         self._in_flight = True
         try:
-            with np.errstate(all="raise"):
+            with np.errstate(
+                divide="raise",
+                over="raise",
+                under="ignore",
+                invalid="raise",
+            ):
                 return self._evaluate_impl(frame)
         except FloatingPointError as error:
             return self._failure(

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -621,30 +621,10 @@ def print_no_duplicate_warning(filename: Path) -> None:
 
 
 FITMETHOD_ERROR_MESSAGE = """\
-  - "FITMETHOD" must be one of:
-        "leastsq": Levenberg-Marquardt (default)
-        "least_squares": least-squares minimization (Trust Region Reflective method)
-        "differential_evolution": differential evolution
-        "brute": brute force method
-        "basinhopping": basinhopping
-        "ampgo": Adaptive Memory Programming for Global Optimization
-        "nelder": Nelder-Mead
-        "lbfgsb": L-BFGS-B
-        "powell": Powell
-        "cg": Conjugate-Gradient
-        "newton": Newton-CG
-        "cobyla": Cobyla
-        "bfgs": BFGS
-        "tnc": Truncated Newton
-        "trust-ncg": Newton-CG trust-region
-        "trust-exact": nearly exact trust-region
-        "trust-krylov": Newton GLTR trust-region
-        "trust-constr": trust-region for constrained optimization
-        "dogleg": Dog-leg trust-region
-        "slsqp": Sequential Linear Squares Programming
-        "emcee": Maximum likelihood via Monte-Carlo Markov Chain
-        "shgo": Simplicial Homology Global Optimization
-        "dual_annealing": Dual Annealing optimization"""
+  - "FITMETHOD" supports only "trf" (the default).
+    "least_squares" is accepted temporarily as an alias for "trf".
+    Historical optimizer names, including "leastsq" and
+    "differential_evolution", are not supported."""
 
 INCLUDE_ERROR_MESSAGE = """\
   - "INCLUDE" must be a list of nuclei to be included or '*' to select all the profiles.

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -228,8 +228,6 @@ def run_methods(
     *,
     session: AnalysisSession,
 ) -> None:
-    parameter_store = experiments.parameter_store
-
     for index, (section, method) in enumerate(methods.items(), start=1):
         if section:
             print_step_name(section, index, len(methods))
@@ -249,7 +247,10 @@ def run_methods(
         print_fitmethod(effective_method.fitmethod)
 
         # Update the parameter "vary" and "expr" status
-        parameter_store.set_parameter_status(effective_method)
+        session.apply_current_parameter_roles(
+            effective_method,
+            experiments.param_ids,
+        )
 
         path_sect = path / section if len(methods) > 1 else path
 

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -3,10 +3,9 @@
 import shutil
 from pathlib import Path
 
-from chemex.configuration.methods import Methods, Statistics
+from chemex.configuration.methods import Method, Methods, Statistics
 from chemex.containers.experiments import Experiments
 from chemex.messages import (
-    print_calculation_stopped_error,
     print_fitmethod,
     print_grid_statistic_warning,
     print_group_name,
@@ -16,7 +15,6 @@ from chemex.messages import (
     print_running_statistics,
     print_step_name,
 )
-from chemex.optimize.gridding import run_grid
 from chemex.optimize.grouping import create_groups
 from chemex.optimize.helper import (
     execute_post_fit,
@@ -29,7 +27,6 @@ from chemex.optimize.minimizer import (
 from chemex.optimize.native_deterministic import (
     NativeDeterministicFit,
     run_native_deterministic,
-    uses_native_deterministic,
 )
 from chemex.optimize.resampling import (
     run_native_resampling_statistics,
@@ -123,10 +120,17 @@ def _fit_groups(
         )
 
         parameter_store.update_from_parameters(best_lmfit_params)
+        residuals = group.experiments.residuals(best_lmfit_params)
+        nvarys = sum(
+            parameter.vary and not parameter.expr
+            for parameter in best_lmfit_params.values()
+        )
         execute_post_fit(
             group.experiments,
             group_path,
             plot=plot_flg,
+            residuals=residuals,
+            nvarys=nvarys,
         )
 
         # Run Monte Carlo and/or bootstrap analysis
@@ -139,7 +143,17 @@ def _fit_groups(
         )
 
     if len(groups) > 1:
-        execute_post_fit_groups(experiments, path, plot)
+        params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
+        execute_post_fit_groups(
+            experiments,
+            path,
+            plot,
+            residuals=experiments.residuals(params_lf),
+            nvarys=sum(
+                parameter.vary and not parameter.expr
+                for parameter in params_lf.values()
+            ),
+        )
 
 
 def _run_native_statistics(
@@ -227,56 +241,29 @@ def run_methods(
             print_no_data()
             continue
 
-        use_native_deterministic = uses_native_deterministic(method)
-        print_fitmethod("trf" if use_native_deterministic else method.fitmethod)
-
-        # Update the parameter "vary" and "expr" status
-        parameter_store.set_parameter_status(method)
-
+        effective_method: Method = method
         if method.grid and method.statistics:
             print_grid_statistic_warning()
-            method.statistics = None
+            effective_method = method.model_copy(update={"statistics": None})
+
+        print_fitmethod(effective_method.fitmethod)
+
+        # Update the parameter "vary" and "expr" status
+        parameter_store.set_parameter_status(effective_method)
 
         path_sect = path / section if len(methods) > 1 else path
 
-        if use_native_deterministic:
-            fit = run_native_deterministic(
-                experiments,
-                method,
-                path_sect,
-                plot_level,
-                session=session,
-            )
-            _run_requested_native_statistics(
-                experiments,
-                path_sect,
-                method.statistics,
-                fit,
-                session=session,
-            )
-            continue
-
-        if method.grid:
-            try:
-                run_grid(
-                    experiments,
-                    method.grid,
-                    path_sect,
-                    plot_level,
-                    method.fitmethod,
-                )
-            except KeyboardInterrupt:
-                print_calculation_stopped_error()
-                raise
-        else:
-            legacy_fitmethod = (
-                "least_squares" if method.fitmethod == "trf" else method.fitmethod
-            )
-            _fit_groups(
-                experiments,
-                path_sect,
-                plot_level,
-                legacy_fitmethod,
-                method.statistics,
-                execution=session.execution,
-            )
+        fit = run_native_deterministic(
+            experiments,
+            effective_method,
+            path_sect,
+            plot_level,
+            session=session,
+        )
+        _run_requested_native_statistics(
+            experiments,
+            path_sect,
+            effective_method.statistics,
+            fit,
+            session=session,
+        )

--- a/src/chemex/optimize/gridding.py
+++ b/src/chemex/optimize/gridding.py
@@ -280,7 +280,25 @@ def run_grid(
     plot_grid_1d(grids_1d, path / "Grid", parameter_store=parameter_store)
     plot_grid_2d(grids_2d, path / "Grid", parameter_store=parameter_store)
 
+    params_lf = parameter_store.build_lmfit_params(experiments.param_ids)
+    residuals = experiments.residuals(params_lf)
+    nvarys = sum(
+        parameter.vary and not parameter.expr for parameter in params_lf.values()
+    )
+
     if len(groups) > 1:
-        execute_post_fit_groups(experiments, path, plot)
+        execute_post_fit_groups(
+            experiments,
+            path,
+            plot,
+            residuals=residuals,
+            nvarys=nvarys,
+        )
     else:
-        execute_post_fit(experiments, path, plot=plot != "nothing")
+        execute_post_fit(
+            experiments,
+            path,
+            plot=plot != "nothing",
+            residuals=residuals,
+            nvarys=nvarys,
+        )

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 import numpy as np
@@ -60,19 +60,11 @@ def _write_statistics(
     experiments: Experiments,
     path: Path,
     *,
-    residuals: Array | None = None,
-    nvarys: int | None = None,
+    residuals: Array,
+    nvarys: int,
 ) -> None:
     """Write fitting statistics to a file."""
-    if residuals is None:
-        params_lf = experiments.parameter_store.build_lmfit_params(
-            experiments.param_ids
-        )
-        stats = calculate_statistics(experiments, params_lf)
-    else:
-        if nvarys is None:
-            raise ValueError("Native residual statistics require a variable count")
-        stats = calculate_statistics_from_residuals(residuals, nvarys)
+    stats = calculate_statistics_from_residuals(residuals, nvarys)
     filename = path / "statistics.toml"
     with filename.open("w", encoding="utf-8") as f:
         f.write(f'"number of data points"                = {stats["ndata"]}\n')
@@ -91,8 +83,8 @@ def _write_files(
     experiments: Experiments,
     path: Path,
     *,
-    residuals: Array | None = None,
-    nvarys: int | None = None,
+    residuals: Array,
+    nvarys: int,
 ) -> None:
     """Write the results of the fit to output files."""
     print_writing_results(path)
@@ -148,8 +140,8 @@ def execute_post_fit(
     path: Path,
     *,
     plot: bool = False,
-    residuals: Array | None = None,
-    nvarys: int | None = None,
+    residuals: Array,
+    nvarys: int,
 ) -> None:
     _write_files(experiments, path, residuals=residuals, nvarys=nvarys)
     if plot:
@@ -160,9 +152,10 @@ def execute_simulation(
     experiments: Experiments,
     path: Path,
     *,
+    parameter_values: Mapping[str, float],
     plot: bool = False,
 ) -> None:
-    experiments.prepare_for_simulation()
+    experiments.prepare_for_simulation(parameter_values)
     _write_simulation_files(experiments, path)
     if plot:
         _write_simulation_plots(experiments, path)
@@ -173,19 +166,11 @@ def execute_post_fit_groups(
     path: Path,
     plot: str,
     *,
-    residuals: Array | None = None,
-    nvarys: int | None = None,
+    residuals: Array,
+    nvarys: int,
 ) -> None:
     print_group_name("All groups")
-    if residuals is None:
-        params_lf = experiments.parameter_store.build_lmfit_params(
-            experiments.param_ids
-        )
-        statistics = calculate_statistics(experiments, params_lf)
-    else:
-        if nvarys is None:
-            raise ValueError("Native residual statistics require a variable count")
-        statistics = calculate_statistics_from_residuals(residuals, nvarys)
+    statistics = calculate_statistics_from_residuals(residuals, nvarys)
     print_chi2(statistics["chisqr"], statistics["redchi"])
     execute_post_fit(
         experiments,

--- a/src/chemex/optimize/method_step.py
+++ b/src/chemex/optimize/method_step.py
@@ -511,7 +511,14 @@ def _validate_recursive_dataclass_children(  # noqa: C901 - closed evidence tree
 
 def _semantic_method_record(method: Method) -> dict[str, object]:
     """Return the closed scientific/lifecycle Method fields used by #641."""
-    record = cast("dict[str, object]", method.model_dump(mode="json"))
+    # Profile selection has already been materialized in the evaluation plan,
+    # whose identity captures the selected profiles and observations.  Exclude
+    # the parsed SpinSystem objects here just as normalized method provenance
+    # does, avoiding a second and non-canonical serialization of that state.
+    record = cast(
+        "dict[str, object]",
+        method.model_dump(mode="json", exclude={"include", "exclude"}),
+    )
     statistics = record.get("statistics")
     if isinstance(statistics, dict):
         mcmc = statistics.get("mcmc")
@@ -527,6 +534,21 @@ def _operational_method_record(method: Method) -> dict[str, object]:
     return {
         "mcmc_workers": None if mcmc is None else mcmc.workers,
     }
+
+
+def _method_reconstruction_record(method: Method) -> dict[str, object]:
+    """Return validation input without serializing SpinSystem internals."""
+    record = cast(
+        "dict[str, object]",
+        method.model_dump(exclude={"include", "exclude"}, exclude_none=True),
+    )
+    for field_name in ("include", "exclude"):
+        selection = getattr(method, field_name)
+        if isinstance(selection, list):
+            record[field_name] = [str(item) for item in selection]
+        elif selection is not None:
+            record[field_name] = selection
+    return record
 
 
 def _direct_policy_semantics(invocation: DirectTrfInvocation) -> tuple[object, ...]:
@@ -1004,12 +1026,11 @@ def _validate_method_step_workflow(  # noqa: C901 - closed recursive workflow tr
     )
     _validate_rederived_identity(workflow.parameterization)
     try:
-        canonical_method = Method.model_validate(
-            workflow.method.model_dump(exclude_none=True)
-        )
+        method_record = _method_reconstruction_record(workflow.method)
+        canonical_method = Method.model_validate(method_record)
     except Exception as error:
         raise ValueError("Method-step Method integrity validation failed") from error
-    if canonical_method.model_dump() != workflow.method.model_dump():
+    if _method_reconstruction_record(canonical_method) != method_record:
         raise ValueError("Method-step Method integrity validation failed")
     try:
         restored_plan = type(workflow.engine.plan).from_record(

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -11,7 +11,11 @@ from chemex.configuration.methods import Method
 from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import EvaluationEngine, EvaluationResult
 from chemex.messages import print_group_name, print_minimizing
-from chemex.optimize.direct_trf import AcceptedFitResult, OptimizationProblem
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    DirectTrfInvocation,
+    OptimizationProblem,
+)
 from chemex.optimize.grid_direct_trf import GridDirectTrfInvocation
 from chemex.optimize.gridding import (
     GridResult,
@@ -23,6 +27,7 @@ from chemex.optimize.gridding import (
 from chemex.optimize.grouped_direct_trf import (
     FitDecomposition,
     GroupedDirectTrfInvocation,
+    GroupedDirectTrfOutcome,
 )
 from chemex.optimize.grouped_grid_direct_trf import GroupedGridDirectTrfOutcome
 from chemex.optimize.grouping import Group, create_groups
@@ -43,8 +48,10 @@ from chemex.parameters.parameterization import ActiveParameterization, Parameter
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
 
-# Match scipy.optimize.least_squares' default maximum when max_nfev is omitted.
-_TRF_EVALUATIONS_PER_COORDINATE = 100
+# Preserve the retained product's historical total objective-request ceiling.
+# lmfit's least_squares wrapper used 2000 * (nvars + 1) and counted numerical
+# Jacobian requests in that total.  Native Direct records the same total itself.
+_TRF_OBJECTIVE_REQUESTS_PER_DIMENSION = 2000
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,17 +71,17 @@ class NativeDeterministicFit:
 
 def uses_native_deterministic(method: Method) -> bool:
     """Return whether one whole method occurrence uses native TRF."""
-    if method.statistics is not None and method.statistics.mcmc is not None:
-        return not method.grid
-    if method.statistics is not None:
-        return not method.grid
-    if "fitmethod" not in method.model_fields_set:
-        return True
-    return method.fitmethod in {"trf", "least_squares"}
+    return method.fitmethod == "trf"
 
 
 def _objective_request_budget(problem: OptimizationProblem) -> int:
-    return _TRF_EVALUATIONS_PER_COORDINATE * max(1, len(problem.controlled_ids))
+    coordinate_count = max(1, len(problem.controlled_ids))
+    return _TRF_OBJECTIVE_REQUESTS_PER_DIMENSION * (coordinate_count + 1)
+
+
+def _product_x_scale(problem: OptimizationProblem) -> tuple[float, ...]:
+    """Scale native product coordinates without changing physical semantics."""
+    return tuple(max(1.0, abs(value)) for value in problem.start)
 
 
 def _has_controlled_parameters(parameterization: ActiveParameterization) -> bool:
@@ -154,12 +161,18 @@ def _build_invocation(
                 (param_id, tuple(values.tolist())) for param_id, values in grid.items()
             ),
             objective_request_budget=_objective_request_budget(problem),
+            x_scale=_product_x_scale(problem),
         )
         return MethodStepStrategy.GRID_DIRECT_TRF, invocation
-    invocation = GroupedDirectTrfInvocation.for_decomposition(
-        decomposition,
-        objective_request_budgets=tuple(
-            _objective_request_budget(component.problem)
+    invocation = GroupedDirectTrfInvocation(
+        decomposition.root_problem_identity,
+        decomposition.identity,
+        tuple(
+            DirectTrfInvocation.for_problem(
+                component.problem,
+                objective_request_budget=_objective_request_budget(component.problem),
+                x_scale=_product_x_scale(component.problem),
+            )
             for component in decomposition.components
         ),
     )
@@ -374,9 +387,28 @@ def run_native_deterministic(
     print_minimizing()
     outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
     if outcome.lifecycle is not MethodStepLifecycle.COMMITTED:
+        primary = outcome.primary_execution
+        failures = (
+            tuple(
+                (component.controlled_ids, component.failure)
+                for component in primary.components
+                if component.failure is not None
+            )
+            if isinstance(primary, GroupedDirectTrfOutcome)
+            else ()
+        )
+        detail = (
+            ""
+            if not failures
+            else ": "
+            + "; ".join(
+                f"{controlled_ids!r}: {failure.category}: {failure.message}"
+                for controlled_ids, failure in failures
+            )
+        )
         msg = (
             "Native deterministic fit did not commit: "
-            f"{outcome.primary_terminal or outcome.lifecycle.value}"
+            f"{outcome.primary_terminal or outcome.lifecycle.value}{detail}"
         )
         raise RuntimeError(msg)
 

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -69,11 +69,6 @@ class NativeDeterministicFit:
         return _objective_request_budget(self.problem)
 
 
-def uses_native_deterministic(method: Method) -> bool:
-    """Return whether one whole method occurrence uses native TRF."""
-    return method.fitmethod == "trf"
-
-
 def _objective_request_budget(problem: OptimizationProblem) -> int:
     coordinate_count = max(1, len(problem.controlled_ids))
     return _TRF_OBJECTIVE_REQUESTS_PER_DIMENSION * (coordinate_count + 1)

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -9,7 +9,7 @@ ensures physical validity of J couplings.
 import re
 import sys
 from collections import Counter, defaultdict
-from collections.abc import Hashable, Iterable, Sequence
+from collections.abc import Hashable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
@@ -566,6 +566,7 @@ class ParameterStore:
     _database: ParameterCatalog
     _database_mf: ParameterCatalog
     _defaults_applied: bool = field(default=False, init=False, repr=False)
+    _defaults: DefaultListType = field(default_factory=list, init=False, repr=False)
     _configuration_locked: bool = field(default=False, init=False, repr=False)
     _legacy_values_adapter: "LegacyValuesAdapter | None" = field(
         default=None,
@@ -703,19 +704,29 @@ class ParameterStore:
             msg = "Parameter defaults have already been applied"
             raise RuntimeError(msg)
         self._defaults_applied = False
+        self._defaults = list(defaults)
         self._database_mf.set_defaults(defaults)
 
         if self.model.model_free:
             self._defaults_applied = True
             return
 
-        params_mf = self._database_mf.build_lmfit_params(model_name=self.model.name)
-        self.database.set_values(params_mf.valuesdict())
-
         self.database.set_defaults(defaults)
 
         self.database.check_params()
         self._defaults_applied = True
+
+    def seed_from_model_free_values(self, values: Mapping[str, float]) -> None:
+        """Apply native model-free values before explicit ordinary defaults."""
+        self._ensure_configuration_open()
+        if self.model.model_free:
+            return
+        if not self._defaults_applied:
+            msg = "Parameter defaults must be parsed before model-free initialization"
+            raise RuntimeError(msg)
+        self._database.set_values(dict(values))
+        self._database.set_defaults(self._defaults)
+        self._database.check_params()
 
     def set_vary(self, section_names: Sequence[str], vary: bool) -> Counter[str]:
         """Set variability of parameters in the active catalog by section name.
@@ -770,6 +781,7 @@ class ParameterStore:
         self._database.clear()
         self._database_mf.clear()
         self._defaults_applied = False
+        self._defaults.clear()
         self._configuration_locked = False
 
 

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -126,11 +126,11 @@ class ParameterFactory:
 
     @property
     def native_construction_error(self) -> Exception | None:
-        """Return the failure that disabled the non-authoritative native candidate."""
+        """Return the failure that prevented native parameter construction."""
         return self._native_construction_error
 
     def disable_native_candidate(self, error: Exception) -> None:
-        """Record the first native failure without disturbing legacy construction."""
+        """Record the first native construction failure for fail-closed reporting."""
         if self._native_construction_error is None:
             self._native_construction_error = error
 
@@ -375,7 +375,7 @@ class ParameterFactory:
         )
 
     def try_seal_definitions(self) -> bool:
-        """Seal definitions without allowing the native candidate to veto legacy."""
+        """Attempt to seal definitions and retain the first construction failure."""
         if self._native_construction_error is not None:
             return False
         try:
@@ -386,7 +386,7 @@ class ParameterFactory:
         return True
 
     def try_seal_configuration(self) -> bool:
-        """Seal configuration without allowing the native candidate to veto legacy."""
+        """Attempt to seal configuration and retain the first construction failure."""
         if self._native_construction_error is not None:
             return False
         try:

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -89,6 +89,14 @@ class ParameterFactory:
         str,
         list[ParameterDeclarationContribution],
     ] = field(default_factory=dict)
+    _model_free_definition_contributions: dict[
+        str,
+        list[DefinitionContribution],
+    ] = field(default_factory=dict)
+    _model_free_declaration_contributions: dict[
+        str,
+        list[ParameterDeclarationContribution],
+    ] = field(default_factory=dict)
     _sealed_definitions: SealedDefinitions | None = field(default=None, repr=False)
     _sealed_configuration: SealedConfiguration | None = field(default=None, repr=False)
     _sealed_parameter_model: SealedParameterModel | None = field(
@@ -159,8 +167,12 @@ class ParameterFactory:
         parameters: Parameters,
         *,
         contributor: str,
+        contributions: dict[str, list[DefinitionContribution]] | None = None,
     ) -> None:
         """Extract ParamDefinition contributions from parameters before legacy merge."""
+        target = (
+            self._definition_contributions if contributions is None else contributions
+        )
         for param_id, param_setting in parameters.items():
             contribution = DefinitionContribution(
                 definition=ParamDefinition(
@@ -176,7 +188,7 @@ class ParameterFactory:
                 ),
                 contributor=contributor,
             )
-            self._definition_contributions.setdefault(param_id, []).append(contribution)
+            target.setdefault(param_id, []).append(contribution)
 
     def _collect_declarations(
         self,
@@ -184,7 +196,13 @@ class ParameterFactory:
         *,
         contributor: str,
         model_owned_ids: frozenset[str],
+        contributions: (
+            dict[str, list[ParameterDeclarationContribution]] | None
+        ) = None,
     ) -> None:
+        target = (
+            self._declaration_contributions if contributions is None else contributions
+        )
         for param_id, parameter in parameters.items():
             contribution = ParameterDeclarationContribution(
                 param_id=param_id,
@@ -193,9 +211,7 @@ class ParameterFactory:
                 contributor=contributor,
                 model_owned=param_id in model_owned_ids and bool(parameter.expr),
             )
-            self._declaration_contributions.setdefault(param_id, []).append(
-                contribution
-            )
+            target.setdefault(param_id, []).append(contribution)
 
     def create_parameters(
         self,
@@ -258,6 +274,23 @@ class ParameterFactory:
                     contributor=construction_context,
                     model_owned_ids=model_owned_ids,
                 )
+                if not self.parameter_store.model.model_free:
+                    model_free_owned_ids = frozenset(
+                        name_map_mf[name]
+                        for name in kinetic_names
+                        if name in name_map_mf
+                    )
+                    self._collect_definitions(
+                        parameters_mf,
+                        contributor=construction_context,
+                        contributions=self._model_free_definition_contributions,
+                    )
+                    self._collect_declarations(
+                        parameters_mf,
+                        contributor=construction_context,
+                        model_owned_ids=model_free_owned_ids,
+                        contributions=self._model_free_declaration_contributions,
+                    )
             except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
                 self._native_construction_error = error
 
@@ -318,6 +351,29 @@ class ParameterFactory:
             declarations=declarations,
         )
 
+    def build_model_free_parameter_model(self) -> SealedParameterModel | None:
+        """Build the native model-free bootstrap used by ordinary models."""
+        if self.parameter_store.model.model_free:
+            return None
+        definitions = canonicalize_definitions(
+            self._model_free_definition_contributions,
+        )
+        configuration = build_sealed_configuration(
+            definitions,
+            self.parameter_store._database_mf._parameters,
+        )
+        declarations = seal_parameter_declarations(
+            definitions,
+            self._model_free_declaration_contributions,
+        )
+        return SealedParameterModel(
+            model_name=self.parameter_store.model.name,
+            model_identity=self.parameter_store.model.identity,
+            definitions=definitions,
+            configuration=configuration,
+            declarations=declarations,
+        )
+
     def try_seal_definitions(self) -> bool:
         """Seal definitions without allowing the native candidate to veto legacy."""
         if self._native_construction_error is not None:
@@ -361,6 +417,8 @@ class ParameterFactory:
         self._settings_cache.clear()
         self._definition_contributions.clear()
         self._declaration_contributions.clear()
+        self._model_free_definition_contributions.clear()
+        self._model_free_declaration_contributions.clear()
         self._sealed_definitions = None
         self._sealed_configuration = None
         self._sealed_parameter_model = None

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -1,8 +1,8 @@
 """Immutable native parameter roles, constraints, and resolved scalar values.
 
-This module is a non-authoritative migration seam.  It compiles the currently
-supported method declarations beside the legacy lmfit path and never mutates
-parameter definitions, configuration, or committed Analysis Values.
+This module compiles active v1 method roles for authoritative native evaluation
+without mutating parameter definitions, configuration, or committed Analysis
+Values.
 """
 
 from __future__ import annotations

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -1017,6 +1017,32 @@ def _validate_model_derivation_authority(
             )
 
 
+def _validate_estimation_authority(
+    rules: Sequence[_RoleRule],
+    declarations: SealedParameterDeclarations,
+    active_ids: set[str],
+) -> None:
+    for rule in rules:
+        if rule.role is not ParameterRole.FIT:
+            continue
+        unsupported_matches = tuple(
+            param_id
+            for param_id in rule.matches
+            if param_id in active_ids
+            and declarations[param_id].model_expression
+            and not declarations[param_id].supports_estimation
+        )
+        if unsupported_matches:
+            raise IncompatibleParameterizationInputError(
+                "Method rule cannot estimate a parameter that lacks scientific "
+                "estimation support",
+                selector=rule.selector,
+                role=rule.role.value,
+                ordinal=rule.ordinal,
+                param_ids=unsupported_matches,
+            )
+
+
 def _replace_selectors(right: str) -> tuple[str, Mapping[str, str]]:
     selectors = _scan_selectors(right)
     replacements: dict[str, str] = {}
@@ -1598,6 +1624,7 @@ def compile_active_parameterization(
         binder,
         required,
     )
+    _validate_estimation_authority(rules, parameter_model.declarations, active)
     _validate_rules_in_active_scope(rules, active)
 
     scope_ids = tuple(

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -81,7 +81,7 @@ class AnalysisSession:
         self.model.reset()
 
     def try_build_analysis_values(self) -> bool:
-        """Seal configuration and initialize the non-authoritative native values."""
+        """Seal configuration and initialize authoritative native analysis values."""
         try:
             model_free_parameter_model = (
                 self.parameter_factory.build_model_free_parameter_model()

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -16,6 +16,7 @@ from chemex.parameters.factory import ParameterFactory
 from chemex.parameters.legacy_adapter import LegacyValuesAdapter
 from chemex.parameters.parameterization import (
     ActiveParameterization,
+    ModelDerivationOverrideError,
     build_initial_analysis_values,
     compile_active_parameterization,
 )
@@ -185,10 +186,18 @@ class AnalysisSession:
         constraints: list[str] = []
         for param_id, parameter in parameters.items():
             declaration = parameter_model.declarations[param_id]
-            if declaration.model_expression:
+            if declaration.model_owned:
+                if parameter.vary or parameter.expr != declaration.model_expression:
+                    raise ModelDerivationOverrideError(
+                        "Current parameter role cannot override a model-owned "
+                        "derivation",
+                        param_ids=(param_id,),
+                    )
                 continue
             selector = str(parameter.param_name)
             if parameter.expr:
+                if parameter.expr == declaration.model_expression:
+                    continue
                 expression = parameter.expr
                 for dependency in sorted(
                     parameter.dependencies,
@@ -198,7 +207,7 @@ class AnalysisSession:
                     dependency_name = parameters[dependency].param_name
                     expression = expression.replace(
                         dependency,
-                        f"[{dependency_name}]",
+                        str(dependency_name),
                     )
                 constraints.append(f"[{selector}] = {expression}")
             elif parameter.vary:
@@ -216,6 +225,15 @@ class AnalysisSession:
             effective_method,
             required_ids,
         )
+
+    def apply_current_parameter_roles(
+        self,
+        method: Method,
+        required_ids: set[str],
+    ) -> None:
+        """Validate explicit method intent, then update inherited v1 roles."""
+        self.compile_parameterization(method, required_ids)
+        self.parameters.set_parameter_status(method)
 
     def try_compile_parameterization(
         self,

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -81,6 +81,41 @@ class AnalysisSession:
 
     def try_build_analysis_values(self) -> bool:
         """Seal configuration and initialize the non-authoritative native values."""
+        try:
+            model_free_parameter_model = (
+                self.parameter_factory.build_model_free_parameter_model()
+            )
+            if model_free_parameter_model is not None:
+                model_free_values = AnalysisValues()
+                model_free_configuration = model_free_parameter_model.configuration
+                model_free_initial_values = (
+                    build_initial_analysis_values(model_free_parameter_model)
+                    if any(
+                        item.effective_value is None
+                        for item in model_free_configuration
+                    )
+                    else None
+                )
+                model_free_values.initialize(
+                    self.model.spec.identity,
+                    model_free_configuration,
+                    _native_initial_values=model_free_initial_values,
+                )
+                model_free_snapshot = model_free_values.snapshot()
+                model_free_parameterization = compile_active_parameterization(
+                    model_free_parameter_model,
+                    model_free_snapshot,
+                    Method(),
+                    set(model_free_parameter_model.declarations),
+                )
+                resolved_model_free_values = model_free_parameterization.resolve(
+                    model_free_parameterization.frame_from_snapshot(model_free_snapshot)
+                )
+                self.parameters.seed_from_model_free_values(resolved_model_free_values)
+        except Exception as error:  # noqa: BLE001 - native initialization boundary
+            self.parameter_factory.disable_native_candidate(error)
+            self.legacy_values_adapter.disable(error)
+            return False
         if not self.parameter_factory.try_seal_configuration():
             return False
         configuration = self.parameter_factory.sealed_configuration
@@ -102,6 +137,10 @@ class AnalysisSession:
                 configuration,
                 _native_initial_values=initial_values,
             )
+            resolved_values = self.resolve_current_values(
+                set(parameter_model.declarations)
+            )
+            self.sync_parameter_store_from_analysis_values(dict(resolved_values))
         except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
             self.parameter_factory.disable_native_candidate(error)
             self.legacy_values_adapter.disable(error)

--- a/tests/configuration/test_methods.py
+++ b/tests/configuration/test_methods.py
@@ -6,6 +6,30 @@ from pydantic import ValidationError
 from chemex.configuration.methods import Method, Statistics
 
 
+def test_fitmethod_defaults_to_canonical_trf() -> None:
+    method = Method()
+
+    assert method.fitmethod == "trf"
+
+
+@pytest.mark.parametrize("fitmethod", ("trf", "TRF", "least_squares"))
+def test_fitmethod_accepts_only_trf_surface_and_canonicalizes_alias(
+    fitmethod: str,
+) -> None:
+    method = Method.model_validate({"FITMETHOD": fitmethod})
+
+    assert method.fitmethod == "trf"
+
+
+@pytest.mark.parametrize(
+    "fitmethod",
+    ("leastsq", "differential_evolution", "nelder", "arbitrary"),
+)
+def test_fitmethod_rejects_legacy_and_arbitrary_spellings(fitmethod: str) -> None:
+    with pytest.raises(ValidationError, match="FITMETHOD supports only 'trf'"):
+        Method.model_validate({"FITMETHOD": fitmethod})
+
+
 def test_statistics_parse_mcmc_short_form() -> None:
     statistics = Statistics.model_validate({"MCMC": 5000})
 

--- a/tests/qualification/compare_lmfit_removal_pr1.py
+++ b/tests/qualification/compare_lmfit_removal_pr1.py
@@ -1,0 +1,448 @@
+"""Compare the four #657 native product cases with the frozen legacy outputs.
+
+This is intentionally a narrow reader for the immutable v1 anchor archive, not
+a revival of migration-core authority or gating.  Tolerances are declared in
+``CASES`` before any ChemEx process is started.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+ARCHIVE = ROOT / "tests/fixtures/migration_core_canonical_anchor_release_v1.tar.xz"
+FLOAT = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+UNCERTAINTY = re.compile(rf"±\s*(?P<value>{FLOAT})")
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackTolerance:
+    population_abs: float
+    shift_abs: float
+    relaxation_abs: float
+    rate_relative: float
+    other_relative: float
+    other_abs: float
+
+
+@dataclass(frozen=True, slots=True)
+class Case:
+    slug: str
+    attempt: str
+    example: Path
+    model: str
+    experiments: tuple[str, ...]
+    parameters: tuple[str, ...]
+    methods: tuple[str, ...]
+    fallback: FallbackTolerance
+
+
+# Frozen uncertainties remain the first choice.  These fallbacks cover values
+# for which the legacy report has no finite positive uncertainty: populations
+# are fractions, shifts are ppm, relaxation values are s^-1, and kinetic rates
+# span orders of magnitude.  CPMG/CEST use 1% rate/other relative tolerance;
+# binding and the more weakly conditioned three-state D-CEST case use 2%.
+CASES = (
+    Case(
+        "cpmg-15n-ip",
+        "96fdb5d9f0425b92a892e7ea784d95481ebeebbfa62655785b79fc1ef3a3ba4b",
+        ROOT / "examples/Experiments/CPMG_15N_IP",
+        "2st",
+        ("Experiments/*.toml",),
+        ("Parameters/parameters.toml",),
+        ("Methods/method.toml",),
+        FallbackTolerance(0.002, 0.01, 0.02, 0.01, 0.01, 1.0e-5),
+    ),
+    Case(
+        "cest-13c-label-cn",
+        "b2aa92f23ed505402bd9419b717c8a245f06ebd525d8ff8be11fce3465f2f614",
+        ROOT / "examples/Experiments/CEST_13C_LABEL_CN",
+        "2st",
+        ("Experiments/*.toml",),
+        ("Parameters/parameters.toml",),
+        ("Methods/method.toml",),
+        FallbackTolerance(0.002, 0.01, 0.02, 0.01, 0.01, 1.0e-5),
+    ),
+    Case(
+        "2st-binding",
+        "2c87cd4769195e59860646f380adb0d72fb05b6844b41c51e40969f922664b1a",
+        ROOT / "examples/Combinations/2stBinding",
+        "2st_binding",
+        ("Experiments/*.toml",),
+        ("Parameters/*.toml",),
+        ("Methods/*.toml",),
+        FallbackTolerance(0.003, 0.015, 0.03, 0.02, 0.02, 2.0e-5),
+    ),
+    Case(
+        "dcest-fifu-drd",
+        "714f523c0fedb5a4bc422ddfa51e0a1fbf45bcb2ecc81444e1ce0a70ba87fbb5",
+        ROOT / "examples/Experiments/DCEST_15N_3States",
+        "3st_fork",
+        ("Experiments/*.toml", "Experiments/DRD/*.toml"),
+        ("Parameters/parameters.toml",),
+        ("Methods/method.toml",),
+        FallbackTolerance(0.003, 0.015, 0.03, 0.02, 0.02, 2.0e-5),
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterValue:
+    identifier: tuple[str, str]
+    value: float
+    uncertainty: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class DataRow:
+    profile: str
+    masked: bool
+    values: tuple[float, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FitRow:
+    profile: str
+    coordinates: tuple[float, ...]
+
+
+def _members(archive: tarfile.TarFile, case: Case) -> dict[str, str]:
+    root = f"publisher/attempts/{case.attempt}/terminal/success"
+    manifest_file = archive.extractfile(f"{root}/manifest.json")
+    if manifest_file is None:
+        raise AssertionError(f"missing frozen manifest for {case.slug}")
+    manifest = json.load(manifest_file)
+    return {
+        member["role"].removeprefix("legacy-output:"): (
+            f"{root}/members/{member['content_hash']}"
+        )
+        for member in manifest["bundle"]["members"]
+        if member["role"].startswith("legacy-output:")
+    }
+
+
+def _read_member(archive: tarfile.TarFile, name: str) -> str:
+    file = archive.extractfile(name)
+    if file is None:
+        raise AssertionError(f"missing frozen member {name}")
+    return file.read().decode()
+
+
+def _comparable_paths(paths: set[str]) -> set[str]:
+    # The frozen reference intentionally omitted regenerated PDF and .exp plot
+    # companions.  Every retained frozen product path (including .fit curves
+    # and statistics) must otherwise match exactly; run_info is a newer extra.
+    return {
+        path
+        for path in paths
+        if "run_info" not in Path(path).parts
+        and Path(path).suffix not in {".exp", ".pdf"}
+    }
+
+
+def _data_rows(text: str) -> tuple[tuple[str, ...], tuple[DataRow, ...]]:
+    profiles: list[str] = []
+    rows: list[DataRow] = []
+    profile = ""
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            profile = line
+            profiles.append(line)
+            continue
+        masked = line.startswith("#") and "NOT USED IN THE FIT" in line
+        if line.startswith("#") and not masked:
+            continue
+        if not profile:
+            raise AssertionError("data row appears before its profile section")
+        numeric = line.removeprefix("#").split("#", 1)[0]
+        values = tuple(float(value) for value in numeric.split())
+        if not values or any(not math.isfinite(value) for value in values):
+            raise AssertionError(f"{profile}: data contains a non-finite value")
+        rows.append(DataRow(profile, masked, values))
+    return tuple(profiles), tuple(rows)
+
+
+def _parameter_values(text: str) -> tuple[ParameterValue, ...]:
+    section = ""
+    result: list[ParameterValue] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line
+            continue
+        key, separator, remainder = line.partition("=")
+        if not separator:
+            continue
+        value_text, _comment, comment = remainder.partition("#")
+        match = UNCERTAINTY.search(comment)
+        value = float(value_text.strip())
+        uncertainty = None if match is None else float(match.group("value"))
+        if not math.isfinite(value) or (
+            uncertainty is not None and not math.isfinite(uncertainty)
+        ):
+            raise AssertionError(f"{section} {key.strip()}: non-finite parameter data")
+        result.append(
+            ParameterValue(
+                (section, key.strip()),
+                value,
+                uncertainty,
+            )
+        )
+    return tuple(result)
+
+
+def _fit_schema(
+    text: str,
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[FitRow, ...]]:
+    profiles: list[str] = []
+    headers: list[str] = []
+    rows: list[FitRow] = []
+    profile = ""
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            profile = line
+            profiles.append(line)
+            continue
+        if line.startswith("#"):
+            headers.append(line)
+            continue
+        if not profile:
+            raise AssertionError("fit row appears before its profile section")
+        values = tuple(float(value) for value in line.split())
+        if len(values) < 2 or any(not math.isfinite(value) for value in values):
+            raise AssertionError(f"{profile}: fit curve has an invalid numeric row")
+        rows.append(FitRow(profile, values[:-1]))
+    return tuple(profiles), tuple(headers), tuple(rows)
+
+
+def _statistics_schema(text: str) -> tuple[tuple[str, str], ...]:
+    record = tomllib.loads(text)
+    return tuple((key, type(value).__name__) for key, value in record.items())
+
+
+def _compare_output_schema(path: str, legacy: str, native: str) -> None:
+    if path.endswith(".fit"):
+        if _fit_schema(native) != _fit_schema(legacy):
+            raise AssertionError(f"{path}: fit curve schema or row order differs")
+    elif Path(path).name == "statistics.toml":
+        if _statistics_schema(native) != _statistics_schema(legacy):
+            raise AssertionError(f"{path}: statistics schema differs")
+    else:
+        raise AssertionError(f"{path}: unsupported frozen output schema")
+
+
+def _fallback_limit(identifier: tuple[str, str], legacy: float, case: Case) -> float:
+    name = identifier[0].upper() + " " + identifier[1].upper()
+    parameter_name = identifier[1].upper()
+    policy = case.fallback
+    if re.fullmatch(r"P[A-Z]", parameter_name) or "POPULATION" in name:
+        return policy.population_abs
+    if "DW_" in name or "CS_" in name:
+        return policy.shift_abs
+    if any(token in name for token in ("R1_", "R2_", "R1A_", "R2A_")):
+        return policy.relaxation_abs
+    if any(token in name for token in ("KEX", "KAB", "KBA", "KAC", "KCA")):
+        return max(policy.other_abs, policy.rate_relative * abs(legacy))
+    return max(policy.other_abs, policy.other_relative * abs(legacy))
+
+
+def _compare_data(
+    path: str, legacy_text: str, native_text: str
+) -> tuple[float, str | None]:
+    legacy_profiles, legacy_rows = _data_rows(legacy_text)
+    native_profiles, native_rows = _data_rows(native_text)
+    if native_profiles != legacy_profiles:
+        raise AssertionError(f"{path}: selected profile order differs")
+    if len(native_rows) != len(legacy_rows):
+        raise AssertionError(f"{path}: selected data-point count differs")
+    worst_fraction = 0.0
+    worst_detail: str | None = None
+    for index, (legacy, native) in enumerate(
+        zip(legacy_rows, native_rows, strict=True)
+    ):
+        if (
+            native.profile != legacy.profile
+            or native.masked != legacy.masked
+            or len(legacy.values) < 4
+            or len(native.values) != len(legacy.values)
+        ):
+            raise AssertionError(f"{path}:{index}: data schema differs")
+        if native.values[:-1] != legacy.values[:-1]:
+            raise AssertionError(f"{path}:{index}: metadata/exp/error ordering differs")
+        limit = 0.1 * abs(legacy.values[-2])
+        difference = abs(native.values[-1] - legacy.values[-1])
+        if limit:
+            fraction = difference / limit
+            if fraction > worst_fraction:
+                worst_fraction = fraction
+                worst_detail = (
+                    f"{path}:{index}: calculated difference {difference} versus "
+                    f"0.1 * experimental error = {limit}"
+                )
+    return worst_fraction, worst_detail
+
+
+def _compare_parameters(
+    path: str,
+    legacy_text: str,
+    native_text: str,
+    case: Case,
+) -> tuple[float, str | None]:
+    legacy = _parameter_values(legacy_text)
+    native = _parameter_values(native_text)
+    if tuple(item.identifier for item in native) != tuple(
+        item.identifier for item in legacy
+    ):
+        raise AssertionError(f"{path}: parameter identifiers/order or roles differ")
+    worst_fraction = 0.0
+    worst_detail: str | None = None
+    for legacy_item, native_item in zip(legacy, native, strict=True):
+        uncertainty = legacy_item.uncertainty
+        limit = (
+            0.1 * uncertainty
+            if uncertainty is not None
+            and math.isfinite(uncertainty)
+            and uncertainty > 0.0
+            else _fallback_limit(legacy_item.identifier, legacy_item.value, case)
+        )
+        difference = abs(native_item.value - legacy_item.value)
+        if limit:
+            fraction = difference / limit
+            if fraction > worst_fraction:
+                worst_fraction = fraction
+                worst_detail = (
+                    f"{path}:{legacy_item.identifier}: parameter difference "
+                    f"{difference} versus limit {limit}"
+                )
+    return worst_fraction, worst_detail
+
+
+def _expand(case: Case, patterns: tuple[str, ...]) -> list[str]:
+    return [
+        str(path) for pattern in patterns for path in sorted(case.example.glob(pattern))
+    ]
+
+
+def _run_case(case: Case, output: Path) -> None:
+    if output.exists():
+        shutil.rmtree(output)
+    command = [
+        sys.executable,
+        "-m",
+        "chemex",
+        "fit",
+        "-e",
+        *_expand(case, case.experiments),
+        "-p",
+        *_expand(case, case.parameters),
+        "-m",
+        *_expand(case, case.methods),
+        "-d",
+        case.model,
+        "-o",
+        str(output),
+        "--workers",
+        "1",
+        "--native-threads",
+        "1",
+    ]
+    subprocess.run(command, cwd=case.example, check=True)  # noqa: S603
+
+
+def compare_case(
+    archive: tarfile.TarFile, case: Case, output: Path
+) -> dict[str, object]:
+    members = _members(archive, case)
+    expected = _comparable_paths(set(members))
+    actual = _comparable_paths(
+        {
+            path.relative_to(output).as_posix()
+            for path in output.rglob("*")
+            if path.is_file()
+        }
+    )
+    if actual != expected:
+        raise AssertionError(
+            f"{case.slug}: structured output paths differ; "
+            f"missing={sorted(expected - actual)!r}, unexpected={sorted(actual - expected)!r}"
+        )
+
+    worst_data_fraction = 0.0
+    worst_parameter_fraction = 0.0
+    worst_data_detail: str | None = None
+    worst_parameter_detail: str | None = None
+    for path in sorted(expected):
+        legacy = _read_member(archive, members[path])
+        native = (output / path).read_text(encoding="utf-8")
+        if path.endswith(".dat"):
+            fraction, detail = _compare_data(path, legacy, native)
+            if fraction > worst_data_fraction:
+                worst_data_fraction = fraction
+                worst_data_detail = detail
+        elif "Parameters" in Path(path).parts:
+            fraction, detail = _compare_parameters(path, legacy, native, case)
+            if fraction > worst_parameter_fraction:
+                worst_parameter_fraction = fraction
+                worst_parameter_detail = detail
+        else:
+            _compare_output_schema(path, legacy, native)
+    passed = worst_data_fraction <= 1.0 and worst_parameter_fraction <= 1.0
+    return {
+        "status": "PASS" if passed else "FAIL",
+        "comparable_output_path_count": len(expected),
+        "worst_calculated_fraction_of_limit": worst_data_fraction,
+        "worst_parameter_fraction_of_limit": worst_parameter_fraction,
+        "worst_calculated_comparison": worst_data_detail,
+        "worst_parameter_comparison": worst_parameter_detail,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive", type=Path, default=ARCHIVE)
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--run", action="store_true")
+    parser.add_argument(
+        "--case", choices=[case.slug for case in CASES], action="append"
+    )
+    args = parser.parse_args()
+    selected = tuple(case for case in CASES if not args.case or case.slug in args.case)
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    results: dict[str, dict[str, object]] = {}
+    with tarfile.open(args.archive, mode="r:xz") as archive:
+        for case in selected:
+            output = args.output_root / case.slug
+            if args.run:
+                _run_case(case, output)
+            try:
+                results[case.slug] = compare_case(archive, case, output)
+            except AssertionError as error:
+                results[case.slug] = {
+                    "status": "FAIL",
+                    "structural_failure": str(error),
+                }
+    print(json.dumps(results, indent=2, sort_keys=True))
+    if any(result["status"] != "PASS" for result in results.values()):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/qualification/compare_lmfit_removal_pr1.py
+++ b/tests/qualification/compare_lmfit_removal_pr1.py
@@ -95,7 +95,7 @@ CASES = (
     ),
 )
 
-# This is the one case-specific #657 disposition established by same-vector
+# This CEST case-specific #657 disposition was established by same-vector
 # cross-evaluation on Asterix.  It is deliberately not a tolerance waiver:
 # legacy-parity remains failed, while the independently diagnosed same objective
 # has a reproducible lower native basin.  The published statistics values below
@@ -163,6 +163,86 @@ _CEST_SIGNATURE_ABSOLUTE_LIMITS = {
     "legacy_l18cd1_chi_square": 0.01,
     "native_l18cd1_chi_square": 0.01,
 }
+
+# The repaired mixed CEST/CPMG parameterization restores all intended R2_B
+# coordinates.  The remaining eight-residue STEP2 difference was independently
+# shown on Asterix to be two stable basins of the same objective.  This scope is
+# exact and compactly generated so a new STEP1, residue, profile, or parameter
+# discrepancy cannot inherit the disposition.
+_BINDING_ACCEPTED_DIFFERENCE = {
+    "statistics_path": "STEP2/All/statistics.toml",
+    "published_legacy_chi_square": 37771.2,
+    "published_native_chi_square": 35802.6,
+    "diagnosed_legacy_chi_square": 37771.20405101328,
+    "diagnosed_native_chi_square": 35802.60988668793,
+}
+_BINDING_DIFFERENT_GROUPS = (
+    ("31_513N", "513N"),
+    ("59_551N", "551N"),
+    ("63_555N", "555N"),
+    ("66_558N", "558N"),
+    ("67_559N", "559N"),
+    ("68_560N", "560N"),
+    ("74_571N", "571N"),
+    ("75_572N", "572N"),
+)
+_BINDING_DATASETS = (
+    "cest_10hz_10p_1",
+    "cest_10hz_10p_2",
+    "cest_20hz_10p",
+    "cpmg_10p",
+    "cpmg_13p",
+    "cpmg_3p",
+    "cpmg_6p",
+)
+_BINDING_PARAMETER_FAILURES = {
+    residue: {
+        "constrained.toml": (
+            ('["R1_B, B0->800.0MHZ"]', "[CS_B]") if residue != "572N" else ("[CS_B]",)
+        ),
+        "fitted.toml": (
+            (
+                '["R1_A, B0->800.0MHZ"]',
+                '["R2_A, B0->800.0MHZ"]',
+                '["R2_B, B0->800.0MHZ"]',
+                "[DW_AB]",
+            )
+            if residue != "572N"
+            else ('["R2_B, B0->800.0MHZ"]', "[DW_AB]")
+        ),
+    }
+    for _group, residue in _BINDING_DIFFERENT_GROUPS
+}
+_BINDING_ACCEPTED_FAILURE_SCOPE = frozenset(
+    {
+        f"data:{root}/Data/{dataset}.dat:[{residue}]"
+        for group, residue in _BINDING_DIFFERENT_GROUPS
+        for root in ("STEP2/All", f"STEP2/Groups/{group}")
+        for dataset in _BINDING_DATASETS
+    }
+    | {
+        f"parameter:{root}/Parameters/{filename}:{(identifier, residue)!r}"
+        for group, residue in _BINDING_DIFFERENT_GROUPS
+        for root in ("STEP2/All", f"STEP2/Groups/{group}")
+        for filename, identifiers in _BINDING_PARAMETER_FAILURES[residue].items()
+        for identifier in identifiers
+    }
+)
+_BINDING_ACCEPTED_NUMERICAL_SIGNATURE = {
+    "legacy_513n_r2_b": 6.59550,
+    "native_513n_r2_b": 3.42548,
+    "legacy_513n_dw_ab": -0.0720231,
+    "native_513n_dw_ab": 0.0749041,
+    "legacy_560n_r2_b": 3.51575,
+    "native_560n_r2_b": 5.25795,
+    "legacy_560n_dw_ab": 0.0737021,
+    "native_560n_dw_ab": -0.0605078,
+}
+# These limits fingerprint product-output rounding only.  They do not alter the
+# original parameter/data parity tolerances, which continue to fail.
+_BINDING_SIGNATURE_ABSOLUTE_LIMITS = dict.fromkeys(
+    _BINDING_ACCEPTED_NUMERICAL_SIGNATURE, 0.001
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -316,30 +396,84 @@ def _comparison_disposition(
 ) -> dict[str, object]:
     if parity_passed:
         return {"status": "PASS_PARITY"}
-    if case.slug != "cest-13c-label-cn":
+    if case.slug == "cest-13c-label-cn":
+        path = str(_CEST_ACCEPTED_DIFFERENCE["statistics_path"])
+        observed = published_chi_squares.get(path)
+        expected = (
+            float(_CEST_ACCEPTED_DIFFERENCE["published_legacy_chi_square"]),
+            float(_CEST_ACCEPTED_DIFFERENCE["published_native_chi_square"]),
+        )
+        signature_matches = numerical_signature.keys() == (
+            _CEST_ACCEPTED_NUMERICAL_SIGNATURE.keys()
+        ) and all(
+            math.isclose(
+                numerical_signature[name],
+                expected_value,
+                rel_tol=0.0,
+                abs_tol=_CEST_SIGNATURE_ABSOLUTE_LIMITS[name],
+            )
+            for name, expected_value in _CEST_ACCEPTED_NUMERICAL_SIGNATURE.items()
+        )
+        if (
+            observed != expected
+            or parity_failure_scope != _CEST_ACCEPTED_FAILURE_SCOPE
+            or not signature_matches
+        ):
+            return {"status": "FAIL"}
+        return {
+            "status": "ACCEPTED_DIFFERENCE",
+            "parity_status": "FAIL",
+            "objective_semantics_parity": "PASS",
+            "observed_numerical_signature": numerical_signature,
+            "disposition": (
+                "Frozen legacy observation is not the normative optimum; native and "
+                "legacy evaluate the same objective, and native TRF reproducibly "
+                "reaches the lower accepted basin."
+            ),
+            "diagnosed_legacy_chi_square": _CEST_ACCEPTED_DIFFERENCE[
+                "diagnosed_legacy_chi_square"
+            ],
+            "diagnosed_native_chi_square": _CEST_ACCEPTED_DIFFERENCE[
+                "diagnosed_native_chi_square"
+            ],
+            "diagnosed_legacy_l18cd1_chi_square": _CEST_ACCEPTED_DIFFERENCE[
+                "diagnosed_legacy_l18cd1_chi_square"
+            ],
+            "diagnosed_native_l18cd1_chi_square": _CEST_ACCEPTED_DIFFERENCE[
+                "diagnosed_native_l18cd1_chi_square"
+            ],
+        }
+    if case.slug != "2st-binding":
         return {"status": "FAIL"}
 
-    path = str(_CEST_ACCEPTED_DIFFERENCE["statistics_path"])
+    path = str(_BINDING_ACCEPTED_DIFFERENCE["statistics_path"])
     observed = published_chi_squares.get(path)
     expected = (
-        float(_CEST_ACCEPTED_DIFFERENCE["published_legacy_chi_square"]),
-        float(_CEST_ACCEPTED_DIFFERENCE["published_native_chi_square"]),
+        float(_BINDING_ACCEPTED_DIFFERENCE["published_legacy_chi_square"]),
+        float(_BINDING_ACCEPTED_DIFFERENCE["published_native_chi_square"]),
     )
     signature_matches = numerical_signature.keys() == (
-        _CEST_ACCEPTED_NUMERICAL_SIGNATURE.keys()
+        _BINDING_ACCEPTED_NUMERICAL_SIGNATURE.keys()
     ) and all(
         math.isclose(
             numerical_signature[name],
             expected_value,
             rel_tol=0.0,
-            abs_tol=_CEST_SIGNATURE_ABSOLUTE_LIMITS[name],
+            abs_tol=_BINDING_SIGNATURE_ABSOLUTE_LIMITS[name],
         )
-        for name, expected_value in _CEST_ACCEPTED_NUMERICAL_SIGNATURE.items()
+        for name, expected_value in _BINDING_ACCEPTED_NUMERICAL_SIGNATURE.items()
+    )
+    diagnosed_legacy = float(
+        _BINDING_ACCEPTED_DIFFERENCE["diagnosed_legacy_chi_square"]
+    )
+    diagnosed_native = float(
+        _BINDING_ACCEPTED_DIFFERENCE["diagnosed_native_chi_square"]
     )
     if (
         observed != expected
-        or parity_failure_scope != _CEST_ACCEPTED_FAILURE_SCOPE
+        or parity_failure_scope != _BINDING_ACCEPTED_FAILURE_SCOPE
         or not signature_matches
+        or diagnosed_native >= diagnosed_legacy
     ):
         return {"status": "FAIL"}
     return {
@@ -350,20 +484,10 @@ def _comparison_disposition(
         "disposition": (
             "Frozen legacy observation is not the normative optimum; native and "
             "legacy evaluate the same objective, and native TRF reproducibly reaches "
-            "the lower accepted basin."
+            "the lower accepted STEP2 basin."
         ),
-        "diagnosed_legacy_chi_square": _CEST_ACCEPTED_DIFFERENCE[
-            "diagnosed_legacy_chi_square"
-        ],
-        "diagnosed_native_chi_square": _CEST_ACCEPTED_DIFFERENCE[
-            "diagnosed_native_chi_square"
-        ],
-        "diagnosed_legacy_l18cd1_chi_square": _CEST_ACCEPTED_DIFFERENCE[
-            "diagnosed_legacy_l18cd1_chi_square"
-        ],
-        "diagnosed_native_l18cd1_chi_square": _CEST_ACCEPTED_DIFFERENCE[
-            "diagnosed_native_l18cd1_chi_square"
-        ],
+        "diagnosed_legacy_chi_square": diagnosed_legacy,
+        "diagnosed_native_chi_square": diagnosed_native,
     }
 
 
@@ -409,6 +533,44 @@ def _cest_numerical_signature(
             ("native", native_values),
         )
     }
+
+
+def _binding_numerical_signature(
+    path: str,
+    legacy: str,
+    native: str,
+) -> dict[str, float]:
+    if path != "STEP2/All/Parameters/fitted.toml":
+        return {}
+    legacy_values = {item.identifier: item.value for item in _parameter_values(legacy)}
+    native_values = {item.identifier: item.value for item in _parameter_values(native)}
+    identifiers = {
+        "513n_r2_b": ('["R2_B, B0->800.0MHZ"]', "513N"),
+        "513n_dw_ab": ("[DW_AB]", "513N"),
+        "560n_r2_b": ('["R2_B, B0->800.0MHZ"]', "560N"),
+        "560n_dw_ab": ("[DW_AB]", "560N"),
+    }
+    return {
+        f"{implementation}_{name}": values[identifier]
+        for name, identifier in identifiers.items()
+        for implementation, values in (
+            ("legacy", legacy_values),
+            ("native", native_values),
+        )
+    }
+
+
+def _case_numerical_signature(
+    case: Case,
+    path: str,
+    legacy: str,
+    native: str,
+) -> dict[str, float]:
+    if case.slug == "cest-13c-label-cn":
+        return _cest_numerical_signature(path, legacy, native)
+    if case.slug == "2st-binding":
+        return _binding_numerical_signature(path, legacy, native)
+    return {}
 
 
 def _compare_output_schema(path: str, legacy: str, native: str) -> None:
@@ -577,20 +739,18 @@ def compare_case(
         if path.endswith(".dat"):
             fraction, detail, failures = _compare_data(path, legacy, native)
             parity_failure_scope.update(failures)
-            if case.slug == "cest-13c-label-cn":
-                numerical_signature.update(
-                    _cest_numerical_signature(path, legacy, native)
-                )
+            numerical_signature.update(
+                _case_numerical_signature(case, path, legacy, native)
+            )
             if fraction > worst_data_fraction:
                 worst_data_fraction = fraction
                 worst_data_detail = detail
         elif "Parameters" in Path(path).parts:
             fraction, detail, failures = _compare_parameters(path, legacy, native, case)
             parity_failure_scope.update(failures)
-            if case.slug == "cest-13c-label-cn":
-                numerical_signature.update(
-                    _cest_numerical_signature(path, legacy, native)
-                )
+            numerical_signature.update(
+                _case_numerical_signature(case, path, legacy, native)
+            )
             if fraction > worst_parameter_fraction:
                 worst_parameter_fraction = fraction
                 worst_parameter_detail = detail

--- a/tests/qualification/compare_lmfit_removal_pr1.py
+++ b/tests/qualification/compare_lmfit_removal_pr1.py
@@ -95,6 +95,75 @@ CASES = (
     ),
 )
 
+# This is the one case-specific #657 disposition established by same-vector
+# cross-evaluation on Asterix.  It is deliberately not a tolerance waiver:
+# legacy-parity remains failed, while the independently diagnosed same objective
+# has a reproducible lower native basin.  The published statistics values below
+# are exact at ChemEx's output precision and prevent this disposition from
+# accepting an unrelated future numerical change.
+_CEST_ACCEPTED_DIFFERENCE = {
+    "statistics_path": "STEP2/All/statistics.toml",
+    "published_legacy_chi_square": 3140.90,
+    "published_native_chi_square": 2849.45,
+    "diagnosed_legacy_chi_square": 3140.903510372318,
+    "diagnosed_native_chi_square": 2849.4551945314374,
+    "diagnosed_legacy_l18cd1_chi_square": 1093.424072389286,
+    "diagnosed_native_l18cd1_chi_square": 801.9806529406368,
+}
+_CEST_ACCEPTED_FAILURE_SCOPE = frozenset(
+    {
+        "data:STEP2/All/Data/23hz.dat:[L18CD1]",
+        "data:STEP2/Groups/3_L18CD1/Data/23hz.dat:[L18CD1]",
+        *(
+            f"parameter:{root}/constrained.toml:{identifier!r}"
+            for root in (
+                "STEP2/All/Parameters",
+                "STEP2/Groups/3_L18CD1/Parameters",
+            )
+            for identifier in (
+                ('["R1_B, B0->598.8MHZ"]', "L18CD1"),
+                ('["R2_B, B0->598.8MHZ"]', "L18CD1"),
+                ("[CS_B]", "L18CD1"),
+            )
+        ),
+        *(
+            f"parameter:{root}/fitted.toml:{identifier!r}"
+            for root in (
+                "STEP2/All/Parameters",
+                "STEP2/Groups/3_L18CD1/Parameters",
+            )
+            for identifier in (
+                ('["R1_A, B0->598.8MHZ"]', "L18CD1"),
+                ('["R2_A, B0->598.8MHZ"]', "L18CD1"),
+                ("[CS_A]", "L18CD1"),
+                ("[DW_AB]", "L18CD1"),
+            )
+        ),
+    }
+)
+_CEST_ACCEPTED_NUMERICAL_SIGNATURE = {
+    "legacy_cs_a": 24.9724,
+    "native_cs_a": 24.9288,
+    "legacy_dw_ab": -0.142414,
+    "native_dw_ab": 0.193203,
+    "legacy_cs_b": 24.8300,
+    "native_cs_b": 25.1220,
+    "legacy_l18cd1_chi_square": 1093.424158056536,
+    "native_l18cd1_chi_square": 801.9787254040632,
+}
+# These identify the diagnosed basin at product-output precision; they do not
+# relax or replace any legacy-parity tolerance declared in ``CASES``.
+_CEST_SIGNATURE_ABSOLUTE_LIMITS = {
+    "legacy_cs_a": 0.001,
+    "native_cs_a": 0.001,
+    "legacy_dw_ab": 0.001,
+    "native_dw_ab": 0.001,
+    "legacy_cs_b": 0.001,
+    "native_cs_b": 0.001,
+    "legacy_l18cd1_chi_square": 0.01,
+    "native_l18cd1_chi_square": 0.01,
+}
+
 
 @dataclass(frozen=True, slots=True)
 class ParameterValue:
@@ -238,6 +307,110 @@ def _statistics_schema(text: str) -> tuple[tuple[str, str], ...]:
     return tuple((key, type(value).__name__) for key, value in record.items())
 
 
+def _comparison_disposition(
+    case: Case,
+    parity_passed: bool,
+    published_chi_squares: dict[str, tuple[float, float]],
+    parity_failure_scope: frozenset[str],
+    numerical_signature: dict[str, float],
+) -> dict[str, object]:
+    if parity_passed:
+        return {"status": "PASS_PARITY"}
+    if case.slug != "cest-13c-label-cn":
+        return {"status": "FAIL"}
+
+    path = str(_CEST_ACCEPTED_DIFFERENCE["statistics_path"])
+    observed = published_chi_squares.get(path)
+    expected = (
+        float(_CEST_ACCEPTED_DIFFERENCE["published_legacy_chi_square"]),
+        float(_CEST_ACCEPTED_DIFFERENCE["published_native_chi_square"]),
+    )
+    signature_matches = numerical_signature.keys() == (
+        _CEST_ACCEPTED_NUMERICAL_SIGNATURE.keys()
+    ) and all(
+        math.isclose(
+            numerical_signature[name],
+            expected_value,
+            rel_tol=0.0,
+            abs_tol=_CEST_SIGNATURE_ABSOLUTE_LIMITS[name],
+        )
+        for name, expected_value in _CEST_ACCEPTED_NUMERICAL_SIGNATURE.items()
+    )
+    if (
+        observed != expected
+        or parity_failure_scope != _CEST_ACCEPTED_FAILURE_SCOPE
+        or not signature_matches
+    ):
+        return {"status": "FAIL"}
+    return {
+        "status": "ACCEPTED_DIFFERENCE",
+        "parity_status": "FAIL",
+        "objective_semantics_parity": "PASS",
+        "observed_numerical_signature": numerical_signature,
+        "disposition": (
+            "Frozen legacy observation is not the normative optimum; native and "
+            "legacy evaluate the same objective, and native TRF reproducibly reaches "
+            "the lower accepted basin."
+        ),
+        "diagnosed_legacy_chi_square": _CEST_ACCEPTED_DIFFERENCE[
+            "diagnosed_legacy_chi_square"
+        ],
+        "diagnosed_native_chi_square": _CEST_ACCEPTED_DIFFERENCE[
+            "diagnosed_native_chi_square"
+        ],
+        "diagnosed_legacy_l18cd1_chi_square": _CEST_ACCEPTED_DIFFERENCE[
+            "diagnosed_legacy_l18cd1_chi_square"
+        ],
+        "diagnosed_native_l18cd1_chi_square": _CEST_ACCEPTED_DIFFERENCE[
+            "diagnosed_native_l18cd1_chi_square"
+        ],
+    }
+
+
+def _profile_chi_square(text: str, profile: str) -> float:
+    _profiles, rows = _data_rows(text)
+    return sum(
+        ((row.values[-1] - row.values[-3]) / row.values[-2]) ** 2
+        for row in rows
+        if row.profile == profile and not row.masked
+    )
+
+
+def _cest_numerical_signature(
+    path: str,
+    legacy: str,
+    native: str,
+) -> dict[str, float]:
+    if path == "STEP2/All/Data/23hz.dat":
+        return {
+            "legacy_l18cd1_chi_square": _profile_chi_square(legacy, "[L18CD1]"),
+            "native_l18cd1_chi_square": _profile_chi_square(native, "[L18CD1]"),
+        }
+    if path not in {
+        "STEP2/All/Parameters/fitted.toml",
+        "STEP2/All/Parameters/constrained.toml",
+    }:
+        return {}
+    legacy_values = {item.identifier: item.value for item in _parameter_values(legacy)}
+    native_values = {item.identifier: item.value for item in _parameter_values(native)}
+    identifiers = (
+        {
+            "cs_a": ("[CS_A]", "L18CD1"),
+            "dw_ab": ("[DW_AB]", "L18CD1"),
+        }
+        if path.endswith("fitted.toml")
+        else {"cs_b": ("[CS_B]", "L18CD1")}
+    )
+    return {
+        f"{implementation}_{name}": values[identifier]
+        for name, identifier in identifiers.items()
+        for implementation, values in (
+            ("legacy", legacy_values),
+            ("native", native_values),
+        )
+    }
+
+
 def _compare_output_schema(path: str, legacy: str, native: str) -> None:
     if path.endswith(".fit"):
         if _fit_schema(native) != _fit_schema(legacy):
@@ -266,7 +439,7 @@ def _fallback_limit(identifier: tuple[str, str], legacy: float, case: Case) -> f
 
 def _compare_data(
     path: str, legacy_text: str, native_text: str
-) -> tuple[float, str | None]:
+) -> tuple[float, str | None, frozenset[str]]:
     legacy_profiles, legacy_rows = _data_rows(legacy_text)
     native_profiles, native_rows = _data_rows(native_text)
     if native_profiles != legacy_profiles:
@@ -275,6 +448,7 @@ def _compare_data(
         raise AssertionError(f"{path}: selected data-point count differs")
     worst_fraction = 0.0
     worst_detail: str | None = None
+    failures: set[str] = set()
     for index, (legacy, native) in enumerate(
         zip(legacy_rows, native_rows, strict=True)
     ):
@@ -291,13 +465,15 @@ def _compare_data(
         difference = abs(native.values[-1] - legacy.values[-1])
         if limit:
             fraction = difference / limit
+            if fraction > 1.0:
+                failures.add(f"data:{path}:{legacy.profile}")
             if fraction > worst_fraction:
                 worst_fraction = fraction
                 worst_detail = (
                     f"{path}:{index}: calculated difference {difference} versus "
                     f"0.1 * experimental error = {limit}"
                 )
-    return worst_fraction, worst_detail
+    return worst_fraction, worst_detail, frozenset(failures)
 
 
 def _compare_parameters(
@@ -305,7 +481,7 @@ def _compare_parameters(
     legacy_text: str,
     native_text: str,
     case: Case,
-) -> tuple[float, str | None]:
+) -> tuple[float, str | None, frozenset[str]]:
     legacy = _parameter_values(legacy_text)
     native = _parameter_values(native_text)
     if tuple(item.identifier for item in native) != tuple(
@@ -314,6 +490,7 @@ def _compare_parameters(
         raise AssertionError(f"{path}: parameter identifiers/order or roles differ")
     worst_fraction = 0.0
     worst_detail: str | None = None
+    failures: set[str] = set()
     for legacy_item, native_item in zip(legacy, native, strict=True):
         uncertainty = legacy_item.uncertainty
         limit = (
@@ -326,13 +503,15 @@ def _compare_parameters(
         difference = abs(native_item.value - legacy_item.value)
         if limit:
             fraction = difference / limit
+            if fraction > 1.0:
+                failures.add(f"parameter:{path}:{legacy_item.identifier!r}")
             if fraction > worst_fraction:
                 worst_fraction = fraction
                 worst_detail = (
                     f"{path}:{legacy_item.identifier}: parameter difference "
                     f"{difference} versus limit {limit}"
                 )
-    return worst_fraction, worst_detail
+    return worst_fraction, worst_detail, frozenset(failures)
 
 
 def _expand(case: Case, patterns: tuple[str, ...]) -> list[str]:
@@ -389,25 +568,50 @@ def compare_case(
     worst_parameter_fraction = 0.0
     worst_data_detail: str | None = None
     worst_parameter_detail: str | None = None
+    published_chi_squares: dict[str, tuple[float, float]] = {}
+    parity_failure_scope: set[str] = set()
+    numerical_signature: dict[str, float] = {}
     for path in sorted(expected):
         legacy = _read_member(archive, members[path])
         native = (output / path).read_text(encoding="utf-8")
         if path.endswith(".dat"):
-            fraction, detail = _compare_data(path, legacy, native)
+            fraction, detail, failures = _compare_data(path, legacy, native)
+            parity_failure_scope.update(failures)
+            if case.slug == "cest-13c-label-cn":
+                numerical_signature.update(
+                    _cest_numerical_signature(path, legacy, native)
+                )
             if fraction > worst_data_fraction:
                 worst_data_fraction = fraction
                 worst_data_detail = detail
         elif "Parameters" in Path(path).parts:
-            fraction, detail = _compare_parameters(path, legacy, native, case)
+            fraction, detail, failures = _compare_parameters(path, legacy, native, case)
+            parity_failure_scope.update(failures)
+            if case.slug == "cest-13c-label-cn":
+                numerical_signature.update(
+                    _cest_numerical_signature(path, legacy, native)
+                )
             if fraction > worst_parameter_fraction:
                 worst_parameter_fraction = fraction
                 worst_parameter_detail = detail
         else:
             _compare_output_schema(path, legacy, native)
+            if Path(path).name == "statistics.toml":
+                published_chi_squares[path] = (
+                    float(tomllib.loads(legacy)["chi-square"]),
+                    float(tomllib.loads(native)["chi-square"]),
+                )
     passed = worst_data_fraction <= 1.0 and worst_parameter_fraction <= 1.0
     return {
-        "status": "PASS" if passed else "FAIL",
+        **_comparison_disposition(
+            case,
+            passed,
+            published_chi_squares,
+            frozenset(parity_failure_scope),
+            numerical_signature,
+        ),
         "comparable_output_path_count": len(expected),
+        "parity_failure_scope": sorted(parity_failure_scope),
         "worst_calculated_fraction_of_limit": worst_data_fraction,
         "worst_parameter_fraction_of_limit": worst_parameter_fraction,
         "worst_calculated_comparison": worst_data_detail,
@@ -440,7 +644,8 @@ def main() -> None:
                     "structural_failure": str(error),
                 }
     print(json.dumps(results, indent=2, sort_keys=True))
-    if any(result["status"] != "PASS" for result in results.values()):
+    successful = {"PASS_PARITY", "ACCEPTED_DIFFERENCE"}
+    if any(result["status"] not in successful for result in results.values()):
         raise SystemExit(1)
 
 

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -103,6 +103,9 @@ class StubSession:
     ) -> None:
         return None
 
+    def resolve_current_values(self, _required_ids: set[str]) -> dict[str, float]:
+        return {}
+
 
 class WriterParameterStore:
     def __init__(self, parameters: dict[str, ParamSetting]) -> None:
@@ -141,6 +144,9 @@ class FakeExperiments:
         self.param_ids: set[str] = set()
 
     def filter(self) -> None:
+        self.filtered += 1
+
+    def filter_from_values(self, _values: object) -> None:
         self.filtered += 1
 
     def select(self, selection: Selection) -> None:
@@ -401,7 +407,7 @@ def test_run_uses_explicit_session_for_fit_flow(
     assert recorded["outcome"] == "complete"
 
 
-def test_run_continues_when_native_configuration_is_unavailable(
+def test_run_fails_closed_when_native_configuration_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = StubSession()
@@ -427,9 +433,10 @@ def test_run_continues_when_native_configuration_is_unavailable(
         lambda *_args, **_kwargs: None,
     )
 
-    chemex_module.run(make_args("fit"), session=session)
+    with pytest.raises(RuntimeError, match="Native parameter initialization failed"):
+        chemex_module.run(make_args("fit"), session=session)
 
-    assert fit_ran == [True]
+    assert fit_ran == []
     assert session.parameter_factory.seal_configuration_calls == 1
     assert session.build_analysis_values_calls == 1
 
@@ -455,9 +462,15 @@ def test_run_uses_explicit_session_for_simulation_flow(
         experiments_arg: FakeExperiments,
         path: Path,
         *,
+        parameter_values: object,
         plot: bool = False,
     ) -> None:
-        recorded["simulation"] = (experiments_arg, path, plot)
+        recorded["simulation"] = (
+            experiments_arg,
+            path,
+            parameter_values,
+            plot,
+        )
 
     monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
     monkeypatch.setattr(chemex_module, "read_defaults", lambda _filenames: defaults)
@@ -471,6 +484,7 @@ def test_run_uses_explicit_session_for_simulation_flow(
     np.testing.assert_equal(session.build_analysis_values_calls, 1)
     np.testing.assert_equal(session.parameters.fix_all_calls, 1)
     np.testing.assert_equal(recorded["build"][2], session)
+    assert recorded["simulation"] == (experiments, Path("Output"), {}, True)
 
 
 def test_run_rejects_experiments_built_under_a_different_session(
@@ -560,46 +574,6 @@ def test_main_dispatches_analysis_commands(monkeypatch: pytest.MonkeyPatch) -> N
     chemex_module.main()
 
     np.testing.assert_equal(calls, ["logo", "plugins", "run"])
-
-
-def test_run_methods_passes_execution_to_fit_groups(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = StubSession()
-    experiments = FakeExperiments(parameter_store=session.parameters)
-    recorded: dict[str, object] = {}
-
-    def fake_fit_groups(
-        experiments_arg: FakeExperiments,
-        path: Path,
-        plot: str,
-        fitmethod: str,
-        statistics: object,
-        *,
-        execution: ExecutionSettings | None = None,
-    ) -> None:
-        recorded["fit_groups"] = (
-            experiments_arg,
-            path,
-            plot,
-            fitmethod,
-            statistics,
-            execution,
-        )
-
-    monkeypatch.setattr(fitting_module, "_fit_groups", fake_fit_groups)
-
-    fitting_module.run_methods(
-        experiments,
-        {"": Method(fitmethod="leastsq")},
-        Path("Output"),
-        "normal",
-        session=session,
-    )
-
-    np.testing.assert_equal(len(experiments.selections), 1)
-    np.testing.assert_equal(len(session.parameters.status_calls), 1)
-    np.testing.assert_equal(recorded["fit_groups"][5], session.execution)
 
 
 def test_run_methods_skips_fit_when_selection_removes_all_profiles(
@@ -811,7 +785,12 @@ def test_execute_post_fit_writes_parameters_from_experiments_store(
         lambda *_args, **_kwargs: None,
     )
 
-    helper_module.execute_post_fit(experiments, tmp_path)
+    helper_module.execute_post_fit(
+        experiments,
+        tmp_path,
+        residuals=np.array([], dtype=float),
+        nvarys=0,
+    )
 
     np.testing.assert_equal(int((tmp_path / "Parameters" / "fixed.toml").exists()), 1)
 

--- a/tests/test_analysis_values.py
+++ b/tests/test_analysis_values.py
@@ -13,12 +13,13 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 from lmfit import Parameters as LmfitParameters
 
 from chemex import chemex as chemex_module
-from chemex.configuration.methods import Selection
+from chemex.configuration.methods import Method, Selection
 from chemex.configuration.parameters import read_defaults
 from chemex.experiments.builder import build_experiments
 from chemex.parameters.legacy_adapter import LegacyValuesAdapter
@@ -42,6 +43,8 @@ SHIPPED_PARAMETERS = (
     ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
 )
 SHIPPED_METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+CPMG_EXPERIMENT = ROOT / "examples/Experiments/CPMG_15N_IP/Experiments/500mhz.toml"
+CPMG_PARAMETERS = ROOT / "examples/Experiments/CPMG_15N_IP/Parameters/parameters.toml"
 
 
 def _configuration() -> SealedConfiguration:
@@ -69,6 +72,43 @@ def _build_shipped_session(
     session.parameters.set_defaults(read_defaults([SHIPPED_PARAMETERS]))
     assert session.try_build_analysis_values()
     return session
+
+
+def test_revision_zero_model_values_and_constraints_resolve_without_lmfit() -> None:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        [CPMG_EXPERIMENT],
+        Selection(include=[SpinSystem.from_name("15N-HN")], exclude=None),
+        session=session,
+    )
+
+    with patch(
+        "chemex.parameters.database.ParameterCatalog.build_lmfit_params",
+        side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+    ):
+        session.parameters.set_defaults(read_defaults([CPMG_PARAMETERS]))
+        assert session.try_build_analysis_values()
+        initial = session.resolve_current_values(experiments.param_ids)
+
+        session.parameters.set_parameter_status(
+            Method(constraints=["[PB] = [KEX_AB] / 10000.0"])
+        )
+        constrained = session.resolve_current_values(experiments.param_ids)
+
+    assert initial["__PB"] == pytest.approx(0.07)
+    assert initial["__PA"] == pytest.approx(0.93)
+    assert initial["__KAB"] == pytest.approx(28.0)
+    assert initial["__KBA"] == pytest.approx(372.0)
+    assert constrained["__PB"] == pytest.approx(0.04)
+    assert constrained["__PA"] == pytest.approx(0.96)
+    assert constrained["__KAB"] == pytest.approx(16.0)
+    assert constrained["__KBA"] == pytest.approx(384.0)
+
+    stored = session.parameters.get_parameters({"__PB", "__PA", "__KAB", "__KBA"})
+    assert stored["__PA"].value == pytest.approx(0.93)
+    assert stored["__KAB"].value == pytest.approx(28.0)
+    assert stored["__KBA"].value == pytest.approx(372.0)
 
 
 def _shipped_args(command: str, output: Path) -> Namespace:
@@ -422,12 +462,12 @@ def test_shipped_fit_is_native_authoritative_and_mirrors_committed_values(
     assert list((candidate_output / "Parameters").rglob("*.toml"))
 
 
-def test_shipped_simulation_survives_native_initialization_failure(
+def test_shipped_simulation_fails_closed_on_native_initialization_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     candidate_output = tmp_path / "candidate-enabled"
-    legacy_only_output = tmp_path / "legacy-only"
+    failed_output = tmp_path / "failed"
     session = AnalysisSession.create()
 
     chemex_module.run(_shipped_args("simulate", candidate_output), session=session)
@@ -445,20 +485,18 @@ def test_shipped_simulation_survives_native_initialization_failure(
 
     monkeypatch.setattr(AnalysisValues, "initialize", fail_native_initialization)
 
-    legacy_session = AnalysisSession.create()
-    chemex_module.run(
-        _shipped_args("simulate", legacy_only_output),
-        session=legacy_session,
-    )
+    failed_session = AnalysisSession.create()
+    with pytest.raises(RuntimeError, match="native initialization failed"):
+        chemex_module.run(
+            _shipped_args("simulate", failed_output),
+            session=failed_session,
+        )
 
-    assert list((legacy_only_output / "Data").rglob("*.dat"))
-    assert _authoritative_output_contents(candidate_output) == (
-        _authoritative_output_contents(legacy_only_output)
-    )
+    assert not failed_output.exists()
     assert isinstance(
-        legacy_session.parameter_factory.native_construction_error,
+        failed_session.parameter_factory.native_construction_error,
         RuntimeError,
     )
-    assert isinstance(legacy_session.legacy_values_adapter.failure, RuntimeError)
+    assert isinstance(failed_session.legacy_values_adapter.failure, RuntimeError)
     with pytest.raises(RuntimeError, match="not initialized"):
-        legacy_session.analysis_values.snapshot()
+        failed_session.analysis_values.snapshot()

--- a/tests/test_lmfit_removal_pr1_qualification.py
+++ b/tests/test_lmfit_removal_pr1_qualification.py
@@ -5,7 +5,10 @@ from collections.abc import Callable
 import pytest
 
 from tests.qualification.compare_lmfit_removal_pr1 import (
+    _CEST_ACCEPTED_FAILURE_SCOPE,
+    _CEST_ACCEPTED_NUMERICAL_SIGNATURE,
     CASES,
+    _comparison_disposition,
     _data_rows,
     _fallback_limit,
     _fit_schema,
@@ -48,6 +51,72 @@ def test_fit_and_statistics_schema_preserve_structure_without_numerical_parity()
         ("number", "int"),
         ("score", "float"),
     )
+
+
+def test_cest_accepted_difference_is_explicit_and_not_a_parity_pass() -> None:
+    case = next(case for case in CASES if case.slug == "cest-13c-label-cn")
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (3140.90, 2849.45)},
+        _CEST_ACCEPTED_FAILURE_SCOPE,
+        dict(_CEST_ACCEPTED_NUMERICAL_SIGNATURE),
+    )
+
+    assert disposition["status"] == "ACCEPTED_DIFFERENCE"
+    assert disposition["parity_status"] == "FAIL"
+    assert disposition["objective_semantics_parity"] == "PASS"
+    assert disposition["diagnosed_legacy_l18cd1_chi_square"] == pytest.approx(
+        1093.424072389286
+    )
+    assert disposition["diagnosed_native_l18cd1_chi_square"] == pytest.approx(
+        801.9806529406368
+    )
+
+
+def test_cest_accepted_difference_rejects_an_unrecorded_objective() -> None:
+    case = next(case for case in CASES if case.slug == "cest-13c-label-cn")
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (3140.90, 2850.00)},
+        _CEST_ACCEPTED_FAILURE_SCOPE,
+        dict(_CEST_ACCEPTED_NUMERICAL_SIGNATURE),
+    )
+
+    assert disposition == {"status": "FAIL"}
+
+
+def test_cest_accepted_difference_rejects_an_unrelated_parity_failure() -> None:
+    case = next(case for case in CASES if case.slug == "cest-13c-label-cn")
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (3140.90, 2849.45)},
+        _CEST_ACCEPTED_FAILURE_SCOPE | {"data:STEP1/Data/23hz.dat:[I28CG2]"},
+        dict(_CEST_ACCEPTED_NUMERICAL_SIGNATURE),
+    )
+
+    assert disposition == {"status": "FAIL"}
+
+
+def test_cest_accepted_difference_rejects_an_unrelated_numerical_state() -> None:
+    case = next(case for case in CASES if case.slug == "cest-13c-label-cn")
+    signature = dict(_CEST_ACCEPTED_NUMERICAL_SIGNATURE)
+    signature["native_dw_ab"] = 0.3
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (3140.90, 2849.45)},
+        _CEST_ACCEPTED_FAILURE_SCOPE,
+        signature,
+    )
+
+    assert disposition == {"status": "FAIL"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lmfit_removal_pr1_qualification.py
+++ b/tests/test_lmfit_removal_pr1_qualification.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from tests.qualification.compare_lmfit_removal_pr1 import (
+    CASES,
+    _data_rows,
+    _fallback_limit,
+    _fit_schema,
+    _parameter_values,
+    _statistics_schema,
+)
+
+
+def test_population_fallback_uses_declared_absolute_tolerance() -> None:
+    case = CASES[0]
+
+    assert _fallback_limit(("[GLOBAL]", "PA"), 0.93, case) == pytest.approx(
+        case.fallback.population_abs
+    )
+
+
+def test_data_reader_preserves_profile_order_and_masked_rows() -> None:
+    profiles, rows = _data_rows(
+        """[G2N-HN]
+  1.0  2.0  0.5  2.1
+# 3.0  4.0  0.6  4.1 # NOT USED IN THE FIT
+"""
+    )
+
+    assert profiles == ("[G2N-HN]",)
+    assert tuple((row.profile, row.masked, row.values) for row in rows) == (
+        ("[G2N-HN]", False, (1.0, 2.0, 0.5, 2.1)),
+        ("[G2N-HN]", True, (3.0, 4.0, 0.6, 4.1)),
+    )
+
+
+def test_fit_and_statistics_schema_preserve_structure_without_numerical_parity() -> (
+    None
+):
+    legacy_fit = "[G2N-HN]\n# TIME CALC\n1.0 2.0\n3.0 4.0\n"
+    native_fit = "[G2N-HN]\n# TIME CALC\n1.0 20.0\n3.0 40.0\n"
+
+    assert _fit_schema(native_fit) == _fit_schema(legacy_fit)
+    assert _statistics_schema('"number" = 1\n"score" = 2.0\n') == (
+        ("number", "int"),
+        ("score", "float"),
+    )
+
+
+@pytest.mark.parametrize(
+    "reader,text",
+    (
+        (_data_rows, "[G2N-HN]\n1.0 2.0 0.5 nan\n"),
+        (_parameter_values, "[GLOBAL]\nPB = nan\n"),
+    ),
+)
+def test_comparison_readers_reject_non_finite_values(
+    reader: Callable[[str], object],
+    text: str,
+) -> None:
+    with pytest.raises(AssertionError, match="non-finite"):
+        reader(text)

--- a/tests/test_lmfit_removal_pr1_qualification.py
+++ b/tests/test_lmfit_removal_pr1_qualification.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 import pytest
 
 from tests.qualification.compare_lmfit_removal_pr1 import (
+    _BINDING_ACCEPTED_FAILURE_SCOPE,
+    _BINDING_ACCEPTED_NUMERICAL_SIGNATURE,
     _CEST_ACCEPTED_FAILURE_SCOPE,
     _CEST_ACCEPTED_NUMERICAL_SIGNATURE,
     CASES,
@@ -117,6 +119,103 @@ def test_cest_accepted_difference_rejects_an_unrelated_numerical_state() -> None
     )
 
     assert disposition == {"status": "FAIL"}
+
+
+def test_binding_accepted_difference_is_explicit_and_not_a_parity_pass() -> None:
+    case = next(case for case in CASES if case.slug == "2st-binding")
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (37771.2, 35802.6)},
+        _BINDING_ACCEPTED_FAILURE_SCOPE,
+        dict(_BINDING_ACCEPTED_NUMERICAL_SIGNATURE),
+    )
+
+    assert disposition["status"] == "ACCEPTED_DIFFERENCE"
+    assert disposition["parity_status"] == "FAIL"
+    assert disposition["objective_semantics_parity"] == "PASS"
+    assert disposition["diagnosed_legacy_chi_square"] == pytest.approx(
+        37771.20405101328
+    )
+    assert disposition["diagnosed_native_chi_square"] == pytest.approx(
+        35802.60988668793
+    )
+
+
+def test_binding_accepted_difference_rejects_a_step1_failure() -> None:
+    case = next(case for case in CASES if case.slug == "2st-binding")
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (37771.2, 35802.6)},
+        _BINDING_ACCEPTED_FAILURE_SCOPE | {"data:STEP1/All/Data/cpmg_10p.dat:[513N]"},
+        dict(_BINDING_ACCEPTED_NUMERICAL_SIGNATURE),
+    )
+
+    assert disposition == {"status": "FAIL"}
+
+
+@pytest.mark.parametrize(
+    "unexpected_failure",
+    (
+        "data:STEP2/All/Data/cest_20hz_10p.dat:[575N]",
+        ("parameter:STEP2/All/Parameters/fitted.toml:('[DW_AB]', '575N')"),
+    ),
+)
+def test_binding_accepted_difference_rejects_an_unrelated_step2_failure(
+    unexpected_failure: str,
+) -> None:
+    case = next(case for case in CASES if case.slug == "2st-binding")
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (37771.2, 35802.6)},
+        _BINDING_ACCEPTED_FAILURE_SCOPE | {unexpected_failure},
+        dict(_BINDING_ACCEPTED_NUMERICAL_SIGNATURE),
+    )
+
+    assert disposition == {"status": "FAIL"}
+
+
+def test_binding_accepted_difference_rejects_a_changed_objective() -> None:
+    case = next(case for case in CASES if case.slug == "2st-binding")
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (37771.2, 35803.0)},
+        _BINDING_ACCEPTED_FAILURE_SCOPE,
+        dict(_BINDING_ACCEPTED_NUMERICAL_SIGNATURE),
+    )
+
+    assert disposition == {"status": "FAIL"}
+
+
+def test_binding_accepted_difference_rejects_an_unrelated_numerical_state() -> None:
+    case = next(case for case in CASES if case.slug == "2st-binding")
+    signature = dict(_BINDING_ACCEPTED_NUMERICAL_SIGNATURE)
+    signature["native_560n_dw_ab"] = -0.08
+
+    disposition = _comparison_disposition(
+        case,
+        False,
+        {"STEP2/All/statistics.toml": (37771.2, 35802.6)},
+        _BINDING_ACCEPTED_FAILURE_SCOPE,
+        signature,
+    )
+
+    assert disposition == {"status": "FAIL"}
+
+
+def test_successful_parity_remains_pass_parity() -> None:
+    case = next(case for case in CASES if case.slug == "2st-binding")
+
+    disposition = _comparison_disposition(case, True, {}, frozenset(), {})
+
+    assert disposition == {"status": "PASS_PARITY"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_native_evaluation.py
+++ b/tests/test_native_evaluation.py
@@ -50,6 +50,10 @@ from chemex.typing import Array
 ROOT = Path(__file__).parent.parent
 EXPERIMENT = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Experiments/3hz.toml"
 PARAMETERS = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Parameters/parameters.toml"
+CEST_EXPERIMENT = ROOT / "examples/Experiments/CEST_13C_LABEL_CN/Experiments/23hz.toml"
+CEST_PARAMETERS = (
+    ROOT / "examples/Experiments/CEST_13C_LABEL_CN/Parameters/parameters.toml"
+)
 
 
 def _shipped_dcest(*names: str) -> tuple[AnalysisSession, Experiments]:
@@ -77,6 +81,37 @@ def _evaluation_frame(
         parameterization,
         parameterization.frame_from_snapshot(session.analysis_values.snapshot()),
     )
+
+
+def test_cest_infinite_sweep_width_sentinel_has_a_stable_native_plan() -> None:
+    identities: list[str] = []
+    for _ in range(2):
+        session = AnalysisSession.create()
+        session.set_model("2st")
+        experiments = build_experiments(
+            [CEST_EXPERIMENT],
+            Selection(
+                include=[SpinSystem.from_name("L18CB")],
+                exclude=None,
+            ),
+            session=session,
+        )
+        session.parameters.set_defaults(read_defaults([CEST_PARAMETERS]))
+        assert session.try_build_analysis_values()
+        parameterization = session.compile_current_parameterization(
+            experiments.param_ids
+        )
+        engine = EvaluationEngine.from_experiments(
+            experiments,
+            parameterization,
+        )
+        identities.append(engine.plan.identity)
+        outcome = engine.new_evaluator().evaluate(
+            _evaluation_frame(session, parameterization)
+        )
+        assert isinstance(outcome, EvaluationResult)
+
+    assert identities[0] == identities[1]
 
 
 def test_shipped_two_profile_dcest_plan_matches_legacy_completely() -> None:

--- a/tests/test_native_method_step.py
+++ b/tests/test_native_method_step.py
@@ -124,6 +124,18 @@ PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.
 METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
 
 
+def test_semantic_method_record_excludes_materialized_profile_selection() -> None:
+    method = Method(include=["G2N-HN"], exclude=["H3N-HN"])
+
+    record = method_step_module._semantic_method_record(method)
+
+    assert "include" not in record
+    assert "exclude" not in record
+    assert record["fitmethod"] == "trf"
+    reconstruction = method_step_module._method_reconstruction_record(method)
+    assert Method.model_validate(reconstruction) == method
+
+
 class _OptimizationInputs(TypedDict):
     starting_snapshot: AnalysisValuesSnapshot
     parameter_model: SealedParameterModel

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -7,11 +7,13 @@ import tomllib
 from pathlib import Path
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 import chemex.optimize.direct_trf as direct_trf_module
 import chemex.optimize.fitting as fitting_module
 import chemex.optimize.mcmc as mcmc_module
+import chemex.optimize.native_deterministic as native_deterministic_module
 import chemex.optimize.native_mcmc as native_mcmc_module
 import chemex.optimize.native_resampling as native_resampling_module
 import chemex.optimize.resampling as resampling_module
@@ -58,6 +60,83 @@ def _fit_arguments(
             str(workers),
         ]
     )
+
+
+def _simulation_arguments(output: Path):
+    return build_parser().parse_args(
+        [
+            "simulate",
+            "-e",
+            str(EXPERIMENT),
+            "-p",
+            str(PARAMETERS),
+            "-o",
+            str(output),
+            "--include",
+            "G2N-HN",
+            "--plot",
+            "nothing",
+        ]
+    )
+
+
+def test_product_trf_uses_legacy_request_ceiling_and_physical_coordinate_scale() -> (
+    None
+):
+    problem = type(
+        "Problem",
+        (),
+        {
+            "controlled_ids": ("a", "b", "c", "d"),
+            "start": (0.01, -2.0, 0.0, 150.0),
+        },
+    )()
+
+    assert (
+        native_deterministic_module._objective_request_budget(
+            problem  # ty: ignore[invalid-argument-type]
+        )
+        == 10000
+    )
+    assert native_deterministic_module._product_x_scale(
+        problem  # ty: ignore[invalid-argument-type]
+    ) == (1.0, 2.0, 1.0, 150.0)
+
+
+def test_real_simulation_uses_native_values_and_preserves_back_calculation(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+
+    with (
+        patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy residual evaluation was entered"),
+        ),
+    ):
+        run(_simulation_arguments(output), session=session)
+
+    data_path = output / "Data" / "800mhz.dat"
+    calculated = np.loadtxt(data_path, comments="#", skiprows=2, usecols=1)
+    legacy_calculated = np.array(
+        [
+            1.18750357e06,
+            9.66031999e05,
+            7.85819221e05,
+            6.39171094e05,
+            5.19835478e05,
+            4.22730273e05,
+            3.43723059e05,
+        ]
+    )
+    np.testing.assert_allclose(calculated, legacy_calculated, rtol=1.0e-6)
+    assert (output / "Parameters" / "fixed.toml").is_file()
+    assert (output / "Parameters" / "constrained.toml").is_file()
 
 
 def _run_real_fit_cli(output: Path, method: Path, parameters: Path) -> None:
@@ -118,6 +197,10 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
 
     with (
         patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
+        patch(
             "lmfit.Minimizer.minimize",
             side_effect=AssertionError("legacy lmfit optimizer was called"),
         ),
@@ -153,6 +236,78 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     time_2, intensity_2 = curve[-1]
     fitted_curve_rate = -math.log(intensity_2 / intensity_1) / (time_2 - time_1)
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
+
+
+def test_explicit_trf_and_least_squares_alias_have_identical_native_product_output(
+    tmp_path: Path,
+) -> None:
+    outputs: dict[str, Path] = {}
+    with (
+        patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy evaluation was called"),
+        ),
+    ):
+        for spelling in ("trf", "least_squares"):
+            method = tmp_path / f"{spelling}.toml"
+            method.write_text(
+                f'[DEFAULT]\nFITMETHOD = "{spelling}"\nFIX = ["PB", "KEX_AB"]\n',
+                encoding="utf-8",
+            )
+            output = tmp_path / spelling
+            run(
+                _fit_arguments(output, method),
+                session=AnalysisSession.create(),
+            )
+            outputs[spelling] = output
+
+    for relative in (
+        Path("Parameters/fitted.toml"),
+        Path("Data/800mhz.dat"),
+        Path("statistics.toml"),
+    ):
+        assert (outputs["least_squares"] / relative).read_bytes() == (
+            outputs["trf"] / relative
+        ).read_bytes()
+
+
+@pytest.mark.parametrize("fitmethod", ("leastsq", "differential_evolution"))
+def test_invalid_fitmethod_fails_before_defaults_and_output_invalidation(
+    tmp_path: Path,
+    fitmethod: str,
+) -> None:
+    output = tmp_path / "Output"
+    output.mkdir()
+    sentinel = output / "Data"
+    sentinel.mkdir()
+    preserved = sentinel / "preserved.dat"
+    preserved.write_text("existing result\n", encoding="utf-8")
+    method = tmp_path / "method.toml"
+    method.write_text(
+        f'[DEFAULT]\nFITMETHOD = "{fitmethod}"\n',
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "chemex.parameters.database.ParameterStore.set_defaults",
+            side_effect=AssertionError("parameter defaults were resolved"),
+        ),
+        pytest.raises(SystemExit) as raised,
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    assert raised.value.code == 1
+    assert preserved.read_text(encoding="utf-8") == "existing result\n"
+    assert not (output / "run_info").exists()
 
 
 def test_parameters_used_supports_real_cli_restart_round_trip(tmp_path: Path) -> None:
@@ -1152,9 +1307,19 @@ def test_real_grid_fit_uses_native_cartesian_trf_and_writes_grid_output(
     session = AnalysisSession.create()
     method = _grid_method(tmp_path / "method.toml")
 
-    with patch(
-        "lmfit.Minimizer.minimize",
-        side_effect=AssertionError("legacy lmfit optimizer was called"),
+    with (
+        patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
+        patch(
+            "chemex.containers.experiments.Experiments.residuals",
+            side_effect=AssertionError("legacy evaluation was called"),
+        ),
+        patch(
+            "lmfit.Minimizer.minimize",
+            side_effect=AssertionError("legacy lmfit optimizer was called"),
+        ),
     ):
         run(_fit_arguments(output, method), session=session)
 
@@ -1297,34 +1462,6 @@ FIX = ["PB", "KEX_AB"]
     assert _read_outcome(output)["status"] == "incomplete"
 
 
-def test_native_step_clears_generic_error_from_preceding_legacy_step(
-    tmp_path: Path,
-) -> None:
-    output = tmp_path / "Output"
-    method = tmp_path / "method.toml"
-    method.write_text(
-        """[LEGACY]
-FITMETHOD = "leastsq"
-FIX = ["PB", "KEX_AB"]
-
-[NATIVE]
-""",
-        encoding="utf-8",
-    )
-    session = AnalysisSession.create()
-
-    run(_fit_arguments(output, method), session=session)
-
-    legacy = (output / "LEGACY" / "Parameters" / "fitted.toml").read_text(
-        encoding="utf-8"
-    )
-    native = (output / "NATIVE" / "Parameters" / "fitted.toml").read_text(
-        encoding="utf-8"
-    )
-    assert "±" in legacy
-    assert "(error not calculated)" in native
-
-
 def test_native_backend_failure_cannot_commit_or_publish_fitted_output(
     tmp_path: Path,
 ) -> None:
@@ -1434,8 +1571,9 @@ STATISTICS = { "MC" = 1 }
     assert (output / "Statistics" / "MonteCarlo" / "samples.tsv").is_file()
 
 
-def test_grid_with_statistics_remains_wholly_on_legacy_dispatch(
+def test_grid_with_statistics_warns_and_runs_native_grid_only(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     output = tmp_path / "Output"
     method = tmp_path / "method.toml"
@@ -1450,11 +1588,22 @@ STATISTICS = { "MC" = 1 }
 
     with (
         patch(
-            "chemex.optimize.fitting.run_native_deterministic",
-            side_effect=AssertionError("native deterministic dispatch was called"),
+            "chemex.optimize.gridding.run_grid",
+            side_effect=AssertionError("legacy GRID dispatch was called"),
         ),
-        patch("chemex.optimize.fitting.run_grid") as run_grid,
+        patch(
+            "chemex.parameters.database.ParameterStore.build_lmfit_params",
+            side_effect=AssertionError("legacy lmfit Parameters were constructed"),
+        ),
+        patch(
+            "chemex.optimize.fitting.run_native_resampling_statistics",
+            side_effect=AssertionError("statistics after GRID were entered"),
+        ),
     ):
         run(_fit_arguments(output, method), session=session)
 
-    run_grid.assert_called_once()
+    captured = capsys.readouterr()
+    assert "GRID" in captured.out
+    assert "STATISTICS" in captured.out
+    assert (output / "Grid").is_dir()
+    assert not (output / "Statistics").exists()

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -1927,7 +1927,7 @@ def test_native_run_information_archives_each_method_section(
     tmp_path: Path,
 ) -> None:
     run_state = _committed_fit()
-    first = _evaluation_only(Method(fitmethod="leastsq", fix=["R1A_A", "PB", "KEX_AB"]))
+    first = _evaluation_only(Method(fix=["R1A_A", "PB", "KEX_AB"]))
     second = _evaluation_only(Method(fitmethod="trf", fix=["R1A_A", "PB", "KEX_AB"]))
     output = tmp_path / "Output"
     steps = (

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -67,6 +67,109 @@ FIT_PARAMETERS = (
     ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
 )
 FIT_METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+BINDING_ROOT = ROOT / "examples/Combinations/2stBinding"
+BINDING_EXPERIMENTS = tuple(sorted((BINDING_ROOT / "Experiments").glob("*.toml")))
+BINDING_PARAMETERS = BINDING_ROOT / "Parameters/params.toml"
+BINDING_METHOD = BINDING_ROOT / "Methods/method.toml"
+
+_BINDING_STEP1_R2_B_IDS = {
+    "__R2_B_486N_800_0MHZ",
+    "__R2_B_488N_800_0MHZ",
+    "__R2_B_489N_800_0MHZ",
+    "__R2_B_489NE_800_0MHZ",
+    "__R2_B_491N_800_0MHZ",
+    "__R2_B_492N_800_0MHZ",
+    "__R2_B_493N_800_0MHZ",
+    "__R2_B_494N_800_0MHZ",
+    "__R2_B_495N_800_0MHZ",
+    "__R2_B_496N_800_0MHZ",
+    "__R2_B_497N_800_0MHZ",
+    "__R2_B_498N_800_0MHZ",
+    "__R2_B_499N_800_0MHZ",
+}
+_BINDING_STEP2_R2_B_IDS = {
+    f"__R2_B_{spin}_800_0MHZ"
+    for spin in (
+        "480N",
+        "481N",
+        "482N",
+        "483N",
+        "484N",
+        "485N",
+        "486N",
+        "488N",
+        "489N",
+        "489NE",
+        "491N",
+        "492N",
+        "493N",
+        "494N",
+        "495N",
+        "496N",
+        "497N",
+        "498N",
+        "499N",
+        "500N",
+        "501N",
+        "502N",
+        "503N",
+        "504N",
+        "505N",
+        "506N",
+        "509N",
+        "510N",
+        "511N",
+        "512N",
+        "513N",
+        "514N",
+        "515N",
+        "516N",
+        "518N",
+        "520N",
+        "521N",
+        "522N",
+        "523N",
+        "524N",
+        "526N",
+        "527N",
+        "528N",
+        "529N",
+        "530N",
+        "532N",
+        "533N",
+        "535N",
+        "537N",
+        "538N",
+        "540N",
+        "541N",
+        "543N",
+        "544N",
+        "545N",
+        "546N",
+        "547N",
+        "550N",
+        "551N",
+        "552N",
+        "553N",
+        "554N",
+        "555N",
+        "556N",
+        "557N",
+        "558N",
+        "559N",
+        "560N",
+        "566N",
+        "567N",
+        "568N",
+        "569N",
+        "570N",
+        "571N",
+        "572N",
+        "573N",
+        "574N",
+        "575N",
+    )
+}
 
 
 def _build_dcest_session() -> tuple[AnalysisSession, set[str]]:
@@ -346,6 +449,151 @@ def test_sealing_retains_model_derivation_when_estimation_is_supported() -> None
 
     assert declarations[definition.param_id].supports_estimation
     assert declarations[definition.param_id].model_expression == "1.0 - __PB"
+
+
+def test_non_model_owned_baseline_expression_can_compile_as_fit() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", True, "__A", model_owned=False),
+    )
+    parameter_model, snapshot = _native_fixture(declarations)
+
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(fit=("B",)),
+        {"__B"},
+    )
+
+    declaration = parameter_model.declarations["__B"]
+    assert declaration.model_expression == "__A"
+    assert declaration.supports_estimation
+    assert not declaration.model_owned
+    assert parameterization.role("__B") is ParameterRole.FIT
+
+
+def test_non_model_owned_baseline_expression_remains_active_constraint() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", True, "__A", model_owned=False),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 3.0, "__B": 20.0},
+    )
+
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(constraints=("[B] = [A]",)),
+        {"__B"},
+    )
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert parameterization.role("__B") is ParameterRole.DERIVED
+    assert resolved["__B"] == pytest.approx(3.0)
+
+
+def test_model_owned_expression_cannot_compile_as_fit() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", True, "__A", model_owned=True),
+    )
+    parameter_model, snapshot = _native_fixture(declarations)
+
+    with pytest.raises(ModelDerivationOverrideError):
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(fit=("B",)),
+            {"__B"},
+        )
+
+
+@pytest.mark.parametrize(
+    "method",
+    (
+        Method(fit=("PA",)),
+        Method(fix=("PA",)),
+        Method(constraints=("[PA] = 0.5",)),
+    ),
+)
+def test_product_role_application_rejects_model_owned_override(method: Method) -> None:
+    session, required_ids = _build_dcest_session()
+
+    with pytest.raises(ModelDerivationOverrideError):
+        session.apply_current_parameter_roles(method, required_ids)
+
+
+def test_non_estimable_declaration_cannot_compile_as_fit() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__B", False, "__A", model_owned=False),
+    )
+    parameter_model, snapshot = _native_fixture(declarations)
+
+    with pytest.raises(IncompatibleParameterizationInputError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(fit=("B",)),
+            {"__B"},
+        )
+
+    assert raised.value.context["param_ids"] == ("__B",)
+
+
+def test_binding_current_roles_compile_all_estimable_r2_b_coordinates() -> None:
+    session = AnalysisSession.create()
+    session.set_model("2st_binding")
+    experiments = build_experiments(
+        BINDING_EXPERIMENTS,
+        Selection(include=None, exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([BINDING_PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    methods = read_methods([BINDING_METHOD])
+
+    experiments.select(methods["STEP1"].selection)
+    session.apply_current_parameter_roles(methods["STEP1"], experiments.param_ids)
+    step1 = session.compile_current_parameterization(experiments.param_ids)
+    step1_fit_ids = {
+        param_id
+        for param_id in step1.independent_ids
+        if step1.role(param_id) is ParameterRole.FIT
+    }
+    step1_r2_b_ids = {
+        param_id for param_id in step1_fit_ids if param_id.startswith("__R2_B_")
+    }
+
+    assert len(step1_fit_ids) == 53
+    assert step1_r2_b_ids == _BINDING_STEP1_R2_B_IDS
+    for param_id in _BINDING_STEP1_R2_B_IDS:
+        declaration = session.parameter_factory.sealed_parameter_model.declarations[
+            param_id
+        ]
+        assert declaration.model_expression
+        assert declaration.supports_estimation
+        assert not declaration.model_owned
+
+    experiments.select(methods["STEP2"].selection)
+    session.apply_current_parameter_roles(methods["STEP2"], experiments.param_ids)
+    step2 = session.compile_current_parameterization(experiments.param_ids)
+    step2_fit_ids = {
+        param_id
+        for param_id in step2.independent_ids
+        if step2.role(param_id) is ParameterRole.FIT
+    }
+    step2_r2_b_ids = {
+        param_id for param_id in step2_fit_ids if param_id.startswith("__R2_B_")
+    }
+
+    assert len(step2_fit_ids) == 312
+    assert len(_BINDING_STEP2_R2_B_IDS) == 78
+    assert step2_r2_b_ids == _BINDING_STEP2_R2_B_IDS
 
 
 def test_constraint_chain_is_deterministic_and_freshly_reresolves() -> None:

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -35,7 +35,7 @@ class FitExperiments:
         self.param_ids = param_ids
         self.filter_calls = 0
 
-    def filter(self) -> None:
+    def filter_from_values(self, _values: object) -> None:
         self.filter_calls += 1
 
 
@@ -352,7 +352,7 @@ def test_run_fit_creates_run_info(
         experiments,
         SimpleNamespace(
             execution=None,
-            try_compile_parameterization=lambda *_args: None,
+            resolve_current_values=lambda *_args: {parameter.id_: parameter.value},
         ),
         argv=["chemex", "fit"],
     )

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -15,6 +15,13 @@ Method files define the fitting methods used in ChemEx. In these files, you can:
 
 Provide the method file to ChemEx using the `-m` or `--method` option.
 
+`FITMETHOD` is deliberately closed to the native trust-region reflective
+solver. Omit it or set `FITMETHOD = "trf"`. The spelling `"least_squares"` is
+accepted temporarily as an alias and is canonicalized to `"trf"`; historical
+optimizer names fail during method-file validation, before fit outputs are
+invalidated. When `GRID` and `STATISTICS` occur in the same step, ChemEx prints
+the compatibility warning, executes the native grid, and ignores statistics.
+
 Method files are structured in sections, each representing a fitting step. Fitting steps are executed in the order they appear, and parameter settings inherit from previous steps if not redefined.
 
 :::tip

--- a/website/docs/user_guide/fitting/parameter_files.md
+++ b/website/docs/user_guide/fitting/parameter_files.md
@@ -85,4 +85,4 @@ PARAMETER_WITH_NO_BOUNDS = <initial_value>
 PARAMETER_WITH_BOUNDS = [<initial_value>, <lower_bound>, <upper_bound>]
 ```
 
-Setting bounds helps prevent parameters from reaching unrealistic values during χ<sup>2</sup> minimization. However, avoid overly strict bounds as they can hinder convergence. Some minimization algorithms, such as `differential_evolution`, require finite bounds for all fitted parameters.
+Setting bounds helps prevent parameters from reaching unrealistic values during χ<sup>2</sup> minimization. However, avoid overly strict bounds as they can hinder convergence. The supported `trf` fit method honors finite bounds when they are supplied.


### PR DESCRIPTION
## Summary

PR 1 of the final lmfit-removal stage for #657, against the #566 native frontier. It closes every retained product call path on native semantics while deliberately leaving dependency/import deletion to PR 2. #611 is referenced only for the established method-surface context.

- closes `FITMETHOD` to `trf`, with `least_squares` as a temporary canonicalizing alias;
- resolves revision-zero/default/model-derived values through authoritative native `AnalysisValues`;
- filters Direct, grouped Direct, GRID, grouped GRID, and GRID + STATISTICS through resolved native values;
- makes `simulate`/back-calculation consume resolved value mappings;
- makes GRID + STATISTICS warn, discard statistics, and run native GRID only;
- requires native publication callers to supply residuals and `nvarys`, removing reachable lmfit reconstruction fallbacks;
- adds a narrow immutable legacy-output reader for the four missing representative comparisons.

This does not remove lmfit/asteval/numdifftools from packaging, add FORMAT_VERSION 2, add DE product integration, or revive migration-core/GatePlan/calibration/provenance frameworks.

## Mixed-experiment role repair

The initial PR head compiled current roles with `if declaration.model_expression: continue`. That incorrectly treated every sealed baseline expression as non-overridable. In the mixed 2stBinding CEST/CPMG workflow, CPMG contributes baseline `R2_B = R2_A`, CEST supports estimating `R2_B`, and the active v1 ParameterStore correctly presents `R2_B` as varying with no expression.

The repaired compiler now:

- keeps genuinely `model_owned` derivations authoritative;
- validates original Method intent before ParameterStore mutation, so model-owned FIT/FIX/CONSTRAINT overrides all fail closed;
- lets a non-model-owned baseline expression follow the active presentation FIT/FIX/constraint role;
- leaves an unchanged presentation expression on its sealed baseline derivation;
- rejects FIT of an expression-bearing declaration that lacks sealed estimation support.

2stBinding native controls changed from 40 to 53 in STEP1 (the exact 13 selected `R2_B` IDs are restored) and from 234 to 312 in STEP2 (all exact 78 `R2_B` IDs are restored). Tests assert independently frozen ID sets, not counts alone.

## Product contract

- omitted `FITMETHOD` -> `trf`
- `FITMETHOD = "trf"` -> `trf`
- `FITMETHOD = "least_squares"` -> canonical `trf`
- `leastsq`, `differential_evolution`, and all other spellings fail closed before output invalidation, filtering, parameter resolution, or optimizer execution
- GRID + STATISTICS retains the existing warning, executes native GRID, and ignores STATISTICS

## Scientific qualification

Asterix Linux/amd64, Python 3.13.5, established #652 image:

- image `sha256:ed4f97e00bd6fe494f46772cc31a338d756b5bb5fe6e4e480d987af51af85550`
- candidate commit `b2335a3194697406219f41fd9825e3248188cf93`
- candidate wheel SHA-256 `0eabba075d27934b3bab6bc1393d7afa8684adceb2880bccb70ab7764956a3ae`
- frozen reference `tests/fixtures/migration_core_canonical_anchor_release_v1.tar.xz`

Declared before execution and unchanged: calculated values use `0.1 * experimental_error`; fitted parameters use `0.1 * frozen uncertainty` when usable. Existing case-specific fallback tolerances are unchanged.

| Case | Result | Worst calc fraction | Worst parameter fraction |
| --- | --- | ---: | ---: |
| CPMG_15N_IP | PASS_PARITY | 0.0268 | 0.0346 |
| CEST_13C_LABEL_CN | ACCEPTED_DIFFERENCE (parity remains FAIL) | 70.50 | 207.03 |
| 2stBinding | ACCEPTED_DIFFERENCE (parity remains FAIL) | 353.78 | 500.08 |
| DCEST_15N_3States FIFU/DRD | PASS_PARITY | 0.0203 | 0.0277 |

Exact output paths/schema, parameter identifiers/order/roles, selected profiles/masks, data ordering, `.fit` coordinate schema, and statistics schema are asserted before numerical disposition. Neither accepted difference changes or widens the original parity tolerances.

### CEST disposition

Same-vector evaluation established objective-semantics parity to numerical precision. Frozen and native states are distinct stationary basins on the same objective, and the shipped native policy reproducibly reaches the lower basin:

- STEP2 frozen-state chi-square: `3140.903510372318`
- STEP2 native-state chi-square: `2849.4551945314374`
- L18CD1 frozen/native contributions: `1093.424072389286` / `801.9806529406368`
- legacy L18CD1 CS_A / DW_AB / implied CS_B: `24.9724 / -0.142414 / 24.8300` ppm
- native L18CD1 CS_A / DW_AB / implied CS_B: `24.9288 / 0.193203 / 25.1220` ppm

CEST is an explicit case-scoped **ACCEPTED_DIFFERENCE**, not a tolerance pass. The comparator accepts only the diagnosed STEP2/L18CD1 failure scope, published objective pair, and numerical basin signature; unrelated scope/objective/state remains FAIL.

### 2stBinding disposition after role repair

STEP1 now reproduces the frozen result with 53 controlled coordinates:

- chi-square `4236.146104039377`
- KOFF `66.26980300935762 s^-1`

STEP2 starts from that exact authoritative KOFF, fixes it according to the method, uses KD `2.3e-6`, resolves KON `28812957.830155484`, and controls the intended 312 coordinates including all 78 `R2_B` values. Authoritative-state/start disagreement, presentation/native role differences, and out-of-bounds values are all zero.

Same-vector native/legacy objective evaluation:

| State | Native chi-square | Legacy chi-square | Max residual disagreement |
| --- | ---: | ---: | ---: |
| STEP2 start | 657032.2709204436 | 657032.2709204436 | 1.5632e-13 |
| reconstructed legacy basin | 37771.20405101328 | 37771.20405101329 | 1.3012e-13 |
| native basin | 35802.60988668793 | 35802.60988668793 | 1.8552e-13 |

Cross-starts confirm two stable local basins:

- native TRF from legacy: `37771.20405101328 -> 37771.20404540330`, largest displacement about `3.52e-4` in `R2_B`, all 78 groups converged;
- legacy LM from native: `35802.60988668793 -> 35802.60985670663`, largest displacement about `3.34e-3` in `R2_B`, all 78 groups succeeded.

Native improves the same objective by `1968.59416432535` (about 5.21%). The compact product-output fingerprint is:

- 513N legacy/native `R2_B`: `6.59550 / 3.42548`; `DW_AB`: `-0.0720231 / +0.0749041`;
- 560N legacy/native `R2_B`: `3.51575 / 5.25795`; `DW_AB`: `+0.0737021 / -0.0605078`.

The comparator requires the exact diagnosed 202-entry STEP2 failure scope (112 data/profile paths and 90 parameter/path identifiers), the exact published `37771.2 / 35802.6` objective pair, and this small fingerprint. Any STEP1, unrelated STEP2, structural, objective, or fingerprint change remains FAIL. 2stBinding is therefore an explicit case-scoped **ACCEPTED_DIFFERENCE** with `parity_status = FAIL` and `objective_semantics_parity = PASS`. No shipped GRID change is needed.

## Final TRF numerical policy

The predeclared P0-P3 experiment separated scaling and budget:

| Probe | x_scale | Budget | CEST STEP2 result |
| --- | --- | --- | --- |
| P0 | all ones | old | L18CD1 exhausts 400 |
| P1 | all ones | expanded | L18CD1 exhausts 10,000 |
| P2 | `max(1, abs(start))` | old | L18CD1 exhausts 400 |
| P3 | `max(1, abs(start))` | expanded | all 15 profiles succeed; chi-square `2849.455`; 1,305 total requests, maximum 749 |

Final product policy:

- fixed invocation scale `x_scale_i = max(1, abs(start_i))`;
- objective-request budget `2000 * (controlled_coordinate_count + 1)`;
- adaptive `x_scale="jac"` remains unsupported.

Neither change alone is sufficient for the shipped representative CEST workflow. The decision is recorded on #573 and #657.

## Coarse performance guardrail

The selected P3 policies are unchanged by the final role/disposition work, so the guardrail was not rerun. Existing Asterix record, three repetitions; baseline `4db6260e44a2f10f66dc48ba479cdbc945890fff`:

| Workflow | Baseline median | Candidate median | Ratio | Baseline peak RSS | Candidate peak RSS | Ratio |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RELAXATION_HZNZ Direct | 2.063 s | 2.172 s | 1.053x | 184,483,840 B | 184,078,336 B | 0.998x |
| grouped GRID | 2.311 s | 2.382 s | 1.031x | 187,826,176 B | 187,977,728 B | 1.001x |
| combined statistics, 2 workers | 2.920 s | 2.980 s | 1.021x | 199,888,896 B | 202,321,920 B | 1.012x |

All 2x gates pass. Deterministic grouped-GRID and statistics sample/replicate counts match.

## Validation

- focused qualification/parameterization/session/native-product suite: 216 passed on Python 3.13 and 216 passed on Python 3.14;
- final full Python 3.13 suite: 1,201 passed, with one existing emcee autocorrelation warning;
- final-wheel Asterix qualification: all four workflows freshly executed; final matrix above;
- `ty check`: pass;
- `ruff check .`: pass;
- `ruff format --check .`: pass (411 files);
- `git diff --check`: pass;
- `uv build`: pass;
- standards review: clean;
- specification review: clean.

The PR remains draft for maintainer review and is not merged. With both accepted differences explicitly dispositioned, no non-mechanical product work remains before PR 2 dependency/import/dead-compatibility deletion.
