### PR TITLE
Restore native minimization progress reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 ## [Unreleased]
 
 ### Changed
+- Native deterministic minimization once again reports fit progress. The Rich
+  display shows objective evaluations, best and reduced chi-square, relative
+  improvement, elapsed time, and applicable step/group or aggregated GRID
+  context; objective evaluations are no longer mislabeled as solver iterations.
+  Internal MC, BS, and BSN refits remain under the existing statistics-level
+  reporting rather than opening a progress stream for every replicate.
 - Removed the unreachable legacy optimizer, MCMC, resampling, parameter-container,
   and live legacy-observation compatibility paths. ChemEx deterministic fitting
   now uses bounded SciPy TRF exclusively through the native ChemEx parameter and

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -15,11 +15,16 @@ Typical usage example:
 """
 
 from collections import Counter
+from collections.abc import Callable, Mapping
+from contextlib import suppress
+from dataclasses import replace
 from pathlib import Path
+from time import monotonic
 
 from pydantic import ValidationError
 from rich import box
 from rich.console import Console
+from rich.live import Live
 from rich.padding import Padding
 from rich.panel import Panel
 from rich.rule import Rule
@@ -28,8 +33,297 @@ from rich.table import Table
 from rich.text import Text
 
 from chemex import __version__
+from chemex.optimize.progress import (
+    FitProgressContext,
+    ProgressEvent,
+    ProgressPhase,
+    ProgressRateLimiter,
+    ProgressUpdate,
+)
 
 console = Console()
+
+
+class MinimizationProgressReporter:
+    """Own Rich rendering and UX policy for one visible deterministic fit."""
+
+    def __init__(
+        self,
+        output_console: Console,
+        *,
+        interactive: bool,
+        retained_observation_count: int,
+        controlled_parameter_count: int,
+        step_name: str = "",
+        group_labels: Mapping[frozenset[str], str] | None = None,
+        grid: bool = False,
+        enabled: bool = True,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        self._console = output_console
+        self._interactive = interactive
+        self._retained_observation_count = retained_observation_count
+        self._controlled_parameter_count = controlled_parameter_count
+        self._step_name = step_name
+        self._group_labels = {} if group_labels is None else dict(group_labels)
+        self._grid = grid
+        self._enabled = enabled
+        self._clock = clock
+        self._started_at: float | None = None
+        self._live: Live | None = None
+        self._limiters: dict[FitProgressContext, ProgressRateLimiter] = {}
+        self._noninteractive_limiter = ProgressRateLimiter(interactive=False)
+        self._noninteractive_started = False
+        self._noninteractive_reported_best: dict[FitProgressContext, float] = {}
+        self._grid_limiter = ProgressRateLimiter(interactive=interactive)
+        self._grid_started = False
+        self._completed_by_context: dict[FitProgressContext, int] = {}
+        self._finished = False
+        self._active = False
+
+    @property
+    def is_active(self) -> bool:
+        """Whether the reporter currently owns an active rendering scope."""
+        return self._active
+
+    def __enter__(self) -> "MinimizationProgressReporter":
+        self._active = True
+        if not self._enabled:
+            return self
+        self._started_at = self._clock()
+        if self._interactive:
+            try:
+                self._live = Live(
+                    "",
+                    console=self._console,
+                    auto_refresh=False,
+                    transient=True,
+                )
+                self._live.start(refresh=True)
+            except Exception:  # noqa: BLE001 - reporting is non-scientific
+                self._disable()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: object,
+    ) -> bool:
+        if self._enabled and exc_type is not None and not self._finished:
+            status = (
+                "interrupted" if issubclass(exc_type, KeyboardInterrupt) else "failed"
+            )
+            self._stop_live()
+            with suppress(Exception):
+                self._render_final(None, status)
+        else:
+            self._stop_live()
+        self._active = False
+        return False
+
+    def observe(self, context: FitProgressContext, event: ProgressEvent) -> None:
+        """Observe one contextual scalar event without affecting the fit."""
+        if not self._enabled:
+            return
+        try:
+            event = replace(event, elapsed_seconds=self._elapsed())
+            self._completed_by_context[context] = max(
+                event.objective_evaluations_completed,
+                self._completed_by_context.get(context, 0),
+            )
+            update = (
+                self._observe_grid(event)
+                if self._grid
+                else (
+                    self._limiter(context).observe(event)
+                    if self._interactive
+                    else self._observe_noninteractive(context, event)
+                )
+            )
+            if event.phase is ProgressPhase.TERMINATED and context.group_total == 1:
+                update = None
+            if update is not None:
+                self._render(
+                    _format_progress(
+                        context,
+                        update,
+                        self._context_label(context),
+                        self._step_name,
+                    )
+                )
+        except KeyboardInterrupt:
+            self._stop_live()
+            raise
+        except Exception:  # noqa: BLE001 - reporting failure is non-scientific
+            self._disable()
+
+    def finish(
+        self,
+        *,
+        final_chi_square: float | None,
+        terminal_status: str,
+    ) -> None:
+        """Close live rendering and emit one persistent aggregate terminal line."""
+        if not self._enabled or self._finished:
+            return
+        self._finished = True
+        self._stop_live()
+        try:
+            self._render_final(final_chi_square, terminal_status)
+        except KeyboardInterrupt:
+            raise
+        except Exception:  # noqa: BLE001 - reporting is non-scientific
+            self._disable()
+
+    def _limiter(self, context: FitProgressContext) -> ProgressRateLimiter:
+        return self._limiters.setdefault(
+            context,
+            ProgressRateLimiter(interactive=self._interactive),
+        )
+
+    def _observe_grid(self, event: ProgressEvent) -> ProgressUpdate | None:
+        if event.phase is ProgressPhase.STARTED:
+            if self._grid_started:
+                return None
+            self._grid_started = True
+            return self._grid_limiter.observe(event)
+        if event.phase is ProgressPhase.TERMINATED:
+            return None
+        probe = replace(
+            event,
+            current_chi_square=None,
+            best_chi_square=None,
+        )
+        selected = self._grid_limiter.observe(probe)
+        return None if selected is None else ProgressUpdate(event, None)
+
+    def _observe_noninteractive(
+        self,
+        context: FitProgressContext,
+        event: ProgressEvent,
+    ) -> ProgressUpdate | None:
+        phase = (
+            ProgressPhase.STARTED
+            if not self._noninteractive_started
+            else ProgressPhase.EVALUATED
+        )
+        self._noninteractive_started = True
+        elapsed = event.elapsed_seconds
+        probe = replace(
+            event,
+            phase=phase,
+            current_chi_square=None,
+            best_chi_square=None,
+            elapsed_seconds=elapsed,
+            terminal_status=None,
+        )
+        if self._noninteractive_limiter.observe(probe) is None:
+            return None
+        previous = self._noninteractive_reported_best.get(context)
+        best = event.best_chi_square
+        relative_change = (
+            None
+            if best is None or previous is None
+            else 0.0
+            if previous == 0.0
+            else (best - previous) / abs(previous)
+        )
+        if best is not None:
+            self._noninteractive_reported_best[context] = best
+        return ProgressUpdate(
+            replace(event, phase=phase, elapsed_seconds=elapsed, terminal_status=None),
+            relative_change,
+        )
+
+    def _context_label(self, context: FitProgressContext) -> str:
+        return self._group_labels.get(frozenset(context.controlled_ids), "")
+
+    def _elapsed(self) -> float:
+        return (
+            0.0
+            if self._started_at is None
+            else max(0.0, self._clock() - self._started_at)
+        )
+
+    def _render(self, line: str) -> None:
+        text = Text(line)
+        if self._live is not None:
+            self._live.update(text, refresh=True)
+        else:
+            self._console.print(text)
+
+    def _render_final(self, chi_square: float | None, status: str) -> None:
+        reduced = (
+            None
+            if chi_square is None
+            else chi_square
+            / max(
+                1,
+                self._retained_observation_count - self._controlled_parameter_count,
+            )
+        )
+        parts = [f"eval {sum(self._completed_by_context.values())} total"]
+        if chi_square is not None:
+            parts.append(f"final χ² {_format_scalar(chi_square)}")
+        if reduced is not None:
+            parts.append(f"red. χ² {_format_scalar(reduced)}")
+        parts.extend((f"{self._elapsed():.1f} s", status))
+        prefix = f"[{self._step_name}] " if self._step_name else ""
+        self._console.print(Text(prefix + " · ".join(parts)))
+
+    def _stop_live(self) -> None:
+        if self._live is None:
+            return
+        live, self._live = self._live, None
+        with suppress(Exception):
+            live.stop()
+
+    def _disable(self) -> None:
+        self._enabled = False
+        self._stop_live()
+
+
+def _format_scalar(value: float) -> str:
+    return f"{value:.6g}"
+
+
+def _format_progress(
+    context: FitProgressContext,
+    update: ProgressUpdate,
+    group_label: str,
+    step_name: str,
+) -> str:
+    event = update.event
+    labels: list[str] = [step_name] if step_name else []
+    if context.grid_seed_ordinal is not None and context.grid_seed_total is not None:
+        labels.append(
+            f"GRID seed {context.grid_seed_ordinal}/{context.grid_seed_total}"
+        )
+    if context.group_total > 1:
+        labels.append(f"group {context.group_ordinal}/{context.group_total}")
+        if group_label:
+            labels.append(group_label)
+    prefix = f"[{' · '.join(labels)}] " if labels else ""
+    parts = [
+        (
+            f"eval {event.objective_evaluations_completed}/"
+            f"{event.objective_request_budget}"
+        )
+    ]
+    if event.best_chi_square is None:
+        parts.append("starting")
+    else:
+        parts.append(f"best χ² {_format_scalar(event.best_chi_square)}")
+        reduced = event.reduced_chi_square
+        if reduced is not None:
+            parts.append(f"red. χ² {_format_scalar(reduced)}")
+    if update.relative_best_change is not None:
+        parts.append(f"Δχ² {100.0 * update.relative_best_change:+.2f}%")
+    parts.append(f"{event.elapsed_seconds:.1f} s")
+    if event.terminal_status:
+        parts.append(event.terminal_status)
+    return prefix + " · ".join(parts)
 
 
 LOGO = r"""
@@ -228,17 +522,17 @@ def print_section(name: str) -> None:
 
 def print_chi2_table_header() -> None:
     """Print the header for the chi-squared table."""
-    header = Text(f"{'Iteration':>9s}  {'χ²':>12s}  {'Reduced χ²':>12s}")
+    header = Text(f"{'Evaluation':>10s}  {'χ²':>12s}  {'Reduced χ²':>12s}")
     console.print()
     console.print(Padding.indent(header, 5), style="bold")
     console.print(Padding.indent("─" * 39, 4))
 
 
 def print_chi2_table_line(iteration: int, chisqr: float, redchi: float) -> None:
-    """Print a line in the chi-squared table with iteration and chi-squared values.
+    """Print a line in the chi-squared table with evaluation and chi-squared values.
 
     Args:
-        iteration (int): Iteration number.
+        iteration (int): Objective evaluation number (legacy keyword name).
         chisqr (float): Chi-squared value.
         redchi (float): Reduced chi-squared value.
 
@@ -251,7 +545,7 @@ def print_chi2_table_footer(iteration: int, chisqr: float, redchi: float) -> Non
     """Print the footer for the chi-squared table.
 
     Args:
-        iteration (int): Iteration number.
+        iteration (int): Objective evaluation number (legacy keyword name).
         chisqr (float): Chi-squared value.
         redchi (float): Reduced chi-squared value.
 

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from numbers import Real
 from threading import Event, RLock
+from time import monotonic
 from typing import SupportsIndex, cast
 from uuid import uuid4
 from weakref import ReferenceType, WeakKeyDictionary, ref
@@ -31,6 +32,7 @@ from chemex.evaluation.native import (
     EvaluationPlan,
     EvaluationResult,
 )
+from chemex.optimize.progress import ProgressEvent, ProgressObserver, ProgressPhase
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     IndependentValueFrame,
@@ -2229,6 +2231,108 @@ class _AttemptStop(RuntimeError):
         super().__init__(failure.message or failure.category)
 
 
+class _ProgressEmitter:
+    """Fail-safe observer adapter for one Direct-TRF attempt."""
+
+    def __init__(
+        self,
+        problem: OptimizationProblem,
+        invocation: DirectTrfInvocation,
+        retained_observation_count: int,
+        observer: ProgressObserver | None,
+    ) -> None:
+        self._problem = problem
+        self._invocation = invocation
+        self._retained_observation_count = retained_observation_count
+        self._observer = observer
+        self._started_at = monotonic() if observer is not None else None
+        self._current: CandidateSummary | None = None
+
+    def start(self) -> None:
+        if self._observer is None:
+            return
+        self._emit(
+            ProgressEvent(
+                ProgressPhase.STARTED,
+                0,
+                0,
+                0,
+                self._problem.start,
+                None,
+                None,
+                self._retained_observation_count,
+                len(self._problem.controlled_ids),
+                self._invocation.objective_request_budget,
+                self._elapsed(),
+            )
+        )
+
+    def evaluated(
+        self,
+        counters: AttemptCounters,
+        current: CandidateSummary,
+        best: CandidateSummary,
+    ) -> None:
+        if self._observer is None:
+            return
+        self._current = current
+        self._emit(
+            ProgressEvent(
+                ProgressPhase.EVALUATED,
+                counters.solver_requests_received,
+                counters.objective_requests_accepted,
+                counters.objective_evaluations_completed,
+                current.vector,
+                current.chi_square,
+                best.chi_square,
+                self._retained_observation_count,
+                len(self._problem.controlled_ids),
+                self._invocation.objective_request_budget,
+                self._elapsed(),
+            )
+        )
+
+    def finish(self, execution: DirectTrfExecution, status: str) -> None:
+        if self._observer is None:
+            return
+        current = execution.final_candidate or self._current or execution.best_candidate
+        self._emit(
+            ProgressEvent(
+                ProgressPhase.TERMINATED,
+                execution.counters.solver_requests_received,
+                execution.counters.objective_requests_accepted,
+                execution.counters.objective_evaluations_completed,
+                self._problem.start if current is None else current.vector,
+                None if current is None else current.chi_square,
+                (
+                    None
+                    if execution.best_candidate is None
+                    else execution.best_candidate.chi_square
+                ),
+                self._retained_observation_count,
+                len(self._problem.controlled_ids),
+                self._invocation.objective_request_budget,
+                self._elapsed(),
+                status,
+            )
+        )
+
+    def _elapsed(self) -> float:
+        return 0.0 if self._started_at is None else monotonic() - self._started_at
+
+    def _emit(self, event: ProgressEvent) -> None:
+        observer = self._observer
+        if observer is None:
+            return
+        try:
+            observer(event)
+        except KeyboardInterrupt:
+            self._observer = None
+            raise
+        except Exception:  # noqa: BLE001 - UI observation is fail-safe
+            self._observer = None
+
+
 class _LiveAttempt:
     def __init__(
         self,
@@ -2237,12 +2341,14 @@ class _LiveAttempt:
         parameterization: ActiveParameterization,
         evaluator: BoundEvaluator,
         cancellation: CancellationToken,
+        progress: _ProgressEmitter,
     ) -> None:
         self.problem = problem
         self.invocation = invocation
         self.parameterization = parameterization
         self.evaluator = evaluator
         self.cancellation = cancellation
+        self.progress = progress
         self.received = 0
         self.accepted = 0
         self.completed = 0
@@ -2333,6 +2439,7 @@ class _LiveAttempt:
         self.requests.append(request)
         if self.best is None or summary.ordering_key() < self.best.ordering_key():
             self.best = summary
+        self.progress.evaluated(self.counters, summary, self.best)
         if self.cancellation.is_cancelled:
             raise _AttemptStop(
                 DirectTrfTerminal.CANCELLED,
@@ -3269,10 +3376,18 @@ def _execute_direct_trf_attempt(
     parameterization: ActiveParameterization,
     engine: EvaluationEngine,
     token: CancellationToken,
+    progress: _ProgressEmitter,
 ) -> tuple[DirectTrfExecution, _CompletedRequest] | DirectTrfOutcome:
     occurrence_identity = uuid4().hex
     evaluator = engine.new_evaluator()
-    live = _LiveAttempt(problem, invocation, parameterization, evaluator, token)
+    live = _LiveAttempt(
+        problem,
+        invocation,
+        parameterization,
+        evaluator,
+        token,
+        progress,
+    )
     if token.is_cancelled:
         return _failed_outcome(
             _execution(
@@ -3360,6 +3475,7 @@ def execute_direct_trf(
     engine: EvaluationEngine,
     *,
     cancellation: CancellationToken | None = None,
+    progress_observer: ProgressObserver | None = None,
 ) -> DirectTrfOutcome:
     """Execute one bounded Direct-TRF attempt and fresh acceptance materialization."""
     if not problem.acceptance_authority:
@@ -3368,33 +3484,53 @@ def execute_direct_trf(
         )
     _validate_execution_context(problem, invocation, parameterization, engine)
     token = CancellationToken() if cancellation is None else cancellation
-    attempt = _execute_direct_trf_attempt(
+    progress = _ProgressEmitter(
         problem,
         invocation,
-        parameterization,
-        engine,
-        token,
+        engine.plan.retained_observation_count,
+        progress_observer,
     )
+    progress.start()
+    try:
+        attempt = _execute_direct_trf_attempt(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            token,
+            progress,
+        )
+    except DirectTrfInterrupted as error:
+        progress.finish(error.execution, "interrupted")
+        raise
     if isinstance(attempt, DirectTrfOutcome):
+        progress.finish(attempt.execution, attempt.terminal.value)
         return attempt
     execution, request = attempt
-    materialized = _materialize_candidate(
-        execution,
-        problem,
-        invocation,
-        parameterization,
-        engine,
-        request,
-        token,
-    )
+    try:
+        materialized = _materialize_candidate(
+            execution,
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            request,
+            token,
+        )
+    except DirectTrfInterrupted as error:
+        progress.finish(error.execution, "interrupted")
+        raise
     if isinstance(materialized, DirectTrfOutcome):
+        progress.finish(materialized.execution, materialized.terminal.value)
         return materialized
-    return _accepted_outcome(
+    outcome = _accepted_outcome(
         materialized,
         execution,
         problem,
         invocation,
     )
+    progress.finish(execution, outcome.terminal.value)
+    return outcome
 
 
 def execute_direct_trf_candidate(
@@ -3404,17 +3540,30 @@ def execute_direct_trf_candidate(
     engine: EvaluationEngine,
     *,
     cancellation: CancellationToken | None = None,
+    progress_observer: ProgressObserver | None = None,
 ) -> DirectTrfCandidateOutcome:
     """Run Direct TRF for one component without acceptance or commit authority."""
     _validate_execution_context(problem, invocation, parameterization, engine)
     token = CancellationToken() if cancellation is None else cancellation
-    attempt = _execute_direct_trf_attempt(
+    progress = _ProgressEmitter(
         problem,
         invocation,
-        parameterization,
-        engine,
-        token,
+        engine.plan.retained_observation_count,
+        progress_observer,
     )
+    progress.start()
+    try:
+        attempt = _execute_direct_trf_attempt(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            token,
+            progress,
+        )
+    except DirectTrfInterrupted as error:
+        progress.finish(error.execution, "interrupted")
+        raise
     if isinstance(attempt, DirectTrfOutcome):
         terminal = {
             DirectTrfOutcomeTerminal.SOLVER_UNSUCCESSFUL: (
@@ -3425,38 +3574,48 @@ def execute_direct_trf_candidate(
             ),
             DirectTrfOutcomeTerminal.CANCELLED: DirectTrfCandidateTerminal.CANCELLED,
         }[attempt.terminal]
-        return DirectTrfCandidateOutcome(
+        outcome = DirectTrfCandidateOutcome(
             terminal,
             attempt.execution,
             attempt.materialization,
         )
+        progress.finish(attempt.execution, outcome.terminal.value)
+        return outcome
     execution, request = attempt
-    materialized = _materialize_candidate(
-        execution,
-        problem,
-        invocation,
-        parameterization,
-        engine,
-        request,
-        token,
-    )
+    try:
+        materialized = _materialize_candidate(
+            execution,
+            problem,
+            invocation,
+            parameterization,
+            engine,
+            request,
+            token,
+        )
+    except DirectTrfInterrupted as error:
+        progress.finish(error.execution, "interrupted")
+        raise
     if isinstance(materialized, DirectTrfOutcome):
         terminal = (
             DirectTrfCandidateTerminal.CANCELLED
             if materialized.terminal is DirectTrfOutcomeTerminal.CANCELLED
             else DirectTrfCandidateTerminal.MATERIALIZATION_FAILURE
         )
-        return DirectTrfCandidateOutcome(
+        outcome = DirectTrfCandidateOutcome(
             terminal,
             execution,
             materialized.materialization,
         )
-    return DirectTrfCandidateOutcome(
+        progress.finish(execution, outcome.terminal.value)
+        return outcome
+    outcome = DirectTrfCandidateOutcome(
         DirectTrfCandidateTerminal.SUCCESS,
         execution,
         materialized.materialization,
         materialized,
     )
+    progress.finish(execution, outcome.terminal.value)
+    return outcome
 
 
 def _validate_derived_candidate_for_root(

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -159,6 +159,7 @@ def run_methods(
             path_sect,
             plot_level,
             session=session,
+            step_name=section if len(methods) > 1 else "",
         )
         _run_requested_native_statistics(
             experiments,

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -36,6 +36,11 @@ from chemex.optimize.direct_trf import (
     canonical_chi_square,
     execute_direct_trf_candidate,
 )
+from chemex.optimize.progress import (
+    ContextualProgressObserver,
+    FitProgressContext,
+    ProgressObserver,
+)
 from chemex.parameters.parameterization import ActiveParameterization
 
 _SCHEMA_VERSION = 1
@@ -740,6 +745,9 @@ def execute_direct_trf_components(
     engine: EvaluationEngine,
     *,
     cancellation: CancellationToken | None = None,
+    progress_observer: ContextualProgressObserver | None = None,
+    grid_seed_ordinal: int | None = None,
+    grid_seed_total: int | None = None,
 ) -> tuple[FitComponentOutcome, ...]:
     """Execute canonical components without acceptance, commit, or publication."""
     if (
@@ -753,10 +761,14 @@ def execute_direct_trf_components(
     token = CancellationToken() if cancellation is None else cancellation
     outcomes: list[FitComponentOutcome] = []
     stopped = token.is_cancelled
-    for component, component_invocation in zip(
-        decomposition.components,
-        invocation.component_invocations,
-        strict=True,
+    component_total = len(decomposition.components)
+    for group_ordinal, (component, component_invocation) in enumerate(
+        zip(
+            decomposition.components,
+            invocation.component_invocations,
+            strict=True,
+        ),
+        start=1,
     ):
         if stopped:
             outcomes.append(_not_started(component))
@@ -767,12 +779,25 @@ def execute_direct_trf_components(
                 raise DirectTrfConstructionError(
                     "Component evaluator projection differs from its derivation"
                 )
+            context = FitProgressContext(
+                group_ordinal,
+                component_total,
+                component.controlled_ids,
+                grid_seed_ordinal,
+                grid_seed_total,
+            )
+            local_observer: ProgressObserver | None = (
+                None
+                if progress_observer is None
+                else lambda event, context=context: progress_observer(context, event)
+            )
             result = execute_direct_trf_candidate(
                 component.problem,
                 component_invocation,
                 parameterization,
                 child_engine,
                 cancellation=token,
+                progress_observer=local_observer,
             )
         except DirectTrfInterrupted as interrupted:
             interruption_failure = (
@@ -1390,6 +1415,7 @@ def execute_grouped_direct_trf(
     engine: EvaluationEngine,
     *,
     cancellation: CancellationToken | None = None,
+    progress_observer: ContextualProgressObserver | None = None,
 ) -> GroupedDirectTrfOutcome:
     """Execute all exact components, then freshly validate the root aggregate."""
     token = CancellationToken() if cancellation is None else cancellation
@@ -1427,6 +1453,7 @@ def execute_grouped_direct_trf(
         parameterization,
         engine,
         cancellation=token,
+        progress_observer=progress_observer,
     )
     return materialize_grouped_direct_trf(
         problem,

--- a/src/chemex/optimize/grouped_grid_direct_trf.py
+++ b/src/chemex/optimize/grouped_grid_direct_trf.py
@@ -52,6 +52,7 @@ from chemex.optimize.grouped_direct_trf import (
     _validate_component_projections,
     execute_direct_trf_components,
 )
+from chemex.optimize.progress import ContextualProgressObserver
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.values import AnalysisValues
 
@@ -309,6 +310,9 @@ def _execute_seed(
     parameterization: ActiveParameterization,
     engine: EvaluationEngine,
     token: CancellationToken,
+    progress_observer: ContextualProgressObserver | None,
+    grid_seed_ordinal: int,
+    grid_seed_total: int,
 ) -> GroupedGridSeedOutcome:
     if seed.rejection is not None:
         disposition = (
@@ -352,6 +356,9 @@ def _execute_seed(
         parameterization,
         engine,
         cancellation=token,
+        progress_observer=progress_observer,
+        grid_seed_ordinal=grid_seed_ordinal,
+        grid_seed_total=grid_seed_total,
     )
     if any(
         component.disposition is not ComponentDisposition.SUCCEEDED
@@ -735,6 +742,7 @@ def _execute_all_seeds(
     parameterization: ActiveParameterization,
     engine: EvaluationEngine,
     token: CancellationToken,
+    progress_observer: ContextualProgressObserver | None,
 ) -> tuple[GroupedGridSeedOutcome, ...] | GroupedGridDirectTrfOutcome:
     attempted: list[GroupedGridSeedOutcome] = []
     for index, seed in enumerate(invocation.seeds):
@@ -775,6 +783,9 @@ def _execute_all_seeds(
                 parameterization,
                 engine,
                 token,
+                progress_observer,
+                index + 1,
+                len(invocation.seeds),
             )
         except KeyboardInterrupt as error:
             attempt = _seed_exception(
@@ -904,6 +915,7 @@ def execute_grouped_grid_direct_trf(
     engine: EvaluationEngine,
     *,
     cancellation: CancellationToken | None = None,
+    progress_observer: ContextualProgressObserver | None = None,
 ) -> GroupedGridDirectTrfOutcome:
     """Run exact components per seed and accept only the best root aggregate."""
     _validate_context(problem, decomposition, invocation, parameterization, engine)
@@ -915,6 +927,7 @@ def execute_grouped_grid_direct_trf(
         parameterization,
         engine,
         token,
+        progress_observer,
     )
     if isinstance(seed_execution, GroupedGridDirectTrfOutcome):
         return seed_execution

--- a/src/chemex/optimize/method_step.py
+++ b/src/chemex/optimize/method_step.py
@@ -113,6 +113,7 @@ from chemex.optimize.native_resampling import (
     execute_resampling_evidence,
     summarize_resampling_evidence,
 )
+from chemex.optimize.progress import ContextualProgressObserver
 from chemex.optimize.uncertainty import (
     CompiledConstraintLinearizationCapabilities,
     ParameterUnit,
@@ -1778,6 +1779,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
     analysis_values: AnalysisValues,
     cancellation: CancellationToken | None = None,
     checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None = None,
+    progress_observer: ContextualProgressObserver | None = None,
 ) -> MethodStepOutcome:
     """Execute one exact native workflow occurrence."""
     execution_start = _pin_execution_start_workflow(workflow)
@@ -1792,6 +1794,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
             analysis_values=analysis_values,
             cancellation=cancellation,
             checkpoint_observer=checkpoint_observer,
+            progress_observer=progress_observer,
         )
     if cancellation is not None and cancellation.is_cancelled:
         return MethodStepOutcome(
@@ -2070,6 +2073,7 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
     analysis_values: AnalysisValues,
     cancellation: CancellationToken | None,
     checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None,
+    progress_observer: ContextualProgressObserver | None,
 ) -> MethodStepOutcome:
     _validate_execution_start_workflow(workflow, execution_start)
     problem = cast("OptimizationProblem", workflow.problem)
@@ -2086,6 +2090,7 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
                 workflow.parameterization,
                 workflow.engine,
                 cancellation=token,
+                progress_observer=progress_observer,
             )
         elif strategy is MethodStepStrategy.GRID_DIRECT_TRF:
             execution = execute_grouped_grid_direct_trf(
@@ -2095,6 +2100,7 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
                 workflow.parameterization,
                 workflow.engine,
                 cancellation=token,
+                progress_observer=progress_observer,
             )
         else:
             execution = execute_de_direct_trf(

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -10,7 +10,12 @@ import numpy as np
 from chemex.configuration.methods import Method
 from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import EvaluationEngine, EvaluationResult
-from chemex.messages import print_group_name, print_minimizing
+from chemex.messages import (
+    MinimizationProgressReporter,
+    console,
+    print_group_name,
+    print_minimizing,
+)
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     DirectTrfInvocation,
@@ -297,6 +302,7 @@ def run_native_deterministic(
     plot: str,
     *,
     session: AnalysisSession,
+    step_name: str = "",
 ) -> NativeDeterministicFit | None:
     """Execute one complete deterministic method occurrence natively."""
     parameter_model = session.parameter_factory.sealed_parameter_model
@@ -378,8 +384,37 @@ def run_native_deterministic(
         strategy=strategy,
         invocation=invocation,
     )
+    group_labels = {
+        controlled_ids: (
+            group_path.name.split("_", maxsplit=1)[-1] if group_path.name else ""
+        )
+        for group_path, controlled_ids in group_scopes
+    }
+    progress = MinimizationProgressReporter(
+        console,
+        interactive=console.is_terminal,
+        retained_observation_count=engine.plan.retained_observation_count,
+        controlled_parameter_count=len(problem.controlled_ids),
+        step_name=step_name,
+        group_labels=group_labels,
+        grid=bool(method.grid),
+    )
     print_minimizing()
-    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    with progress:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            progress_observer=progress.observe,
+        )
+        accepted_result = outcome.accepted_result
+        progress.finish(
+            final_chi_square=(
+                None if accepted_result is None else accepted_result.chi_square
+            ),
+            terminal_status=outcome.lifecycle.value,
+        )
+    if outcome.lifecycle is MethodStepLifecycle.INTERRUPTED:
+        raise KeyboardInterrupt("Native deterministic fit interrupted")
     if outcome.lifecycle is not MethodStepLifecycle.COMMITTED:
         primary = outcome.primary_execution
         failures = (

--- a/src/chemex/optimize/progress.py
+++ b/src/chemex/optimize/progress.py
@@ -1,0 +1,136 @@
+"""Portable observation data and rate limiting for native minimization."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+_RELATIVE_IMPROVEMENT_THRESHOLD = 1.0e-3
+_INTERACTIVE_HEARTBEAT_SECONDS = 5.0
+_NONINTERACTIVE_HEARTBEAT_SECONDS = 10.0
+
+
+class ProgressPhase(StrEnum):
+    """Lifecycle phase for one native Direct-TRF attempt."""
+
+    STARTED = "started"
+    EVALUATED = "evaluated"
+    TERMINATED = "terminated"
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressEvent:
+    """Already-computed scalar state at one objective-observation boundary."""
+
+    phase: ProgressPhase
+    solver_requests_received: int
+    objective_requests_accepted: int
+    objective_evaluations_completed: int
+    current_vector: tuple[float, ...]
+    current_chi_square: float | None
+    best_chi_square: float | None
+    retained_observation_count: int
+    controlled_parameter_count: int
+    objective_request_budget: int
+    elapsed_seconds: float
+    terminal_status: str | None = None
+
+    @property
+    def reduced_chi_square(self) -> float | None:
+        """Return reduced chi-square using ChemEx's established dof convention."""
+        if self.best_chi_square is None:
+            return None
+        degrees_of_freedom = max(
+            1,
+            self.retained_observation_count - self.controlled_parameter_count,
+        )
+        return self.best_chi_square / degrees_of_freedom
+
+
+type ProgressObserver = Callable[[ProgressEvent], None]
+
+
+@dataclass(frozen=True, slots=True)
+class FitProgressContext:
+    """Orchestration context for one local Direct-TRF attempt."""
+
+    group_ordinal: int
+    group_total: int
+    controlled_ids: tuple[str, ...]
+    grid_seed_ordinal: int | None = None
+    grid_seed_total: int | None = None
+
+
+type ContextualProgressObserver = Callable[[FitProgressContext, ProgressEvent], None]
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressUpdate:
+    """One progress event selected for user-visible reporting."""
+
+    event: ProgressEvent
+    relative_best_change: float | None
+
+
+class ProgressRateLimiter:
+    """Select useful progress updates without changing objective execution."""
+
+    def __init__(self, *, interactive: bool) -> None:
+        self._interactive = interactive
+        self._heartbeat_seconds = (
+            _INTERACTIVE_HEARTBEAT_SECONDS
+            if interactive
+            else _NONINTERACTIVE_HEARTBEAT_SECONDS
+        )
+        self._last_reported_elapsed: float | None = None
+        self._last_reported_best: float | None = None
+
+    def observe(self, event: ProgressEvent) -> ProgressUpdate | None:
+        """Return a visible update when the event satisfies the UX policy."""
+        relative_change = self._relative_change(event.best_chi_square)
+        report = event.phase in {ProgressPhase.STARTED, ProgressPhase.TERMINATED}
+
+        if event.phase is ProgressPhase.EVALUATED:
+            if self._interactive:
+                report = (
+                    self._last_reported_best is None
+                    and event.best_chi_square is not None
+                )
+                if relative_change is not None:
+                    report = (
+                        report or relative_change <= -_RELATIVE_IMPROVEMENT_THRESHOLD
+                    )
+            if self._last_reported_elapsed is not None:
+                report = report or (
+                    event.elapsed_seconds - self._last_reported_elapsed
+                    >= self._heartbeat_seconds
+                )
+
+        if not report:
+            return None
+
+        update = ProgressUpdate(event, relative_change)
+        self._last_reported_elapsed = event.elapsed_seconds
+        if event.best_chi_square is not None:
+            self._last_reported_best = event.best_chi_square
+        return update
+
+    def _relative_change(self, best_chi_square: float | None) -> float | None:
+        previous = self._last_reported_best
+        if best_chi_square is None or previous is None:
+            return None
+        if previous == 0.0:
+            return 0.0
+        return (best_chi_square - previous) / abs(previous)
+
+
+__all__ = [
+    "ContextualProgressObserver",
+    "FitProgressContext",
+    "ProgressEvent",
+    "ProgressPhase",
+    "ProgressObserver",
+    "ProgressRateLimiter",
+    "ProgressUpdate",
+]

--- a/tests/test_minimization_progress.py
+++ b/tests/test_minimization_progress.py
@@ -1,0 +1,441 @@
+"""Behavioral tests for native minimization progress reporting."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from chemex.messages import MinimizationProgressReporter
+from chemex.optimize.progress import (
+    FitProgressContext,
+    ProgressEvent,
+    ProgressPhase,
+    ProgressRateLimiter,
+)
+
+
+def _event(
+    phase: ProgressPhase,
+    *,
+    elapsed: float,
+    completed: int = 0,
+    current: float | None = None,
+    best: float | None = None,
+    terminal: str | None = None,
+    observations: int = 8,
+    parameters: int = 2,
+) -> ProgressEvent:
+    return ProgressEvent(
+        phase=phase,
+        solver_requests_received=completed,
+        objective_requests_accepted=completed,
+        objective_evaluations_completed=completed,
+        current_vector=(1.0, 2.0),
+        current_chi_square=current,
+        best_chi_square=best,
+        retained_observation_count=observations,
+        controlled_parameter_count=parameters,
+        objective_request_budget=100,
+        elapsed_seconds=elapsed,
+        terminal_status=terminal,
+    )
+
+
+def test_progress_policy_reports_start_improvement_heartbeat_and_terminal() -> None:
+    limiter = ProgressRateLimiter(interactive=True)
+
+    started = limiter.observe(_event(ProgressPhase.STARTED, elapsed=0.0))
+    first = limiter.observe(
+        _event(
+            ProgressPhase.EVALUATED,
+            elapsed=0.1,
+            completed=1,
+            current=100.0,
+            best=100.0,
+        )
+    )
+    below_threshold = limiter.observe(
+        _event(
+            ProgressPhase.EVALUATED,
+            elapsed=1.0,
+            completed=2,
+            current=99.95,
+            best=99.95,
+        )
+    )
+    improved = limiter.observe(
+        _event(
+            ProgressPhase.EVALUATED,
+            elapsed=2.0,
+            completed=3,
+            current=99.8,
+            best=99.8,
+        )
+    )
+    heartbeat = limiter.observe(
+        _event(
+            ProgressPhase.EVALUATED,
+            elapsed=7.0,
+            completed=4,
+            current=100.5,
+            best=99.8,
+        )
+    )
+    terminal = limiter.observe(
+        _event(
+            ProgressPhase.TERMINATED,
+            elapsed=7.1,
+            completed=4,
+            current=99.8,
+            best=99.8,
+            terminal="converged",
+        )
+    )
+
+    assert started is not None
+    assert first is not None
+    assert first.relative_best_change is None
+    assert below_threshold is None
+    assert improved is not None
+    assert improved.relative_best_change == pytest.approx(-0.002)
+    assert heartbeat is not None
+    assert heartbeat.relative_best_change == pytest.approx(0.0)
+    assert terminal is not None
+    assert terminal.event.terminal_status == "converged"
+
+
+def test_noninteractive_progress_uses_ten_second_heartbeat() -> None:
+    limiter = ProgressRateLimiter(interactive=False)
+    limiter.observe(_event(ProgressPhase.STARTED, elapsed=0.0))
+    early_improvement = limiter.observe(
+        _event(
+            ProgressPhase.EVALUATED,
+            elapsed=0.1,
+            completed=1,
+            current=100.0,
+            best=100.0,
+        )
+    )
+
+    before_heartbeat = limiter.observe(
+        _event(
+            ProgressPhase.EVALUATED,
+            elapsed=9.9,
+            completed=2,
+            current=90.0,
+            best=90.0,
+        )
+    )
+    heartbeat = limiter.observe(
+        _event(
+            ProgressPhase.EVALUATED,
+            elapsed=10.0,
+            completed=3,
+            current=89.0,
+            best=89.0,
+        )
+    )
+
+    assert early_improvement is None
+    assert before_heartbeat is None
+    assert heartbeat is not None
+
+
+@pytest.mark.parametrize(
+    ("observations", "parameters", "expected"),
+    [(8, 2, 2.0), (2, 2, 12.0), (1, 2, 12.0)],
+)
+def test_progress_reduced_chi_square_uses_existing_nonpositive_dof_convention(
+    observations: int,
+    parameters: int,
+    expected: float,
+) -> None:
+    event = _event(
+        ProgressPhase.EVALUATED,
+        elapsed=1.0,
+        current=12.0,
+        best=12.0,
+        observations=observations,
+        parameters=parameters,
+    )
+
+    assert event.reduced_chi_square == expected
+
+
+def _capturing_console(*, interactive: bool = False) -> tuple[Console, StringIO]:
+    stream = StringIO()
+    return (
+        Console(
+            file=stream,
+            force_terminal=interactive,
+            color_system=None,
+            width=180,
+        ),
+        stream,
+    )
+
+
+def test_noninteractive_reporter_renders_truthful_context_and_final_result() -> None:
+    output_console, stream = _capturing_console()
+    context = FitProgressContext(2, 3, ("__R1A_A_L18CD1",))
+    times = iter((0.0, 0.0, 12.4, 12.5, 12.6))
+    reporter = MinimizationProgressReporter(
+        output_console,
+        interactive=False,
+        retained_observation_count=8,
+        controlled_parameter_count=2,
+        step_name="STEP2",
+        group_labels={frozenset(context.controlled_ids): "L18CD1"},
+        clock=lambda: next(times),
+    )
+
+    with reporter:
+        reporter.observe(context, _event(ProgressPhase.STARTED, elapsed=0.0))
+        reporter.observe(
+            context,
+            _event(
+                ProgressPhase.EVALUATED,
+                elapsed=0.1,
+                completed=1,
+                current=12.0,
+                best=12.0,
+            ),
+        )
+        reporter.observe(
+            context,
+            _event(
+                ProgressPhase.TERMINATED,
+                elapsed=0.2,
+                completed=1,
+                current=12.0,
+                best=12.0,
+                terminal="success",
+            ),
+        )
+        reporter.finish(final_chi_square=12.0, terminal_status="committed")
+
+    rendered = stream.getvalue()
+    assert "STEP2" in rendered
+    assert "group 2/3" in rendered
+    assert "L18CD1" in rendered
+    assert "eval 1/100" in rendered
+    assert "best χ² 12" in rendered
+    assert "red. χ² 2" in rendered
+    assert "eval 1 total" in rendered
+    assert "final χ² 12" in rendered
+    assert "committed" in rendered
+    assert "Iteration" not in rendered
+    assert "iteration" not in rendered
+
+
+def test_noninteractive_reporter_rate_limits_group_transitions_fit_wide() -> None:
+    output_console, stream = _capturing_console()
+    times = iter((0.0, 0.0, 0.1, 0.2, 0.3, 10.1, 10.2, 10.3))
+    reporter = MinimizationProgressReporter(
+        output_console,
+        interactive=False,
+        retained_observation_count=8,
+        controlled_parameter_count=2,
+        clock=lambda: next(times),
+    )
+
+    with reporter:
+        for ordinal in range(1, 4):
+            context = FitProgressContext(ordinal, 3, (f"__P{ordinal}",))
+            reporter.observe(context, _event(ProgressPhase.STARTED, elapsed=0.0))
+            reporter.observe(
+                context,
+                _event(
+                    ProgressPhase.TERMINATED,
+                    elapsed=0.1,
+                    completed=1,
+                    current=12.0 - ordinal,
+                    best=12.0 - ordinal,
+                    terminal="success",
+                ),
+            )
+        reporter.finish(final_chi_square=9.0, terminal_status="committed")
+
+    rendered = stream.getvalue()
+    assert rendered.count("group ") == 2
+    assert "group 1/3" in rendered
+    assert "group 3/3" in rendered
+    assert "eval 3 total" in rendered
+
+
+def test_disabled_reporter_emits_no_output() -> None:
+    output_console, stream = _capturing_console()
+    reporter = MinimizationProgressReporter(
+        output_console,
+        interactive=False,
+        retained_observation_count=8,
+        controlled_parameter_count=2,
+        enabled=False,
+    )
+
+    with reporter:
+        reporter.observe(
+            FitProgressContext(1, 1, ("__PB",)),
+            _event(ProgressPhase.STARTED, elapsed=0.0),
+        )
+        reporter.finish(final_chi_square=12.0, terminal_status="committed")
+
+    assert stream.getvalue() == ""
+
+
+def test_grid_reporter_aggregates_local_attempts_instead_of_streaming_each_seed() -> (
+    None
+):
+    output_console, stream = _capturing_console()
+    reporter = MinimizationProgressReporter(
+        output_console,
+        interactive=False,
+        retained_observation_count=8,
+        controlled_parameter_count=2,
+        grid=True,
+        clock=lambda: 0.0,
+    )
+
+    with reporter:
+        for seed in range(1, 4):
+            context = FitProgressContext(
+                1,
+                1,
+                ("__PB",),
+                grid_seed_ordinal=seed,
+                grid_seed_total=3,
+            )
+            reporter.observe(
+                context,
+                _event(ProgressPhase.STARTED, elapsed=0.0),
+            )
+            reporter.observe(
+                context,
+                _event(
+                    ProgressPhase.EVALUATED,
+                    elapsed=0.1,
+                    completed=1,
+                    current=12.0,
+                    best=12.0,
+                ),
+            )
+            reporter.observe(
+                context,
+                _event(
+                    ProgressPhase.TERMINATED,
+                    elapsed=0.2,
+                    completed=1,
+                    current=12.0,
+                    best=12.0,
+                    terminal="success",
+                ),
+            )
+        reporter.finish(final_chi_square=10.0, terminal_status="committed")
+
+    rendered = stream.getvalue()
+    assert rendered.count("GRID seed") == 1
+    assert "eval 3 total" in rendered
+
+
+def test_keyboard_interrupt_stops_live_reporting_and_prints_a_terminal_line() -> None:
+    output_console, stream = _capturing_console(interactive=True)
+    times = iter((0.0, 0.0, 2.0))
+    reporter = MinimizationProgressReporter(
+        output_console,
+        interactive=True,
+        retained_observation_count=8,
+        controlled_parameter_count=2,
+        clock=lambda: next(times),
+    )
+
+    with pytest.raises(KeyboardInterrupt), reporter:
+        reporter.observe(
+            FitProgressContext(1, 1, ("__PB",)),
+            _event(ProgressPhase.STARTED, elapsed=0.0),
+        )
+        raise KeyboardInterrupt
+
+    assert not reporter.is_active
+    assert "interrupted" in stream.getvalue()
+
+
+def test_exception_fallback_does_not_label_a_local_best_as_final() -> None:
+    output_console, stream = _capturing_console()
+    times = iter((0.0, 0.0, 1.0))
+    reporter = MinimizationProgressReporter(
+        output_console,
+        interactive=False,
+        retained_observation_count=8,
+        controlled_parameter_count=2,
+        clock=lambda: next(times),
+    )
+
+    with pytest.raises(RuntimeError, match="scientific failure"), reporter:
+        reporter.observe(
+            FitProgressContext(1, 2, ("__P1",)),
+            _event(
+                ProgressPhase.EVALUATED,
+                elapsed=0.1,
+                completed=1,
+                current=12.0,
+                best=12.0,
+            ),
+        )
+        raise RuntimeError("scientific failure")
+
+    rendered = stream.getvalue()
+    assert "eval 1 total" in rendered
+    assert "failed" in rendered
+    assert "final χ²" not in rendered
+
+
+@pytest.mark.parametrize("grid", [False, True])
+def test_live_elapsed_time_is_fit_wide_across_local_attempts(grid: bool) -> None:
+    output_console, stream = _capturing_console(interactive=True)
+    times = iter((0.0, 0.0, 1.0, 6.0, 6.1))
+    reporter = MinimizationProgressReporter(
+        output_console,
+        interactive=True,
+        retained_observation_count=8,
+        controlled_parameter_count=2,
+        grid=grid,
+        clock=lambda: next(times),
+    )
+    first = FitProgressContext(
+        1,
+        2,
+        ("__P1",),
+        grid_seed_ordinal=1 if grid else None,
+        grid_seed_total=2 if grid else None,
+    )
+    second = FitProgressContext(
+        2,
+        2,
+        ("__P2",),
+        grid_seed_ordinal=2 if grid else None,
+        grid_seed_total=2 if grid else None,
+    )
+    rendered_updates: list[str] = []
+
+    with (
+        patch.object(reporter, "_render", side_effect=rendered_updates.append),
+        reporter,
+    ):
+        reporter.observe(first, _event(ProgressPhase.STARTED, elapsed=0.0))
+        reporter.observe(second, _event(ProgressPhase.STARTED, elapsed=0.0))
+        reporter.observe(
+            second,
+            _event(
+                ProgressPhase.EVALUATED,
+                elapsed=0.1,
+                completed=1,
+                current=12.0,
+                best=12.0,
+            ),
+        )
+        reporter.finish(final_chi_square=12.0, terminal_status="committed")
+
+    assert any("6.0 s" in line for line in rendered_updates)

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -58,6 +58,7 @@ from chemex.optimize.direct_trf import (
     materialize_root_candidate,
 )
 from chemex.optimize.grouped_direct_trf import FitDecomposition
+from chemex.optimize.progress import ProgressEvent, ProgressPhase
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     compile_active_parameterization,
@@ -653,6 +654,122 @@ def test_cpmg_step1_direct_trf_preserves_requests_and_reuses_profile_kernels() -
     assert outcome.execution.counters.objective_evaluations_completed == 126
     assert kernel_calls == 360
     assert outcome.candidate.chi_square == pytest.approx(285.8191490381348)
+
+
+def test_direct_trf_reports_objective_evaluations_without_iteration_terminology() -> (
+    None
+):
+    _session, _experiments, parameterization, engine, problem, invocation = (
+        _qualification_fit()
+    )
+    events: list[ProgressEvent] = []
+
+    outcome = execute_direct_trf(
+        problem,
+        invocation,
+        parameterization,
+        engine,
+        progress_observer=events.append,
+    )
+
+    assert outcome.terminal is DirectTrfOutcomeTerminal.ACCEPTED
+    assert events[0].phase is ProgressPhase.STARTED
+    assert events[-1].phase is ProgressPhase.TERMINATED
+    evaluated = [event for event in events if event.phase is ProgressPhase.EVALUATED]
+    assert len(evaluated) == outcome.execution.counters.objective_evaluations_completed
+    assert [event.objective_evaluations_completed for event in evaluated] == list(
+        range(1, len(evaluated) + 1)
+    )
+    assert all(event.current_chi_square is not None for event in evaluated)
+    assert all(event.best_chi_square is not None for event in evaluated)
+    assert events[-1].terminal_status == "accepted"
+    assert not any("iteration" in name for name in ProgressEvent.__dataclass_fields__)
+
+
+def test_progress_observation_has_no_numerical_or_kernel_effect() -> None:
+    disabled = _qualification_fit()
+    enabled = _qualification_fit()
+    (
+        disabled_parameterization,
+        disabled_engine,
+        disabled_problem,
+        disabled_invocation,
+    ) = disabled[2:]
+    enabled_parameterization, enabled_engine, enabled_problem, enabled_invocation = (
+        enabled[2:]
+    )
+    pulse_type = type(next(iter(disabled[1])).profiles[0].pulse_sequence)
+    original_calculate = cast("Callable[..., Array]", pulse_type.calculate)
+    kernel_calls = [0, 0]
+    active_run = 0
+
+    def counted_kernel(self: object, spectrometer: object, data: object) -> Array:
+        kernel_calls[active_run] += 1
+        return original_calculate(self, spectrometer, data)
+
+    events: list[ProgressEvent] = []
+
+    with patch.object(pulse_type, "calculate", counted_kernel):
+        without_progress = execute_direct_trf(
+            disabled_problem,
+            disabled_invocation,
+            disabled_parameterization,
+            disabled_engine,
+        )
+        active_run = 1
+        with_progress = execute_direct_trf(
+            enabled_problem,
+            enabled_invocation,
+            enabled_parameterization,
+            enabled_engine,
+            progress_observer=events.append,
+        )
+
+    assert len(events) > 2
+    assert kernel_calls[0] == kernel_calls[1]
+    assert without_progress.terminal is with_progress.terminal
+    assert without_progress.execution.counters == with_progress.execution.counters
+    assert without_progress.execution.backend == with_progress.execution.backend
+    assert without_progress.accepted_result is not None
+    assert with_progress.accepted_result is not None
+    first = without_progress.accepted_result
+    second = with_progress.accepted_result
+    assert first.vector == second.vector
+    assert first.chi_square == second.chi_square
+    assert first.evaluation_result.residuals.tobytes() == (
+        second.evaluation_result.residuals.tobytes()
+    )
+    assert without_progress.materialization is not None
+    assert with_progress.materialization is not None
+    assert without_progress.materialization.cache_hits == (
+        with_progress.materialization.cache_hits
+    )
+    assert without_progress.materialization.cache_misses == (
+        with_progress.materialization.cache_misses
+    )
+
+
+def test_progress_observer_failure_is_suppressed_after_first_event() -> None:
+    _session, _experiments, parameterization, engine, problem, invocation = (
+        _qualification_fit()
+    )
+    observer_calls = 0
+
+    def failing_observer(_event: ProgressEvent) -> None:
+        nonlocal observer_calls
+        observer_calls += 1
+        raise RuntimeError("non-scientific progress failure")
+
+    outcome = execute_direct_trf(
+        problem,
+        invocation,
+        parameterization,
+        engine,
+        progress_observer=failing_observer,
+    )
+
+    assert outcome.terminal is DirectTrfOutcomeTerminal.ACCEPTED
+    assert observer_calls == 1
 
 
 def test_live_commit_authority_is_atomic_under_concurrent_use() -> None:

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -39,6 +39,11 @@ from chemex.optimize.grouped_direct_trf import (
     execute_grouped_direct_trf,
     materialize_grouped_direct_trf,
 )
+from chemex.optimize.progress import (
+    FitProgressContext,
+    ProgressEvent,
+    ProgressPhase,
+)
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
@@ -350,6 +355,44 @@ def test_successful_components_compose_one_fresh_root_accepted_result_and_commit
             analysis_values=session.analysis_values,
         )
     assert session.analysis_values.snapshot() == committed
+
+
+def test_grouped_direct_progress_identifies_each_group_in_order() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(80,) * len(decomposition.components),
+    )
+    observed: list[tuple[FitProgressContext, ProgressEvent]] = []
+
+    outcome = execute_grouped_direct_trf(
+        problem,
+        decomposition,
+        invocation,
+        parameterization,
+        engine,
+        progress_observer=lambda context, event: observed.append((context, event)),
+    )
+
+    assert outcome.terminal is GroupedDirectTrfTerminal.ACCEPTED
+    started = [item for item in observed if item[1].phase is ProgressPhase.STARTED]
+    terminated = [
+        item for item in observed if item[1].phase is ProgressPhase.TERMINATED
+    ]
+    assert [context.group_ordinal for context, _event in started] == list(
+        range(1, len(decomposition.components) + 1)
+    )
+    assert all(
+        context.group_total == len(decomposition.components)
+        for context, _event in started
+    )
+    assert [context.controlled_ids for context, _event in started] == [
+        component.controlled_ids for component in decomposition.components
+    ]
+    assert [context for context, _event in terminated] == [
+        context for context, _event in started
+    ]
 
 
 def test_fresh_root_validation_rejects_an_inconsistent_component_result() -> None:

--- a/tests/test_native_grouped_grid_direct_trf.py
+++ b/tests/test_native_grouped_grid_direct_trf.py
@@ -38,6 +38,11 @@ from chemex.optimize.grouped_grid_direct_trf import (
     commit_grouped_grid_accepted_fit,
     execute_grouped_grid_direct_trf,
 )
+from chemex.optimize.progress import (
+    FitProgressContext,
+    ProgressEvent,
+    ProgressPhase,
+)
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.values import StaleAnalysisValuesError
 from chemex.runtime import AnalysisSession
@@ -317,6 +322,46 @@ def test_each_seed_uses_exact_components_and_only_selected_aggregate_commits() -
             analysis_values=session.analysis_values,
         )
     assert session.analysis_values.snapshot() == committed
+
+
+def test_grouped_grid_progress_includes_seed_and_group_ordinals() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_grid_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    (axis_id,) = problem.controlled_ids[:1]
+    invocation = GridDirectTrfInvocation.for_problem(
+        problem,
+        axes=((axis_id, (problem.start[0], problem.start[0] * 1.1)),),
+        objective_request_budget=10,
+    )
+    observed: list[tuple[FitProgressContext, ProgressEvent]] = []
+
+    def successful_backend(
+        fun: Callable[[Array], Array], x0: Array, **_kwargs: object
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        return _backend_result(candidate, fun(candidate))
+
+    with patch("chemex.optimize.direct_trf.least_squares", successful_backend):
+        outcome = execute_grouped_grid_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+            progress_observer=lambda context, event: observed.append((context, event)),
+        )
+
+    assert outcome.terminal is GroupedGridDirectTrfTerminal.ACCEPTED
+    contexts = [
+        context for context, event in observed if event.phase is ProgressPhase.STARTED
+    ]
+    assert len(contexts) == len(invocation.seeds) * len(decomposition.components)
+    assert [context.grid_seed_ordinal for context in contexts] == [
+        seed_ordinal
+        for seed_ordinal in range(1, len(invocation.seeds) + 1)
+        for _component in decomposition.components
+    ]
+    assert all(context.grid_seed_total == len(invocation.seeds) for context in contexts)
 
 
 def test_selection_orders_whole_aggregates_and_never_combines_marginal_minima() -> None:

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -21,6 +21,7 @@ import chemex.run_info as run_info_module
 from chemex.chemex import run
 from chemex.cli import build_parser
 from chemex.optimize.mcmc import NativeMcmcIncompleteError
+from chemex.optimize.progress import ProgressPhase
 from chemex.optimize.resampling import NativeResamplingIncompleteError
 from chemex.optimize.uncertainty import ParameterUnit
 from chemex.runtime import AnalysisSession
@@ -212,6 +213,50 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     time_2, intensity_2 = curve[-1]
     fitted_curve_rate = -math.log(intensity_2 / intensity_1) / (time_2 - time_1)
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
+
+
+def test_real_direct_fit_reports_objective_evaluation_progress(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run(
+        _fit_arguments(tmp_path / "Output"),
+        session=AnalysisSession.create(),
+    )
+
+    rendered = capsys.readouterr().out
+    assert "eval 0/" in rendered
+    assert "final χ²" in rendered
+    assert "iteration" not in rendered.lower()
+
+
+def test_real_direct_fit_propagates_progress_interrupt_after_cleanup(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    original_observe = native_deterministic_module.MinimizationProgressReporter.observe
+
+    def interrupt_after_evaluation(self, context, event):
+        original_observe(self, context, event)
+        if event.phase is ProgressPhase.EVALUATED:
+            raise KeyboardInterrupt
+
+    with (
+        patch.object(
+            native_deterministic_module.MinimizationProgressReporter,
+            "observe",
+            interrupt_after_evaluation,
+        ),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run(
+            _fit_arguments(tmp_path / "Output"),
+            session=AnalysisSession.create(),
+        )
+
+    rendered = capsys.readouterr().out
+    assert "interrupted" in rendered
+    assert "eval 1 total" in rendered
 
 
 def test_explicit_trf_and_least_squares_alias_have_identical_native_product_output(
@@ -407,6 +452,25 @@ def test_real_grouped_direct_fit_uses_native_aggregate_commit(
     group_outputs = tuple((output / "Groups").glob("*/Parameters/fitted.toml"))
     assert len(group_outputs) == 2
     assert (output / "All" / "Parameters" / "fitted.toml").is_file()
+
+
+def test_real_grouped_direct_progress_has_one_bounded_noninteractive_stream(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run(
+        _fit_arguments(
+            tmp_path / "Output",
+            include=("G2N-HN", "H3N-HN"),
+        ),
+        session=AnalysisSession.create(),
+    )
+
+    rendered = capsys.readouterr().out
+    assert "group 1/2" in rendered
+    assert rendered.count("eval 0/") == 1
+    assert "eval " in rendered
+    assert " total" in rendered
 
 
 def _grid_method(path: Path) -> Path:
@@ -822,6 +886,21 @@ def test_real_mc_fit_is_wholly_native_and_writes_product_statistics(
     assert "(error not calculated)" in fitted
 
 
+def test_resampling_replicates_do_not_create_progress_streams(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 2')
+
+    run(
+        _fit_arguments(tmp_path / "Output", method),
+        session=AnalysisSession.create(),
+    )
+
+    rendered = capsys.readouterr().out
+    assert rendered.count("eval 0/") == 1
+
+
 def test_native_statistics_filter_resolution_fails_closed_before_filtering(
     tmp_path: Path,
 ) -> None:
@@ -1194,6 +1273,22 @@ def test_real_grid_fit_uses_native_cartesian_trf_and_writes_grid_output(
     assert session.analysis_values.snapshot().revision == 1
     assert (output / "Grid" / "grid.out").is_file()
     assert (output / "Parameters" / "fixed.toml").is_file()
+
+
+def test_real_grid_progress_aggregates_local_seed_polishes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    method = _grid_method(tmp_path / "method.toml")
+
+    run(
+        _fit_arguments(tmp_path / "Output", method),
+        session=AnalysisSession.create(),
+    )
+
+    rendered = capsys.readouterr().out
+    assert rendered.count("GRID seed") == 1
+    assert "final χ²" in rendered
 
 
 def test_real_grouped_grid_fit_uses_one_native_aggregate_commit(


### PR DESCRIPTION
Closes #669.

## Summary

- add observer-only native Direct TRF progress events at ChemEx's portable objective-evaluation boundary
- render one Rich live line for interactive fits and bounded, timestamp-free lines for redirected output
- provide step/group context, aggregate GRID seed context, evaluation counts, best and reduced chi-square, relative improvement, elapsed time, and final status
- keep internal MC/BS/BSN refits under their existing statistics-level reporting while retaining visible central deterministic progress
- preserve KeyboardInterrupt propagation after clean reporting teardown

No solver, Jacobian, tolerance, request-budget, cache, residual, parameter-role, or uncertainty policy changes are included.

## Rate limiting

- immediate fit/group start in the interactive live display
- interactive update after a best-chi-square improvement of at least 0.1%, otherwise a five-second completed-evaluation heartbeat
- non-interactive output uses one fit-wide ten-second cadence plus start and final aggregate lines
- GRID local polishes are aggregated instead of opening one stream per seed

## Validation

- focused Direct/grouped/GRID/MC/BS/BSN/MCMC/progress tests: 319 passed before review; final focused review sets also pass
- Python 3.13.13: 1,201 passed
- Python 3.14.5: 1,201 passed
- minimum supported SciPy 1.15.2 focused suite: 145 passed
- ty check, Ruff check, Ruff format check, git diff --check: pass
- uv build: pass
- Docusaurus build: pass
- independent Standards and Specification reviews: pass after resolving all findings

Enabled/disabled representative RELAXATION_HZNZ, CPMG STEP1, and CEST runs produced byte-identical result evidence with identical request and kernel counts. CPMG and CEST timing was indistinguishable within noise; the approximately 3.4 ms relaxation micro-fit added about 0.08 ms.
