### PR TITLE
Optimize native TRF residual evaluation

### DIFF
--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -1294,25 +1294,39 @@ class _NativeKernelCapability:
 
 
 @dataclass(slots=True)
+class _ProfileWorkspace:
+    template: _NativeKernelCapability
+    profile: _NativeKernelCapability = field(init=False)
+    cache: OrderedDict[tuple[float, ...], _CachedProfile] = field(
+        default_factory=OrderedDict
+    )
+
+    def __post_init__(self) -> None:
+        self.profile = deepcopy(self.template)
+
+    def reset(self) -> None:
+        self.profile = deepcopy(self.template)
+        self.cache.clear()
+
+
+@dataclass(slots=True)
 class _Workspace:
-    templates: tuple[_NativeKernelCapability, ...]
-    profiles: tuple[_NativeKernelCapability, ...]
-    profile_caches: tuple[OrderedDict[tuple[float, ...], _CachedProfile], ...]
+    profile_workspaces: tuple[_ProfileWorkspace, ...]
     resolved_values: dict[str, float] | None = None
     hits: int = 0
     misses: int = 0
     poisoned: bool = False
 
     def clear_caches(self) -> None:
-        for cache in self.profile_caches:
-            cache.clear()
+        for workspace in self.profile_workspaces:
+            workspace.cache.clear()
 
     def clear_resolution(self) -> None:
         self.resolved_values = None
 
     def reset(self) -> None:
-        self.profiles = tuple(deepcopy(profile) for profile in self.templates)
-        self.clear_caches()
+        for workspace in self.profile_workspaces:
+            workspace.reset()
         self.clear_resolution()
 
 
@@ -1646,9 +1660,10 @@ class EvaluationEngine:
             self._parameterization,
             self.compatibility_identity,
             _Workspace(
-                tuple(deepcopy(template) for template in self._templates),
-                tuple(deepcopy(template) for template in self._templates),
-                tuple(OrderedDict() for _template in self._templates),
+                tuple(
+                    _ProfileWorkspace(deepcopy(template))
+                    for template in self._templates
+                ),
             ),
         )
 
@@ -1676,7 +1691,9 @@ class BoundEvaluator:
         return CacheStatistics(
             self._workspace.hits,
             self._workspace.misses,
-            sum(len(cache) for cache in self._workspace.profile_caches),
+            sum(
+                len(workspace.cache) for workspace in self._workspace.profile_workspaces
+            ),
         )
 
     def _failure(
@@ -1934,13 +1951,17 @@ class BoundEvaluator:
         resolved: Mapping[str, float],
     ) -> list[_CachedProfile] | EvaluationFailure:
         results: list[_CachedProfile] = []
-        for descriptor, profile, cache in zip(
+        for descriptor, workspace in zip(
             self.plan.profiles,
-            self._workspace.profiles,
-            self._workspace.profile_caches,
+            self._workspace.profile_workspaces,
             strict=True,
         ):
-            cached = self._cached_profile(descriptor, profile, cache, resolved)
+            cached = self._cached_profile(
+                descriptor,
+                workspace.profile,
+                workspace.cache,
+                resolved,
+            )
             if isinstance(cached, EvaluationFailure):
                 return cached
             results.append(cached)

--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -30,7 +30,6 @@ from chemex.parameters.parameterization import (
     ActiveParameterization,
     IndependentValueFrame,
     ParameterizationError,
-    ResolvedParameterValues,
 )
 from chemex.typing import Array
 
@@ -43,6 +42,7 @@ _ORDERING_VERSION = "experiment-profile-row-v1"
 _FAILURE_VERSION = "typed-failure-v1"
 _DIAGNOSTICS_VERSION = "no-contractual-diagnostics-v1"
 _COMPATIBILITY_VERSION = "chemex-profile-kernel-v1"
+_PROFILE_CACHE_CAPACITY = 5
 type FailureStage = Literal[
     "frame",
     "resolution",
@@ -1297,16 +1297,23 @@ class _NativeKernelCapability:
 class _Workspace:
     templates: tuple[_NativeKernelCapability, ...]
     profiles: tuple[_NativeKernelCapability, ...]
-    cache: OrderedDict[tuple[object, ...], _CachedProfile] = field(
-        default_factory=OrderedDict
-    )
+    profile_caches: tuple[OrderedDict[tuple[float, ...], _CachedProfile], ...]
+    resolved_values: dict[str, float] | None = None
     hits: int = 0
     misses: int = 0
     poisoned: bool = False
 
+    def clear_caches(self) -> None:
+        for cache in self.profile_caches:
+            cache.clear()
+
+    def clear_resolution(self) -> None:
+        self.resolved_values = None
+
     def reset(self) -> None:
         self.profiles = tuple(deepcopy(profile) for profile in self.templates)
-        self.cache.clear()
+        self.clear_caches()
+        self.clear_resolution()
 
 
 @dataclass(frozen=True, slots=True)
@@ -1641,6 +1648,7 @@ class EvaluationEngine:
             _Workspace(
                 tuple(deepcopy(template) for template in self._templates),
                 tuple(deepcopy(template) for template in self._templates),
+                tuple(OrderedDict() for _template in self._templates),
             ),
         )
 
@@ -1668,7 +1676,7 @@ class BoundEvaluator:
         return CacheStatistics(
             self._workspace.hits,
             self._workspace.misses,
-            len(self._workspace.cache),
+            sum(len(cache) for cache in self._workspace.profile_caches),
         )
 
     def _failure(
@@ -1699,7 +1707,8 @@ class BoundEvaluator:
             raise RuntimeError("Undeclared native evaluation failure")
         if validity in {"INVALID_PLAN_OR_BINDING", "IMPLEMENTATION_FAILURE"}:
             self._workspace.poisoned = True
-            self._workspace.cache.clear()
+            self._workspace.clear_caches()
+            self._workspace.clear_resolution()
         elif validity == "INVALID_TRIAL":
             self._workspace.reset()
         return EvaluationFailure(
@@ -1716,7 +1725,7 @@ class BoundEvaluator:
         self,
         descriptor: ProfilePlan,
         profile: _NativeKernelCapability,
-        resolved: ResolvedParameterValues,
+        resolved: Mapping[str, float],
     ) -> Array | EvaluationFailure:
         """Run and validate the narrow unscaled profile kernel."""
         try:
@@ -1834,13 +1843,11 @@ class BoundEvaluator:
         self,
         descriptor: ProfilePlan,
         profile: _NativeKernelCapability,
-        resolved: ResolvedParameterValues,
+        cache: OrderedDict[tuple[float, ...], _CachedProfile],
+        resolved: Mapping[str, float],
     ) -> _CachedProfile | EvaluationFailure:
         try:
-            key = (
-                descriptor.identity,
-                *(resolved[param_id] for param_id in descriptor.param_ids),
-            )
+            key = tuple(resolved[param_id] for param_id in descriptor.param_ids)
         except Exception as error:  # noqa: BLE001 - cache integrity fence
             return self._failure(
                 "cache",
@@ -1849,9 +1856,9 @@ class BoundEvaluator:
                 profile_identity=descriptor.identity,
                 message=str(error),
             )
-        cached = self._workspace.cache.get(key)
+        cached = cache.get(key)
         if cached is not None:
-            self._workspace.cache.move_to_end(key)
+            cache.move_to_end(key)
             self._workspace.hits += 1
             return cached
         self._workspace.misses += 1
@@ -1861,17 +1868,16 @@ class BoundEvaluator:
         cached = self._normalize_profile(descriptor, unscaled)
         if isinstance(cached, EvaluationFailure):
             return cached
-        self._workspace.cache[key] = cached
-        self._workspace.cache.move_to_end(key)
-        while len(self._workspace.cache) > 5:
-            self._workspace.cache.popitem(last=False)
+        cache[key] = cached
+        cache.move_to_end(key)
+        while len(cache) > _PROFILE_CACHE_CAPACITY:
+            cache.popitem(last=False)
         return cached
 
-    def _evaluate_impl(
+    def _resolve_frame(
         self,
         frame: EvaluationFrame,
-    ) -> EvaluationResult | EvaluationFailure:
-        """Resolve once and atomically return a complete result or typed failure."""
+    ) -> dict[str, float] | EvaluationFailure:
         if get_ident() != self._owner:
             return self._failure(
                 "binding", "workspace_owner_violation", "INVALID_REQUEST"
@@ -1902,7 +1908,10 @@ class BoundEvaluator:
                 self._parameterization.source_revision,
                 frame._items,
             )
-            resolved = self._parameterization.resolve(lifecycle_frame)
+            resolved = self._parameterization._resolve_values(
+                lifecycle_frame,
+                self._workspace.resolved_values,
+            )
         except ParameterizationError as error:
             return self._failure(
                 "resolution",
@@ -1917,17 +1926,35 @@ class BoundEvaluator:
                 "IMPLEMENTATION_FAILURE",
                 message=str(error),
             )
-        unscaled_parts: list[Array] = []
-        normalized_parts: list[Array] = []
-        residual_parts: list[Array] = []
-        profiles: list[ProfileEvaluation] = []
-        residual_offset = 0
-        for descriptor, profile in zip(
-            self.plan.profiles, self._workspace.profiles, strict=True
+        self._workspace.resolved_values = resolved
+        return resolved
+
+    def _evaluate_profiles(
+        self,
+        resolved: Mapping[str, float],
+    ) -> list[_CachedProfile] | EvaluationFailure:
+        results: list[_CachedProfile] = []
+        for descriptor, profile, cache in zip(
+            self.plan.profiles,
+            self._workspace.profiles,
+            self._workspace.profile_caches,
+            strict=True,
         ):
-            cached = self._cached_profile(descriptor, profile, resolved)
+            cached = self._cached_profile(descriptor, profile, cache, resolved)
             if isinstance(cached, EvaluationFailure):
                 return cached
+            results.append(cached)
+        return results
+
+    def _complete_result(
+        self,
+        resolved: Mapping[str, float],
+        cached_profiles: Sequence[_CachedProfile],
+        residuals: Array,
+    ) -> EvaluationResult:
+        residual_offset = 0
+        profiles: list[ProfileEvaluation] = []
+        for descriptor, cached in zip(self.plan.profiles, cached_profiles, strict=True):
             retained = descriptor.retained_observation_indices
             profiles.append(
                 ProfileEvaluation(
@@ -1942,32 +1969,54 @@ class BoundEvaluator:
                 )
             )
             residual_offset += len(retained)
-            unscaled_parts.append(cached.unscaled)
-            normalized_parts.append(cached.normalized)
-            residual_parts.append(cached.residuals)
-        try:
-            return EvaluationResult(
-                self.plan.identity,
+        return EvaluationResult(
+            self.plan.identity,
+            self._parameterization.evaluator_identity,
+            self.compatibility_identity,
+            ResolvedEvaluationValues(
                 self._parameterization.evaluator_identity,
-                self.compatibility_identity,
-                ResolvedEvaluationValues(
-                    self._parameterization.evaluator_identity,
-                    self._parameterization.program.fingerprint,
-                    resolved._items,
+                self._parameterization.program.fingerprint,
+                tuple(
+                    (param_id, resolved[param_id])
+                    for param_id in self._parameterization.scope_ids
                 ),
-                _readonly(
-                    np.concatenate(unscaled_parts) if unscaled_parts else np.empty(0)
-                ),
-                _readonly(
-                    np.concatenate(normalized_parts)
-                    if normalized_parts
-                    else np.empty(0)
-                ),
-                _readonly(
-                    np.concatenate(residual_parts) if residual_parts else np.empty(0)
-                ),
-                tuple(profiles),
+            ),
+            _readonly(
+                np.concatenate([item.unscaled for item in cached_profiles])
+                if cached_profiles
+                else np.empty(0)
+            ),
+            _readonly(
+                np.concatenate([item.normalized for item in cached_profiles])
+                if cached_profiles
+                else np.empty(0)
+            ),
+            residuals,
+            tuple(profiles),
+        )
+
+    def _evaluate_impl(
+        self,
+        frame: EvaluationFrame,
+        *,
+        materialize: bool,
+    ) -> EvaluationResult | Array | EvaluationFailure:
+        """Run the shared scientific path, optionally materializing full evidence."""
+        resolved = self._resolve_frame(frame)
+        if isinstance(resolved, EvaluationFailure):
+            return resolved
+        cached_profiles = self._evaluate_profiles(resolved)
+        if isinstance(cached_profiles, EvaluationFailure):
+            return cached_profiles
+        try:
+            residuals = _readonly(
+                np.concatenate([item.residuals for item in cached_profiles])
+                if cached_profiles
+                else np.empty(0)
             )
+            if not materialize:
+                return residuals
+            return self._complete_result(resolved, cached_profiles, residuals)
         except Exception as error:  # noqa: BLE001 - result integrity fence
             return self._failure(
                 "result",
@@ -1976,8 +2025,12 @@ class BoundEvaluator:
                 message=str(error),
             )
 
-    def evaluate(self, frame: EvaluationFrame) -> EvaluationResult | EvaluationFailure:
-        """Fence one complete call under the declared single-owner contract."""
+    def _fenced_evaluate(
+        self,
+        frame: EvaluationFrame,
+        *,
+        materialize: bool,
+    ) -> EvaluationResult | Array | EvaluationFailure:
         if os.getpid() != self._owner_pid:
             return self._failure(
                 "binding", "workspace_process_violation", "INVALID_PLAN_OR_BINDING"
@@ -2000,7 +2053,7 @@ class BoundEvaluator:
                 under="ignore",
                 invalid="raise",
             ):
-                return self._evaluate_impl(frame)
+                return self._evaluate_impl(frame, materialize=materialize)
         except FloatingPointError as error:
             return self._failure(
                 "residual", "non_finite_residual", "INVALID_TRIAL", message=str(error)
@@ -2014,3 +2067,17 @@ class BoundEvaluator:
             )
         finally:
             self._in_flight = False
+
+    def evaluate(self, frame: EvaluationFrame) -> EvaluationResult | EvaluationFailure:
+        """Fence one complete call under the declared single-owner contract."""
+        return cast(
+            "EvaluationResult | EvaluationFailure",
+            self._fenced_evaluate(frame, materialize=True),
+        )
+
+    def evaluate_residuals(self, frame: EvaluationFrame) -> Array | EvaluationFailure:
+        """Evaluate one ephemeral solver request without publication evidence."""
+        return cast(
+            "Array | EvaluationFailure",
+            self._fenced_evaluate(frame, materialize=False),
+        )

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -2220,7 +2220,6 @@ class CancellationToken:
 class _CompletedRequest:
     summary: CandidateSummary
     residuals: tuple[float, ...]
-    evaluation_identity: str
 
 
 class _AttemptStop(RuntimeError):
@@ -2299,7 +2298,7 @@ class _LiveAttempt:
                     f"{type(error).__name__}: {error}",
                 ),
             ) from error
-        outcome = self.evaluator.evaluate(frame)
+        outcome = self.evaluator.evaluate_residuals(frame)
         self.completed += 1
         if isinstance(outcome, EvaluationFailure):
             terminal = (
@@ -2318,7 +2317,7 @@ class _LiveAttempt:
         try:
             residuals = tuple(
                 _finite_binary64(value, name=f"residual[{index}]")
-                for index, value in enumerate(outcome.residuals)
+                for index, value in enumerate(outcome)
             )
             chi_square = canonical_chi_square(residuals)
         except (TypeError, ValueError, ObjectiveScalarizationError) as error:
@@ -2330,7 +2329,7 @@ class _LiveAttempt:
                 ),
             ) from error
         summary = CandidateSummary(vector, chi_square, self.received)
-        request = _CompletedRequest(summary, residuals, outcome.identity)
+        request = _CompletedRequest(summary, residuals)
         self.requests.append(request)
         if self.best is None or summary.ordering_key() < self.best.ordering_key():
             self.best = summary
@@ -2705,8 +2704,7 @@ def _validate_materialized_result(
             "Fresh materialization differs from converged request evidence"
         )
     if (
-        materialized.identity != request.evaluation_identity
-        or materialized.plan_identity != problem.evaluation_plan_identity
+        materialized.plan_identity != problem.evaluation_plan_identity
         or materialized.parameterization_identity
         != problem.evaluator_parameterization_identity
         or materialized.evaluator_compatibility_identity
@@ -3509,7 +3507,6 @@ def _validate_derived_candidate_for_root(
     return _CompletedRequest(
         materialization.candidate,
         tuple(float(value) for value in evaluation.residuals),
-        evaluation.identity,
     )
 
 

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -646,8 +646,22 @@ class ActiveParameterization:
         repr=False,
         compare=False,
     )
+    _ordered_constraints: tuple[CompiledConstraint, ...] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _affected_constraint_positions: Mapping[str, tuple[int, ...]] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def __post_init__(self) -> None:
+        # Validate the exact callable references once, when this immutable
+        # parameterization occurrence becomes executable. Repeated resolution
+        # then uses the already-bound functions without source introspection.
+        self.binder.validate_implementations()
         roles = tuple(self._roles)
         role_index = MappingProxyType(dict(roles))
         if tuple(role_index) != self.program.scope_ids:
@@ -655,6 +669,37 @@ class ActiveParameterization:
             raise ValueError(msg)
         object.__setattr__(self, "_roles", roles)
         object.__setattr__(self, "_role_index", role_index)
+        constraints = {item.target_id: item for item in self.program.constraints}
+        ordered_constraints = tuple(
+            constraints[target_id] for target_id in self.program.evaluation_order
+        )
+        outgoing: dict[str, list[str]] = {}
+        for constraint in ordered_constraints:
+            for dependency in constraint.dependencies:
+                outgoing.setdefault(dependency, []).append(constraint.target_id)
+        positions = {
+            constraint.target_id: position
+            for position, constraint in enumerate(ordered_constraints)
+        }
+        affected: dict[str, tuple[int, ...]] = {}
+        for independent_id in self.program.independent_ids:
+            pending = list(outgoing.get(independent_id, ()))
+            targets: set[str] = set()
+            while pending:
+                target_id = pending.pop()
+                if target_id in targets:
+                    continue
+                targets.add(target_id)
+                pending.extend(outgoing.get(target_id, ()))
+            affected[independent_id] = tuple(
+                sorted(positions[target_id] for target_id in targets)
+            )
+        object.__setattr__(self, "_ordered_constraints", ordered_constraints)
+        object.__setattr__(
+            self,
+            "_affected_constraint_positions",
+            MappingProxyType(affected),
+        )
         object.__setattr__(
             self,
             "identity",
@@ -740,23 +785,47 @@ class ActiveParameterization:
             _items=items,
         )
 
-    def resolve(self, frame: IndependentValueFrame) -> ResolvedParameterValues:
+    def _resolve_values(
+        self,
+        frame: IndependentValueFrame,
+        previous: Mapping[str, float] | None = None,
+    ) -> dict[str, float]:
         _validate_frame(self, frame)
-        self.binder.validate_implementations()
-        values = {
+        independent_values = {
             param_id: _finite_scalar(value, param_id=param_id)
             for param_id, value in frame._items
         }
-        constraints = {item.target_id: item for item in self.program.constraints}
-        for position, target_id in enumerate(self.program.evaluation_order):
-            constraint = constraints[target_id]
-            values[target_id] = _evaluate_expression(
+        if previous is None:
+            values = independent_values
+            constraint_positions = range(len(self._ordered_constraints))
+        else:
+            values = dict(previous)
+            changed_ids = {
+                param_id
+                for param_id, value in independent_values.items()
+                if value != previous[param_id]
+            }
+            values.update(independent_values)
+            constraint_positions = sorted(
+                {
+                    position
+                    for param_id in changed_ids
+                    for position in self._affected_constraint_positions[param_id]
+                }
+            )
+        for position in constraint_positions:
+            constraint = self._ordered_constraints[position]
+            values[constraint.target_id] = _evaluate_expression(
                 constraint.expression,
                 values,
                 self.binder,
-                target_id=target_id,
+                target_id=constraint.target_id,
                 position=position,
             )
+        return values
+
+    def resolve(self, frame: IndependentValueFrame) -> ResolvedParameterValues:
+        values = self._resolve_values(frame)
         return ResolvedParameterValues(
             parameterization_identity=self.identity,
             program_fingerprint=self.program.fingerprint,

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -1936,6 +1936,19 @@ def test_real_de_and_real_trf_match_analytical_boundary_optimum() -> None:
             residuals[1] = evaluated.resolved_values[unselected_id] - unselected_target
             return dataclasses.replace(evaluated, residuals=residuals)
 
+        def evaluate_residuals(
+            self,
+            frame: EvaluationFrame,
+        ) -> Array | EvaluationFailure:
+            evaluated = self._delegate.evaluate_residuals(frame)
+            if isinstance(evaluated, EvaluationFailure):
+                return evaluated
+            values = dict(frame._items)
+            residuals = np.zeros_like(evaluated)
+            residuals[0] = values[selected_id] - target_below_bound
+            residuals[1] = values[unselected_id] - unselected_target
+            return residuals
+
     def analytical_new_evaluator() -> AnalyticalBoundaryEvaluator:
         return AnalyticalBoundaryEvaluator(original_new_evaluator())
 

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -29,6 +29,7 @@ from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import (
     BoundEvaluator,
     EvaluationEngine,
+    EvaluationFailure,
     EvaluationFrame,
     EvaluationResult,
 )
@@ -38,6 +39,7 @@ from chemex.optimize.direct_trf import (
     AffineHalfSpace,
     CancellationToken,
     CandidateSummary,
+    DirectTrfCandidateTerminal,
     DirectTrfConstructionError,
     DirectTrfInterrupted,
     DirectTrfInvocation,
@@ -52,8 +54,10 @@ from chemex.optimize.direct_trf import (
     canonical_chi_square,
     commit_accepted_fit,
     execute_direct_trf,
+    execute_direct_trf_candidate,
     materialize_root_candidate,
 )
+from chemex.optimize.grouped_direct_trf import FitDecomposition
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     compile_active_parameterization,
@@ -69,6 +73,7 @@ ROOT = Path(__file__).parent.parent
 EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
 PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
 METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+CPMG_ROOT = ROOT / "examples/Experiments/CPMG_15N_IP"
 
 
 def _qualification_fit(
@@ -544,6 +549,110 @@ def test_representative_single_component_fit_materializes_and_commits_atomically
         )
     assert session.analysis_values.snapshot() == committed
     assert _presentation_values(session, problem.commit_scope) == presentation_before
+
+
+def test_solver_requests_use_lean_residuals_and_acceptance_materializes_fresh() -> None:
+    _session, _experiments, parameterization, engine, problem, invocation = (
+        _qualification_fit()
+    )
+    complete_calls = 0
+    residual_calls = 0
+    original_evaluate = BoundEvaluator.evaluate
+    original_evaluate_residuals = BoundEvaluator.evaluate_residuals
+
+    def counted_complete(
+        evaluator: BoundEvaluator,
+        frame: EvaluationFrame,
+    ) -> EvaluationResult | EvaluationFailure:
+        nonlocal complete_calls
+        complete_calls += 1
+        return original_evaluate(evaluator, frame)
+
+    def counted_residuals(
+        evaluator: BoundEvaluator,
+        frame: EvaluationFrame,
+    ) -> Array | EvaluationFailure:
+        nonlocal residual_calls
+        residual_calls += 1
+        return original_evaluate_residuals(evaluator, frame)
+
+    with (
+        patch.object(BoundEvaluator, "evaluate", counted_complete),
+        patch.object(BoundEvaluator, "evaluate_residuals", counted_residuals),
+    ):
+        outcome = execute_direct_trf(problem, invocation, parameterization, engine)
+
+    assert outcome.terminal is DirectTrfOutcomeTerminal.ACCEPTED
+    assert outcome.materialization is not None
+    assert outcome.materialization.evaluation_count == 1
+    assert outcome.materialization.cache_hits == 0
+    assert outcome.execution.counters.solver_requests_received == 16
+    assert complete_calls == 2  # one preflight and one fresh accepted materialization
+    assert residual_calls == outcome.execution.counters.objective_evaluations_completed
+
+
+def test_cpmg_step1_direct_trf_preserves_requests_and_reuses_profile_kernels() -> None:
+    method = read_methods([CPMG_ROOT / "Methods/method.toml"])["STEP1"]
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        sorted((CPMG_ROOT / "Experiments").glob("*.toml")),
+        method.selection,
+        session=session,
+    )
+    session.parameters.set_defaults(
+        read_defaults([CPMG_ROOT / "Parameters/parameters.toml"])
+    )
+    assert session.try_build_analysis_values()
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    root_problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    decomposition = FitDecomposition.from_root(
+        root_problem,
+        parameterization,
+        engine,
+    )
+    assert len(decomposition.components) == 1
+    component = decomposition.components[0]
+    component_engine = engine.project_profiles(component.root_profile_indices)
+    invocation = DirectTrfInvocation.for_problem(
+        component.problem,
+        objective_request_budget=2000 * (len(component.controlled_ids) + 1),
+        x_scale=tuple(max(1.0, abs(value)) for value in component.problem.start),
+    )
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    original_calculate = pulse_type.calculate
+    kernel_calls = 0
+
+    def counted_kernel(self: object, spectrometer: object, data: object) -> Array:
+        nonlocal kernel_calls
+        kernel_calls += 1
+        return original_calculate(self, spectrometer, data)
+
+    with patch.object(pulse_type, "calculate", counted_kernel):
+        outcome = execute_direct_trf_candidate(
+            component.problem,
+            invocation,
+            parameterization,
+            component_engine,
+        )
+
+    assert outcome.terminal is DirectTrfCandidateTerminal.SUCCESS
+    assert outcome.candidate is not None
+    assert outcome.execution.backend is not None
+    assert outcome.execution.backend.nfev == 7
+    assert outcome.execution.backend.njev == 7
+    assert outcome.execution.counters.solver_requests_received == 126
+    assert outcome.execution.counters.objective_evaluations_completed == 126
+    assert kernel_calls == 360
+    assert outcome.candidate.chi_square == pytest.approx(285.8191490381348)
 
 
 def test_live_commit_authority_is_atomic_under_concurrent_use() -> None:

--- a/tests/test_native_evaluation.py
+++ b/tests/test_native_evaluation.py
@@ -24,6 +24,7 @@ from chemex.evaluation.native import (
     _parameterization_failure_validity,
 )
 from chemex.experiments.builder import build_experiments
+from chemex.parameters import parameterization as parameterization_module
 from chemex.parameters.parameterization import (
     AmbiguousParameterReferenceError,
     ConstraintCycleError,
@@ -692,6 +693,189 @@ def test_workspace_reuse_cache_and_fresh_workspace_are_scientifically_identical(
         first.residuals[0] = 0.0
 
 
+def test_profile_local_caches_reuse_and_invalidate_only_resolved_dependencies() -> None:
+    session, experiments = _shipped_dcest("1N", "2N", "3N", "4N", "5N", "6N", "7N")
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    evaluator = engine.new_evaluator()
+    frame = _evaluation_frame(session, parameterization)
+    pulse_type = type(next(iter(experiments)).profiles[0].pulse_sequence)
+    original = pulse_type.calculate
+    calls: list[object] = []
+
+    def counted(self: object, spectrometer: object, data: object) -> Array:
+        calls.append(self)
+        return original(self, spectrometer, data)
+
+    def perturbed(param_id: str) -> EvaluationFrame:
+        return EvaluationFrame(
+            frame.parameterization_identity,
+            tuple(
+                (item_id, value * 1.000001 if item_id == param_id else value)
+                for item_id, value in frame._items
+            ),
+        )
+
+    with patch.object(pulse_type, "calculate", counted):
+        first = evaluator.evaluate(frame)
+        assert isinstance(first, EvaluationResult)
+        assert len(calls) == 7
+
+        calls.clear()
+        repeated = evaluator.evaluate(frame)
+        assert isinstance(repeated, EvaluationResult)
+        assert len(calls) == 0
+
+        calls.clear()
+        local = evaluator.evaluate(perturbed("__R2_A_1N_800_2MHZ"))
+        assert isinstance(local, EvaluationResult)
+        assert len(calls) == 1
+
+        calls.clear()
+        constrained = evaluator.evaluate(perturbed("__DW_AB_2N"))
+        assert isinstance(constrained, EvaluationResult)
+        assert len(calls) == 1
+
+        calls.clear()
+        global_change = evaluator.evaluate(perturbed("__D2O__0_1000"))
+        assert isinstance(global_change, EvaluationResult)
+        assert len(calls) == 7
+
+        fresh = engine.new_evaluator()
+        assert fresh.cache_statistics == dataclasses.replace(
+            evaluator.cache_statistics,
+            hits=0,
+            misses=0,
+            entries=0,
+        )
+        calls.clear()
+        fresh_result = fresh.evaluate(frame)
+        assert isinstance(fresh_result, EvaluationResult)
+        assert len(calls) == 7
+
+    assert evaluator.cache_statistics.entries == 16
+    np.testing.assert_array_equal(first.residuals, repeated.residuals)
+
+
+def test_solver_residual_evaluation_matches_complete_result_without_materializing_it() -> (
+    None
+):
+    session, experiments = _shipped_dcest("1N", "2N")
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    frame = _evaluation_frame(session, parameterization)
+    complete = engine.new_evaluator().evaluate(frame)
+    assert isinstance(complete, EvaluationResult)
+
+    with patch(
+        "chemex.evaluation.native.EvaluationResult",
+        side_effect=AssertionError(
+            "solver trials must not materialize complete results"
+        ),
+    ):
+        residuals = engine.new_evaluator().evaluate_residuals(frame)
+
+    assert isinstance(residuals, np.ndarray)
+    np.testing.assert_array_equal(residuals, complete.residuals)
+
+
+def test_profile_local_cache_capacity_remains_bounded() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    evaluator = EvaluationEngine.from_experiments(
+        experiments, parameterization
+    ).new_evaluator()
+    frame = _evaluation_frame(session, parameterization)
+    param_id = "__R2_A_1N_800_2MHZ"
+
+    for ordinal in range(7):
+        outcome = evaluator.evaluate(
+            EvaluationFrame(
+                frame.parameterization_identity,
+                tuple(
+                    (
+                        item_id,
+                        value * (1.0 + ordinal * 1.0e-6)
+                        if item_id == param_id
+                        else value,
+                    )
+                    for item_id, value in frame._items
+                ),
+            )
+        )
+        assert isinstance(outcome, EvaluationResult)
+
+    assert 0 < evaluator.cache_statistics.entries <= 5
+
+
+def test_repeated_trial_resolution_reuses_unchanged_constraint_values() -> None:
+    session, experiments = _shipped_dcest("1N", "2N", "3N", "4N", "5N", "6N", "7N")
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    frame = _evaluation_frame(session, parameterization)
+    changed_id = "__D2O__0_1000"
+    changed_frame = EvaluationFrame(
+        frame.parameterization_identity,
+        tuple(
+            (param_id, value * 1.000001 if param_id == changed_id else value)
+            for param_id, value in frame._items
+        ),
+    )
+    original = parameterization_module._evaluate_expression
+    counts = {"reused": 0, "fresh": 0}
+    phase = "reused"
+
+    def counted(*args: object, **kwargs: object) -> float:
+        counts[phase] += 1
+        return original(*args, **kwargs)
+
+    reused = engine.new_evaluator()
+    with patch.object(parameterization_module, "_evaluate_expression", counted):
+        initial = reused.evaluate(frame)
+        initial_count = counts["reused"]
+        changed = reused.evaluate(changed_frame)
+        changed_count = counts["reused"] - initial_count
+        phase = "fresh"
+        fresh = engine.new_evaluator().evaluate(changed_frame)
+
+    assert isinstance(initial, EvaluationResult)
+    assert isinstance(changed, EvaluationResult)
+    assert isinstance(fresh, EvaluationResult)
+    assert 0 < changed_count < initial_count
+    assert counts["fresh"] == initial_count
+    assert changed.resolved_values == fresh.resolved_values
+    np.testing.assert_array_equal(changed.residuals, fresh.residuals)
+
+
+def test_solver_residual_failure_classification_matches_complete_evaluation() -> None:
+    session, experiments = _shipped_dcest()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    frame = _evaluation_frame(session, parameterization)
+
+    with patch.object(
+        type(parameterization),
+        "_resolve_values",
+        side_effect=ConstraintDomainError("outside scientific domain"),
+    ):
+        complete = engine.new_evaluator().evaluate(frame)
+        residuals = engine.new_evaluator().evaluate_residuals(frame)
+
+    assert isinstance(complete, EvaluationFailure)
+    assert isinstance(residuals, EvaluationFailure)
+    assert (
+        residuals.stage,
+        residuals.category,
+        residuals.validity,
+        residuals.message,
+    ) == (
+        complete.stage,
+        complete.category,
+        complete.validity,
+        complete.message,
+    )
+
+
 def test_native_normalization_uses_the_no_epsilon_572_formula() -> None:
     session, experiments = _shipped_dcest()
     profile = next(iter(experiments)).profiles[0]
@@ -1273,7 +1457,7 @@ def test_evaluator_maps_declared_parameterization_failures(
         experiments, parameterization
     ).new_evaluator()
     with patch.object(
-        type(parameterization), "resolve", side_effect=error_type("test")
+        type(parameterization), "_resolve_values", side_effect=error_type("test")
     ):
         outcome = evaluator.evaluate(_evaluation_frame(session, parameterization))
     assert isinstance(outcome, EvaluationFailure)

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -18,7 +18,6 @@ from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
 from chemex.experiments.builder import build_experiments
 from chemex.models.factory import model_factory
-from chemex.nmr.rates import rate_functions
 from chemex.parameters.database import ParameterIndex
 from chemex.parameters.name import ParamName
 from chemex.parameters.parameterization import (
@@ -36,6 +35,7 @@ from chemex.parameters.parameterization import (
     ParameterDeclaration,
     ParameterDeclarationContribution,
     ParameterRole,
+    ScientificFunctionBinder,
     SealedParameterDeclarations,
     SealedParameterModel,
     UnsupportedConstraintExpressionError,
@@ -1140,7 +1140,7 @@ def test_scientific_function_identity_tracks_same_metadata_implementation_change
         second.resolve(first_frame)
 
 
-def test_mutated_bound_scientific_function_cannot_change_compiled_program(
+def test_mutated_scientific_function_is_rejected_at_fresh_binding_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class MutableScientificFunction:
@@ -1177,42 +1177,47 @@ def test_mutated_bound_scientific_function_cannot_change_compiled_program(
     function.scale = 3.0
 
     with pytest.raises(ConstraintProgramMismatchError) as raised:
-        parameterization.resolve(frame)
+        dataclasses.replace(
+            parameterization,
+            occurrence_identity="fresh-binding-occurrence",
+        )
 
     assert raised.value.code == "program_mismatch"
     assert raised.value.context["function_id"] == "mutable"
 
 
-def test_mutated_shipped_rate_class_state_cannot_change_compiled_program(
+def test_valid_scientific_functions_validate_once_per_bound_occurrence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    declarations = (
-        ParameterDeclaration("__H", False),
-        ParameterDeclaration("__TAUC", False),
-        ParameterDeclaration("__S2", False),
-        ParameterDeclaration("__R2", False, 'nh(__H, __TAUC, __S2)["r2_i"]'),
+    validation_calls = 0
+    original_validate = ScientificFunctionBinder.validate_implementations
+
+    def counted_validate(binder: ScientificFunctionBinder) -> None:
+        nonlocal validation_calls
+        validation_calls += 1
+        original_validate(binder)
+
+    monkeypatch.setattr(
+        ScientificFunctionBinder,
+        "validate_implementations",
+        counted_validate,
     )
+    declarations = (ParameterDeclaration("__A", False),)
     parameter_model, snapshot = _native_fixture(
         declarations,
-        values={"__H": 800.0, "__TAUC": 5.0, "__S2": 0.9, "__R2": 0.0},
+        values={"__A": 2.0},
     )
     parameterization = compile_active_parameterization(
         parameter_model,
         snapshot,
         Method(),
-        {"__R2"},
+        {"__A"},
     )
     frame = parameterization.frame_from_snapshot(snapshot)
-    parameterization.resolve(frame)
-    rate_type = type(rate_functions["nh"])
-
-    monkeypatch.setattr(rate_type, "gi", rate_type.gi * 1.01)
-
-    with pytest.raises(ConstraintProgramMismatchError) as raised:
+    for _ in range(200):
         parameterization.resolve(frame)
 
-    assert raised.value.code == "program_mismatch"
-    assert raised.value.context["function_id"] == "nh"
+    assert validation_calls == 1
 
 
 def test_malformed_scientific_function_component_is_typed(


### PR DESCRIPTION
Closes #667.

## Root causes fixed

- Move `ScientificFunctionBinder` implementation validation to immutable `ActiveParameterization` construction. The occurrence retains the exact callable references it validated; ordinary `resolve()` calls perform no source inspection or fingerprint recomputation.
- Replace the evaluator-wide five-entry LRU with a private `_ProfileWorkspace` per `ProfilePlan`, each owning its template, live capability, and bounded five-entry cache. Keys contain only resolved local inputs; aggregate hit/miss/entry statistics remain available.
- Add a residual-only `BoundEvaluator.evaluate_residuals()` seam for SciPy trial points. Full `ProfileEvaluation`, aggregate calculation arrays, resolved-value publication wrappers, and `EvaluationResult` identity are built only by complete evaluations.
- Remove the unused per-request `evaluation_identity`; convergence evidence still matches vector, residuals, chi-square, plan, parameterization, compatibility, and resolved scope against a fresh accepted-point materialization.
- Reuse unchanged resolved constraint values between requests using dependency closure compiled from the existing constraint graph. This preserves complete resolution and failure semantics while removing repeated unrelated expression work.

## Numerical policies deliberately unchanged

- dense `scipy.optimize.least_squares(method="trf")`
- `jac="2-point"`, `diff_step=None`, `tr_solver="exact"`
- `loss="linear"`, `f_scale=1`, `ftol=xtol=gtol=1e-8`
- `x_scale_i = max(1, abs(start_i))`
- objective-request budget `2000 * (n_controlled + 1)`

No progress, covariance, correlation, uncertainty-rendering, output-format, or migration infrastructure changes are included.

## Controlled performance

Python 3.14.5, NumPy 2.5.1, SciPy 1.18.0, macOS arm64/Accelerate, one native/BLAS thread. Old-product and candidate figures are rerun medians where repeated; the main figures are the controlled investigation baseline. The CPMG and CEST STEP1 rows are isolated microbenchmarks built directly from the STEP1 profile selection, without the product workflow's preceding all-profile noise-estimation and `filter_from_values()` pass.

| Case | Old lmfit product | Current main | Candidate | Candidate work / outcome |
|---|---:|---:|---:|---|
| RELAXATION_HZNZ G2 | 0.00424 s | 0.09285 s | 0.00428 s | nfev/njev 8/8; 16 requests; 17 kernels; chi-square 13.2171 |
| CPMG_15N_IP STEP1 (isolated, unfiltered) | 0.15632 s | 1.305 s | 0.13194 s | nfev/njev 7/7; 126 requests; 360 kernels (main: 1,280); 920 hits / 350 misses; chi-square 285.8191 |
| CPMG 27N | 1.04887 s | 5.955 s | 0.64300 s | 1.63x faster than lmfit; nfev/njev 239/231; 932 requests; 1,404 kernels; chi-square 27.8209 |
| CEST_13C_LABEL_CN STEP1 (isolated, unfiltered) | 4.29486 s | 19.780 s | 3.87132 s | nfev/njev 8/8; 280 requests; 627 kernels; 2,475 hits / 616 misses; chi-square 3419.9782 |
| Full CEST workflow | — | accepted native basin | accepted native basin | aggregate chi-square 2849.5 |

The isolated STEP1 absolute chi-squares are not the product-workflow STEP1 values. The earlier all-profile, pre-fit-filtered diagnostic produced 434.5552 for CPMG and 1289.0562 for CEST: CPMG used globally estimated uncertainties from the complete experiment population, while CEST additionally retained 935 rather than 1,040 observations after configured offset filtering. Within every timing-table row, old/main/candidate use the same workload.

The final CPMG profile is dominated by scientific kernel execution, with constraint resolution reduced to a secondary cost. Since all timing targets are met without changing solver requests or numerical policy, a dependency-aware callable Jacobian is not justified in this PR.

## Deterministic regressions

- valid scientific implementations validate once across 200 resolutions; invalid/rebound implementations fail at fresh binding
- seven-profile identical repeat performs zero kernels
- local, transitive constrained, and global perturbations recalculate exactly 1, 1, and 7 profiles
- invalid-trial reset, poisoning, bounded-cache, fresh-evaluator, and resampling/rebinding behavior remain covered
- representative CPMG STEP1 retains exactly 126 objective requests while reducing total kernels from 1,280 to 360
- solver requests use the lean seam; preflight and accepted-point materialization remain complete, immutable, and fresh (`materialization_cache_hits == 0`)

## Validation

- Python 3.14.5: `1178 passed`
- Python 3.13.13: `1178 passed`
- focused evaluation/parameterization/Direct, grouped Direct, DE-polish, GRID, MC/BS/BSN, MCMC, production CPMG/CEST, and accepted-difference qualification tests passed
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `uv build`
- `graphify update .`

Standards and Specification reviews passed. The sole initial Standards judgment call (parallel profile-state tuples) was resolved by `_ProfileWorkspace`; the follow-up review found no remaining standards or smell findings. No user-facing documentation was changed because product/scientific contracts are unchanged.
