### PR TITLE
Restore deterministic native fit uncertainties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 ## [Unreleased]
 
 ### Changed
-- Ordinary successful native deterministic fits now derive fresh accepted-point
-  covariance evidence and report covariance-derived standard errors in
+- Ordinary successful native deterministic fits now derive accepted-point
+  covariance evidence from exact retained optimizer Jacobians or an independent
+  accepted-point fallback and report covariance-derived standard errors in
   `Parameters/fitted.toml`. Observation uncertainties are treated as absolute
   experimental standard deviations, so covariance is not scaled by reduced
   chi-square. Supported arithmetic constraints receive propagated errors;
-  rank, conditioning, boundary, or derivative limitations withhold errors with
-  a concise reason while preserving fitted central values. Full covariance,
+  rank, boundary, normalization, derivative, or covariance-arithmetic failures
+  withhold errors with a concise reason while preserving fitted central values.
+  Condition and weak-mode diagnostics do not impose an arbitrary hard gate. Full covariance,
   correlation, constrained, and independent-block diagnostics are written
   under `Statistics/` without populating the legacy generic `stderr` field or
   mixing deterministic errors with MC, BS, BSN, or MCMC summaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 ## [Unreleased]
 
 ### Changed
+- Ordinary successful native deterministic fits now derive fresh accepted-point
+  covariance evidence and report covariance-derived standard errors in
+  `Parameters/fitted.toml`. Observation uncertainties are treated as absolute
+  experimental standard deviations, so covariance is not scaled by reduced
+  chi-square. Supported arithmetic constraints receive propagated errors;
+  rank, conditioning, boundary, or derivative limitations withhold errors with
+  a concise reason while preserving fitted central values. Full covariance,
+  correlation, constrained, and independent-block diagnostics are written
+  under `Statistics/` without populating the legacy generic `stderr` field or
+  mixing deterministic errors with MC, BS, BSN, or MCMC summaries.
 - Native deterministic minimization once again reports fit progress. The Rich
   display shows objective evaluations, best and reduced chi-square, relative
   improvement, elapsed time, and applicable step/group or aggregated GRID
@@ -28,8 +38,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   `lower_1sigma`, `upper_1sigma`, and `stderr`. MCMC now uses
   `credible_interval_68_lower`, `credible_interval_68_upper`, and
   `half_credible_interval_68_width`; genuine `mcse_mean` remains the Monte Carlo
-  standard error of the posterior mean. Native deterministic fitted-parameter
-  reports continue to state `(error not calculated)`. Clarified that
+  standard error of the posterior mean. Clarified that
   `run_info/parameters_used.toml` is the bound-preserving restart input, while
   the fitted/fixed/constrained parameter files are result reports.
 - Fit output now has a success-last `run_info/outcome.toml` lifecycle marker.
@@ -43,8 +52,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   commit stack in the production `chemex fit` path. Existing v1 method TOML,
   ordered role inheritance, profile selection, calculated-data files, and
   output paths are preserved. Native deterministic fits do not populate the
-  legacy generic `stderr` field; family-qualified uncertainty output remains
-  part of the dedicated output-contract migration. MC, BS, and BSN statistics
+  legacy generic `stderr` field. MC, BS, and BSN statistics
   now start from that committed native fit and run wholly native Direct TRF
   refits with stable ordered seeds across serial and worker execution. Existing
   STATISTICS syntax and output directories are preserved; incomplete analyses

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -37,6 +37,9 @@ python run_benchmarks.py --bottlenecks
 
 # End-to-end workflows (~5-10 minutes)
 python run_benchmarks.py --e2e
+
+# Retained-Jacobian covariance gate for the shipped 96-profile CPMG fit
+python run_benchmarks.py --uncertainty-large-fit
 ```
 
 ### Save Results to File
@@ -93,6 +96,15 @@ Complete workflow tests using real example data:
 **Purpose**: Measure real-world performance on typical user workflows.
 
 **Runtime**: ~5-10 minutes (depends on convergence)
+
+### 4. Large native uncertainty benchmark (`benchmark_large_native_uncertainty.py`)
+
+Runs `CPMG_15N_IP_0013` with plotting disabled and records component TRF, root
+materialization/composition, covariance, and output phases separately. It also
+checks the deterministic 2058-request / 6912-kernel contract, zero covariance
+scientific evaluations, and at most one retained-matrix conversion for the sole
+successful component. The median root-composition-plus-covariance time must not
+exceed half the median component execution time.
 
 ## Benchmark Results
 

--- a/benchmarks/benchmark_large_native_uncertainty.py
+++ b/benchmarks/benchmark_large_native_uncertainty.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Phase benchmark for the shipped 96-profile native covariance workload."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import statistics
+import sys
+import tempfile
+from collections import Counter, defaultdict
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from functools import wraps
+from pathlib import Path
+from time import perf_counter
+from typing import Any, cast
+from unittest.mock import patch
+
+import numpy as np
+import scipy
+
+import chemex.optimize.grouped_direct_trf as grouped_owner
+import chemex.optimize.method_step as method_step_owner
+import chemex.optimize.native_deterministic as product_owner
+from chemex.chemex import run
+from chemex.cli import build_parser
+from chemex.containers.data import Data
+from chemex.experiments.catalog.cpmg_15n_ip_0013 import Cpmg15N0013IpSequence
+from chemex.nmr.spectrometer import Spectrometer
+from chemex.optimize.direct_trf import DirectTrfCandidateOutcome
+from chemex.optimize.grouped_direct_trf import (
+    ComponentDisposition,
+    GroupedDirectTrfOutcome,
+)
+from chemex.optimize.method_step import MethodStepOutcome
+from chemex.optimize.uncertainty import UncertaintyEvidence
+from chemex.runtime import AnalysisSession
+from chemex.typing import Array
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "examples/Experiments/CPMG_15N_IP_0013"
+EXPECTED_VECTOR_SHA256 = (
+    "df17c7858383672b876bd588f0207db45946e9e0f3db82476e0470f556e8f26d"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LargeFitMeasurement:
+    """One exact no-plot workload measurement and deterministic acceptance record."""
+
+    component_seconds: float
+    root_materialization_composition_seconds: float
+    covariance_seconds: float
+    output_seconds: float
+    total_seconds: float
+    profiles: int
+    residuals: int
+    controls: int
+    constrained_outputs: int
+    components: int
+    successful_components: int
+    objective_requests: int
+    fit_acceptance_kernels: int
+    covariance_residual_evaluations: int
+    covariance_kernels: int
+    retained_matrix_conversions: int
+    chi_square: float
+    rank: int
+    vector_sha256: str
+    covariance_sha256: str
+
+
+def _timed[**P, R](
+    phase: str,
+    function: Callable[P, R],
+    timings: dict[str, list[float]],
+    active_phase: list[str],
+) -> Callable[P, R]:
+    @wraps(function)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        previous = active_phase[0]
+        active_phase[0] = phase
+        started = perf_counter()
+        try:
+            return function(*args, **kwargs)
+        finally:
+            timings[phase].append(perf_counter() - started)
+            active_phase[0] = previous
+
+    return wrapped
+
+
+def _matrix_digest(matrix: tuple[tuple[float, ...], ...]) -> str:
+    return hashlib.sha256(np.asarray(matrix, dtype=np.float64).tobytes()).hexdigest()
+
+
+def _vector_digest(vector: tuple[float, ...]) -> str:
+    return hashlib.sha256(np.asarray(vector, dtype=np.float64).tobytes()).hexdigest()
+
+
+def _environment_context() -> dict[str, object]:
+    """Record enough runtime context to interpret exploratory phase timings."""
+    numpy_config = cast(dict[str, Any], np.show_config(mode="dicts"))
+    dependencies = cast(
+        dict[str, object],
+        numpy_config.get("Build Dependencies", {}),
+    )
+    thread_variables = {
+        name: os.environ.get(name)
+        for name in (
+            "OMP_NUM_THREADS",
+            "OPENBLAS_NUM_THREADS",
+            "MKL_NUM_THREADS",
+            "VECLIB_MAXIMUM_THREADS",
+        )
+    }
+    return {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "logical_cpu_count": os.cpu_count(),
+        "python": sys.version,
+        "numpy": np.__version__,
+        "scipy": scipy.__version__,
+        "blas": dependencies.get("blas"),
+        "lapack": dependencies.get("lapack"),
+        "thread_environment": thread_variables,
+    }
+
+
+def _benchmark_arguments(output: Path) -> argparse.Namespace:
+    return build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            *(str(path) for path in sorted((EXAMPLE / "Experiments").glob("*.toml"))),
+            "-p",
+            str(EXAMPLE / "Parameters/parameters.toml"),
+            "-o",
+            str(output),
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+        ]
+    )
+
+
+def measure_large_native_uncertainty() -> LargeFitMeasurement:  # noqa: C901
+    """Run and validate the exact retained-Jacobian large-fit acceptance case."""
+    timings: dict[str, list[float]] = defaultdict(list)
+    active_phase = ["setup"]
+    kernel_calls: Counter[str] = Counter()
+    retained_matrices: list[tuple[tuple[float, ...], ...]] = []
+    retained_matrix_conversions = 0
+    candidate_outcomes: list[DirectTrfCandidateOutcome] = []
+    method_outcomes: list[MethodStepOutcome] = []
+    original_numpy = grouped_owner.np
+    original_calculate = Cpmg15N0013IpSequence.calculate
+
+    class NumpyConversionProbe:
+        def __getattr__(self, name: str) -> object:
+            return getattr(original_numpy, name)
+
+        def asarray(
+            self,
+            value: object,
+            dtype: type[np.float64] | np.dtype[np.float64] | None = None,
+        ) -> Array:
+            nonlocal retained_matrix_conversions
+            if any(value is matrix for matrix in retained_matrices):
+                retained_matrix_conversions += 1
+            return original_numpy.asarray(value, dtype=dtype)
+
+    def count_kernel(
+        self: Cpmg15N0013IpSequence,
+        spectrometer: Spectrometer,
+        data: Data,
+    ) -> Array:
+        kernel_calls[active_phase[0]] += 1
+        return original_calculate(self, spectrometer, data)
+
+    original_candidate = grouped_owner.execute_direct_trf_candidate
+
+    @wraps(original_candidate)
+    def capture_candidate(*args: Any, **kwargs: Any) -> DirectTrfCandidateOutcome:
+        outcome = original_candidate(*args, **kwargs)
+        candidate_outcomes.append(outcome)
+        return outcome
+
+    original_components = grouped_owner.execute_direct_trf_components
+
+    @wraps(original_components)
+    def capture_components(*args: Any, **kwargs: Any):
+        outcomes = original_components(*args, **kwargs)
+        retained_matrices.extend(
+            item.final_residual_jacobian.matrix
+            for item in outcomes
+            if item.final_residual_jacobian is not None
+        )
+        return outcomes
+
+    original_method_step = product_owner.execute_method_step
+
+    @wraps(original_method_step)
+    def capture_method_step(*args: Any, **kwargs: Any) -> MethodStepOutcome:
+        outcome = original_method_step(*args, **kwargs)
+        method_outcomes.append(outcome)
+        return outcome
+
+    started = perf_counter()
+    with tempfile.TemporaryDirectory() as temporary:
+        output = Path(temporary) / "Output"
+        with (
+            patch.object(Cpmg15N0013IpSequence, "calculate", count_kernel),
+            patch.object(grouped_owner, "np", NumpyConversionProbe()),
+            patch.object(
+                grouped_owner, "execute_direct_trf_candidate", capture_candidate
+            ),
+            patch.object(
+                grouped_owner,
+                "execute_direct_trf_components",
+                _timed("component", capture_components, timings, active_phase),
+            ),
+            patch.object(
+                grouped_owner,
+                "materialize_grouped_direct_trf",
+                _timed(
+                    "root",
+                    grouped_owner.materialize_grouped_direct_trf,
+                    timings,
+                    active_phase,
+                ),
+            ),
+            patch.object(
+                method_step_owner,
+                "_execute_uncertainty",
+                _timed(
+                    "covariance",
+                    method_step_owner._execute_uncertainty,
+                    timings,
+                    active_phase,
+                ),
+            ),
+            patch.object(product_owner, "execute_method_step", capture_method_step),
+            patch.object(
+                product_owner,
+                "execute_post_fit",
+                _timed(
+                    "output",
+                    product_owner.execute_post_fit,
+                    timings,
+                    active_phase,
+                ),
+            ),
+        ):
+            run(_benchmark_arguments(output), session=AnalysisSession.create())
+    total_seconds = perf_counter() - started
+
+    if len(method_outcomes) != 1 or len(candidate_outcomes) != 1:
+        raise AssertionError(
+            "Large-fit benchmark expected one method and one component"
+        )
+    method_outcome = method_outcomes[0]
+    primary = cast(GroupedDirectTrfOutcome, method_outcome.primary_execution)
+    accepted = method_outcome.accepted_result
+    candidate = candidate_outcomes[0]
+    if accepted is None or candidate.execution.backend is None:
+        raise AssertionError(
+            "Large-fit benchmark did not retain its accepted TRF result"
+        )
+    uncertainty = next(
+        (
+            artifact
+            for derivation in method_outcome.derivations
+            for artifact in derivation.artifacts
+            if isinstance(artifact, UncertaintyEvidence)
+        ),
+        None,
+    )
+    if (
+        uncertainty is None
+        or uncertainty.residual_jacobian is None
+        or uncertainty.rank_diagnostic is None
+        or uncertainty.covariance is None
+        or uncertainty.constraint_jacobian is None
+    ):
+        raise AssertionError("Large-fit benchmark covariance evidence is incomplete")
+
+    successful_components = sum(
+        item.disposition is ComponentDisposition.SUCCEEDED
+        for item in primary.components
+    )
+    objective_requests = sum(
+        item.execution.counters.objective_requests_accepted
+        for item in candidate_outcomes
+    )
+    fit_acceptance_kernels = kernel_calls["component"] + kernel_calls["root"]
+    covariance_kernels = kernel_calls["covariance"]
+    measurement = LargeFitMeasurement(
+        component_seconds=sum(timings["component"]),
+        root_materialization_composition_seconds=sum(timings["root"]),
+        covariance_seconds=sum(timings["covariance"]),
+        output_seconds=sum(timings["output"]),
+        total_seconds=total_seconds,
+        profiles=len(accepted.evaluation_result.profiles),
+        residuals=accepted.evaluation_result.residuals.size,
+        controls=len(accepted.vector),
+        constrained_outputs=len(uncertainty.constraint_jacobian.output_ids),
+        components=len(primary.components),
+        successful_components=successful_components,
+        objective_requests=objective_requests,
+        fit_acceptance_kernels=fit_acceptance_kernels,
+        covariance_residual_evaluations=uncertainty.residual_jacobian.evaluation_count,
+        covariance_kernels=covariance_kernels,
+        retained_matrix_conversions=retained_matrix_conversions,
+        chi_square=accepted.chi_square,
+        rank=uncertainty.rank_diagnostic.rank,
+        vector_sha256=_vector_digest(accepted.vector),
+        covariance_sha256=_matrix_digest(uncertainty.covariance.covariance),
+    )
+    if (
+        (measurement.profiles, measurement.residuals, measurement.controls)
+        != (96, 2784, 146)
+        or measurement.constrained_outputs != 147
+        or (measurement.components, measurement.successful_components) != (1, 1)
+        or measurement.objective_requests != 2058
+        or measurement.fit_acceptance_kernels != 6912
+        or measurement.covariance_residual_evaluations != 0
+        or measurement.covariance_kernels != 0
+        or measurement.retained_matrix_conversions > successful_components
+        or not math.isclose(
+            measurement.chi_square,
+            12965.326784811383,
+            rel_tol=1.0e-13,
+            abs_tol=1.0e-9,
+        )
+        or measurement.rank != 146
+        or measurement.vector_sha256 != EXPECTED_VECTOR_SHA256
+    ):
+        raise AssertionError(f"Large-fit acceptance contract failed: {measurement!r}")
+    return measurement
+
+
+def run_benchmark(runs: int = 3) -> None:
+    """Run the median phase gate in the existing benchmark lane."""
+    if runs < 1:
+        raise ValueError("runs must be positive")
+    measurements = tuple(measure_large_native_uncertainty() for _ in range(runs))
+    component_median = statistics.median(
+        item.component_seconds for item in measurements
+    )
+    post_fit_median = statistics.median(
+        item.root_materialization_composition_seconds + item.covariance_seconds
+        for item in measurements
+    )
+    ratio = post_fit_median / component_median
+    if ratio > 0.5:
+        raise AssertionError(
+            "Root composition plus covariance exceeded the 0.5x component-time gate: "
+            f"{ratio:.3f}"
+        )
+    print(
+        json.dumps(
+            {
+                "workload": "CPMG_15N_IP_0013",
+                "plot": "nothing",
+                "environment": _environment_context(),
+                "runs": [asdict(item) for item in measurements],
+                "median_component_seconds": component_median,
+                "median_root_plus_covariance_seconds": post_fit_median,
+                "root_plus_covariance_to_component_ratio": ratio,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=3)
+    arguments = parser.parse_args()
+    if arguments.runs < 1:
+        parser.error("--runs must be positive")
+    run_benchmark(arguments.runs)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -8,6 +8,8 @@ Options:
     --quick         Run only quick matrix operation benchmarks
     --bottlenecks   Run specific bottleneck benchmarks
     --e2e           Run end-to-end workflow benchmarks
+    --uncertainty-large-fit
+                    Run the retained-Jacobian large-fit phase gate
     --all           Run all benchmarks (default)
     --save FILE     Save results to FILE
 """
@@ -54,6 +56,16 @@ def run_e2e_benchmarks() -> None:
     run_e2e()
 
 
+def run_large_uncertainty_benchmark() -> None:
+    """Run the shipped 96-profile retained-Jacobian covariance benchmark."""
+    from benchmark_large_native_uncertainty import run_benchmark
+
+    print("\n" + "=" * 70)
+    print("LARGE NATIVE UNCERTAINTY BENCHMARK")
+    print("=" * 70)
+    run_benchmark()
+
+
 def main() -> None:
     """Main benchmark runner."""
     parser = argparse.ArgumentParser(
@@ -94,6 +106,11 @@ Examples:
         help="Run end-to-end workflow benchmarks",
     )
     parser.add_argument(
+        "--uncertainty-large-fit",
+        action="store_true",
+        help="Run the retained-Jacobian large-fit phase gate",
+    )
+    parser.add_argument(
         "--all",
         action="store_true",
         help="Run all benchmarks (default)",
@@ -108,7 +125,7 @@ Examples:
     args = parser.parse_args()
 
     # If no specific benchmark selected, run all
-    if not (args.quick or args.bottlenecks or args.e2e):
+    if not (args.quick or args.bottlenecks or args.e2e or args.uncertainty_large_fit):
         args.all = True
 
     # Print header
@@ -139,6 +156,9 @@ Examples:
 
         if args.e2e or args.all:
             run_e2e_benchmarks()
+
+        if args.uncertainty_large_fit or args.all:
+            run_large_uncertainty_benchmark()
 
         # Final summary
         print("\n" + "=" * 70)

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -284,6 +284,42 @@ class MinimizationProgressReporter:
         self._stop_live()
 
 
+class UncertaintyProgressReporter:
+    """Render the single automatic post-fit uncertainty phase."""
+
+    def __init__(
+        self,
+        output_console: Console,
+        *,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        self._console = output_console
+        self._clock = clock
+        self._started_at: float | None = None
+        self._finished = False
+
+    def start(self) -> None:
+        """Start timing immediately before automatic uncertainty derivation."""
+        if self._started_at is not None:
+            return
+        self._started_at = self._clock()
+        with suppress(Exception):
+            self._console.print(Text("  • Estimating parameter uncertainties..."))
+
+    def finish(self, status: str) -> None:
+        """Emit one concise terminal status without affecting scientific work."""
+        if self._finished:
+            return
+        self._finished = True
+        elapsed = (
+            0.0
+            if self._started_at is None
+            else max(0.0, self._clock() - self._started_at)
+        )
+        with suppress(Exception):
+            self._console.print(Text(f"    {status} · {elapsed:.1f} s"))
+
+
 def _format_scalar(value: float) -> str:
     return f"{value:.6g}"
 

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -100,7 +100,28 @@ class FinalResidualJacobianEvidence:
     trust_region_scale_policy: str = "trust-region-only"
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
+    def _identity_from_digest(self, matrix_digest: str) -> str:
+        return _identity(
+            "native-final-residual-jacobian-evidence",
+            (
+                _BACKEND_JACOBIAN_VERSION,
+                self.source.value,
+                self.controlled_ids,
+                _vector_tokens(self.final_vector),
+                _vector_tokens(self.final_residuals),
+                self.shape,
+                matrix_digest,
+                self.source_identities,
+                self.derivative_method,
+                self.diff_step_policy,
+                self.loss_policy,
+                self.backend_identity,
+                self.external_coordinate_policy,
+                self.trust_region_scale_policy,
+            ),
+        )
+
+    def _validate_scope_and_semantics(self) -> None:
         rows, columns = self.shape
         if (
             rows < 1
@@ -113,6 +134,33 @@ class FinalResidualJacobianEvidence:
             or any(len(row) != columns for row in self.matrix)
         ):
             raise ValueError("Final residual Jacobian has inconsistent scope")
+        if (
+            self.derivative_method != "numerical 2-point"
+            or self.diff_step_policy != "scipy-default-relative-step"
+            or self.loss_policy != "linear"
+            or not self.backend_identity.startswith("scipy-")
+            or "least_squares:method=trf" not in self.backend_identity
+            or self.external_coordinate_policy != "physical-external-unscaled"
+            or self.trust_region_scale_policy != "trust-region-only"
+            or (
+                self.source is ResidualJacobianSource.FIT_PARTITION_COMPOSITION
+                and not self.source_identities
+            )
+        ):
+            raise ValueError("Final residual Jacobian has incompatible semantics")
+
+    def validate_integrity(self) -> None:
+        """Validate immutable scope, semantics, digest, and identity without copying J."""
+        self._validate_scope_and_semantics()
+        matrix_digest = _binary64_matrix_digest(self.matrix, self.shape)
+        if (
+            matrix_digest != self.matrix_binary64_sha256
+            or self._identity_from_digest(matrix_digest) != self.identity
+        ):
+            raise ValueError("Final residual Jacobian integrity validation failed")
+
+    def __post_init__(self) -> None:
+        self._validate_scope_and_semantics()
         vector = tuple(
             _finite_binary64(value, name=f"final vector[{index}]")
             for index, value in enumerate(self.final_vector)
@@ -131,20 +179,6 @@ class FinalResidualJacobianEvidence:
             )
             for row_index, row in enumerate(self.matrix)
         )
-        if (
-            self.derivative_method != "numerical 2-point"
-            or self.diff_step_policy != "scipy-default-relative-step"
-            or self.loss_policy != "linear"
-            or not self.backend_identity.startswith("scipy-")
-            or "least_squares:method=trf" not in self.backend_identity
-            or self.external_coordinate_policy != "physical-external-unscaled"
-            or self.trust_region_scale_policy != "trust-region-only"
-            or (
-                self.source is ResidualJacobianSource.FIT_PARTITION_COMPOSITION
-                and not self.source_identities
-            )
-        ):
-            raise ValueError("Final residual Jacobian has incompatible semantics")
         object.__setattr__(self, "final_vector", vector)
         object.__setattr__(self, "final_residuals", residuals)
         object.__setattr__(self, "matrix", matrix)
@@ -153,25 +187,7 @@ class FinalResidualJacobianEvidence:
         object.__setattr__(
             self,
             "identity",
-            _identity(
-                "native-final-residual-jacobian-evidence",
-                (
-                    _BACKEND_JACOBIAN_VERSION,
-                    self.source.value,
-                    self.controlled_ids,
-                    _vector_tokens(vector),
-                    _vector_tokens(residuals),
-                    self.shape,
-                    matrix_digest,
-                    self.source_identities,
-                    self.derivative_method,
-                    self.diff_step_policy,
-                    self.loss_policy,
-                    self.backend_identity,
-                    self.external_coordinate_policy,
-                    self.trust_region_scale_policy,
-                ),
-            ),
+            self._identity_from_digest(matrix_digest),
         )
 
 

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -22,6 +22,7 @@ from uuid import uuid4
 from weakref import ReferenceType, WeakKeyDictionary, ref
 
 import numpy as np
+from scipy import __version__ as scipy_version
 from scipy.optimize import least_squares
 
 from chemex.evaluation.native import (
@@ -65,6 +66,113 @@ _BACKEND_SETTINGS = (
     ("f_scale", "0x1.0000000000000p+0"),
     ("verbose", 0),
 )
+_BACKEND_JACOBIAN_VERSION = "scipy-final-residual-jacobian-v2"
+
+
+class ResidualJacobianSource(StrEnum):
+    """Closed origins for a retained accepted-point residual Jacobian."""
+
+    SCIPY_FINAL_2_POINT = "scipy-final-2-point"
+    FIT_PARTITION_COMPOSITION = "fit-partition-composition"
+
+
+@dataclass(frozen=True, slots=True)
+class FinalResidualJacobianEvidence:
+    """Finite external-coordinate Jacobian retained from accepted TRF work."""
+
+    source: ResidualJacobianSource
+    controlled_ids: tuple[str, ...]
+    final_vector: tuple[float, ...]
+    final_residuals: tuple[float, ...]
+    shape: tuple[int, int]
+    matrix: tuple[tuple[float, ...], ...] = field(repr=False)
+    matrix_binary64_sha256: str = field(init=False)
+    source_identities: tuple[str, ...] = ()
+    derivative_method: str = "numerical 2-point"
+    diff_step_policy: str = "scipy-default-relative-step"
+    loss_policy: str = "linear"
+    backend_identity: str = field(
+        default_factory=lambda: (
+            f"scipy-{scipy_version}:optimize.least_squares:method=trf"
+        )
+    )
+    external_coordinate_policy: str = "physical-external-unscaled"
+    trust_region_scale_policy: str = "trust-region-only"
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        rows, columns = self.shape
+        if (
+            rows < 1
+            or columns < 1
+            or columns != len(self.controlled_ids)
+            or len(set(self.controlled_ids)) != columns
+            or len(self.final_vector) != columns
+            or len(self.final_residuals) != rows
+            or len(self.matrix) != rows
+            or any(len(row) != columns for row in self.matrix)
+        ):
+            raise ValueError("Final residual Jacobian has inconsistent scope")
+        vector = tuple(
+            _finite_binary64(value, name=f"final vector[{index}]")
+            for index, value in enumerate(self.final_vector)
+        )
+        residuals = tuple(
+            _finite_binary64(value, name=f"final residual[{index}]")
+            for index, value in enumerate(self.final_residuals)
+        )
+        matrix = tuple(
+            tuple(
+                _finite_binary64(
+                    value,
+                    name=f"final residual Jacobian[{row_index},{column_index}]",
+                )
+                for column_index, value in enumerate(row)
+            )
+            for row_index, row in enumerate(self.matrix)
+        )
+        if (
+            self.derivative_method != "numerical 2-point"
+            or self.diff_step_policy != "scipy-default-relative-step"
+            or self.loss_policy != "linear"
+            or not self.backend_identity.startswith("scipy-")
+            or "least_squares:method=trf" not in self.backend_identity
+            or self.external_coordinate_policy != "physical-external-unscaled"
+            or self.trust_region_scale_policy != "trust-region-only"
+            or (
+                self.source is ResidualJacobianSource.FIT_PARTITION_COMPOSITION
+                and not self.source_identities
+            )
+        ):
+            raise ValueError("Final residual Jacobian has incompatible semantics")
+        object.__setattr__(self, "final_vector", vector)
+        object.__setattr__(self, "final_residuals", residuals)
+        object.__setattr__(self, "matrix", matrix)
+        matrix_digest = _binary64_matrix_digest(matrix, self.shape)
+        object.__setattr__(self, "matrix_binary64_sha256", matrix_digest)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-final-residual-jacobian-evidence",
+                (
+                    _BACKEND_JACOBIAN_VERSION,
+                    self.source.value,
+                    self.controlled_ids,
+                    _vector_tokens(vector),
+                    _vector_tokens(residuals),
+                    self.shape,
+                    matrix_digest,
+                    self.source_identities,
+                    self.derivative_method,
+                    self.diff_step_policy,
+                    self.loss_policy,
+                    self.backend_identity,
+                    self.external_coordinate_policy,
+                    self.trust_region_scale_policy,
+                ),
+            ),
+        )
 
 
 class DirectTrfConstructionError(ValueError):
@@ -114,6 +222,19 @@ def _float_token(value: float) -> str:
 
 def _vector_tokens(values: Sequence[float]) -> tuple[str, ...]:
     return tuple(_float_token(value) for value in values)
+
+
+def _binary64_matrix_digest(
+    matrix: Sequence[Sequence[float]],
+    shape: tuple[int, int],
+) -> str:
+    """Hash canonical little-endian binary64 rows without token expansion."""
+    digest = hashlib.sha256()
+    digest.update(f"{shape[0]}x{shape[1]}:".encode("ascii"))
+    dtype = np.dtype("<f8")
+    for row in matrix:
+        digest.update(np.asarray(row, dtype=dtype).tobytes(order="C"))
+    return digest.hexdigest()
 
 
 def _canonical_vector(
@@ -1376,8 +1497,15 @@ class BackendEvidence:
     cost: float
     optimality: float
     active_mask: tuple[int, ...]
-    final_vector: tuple[float, ...]
-    final_residuals: tuple[float, ...]
+    final_residual_jacobian: FinalResidualJacobianEvidence
+
+    @property
+    def final_vector(self) -> tuple[float, ...]:
+        return self.final_residual_jacobian.final_vector
+
+    @property
+    def final_residuals(self) -> tuple[float, ...]:
+        return self.final_residual_jacobian.final_residuals
 
     @property
     def identity(self) -> str:
@@ -1392,8 +1520,7 @@ class BackendEvidence:
                 _float_token(self.cost),
                 _float_token(self.optimality),
                 self.active_mask,
-                _vector_tokens(self.final_vector),
-                _vector_tokens(self.final_residuals),
+                self.final_residual_jacobian.identity,
             ),
         )
 
@@ -1747,6 +1874,12 @@ class AcceptedFitResult:
     commit_scope: tuple[str, ...]
     commit_items: tuple[tuple[str, float], ...]
     origin_context_identity: str
+    final_residual_jacobian: FinalResidualJacobianEvidence | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        kw_only=True,
+    )
     occurrence_witness: _AcceptedOccurrenceWitness | None = field(
         compare=False,
         repr=False,
@@ -1759,6 +1892,18 @@ class AcceptedFitResult:
             raise ValueError("Accepted result cannot have an empty residual objective")
         if not self.origin_context_identity:
             raise ValueError("Accepted result requires an origin context identity")
+        retained = self.final_residual_jacobian
+        if retained is not None and (
+            retained.controlled_ids != self.controlled_ids
+            or retained.final_vector != self.vector
+            or retained.final_residuals
+            != tuple(float(value) for value in self.evaluation_result.residuals)
+            or retained.shape
+            != (self.evaluation_result.residuals.size, len(self.controlled_ids))
+        ):
+            raise ValueError(
+                "Accepted result and retained residual Jacobian lineage differ"
+            )
         identity = _identity(
             "native-accepted-fit-result",
             (
@@ -1780,6 +1925,7 @@ class AcceptedFitResult:
                     for param_id, value in self.commit_items
                 ),
                 self.origin_context_identity,
+                None if retained is None else retained.identity,
             ),
         )
         object.__setattr__(self, "identity", identity)
@@ -2514,9 +2660,10 @@ def _backend_int(value: object, *, name: str, optional: bool = False) -> int | N
 def _normalize_backend(
     result: object,
     *,
-    dimension: int,
+    controlled_ids: tuple[str, ...],
     residual_count: int,
 ) -> BackendEvidence:
+    dimension = len(controlled_ids)
     status_value = _backend_int(getattr(result, "status", None), name="status")
     if status_value is None:
         raise TypeError("SciPy status evidence is missing")
@@ -2556,6 +2703,17 @@ def _normalize_backend(
         for value in active_array
     ):
         raise ValueError("SciPy active_mask evidence is malformed")
+    jacobian_array = np.asarray(getattr(result, "jac", None), dtype=np.float64)
+    if jacobian_array.shape != (residual_count, dimension):
+        raise ValueError("SciPy final Jacobian evidence has the wrong shape")
+    final_residual_jacobian = FinalResidualJacobianEvidence(
+        ResidualJacobianSource.SCIPY_FINAL_2_POINT,
+        controlled_ids,
+        final_vector,
+        final_residuals,
+        (residual_count, dimension),
+        tuple(tuple(float(value) for value in row) for row in jacobian_array),
+    )
     return BackendEvidence(
         status_value,
         bool(success),
@@ -2565,8 +2723,7 @@ def _normalize_backend(
         cost,
         optimality,
         tuple(int(value) for value in active_array),
-        final_vector,
-        final_residuals,
+        final_residual_jacobian,
     )
 
 
@@ -2681,7 +2838,7 @@ def _process_backend_result(
     try:
         backend = _normalize_backend(
             backend_result,
-            dimension=len(problem.controlled_ids),
+            controlled_ids=problem.controlled_ids,
             residual_count=residual_count,
         )
     except Exception as error:  # noqa: BLE001 - malformed third-party result boundary
@@ -3159,6 +3316,7 @@ def _accepted_fit_evidence(
     chi_square: float,
     evaluation_result: EvaluationResult,
     origin_context_identity: str,
+    final_residual_jacobian: FinalResidualJacobianEvidence | None = None,
 ) -> AcceptedFitResult:
     """Construct evidence only from one fresh complete root materialization."""
     if not problem.acceptance_authority:
@@ -3202,6 +3360,7 @@ def _accepted_fit_evidence(
         problem.commit_scope,
         commit_items,
         origin_context_identity,
+        final_residual_jacobian=final_residual_jacobian,
         occurrence_witness=_mint_accepted_occurrence_witness(occurrence_identity),
     )
 
@@ -3291,6 +3450,7 @@ def accept_materialized_fit(
     vector: tuple[float, ...],
     chi_square: float,
     evaluation_result: EvaluationResult,
+    final_residual_jacobian: FinalResidualJacobianEvidence | None = None,
 ) -> tuple[AcceptedFitResult, LiveFitCommitAuthority]:
     """Accept a fresh Direct TRF fit and mint its process-owned capability."""
     origin_context_identity = _direct_fit_commit_origin(
@@ -3309,6 +3469,7 @@ def accept_materialized_fit(
         chi_square=chi_square,
         evaluation_result=evaluation_result,
         origin_context_identity=origin_context_identity,
+        final_residual_jacobian=final_residual_jacobian,
     )
     authority = _mint_fit_commit_authority(accepted, problem)
     return accepted, authority
@@ -3324,6 +3485,7 @@ def _accept_materialized_fit_for_derived_workflow(
     chi_square: float,
     evaluation_result: EvaluationResult,
     authority_context_identity: str,
+    final_residual_jacobian: FinalResidualJacobianEvidence | None = None,
 ) -> AcceptedFitResult:
     """Construct derived evidence after workflow validation, before authority."""
     return _accepted_fit_evidence(
@@ -3335,6 +3497,7 @@ def _accept_materialized_fit_for_derived_workflow(
         chi_square=chi_square,
         evaluation_result=evaluation_result,
         origin_context_identity=authority_context_identity,
+        final_residual_jacobian=final_residual_jacobian,
     )
 
 
@@ -3360,6 +3523,11 @@ def _accepted_outcome(
         vector=candidate.vector,
         chi_square=candidate.chi_square,
         evaluation_result=candidate.evaluation_result,
+        final_residual_jacobian=(
+            None
+            if execution.backend is None
+            else execution.backend.final_residual_jacobian
+        ),
     )
     return DirectTrfOutcome(
         DirectTrfOutcomeTerminal.ACCEPTED,

--- a/src/chemex/optimize/grid_direct_trf.py
+++ b/src/chemex/optimize/grid_direct_trf.py
@@ -28,6 +28,7 @@ from chemex.optimize.direct_trf import (
     DirectTrfInterrupted,
     DirectTrfInvocation,
     DirectTrfTerminal,
+    FinalResidualJacobianEvidence,
     GridSeedProblemDerivation,
     GridSelectionProvenance,
     LiveFitCommitAuthority,
@@ -539,6 +540,9 @@ class GridCandidateRecord(Protocol):
     @property
     def identity(self) -> str: ...
 
+    @property
+    def final_residual_jacobian(self) -> FinalResidualJacobianEvidence | None: ...
+
     def validate_for_grid_selection(
         self,
         problem: OptimizationProblem,
@@ -615,6 +619,13 @@ class GridSeedOutcome:
                 ),
             ),
         )
+
+    @property
+    def final_residual_jacobian(self) -> FinalResidualJacobianEvidence | None:
+        direct = self.direct_outcome
+        if direct is None or direct.execution.backend is None:
+            return None
+        return direct.execution.backend.final_residual_jacobian
 
     def validate_for_grid_selection(
         self,
@@ -869,6 +880,7 @@ class AcceptedGridDirectTrfResult(AcceptedFitResult):
             selected_seed,
             selected_outcome,
             fresh_candidate,
+            final_residual_jacobian=accepted.final_residual_jacobian,
             occurrence_witness=accepted.occurrence_witness,
         )
 
@@ -1441,6 +1453,7 @@ def _finalize_grid_candidates(
         chi_square=promoted.chi_square,
         evaluation_result=promoted.evaluation_result,
         authority_context_identity=provenance.identity,
+        final_residual_jacobian=selected.final_residual_jacobian,
     )
     accepted = AcceptedGridDirectTrfResult.from_accepted(
         root_accepted,

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -26,11 +26,13 @@ from chemex.optimize.direct_trf import (
     DirectTrfInterrupted,
     DirectTrfInvocation,
     DirectTrfTerminal,
+    FinalResidualJacobianEvidence,
     LiveFitCommitAuthority,
     MaterializationTerminal,
     MaterializedDirectTrfCandidate,
     ObjectiveScalarizationError,
     OptimizationProblem,
+    ResidualJacobianSource,
     TerminalFailure,
     accept_materialized_fit,
     canonical_chi_square,
@@ -630,6 +632,12 @@ class FitComponentOutcome:
         repr=False,
         compare=False,
     )
+    final_residual_jacobian: FinalResidualJacobianEvidence | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        kw_only=True,
+    )
     failure: TerminalFailure | None = None
     identity: str = field(init=False)
 
@@ -638,6 +646,16 @@ class FitComponentOutcome:
             self.candidate is not None
         ):
             raise ValueError("Only a successful component may expose a candidate")
+        if self.final_residual_jacobian is not None and (
+            self.candidate is None
+            or self.final_residual_jacobian.controlled_ids != self.controlled_ids
+            or self.final_residual_jacobian.final_vector != self.candidate.vector
+            or self.final_residual_jacobian.final_residuals
+            != tuple(
+                float(value) for value in self.candidate.evaluation_result.residuals
+            )
+        ):
+            raise ValueError("Component final Jacobian differs from its candidate")
         if self.disposition is ComponentDisposition.NOT_STARTED and (
             self.execution_identity is not None or self.failure is not None
         ):
@@ -653,6 +671,9 @@ class FitComponentOutcome:
                     self.disposition.value,
                     self.execution_identity,
                     None if self.candidate is None else self.candidate.identity,
+                    None
+                    if self.final_residual_jacobian is None
+                    else self.final_residual_jacobian.identity,
                     None if self.failure is None else self.failure.identity,
                 ),
             ),
@@ -852,6 +873,11 @@ def execute_direct_trf_components(
                     ComponentDisposition.SUCCEEDED,
                     result.execution.identity,
                     result.candidate,
+                    final_residual_jacobian=(
+                        None
+                        if result.execution.backend is None
+                        else result.execution.backend.final_residual_jacobian
+                    ),
                 )
             )
         elif result.terminal is DirectTrfCandidateTerminal.CANCELLED:
@@ -1175,6 +1201,80 @@ def _aggregate_vector(
     return vector
 
 
+def _compose_partitioned_final_jacobian(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    engine: EvaluationEngine,
+    outcomes: tuple[FitComponentOutcome, ...],
+    aggregate: EvaluationResult,
+) -> FinalResidualJacobianEvidence | None:
+    """Compose exact independent component Jacobians in canonical root order."""
+    proof = decomposition.partition_proof
+    if (
+        not decomposition.components
+        or proof.controlled_ids != problem.controlled_ids
+        or proof.root_plan_identity != engine.plan.identity
+        or len(outcomes) != len(decomposition.components)
+    ):
+        return None
+    row_ranges: list[tuple[int, int]] = []
+    offset = 0
+    for profile in engine.plan.profiles:
+        count = len(profile.retained_observation_indices)
+        row_ranges.append((offset, offset + count))
+        offset += count
+    if offset != aggregate.residuals.size:
+        return None
+    root_columns = {
+        param_id: index for index, param_id in enumerate(problem.controlled_ids)
+    }
+    matrix = np.zeros((offset, len(problem.controlled_ids)), dtype=np.float64)
+    source_identities: list[str] = [proof.identity]
+    for component, outcome in zip(
+        decomposition.components,
+        outcomes,
+        strict=True,
+    ):
+        retained = outcome.final_residual_jacobian
+        candidate = outcome.candidate
+        if (
+            retained is None
+            or candidate is None
+            or retained.controlled_ids != component.controlled_ids
+            or retained.final_vector != candidate.vector
+            or retained.final_residuals
+            != tuple(float(value) for value in candidate.evaluation_result.residuals)
+        ):
+            return None
+        child_offset = 0
+        for root_profile_index in component.root_profile_indices:
+            root_start, root_stop = row_ranges[root_profile_index]
+            count = root_stop - root_start
+            child_stop = child_offset + count
+            if child_stop > retained.shape[0]:
+                return None
+            for child_column, param_id in enumerate(component.controlled_ids):
+                matrix[root_start:root_stop, root_columns[param_id]] = np.asarray(
+                    retained.matrix,
+                    dtype=np.float64,
+                )[child_offset:child_stop, child_column]
+            child_offset = child_stop
+        if child_offset != retained.shape[0]:
+            return None
+        source_identities.append(retained.identity)
+    return FinalResidualJacobianEvidence(
+        ResidualJacobianSource.FIT_PARTITION_COMPOSITION,
+        problem.controlled_ids,
+        tuple(
+            aggregate.resolved_values[param_id] for param_id in problem.controlled_ids
+        ),
+        tuple(float(value) for value in aggregate.residuals),
+        matrix.shape,
+        tuple(tuple(float(value) for value in row) for row in matrix),
+        tuple(source_identities),
+    )
+
+
 def _accept_grouped_aggregate_unchecked(
     problem: OptimizationProblem,
     decomposition: FitDecomposition,
@@ -1210,6 +1310,13 @@ def _accept_grouped_aggregate_unchecked(
             )
     if token.is_cancelled:
         return GroupedDirectTrfOutcome(GroupedDirectTrfTerminal.CANCELLED, outcomes)
+    final_residual_jacobian = _compose_partitioned_final_jacobian(
+        problem,
+        decomposition,
+        engine,
+        outcomes,
+        aggregate,
+    )
     if token.is_cancelled:
         return GroupedDirectTrfOutcome(GroupedDirectTrfTerminal.CANCELLED, outcomes)
     accepted, authority = accept_materialized_fit(
@@ -1220,6 +1327,7 @@ def _accept_grouped_aggregate_unchecked(
         vector=materialized.vector,
         chi_square=materialized.chi_square,
         evaluation_result=aggregate,
+        final_residual_jacobian=final_residual_jacobian,
     )
     return GroupedDirectTrfOutcome(
         GroupedDirectTrfTerminal.ACCEPTED,

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -1246,6 +1246,7 @@ def _compose_partitioned_final_jacobian(
             != tuple(float(value) for value in candidate.evaluation_result.residuals)
         ):
             return None
+        retained_matrix = np.asarray(retained.matrix, dtype=np.float64)
         child_offset = 0
         for root_profile_index in component.root_profile_indices:
             root_start, root_stop = row_ranges[root_profile_index]
@@ -1254,10 +1255,10 @@ def _compose_partitioned_final_jacobian(
             if child_stop > retained.shape[0]:
                 return None
             for child_column, param_id in enumerate(component.controlled_ids):
-                matrix[root_start:root_stop, root_columns[param_id]] = np.asarray(
-                    retained.matrix,
-                    dtype=np.float64,
-                )[child_offset:child_stop, child_column]
+                matrix[root_start:root_stop, root_columns[param_id]] = retained_matrix[
+                    child_offset:child_stop,
+                    child_column,
+                ]
             child_offset = child_stop
         if child_offset != retained.shape[0]:
             return None

--- a/src/chemex/optimize/grouped_grid_direct_trf.py
+++ b/src/chemex/optimize/grouped_grid_direct_trf.py
@@ -19,6 +19,7 @@ from chemex.optimize.direct_trf import (
     ComponentProblemDerivation,
     DirectTrfConstructionError,
     DirectTrfInvocation,
+    FinalResidualJacobianEvidence,
     GridSeedProblemDerivation,
     LiveFitCommitAuthority,
     OptimizationProblem,
@@ -152,6 +153,11 @@ class GroupedGridSeedOutcome:
     ) -> None:
         """Prove exact grouped component ownership before GRID selection."""
         _validate_grouped_grid_seed(self, problem, invocation, seed)
+
+    @property
+    def final_residual_jacobian(self) -> FinalResidualJacobianEvidence | None:
+        """Grouped GRID falls back unless exact root composition is retained."""
+        return None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -14,8 +14,17 @@ from chemex.messages import (
     print_plotting_canceled,
     print_writing_results,
 )
+from chemex.optimize.uncertainty import (
+    RootAnchoredBlockCovarianceEvidence,
+    UncertaintyEvidence,
+)
 from chemex.parameters.database import ParameterStore
-from chemex.printers.parameters import write_parameters
+from chemex.printers.native_reporting import (
+    write_block_uncertainty,
+    write_json,
+    write_uncertainty,
+)
+from chemex.printers.parameters import ParameterUncertaintyView, write_parameters
 from chemex.typing import Array
 
 
@@ -73,11 +82,20 @@ def _write_files(
     *,
     residuals: Array,
     nvarys: int,
+    uncertainty: ParameterUncertaintyView | None = None,
+    uncertainty_evidence: UncertaintyEvidence | None = None,
+    uncertainty_status: tuple[str, str] | None = None,
+    block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None,
 ) -> None:
     """Write the results of the fit to output files."""
     print_writing_results(path)
     path.mkdir(parents=True, exist_ok=True)
-    write_parameters(experiments, path, parameter_store=experiments.parameter_store)
+    write_parameters(
+        experiments,
+        path,
+        parameter_store=experiments.parameter_store,
+        uncertainty=uncertainty,
+    )
     experiments.write(path)
     _write_statistics(
         experiments,
@@ -85,6 +103,25 @@ def _write_files(
         residuals=residuals,
         nvarys=nvarys,
     )
+    if uncertainty_evidence is not None:
+        statistics_path = path / "Statistics"
+        statistics_path.mkdir(exist_ok=True)
+        write_uncertainty(statistics_path, uncertainty_evidence)
+        write_block_uncertainty(statistics_path, block_uncertainty)
+    elif uncertainty_status is not None:
+        terminal, reason = uncertainty_status
+        covariance_path = path / "Statistics" / "Covariance"
+        covariance_path.mkdir(parents=True, exist_ok=True)
+        write_json(
+            covariance_path / "status.json",
+            {
+                "artifact_type": "native_covariance_derivation_status",
+                "schema_version": 1,
+                "status": "incomplete",
+                "terminal": terminal,
+                "reason": reason,
+            },
+        )
 
 
 def _write_simulation_files(
@@ -130,8 +167,21 @@ def execute_post_fit(
     plot: bool = False,
     residuals: Array,
     nvarys: int,
+    uncertainty: ParameterUncertaintyView | None = None,
+    uncertainty_evidence: UncertaintyEvidence | None = None,
+    uncertainty_status: tuple[str, str] | None = None,
+    block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None,
 ) -> None:
-    _write_files(experiments, path, residuals=residuals, nvarys=nvarys)
+    _write_files(
+        experiments,
+        path,
+        residuals=residuals,
+        nvarys=nvarys,
+        uncertainty=uncertainty,
+        uncertainty_evidence=uncertainty_evidence,
+        uncertainty_status=uncertainty_status,
+        block_uncertainty=block_uncertainty,
+    )
     if plot:
         _write_plots(experiments, path)
 
@@ -156,6 +206,10 @@ def execute_post_fit_groups(
     *,
     residuals: Array,
     nvarys: int,
+    uncertainty: ParameterUncertaintyView | None = None,
+    uncertainty_evidence: UncertaintyEvidence | None = None,
+    uncertainty_status: tuple[str, str] | None = None,
+    block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None,
 ) -> None:
     print_group_name("All groups")
     statistics = calculate_statistics_from_residuals(residuals, nvarys)
@@ -166,6 +220,10 @@ def execute_post_fit_groups(
         plot=(plot != "nothing"),
         residuals=residuals,
         nvarys=nvarys,
+        uncertainty=uncertainty,
+        uncertainty_evidence=uncertainty_evidence,
+        uncertainty_status=uncertainty_status,
+        block_uncertainty=block_uncertainty,
     )
 
 

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -108,7 +108,7 @@ def _write_files(
         statistics_path.mkdir(exist_ok=True)
         write_uncertainty(statistics_path, uncertainty_evidence)
         write_block_uncertainty(statistics_path, block_uncertainty)
-    elif uncertainty_status is not None:
+    if uncertainty_status is not None:
         terminal, reason = uncertainty_status
         covariance_path = path / "Statistics" / "Covariance"
         covariance_path.mkdir(parents=True, exist_ok=True)

--- a/src/chemex/optimize/method_step.py
+++ b/src/chemex/optimize/method_step.py
@@ -46,6 +46,7 @@ from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     CancellationToken,
     DirectTrfInvocation,
+    FinalResidualJacobianEvidence,
     FitCommitOperation,
     FitCommitTerminal,
     LiveFitCommitAuthority,
@@ -486,6 +487,9 @@ def _validate_recursive_dataclass_children(  # noqa: C901 - closed evidence tree
         return
     if isinstance(value, AnalysisValuesSnapshot):
         _validate_snapshot_integrity(value)
+        return
+    if isinstance(value, FinalResidualJacobianEvidence):
+        value.validate_integrity()
         return
     if isinstance(value, (AcceptedFitResult, FitCommitOperation)) or not is_dataclass(
         value
@@ -1604,6 +1608,8 @@ def _validate_method_step_outcome(  # noqa: C901 - closed recursive outcome tree
         replace(outcome.primary_execution)
     if outcome.accepted_result is not None:
         accepted = outcome.accepted_result
+        if accepted.final_residual_jacobian is not None:
+            accepted.final_residual_jacobian.validate_integrity()
         reconstructed = replace(accepted, occurrence_witness=None)
         if (
             reconstructed.identity != accepted.identity
@@ -1779,6 +1785,9 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
     analysis_values: AnalysisValues,
     cancellation: CancellationToken | None = None,
     checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None = None,
+    commit_completed_observer: (
+        Callable[[AcceptedFitResult, FitCommitOperation], None] | None
+    ) = None,
     progress_observer: ContextualProgressObserver | None = None,
 ) -> MethodStepOutcome:
     """Execute one exact native workflow occurrence."""
@@ -1794,6 +1803,7 @@ def execute_method_step(  # noqa: C901 - closed evaluation/optimization lifecycl
             analysis_values=analysis_values,
             cancellation=cancellation,
             checkpoint_observer=checkpoint_observer,
+            commit_completed_observer=commit_completed_observer,
             progress_observer=progress_observer,
         )
     if cancellation is not None and cancellation.is_cancelled:
@@ -2073,6 +2083,9 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
     analysis_values: AnalysisValues,
     cancellation: CancellationToken | None,
     checkpoint_observer: Callable[[MethodStepCheckpoint], None] | None,
+    commit_completed_observer: (
+        Callable[[AcceptedFitResult, FitCommitOperation], None] | None
+    ),
     progress_observer: ContextualProgressObserver | None,
 ) -> MethodStepOutcome:
     _validate_execution_start_workflow(workflow, execution_start)
@@ -2263,6 +2276,13 @@ def _execute_optimization(  # noqa: C901 - closed primary transition
     if checkpoint_observer is not None:
         checkpoint_observer(MethodStepCheckpoint.COMMIT_COMPLETED)
         _validate_execution_start_workflow(workflow, execution_start)
+    if commit_completed_observer is not None:
+        try:
+            commit_completed_observer(accepted, operation)
+        except KeyboardInterrupt:
+            token.cancel()
+        except Exception:  # noqa: BLE001, S110 - reporting is non-scientific
+            pass
     committed = operation.terminal is FitCommitTerminal.COMMITTED
     successor = operation.committed_snapshot if committed else None
     derivations = (

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -241,6 +241,28 @@ def _product_uncertainty_result(
     raise RuntimeError("Committed native fit lacks requested uncertainty evidence")
 
 
+def _product_block_uncertainty(
+    evidence: UncertaintyEvidence | None,
+    decomposition: FitDecomposition,
+) -> tuple[
+    RootAnchoredBlockCovarianceEvidence | None,
+    tuple[str, str] | None,
+]:
+    """Derive proof-bound block evidence without invalidating a committed fit."""
+    if evidence is None:
+        return None, None
+    try:
+        return (
+            derive_root_anchored_block_covariance(
+                evidence,
+                decomposition.partition_proof,
+            ),
+            None,
+        )
+    except KeyboardInterrupt:
+        return None, ("interrupted", "block derivation interrupted")
+
+
 def _has_controlled_parameters(parameterization: ActiveParameterization) -> bool:
     return any(
         parameterization.role(param_id) is ParameterRole.FIT
@@ -626,17 +648,11 @@ def run_native_deterministic(
         uncertainty_request.constrained_scope,
         unsupported_constrained_ids,
     )
-    block_uncertainty = (
-        None
-        if uncertainty_evidence is None
-        else derive_root_anchored_block_covariance(
-            uncertainty_evidence,
-            tuple(
-                (component.controlled_ids, component.root_profile_indices)
-                for component in decomposition.components
-            ),
-        )
+    block_uncertainty, block_status = _product_block_uncertainty(
+        uncertainty_evidence,
+        decomposition,
     )
+    uncertainty_status = block_status or uncertainty_status
     if block_uncertainty is not None:
         block_errors = tuple(
             (entry.param_id, entry.value)

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -47,6 +47,7 @@ from chemex.optimize.method_step import (
     DerivationDisposition,
     EvaluationPurpose,
     MethodStepLifecycle,
+    MethodStepOutcome,
     MethodStepStrategy,
     MethodStepWorkflow,
     UncertaintyDerivationRequest,
@@ -66,6 +67,7 @@ from chemex.parameters.parameterization import ActiveParameterization, Parameter
 from chemex.printers.parameters import (
     ParameterUncertaintyView,
     parameter_uncertainty_view,
+    uncertainty_unavailable_reason,
 )
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
@@ -109,13 +111,11 @@ def _product_uncertainty_request(
     """Resolve the normal absolute-observation-sigma covariance policy."""
     environment = ProvenanceEnvironment.from_current_process()
     policy = UncertaintyPolicy(
-        calibration_identity="native-product-local-covariance-numerics-v1",
+        calibration_identity="native-product-local-covariance-numerics-v2",
         numerical_compatibility_requirement=(
-            "binary64-scipy-economical-svd-fixed-pairwise-v1"
+            "binary64-retained-scipy-2point-gesvd-column-equilibrated-v1"
         ),
-        coordinate_scales=tuple(
-            zip(problem.controlled_ids, _product_x_scale(problem), strict=True)
-        ),
+        coordinate_scales=tuple((param_id, 1.0) for param_id in problem.controlled_ids),
         coordinate_units=tuple(
             (param_id, ParameterUnit.UNSPECIFIED) for param_id in problem.controlled_ids
         ),
@@ -126,14 +126,16 @@ def _product_uncertainty_request(
         roundoff_multiplier=64.0,
         smaller_step_extent=8,
         larger_step_extent=8,
-        svd_driver="gesdd",
+        svd_driver="gesvd",
+        # Legacy qualification knobs; covariance rank uses sigma_max*max(m,n)*eps.
         rank_absolute_tolerance=0.0,
-        rank_relative_tolerance=1.0e-12,
+        rank_relative_tolerance=0.0,
         weak_relative_tolerance=1.0e-6,
         singular_value_cluster_relative_tolerance=1.0e-10,
         conditioning_limit=1.0e12,
         correlation_roundoff_multiplier=64.0,
         affine_feasibility_policy="canonical-root-affine-halfspace-zeta-gt-3-v1",
+        residual_jacobian_strategy="retained-backend-or-accepted-2-point",
     )
     constraints = {
         item.target_id: item for item in parameterization.program.constraints
@@ -195,7 +197,7 @@ def _product_uncertainty_request(
 
 
 def _product_uncertainty_result(
-    outcome: object,
+    outcome: MethodStepOutcome,
     controlled_ids: tuple[str, ...],
     supported_constrained_ids: tuple[str, ...],
     unsupported_constrained_ids: tuple[str, ...],
@@ -204,8 +206,7 @@ def _product_uncertainty_result(
     ParameterUncertaintyView,
     tuple[str, str] | None,
 ]:
-    derivations = getattr(outcome, "derivations", ())
-    for derivation in derivations:
+    for derivation in outcome.derivations:
         for artifact in derivation.artifacts:
             if isinstance(artifact, UncertaintyEvidence):
                 return (
@@ -459,6 +460,9 @@ def _write_direct_output(
     """Write established per-group and aggregate output from native evidence."""
     plot_flg = (plot == "normal" and not aggregate_output) or plot == "all"
     controlled_by_path = dict(group_scopes)
+    group_diagnostics = None if aggregate_output else uncertainty_evidence
+    group_status = None if aggregate_output else uncertainty_status
+    group_blocks = None if aggregate_output else block_uncertainty
     for group in groups:
         if message := group.message:
             print_group_name(message)
@@ -469,9 +473,9 @@ def _write_direct_output(
             residuals=_project_residuals(group.experiments, experiments, result),
             nvarys=len(controlled_by_path[group.path]),
             uncertainty=uncertainty,
-            uncertainty_evidence=uncertainty_evidence,
-            uncertainty_status=uncertainty_status,
-            block_uncertainty=block_uncertainty,
+            uncertainty_evidence=group_diagnostics,
+            uncertainty_status=group_status,
+            block_uncertainty=group_blocks,
         )
     if aggregate_output:
         execute_post_fit_groups(
@@ -661,9 +665,9 @@ def run_native_deterministic(
             if entry.value is not None
         )
         block_unavailable = tuple(
-            (param_id, block.unavailable_reason)
+            (param_id, uncertainty_unavailable_reason(block.unavailable_kind))
             for block in block_uncertainty.blocks
-            if block.unavailable_reason
+            if block.unavailable_kind is not None
             for param_id in block.controlled_ids
         )
         block_constrained_errors = tuple(

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -53,10 +53,10 @@ from chemex.optimize.method_step import (
     execute_method_step,
 )
 from chemex.optimize.uncertainty import (
+    MissingFunctionLinearizationCapability,
     ParameterUnit,
     ResidualVarianceScaling,
     RootAnchoredBlockCovarianceEvidence,
-    UncertaintyConstructionError,
     UncertaintyEvidence,
     UncertaintyPolicy,
     compile_constraint_linearization_capabilities,
@@ -169,7 +169,7 @@ def _product_uncertainty_request(
                 (param_id,),
                 (),
             )
-        except UncertaintyConstructionError:
+        except MissingFunctionLinearizationCapability:
             unsupported.append(param_id)
         else:
             supported.append(param_id)
@@ -197,6 +197,7 @@ def _product_uncertainty_request(
 def _product_uncertainty_result(
     outcome: object,
     controlled_ids: tuple[str, ...],
+    supported_constrained_ids: tuple[str, ...],
     unsupported_constrained_ids: tuple[str, ...],
 ) -> tuple[
     UncertaintyEvidence | None,
@@ -229,6 +230,7 @@ def _product_uncertainty_result(
             view = ParameterUncertaintyView(
                 unavailable_reasons=(
                     *((param_id, reason) for param_id in controlled_ids),
+                    *((param_id, reason) for param_id in supported_constrained_ids),
                     *(
                         (param_id, "unsupported constrained derivative")
                         for param_id in unsupported_constrained_ids
@@ -621,6 +623,7 @@ def run_native_deterministic(
     uncertainty_evidence, uncertainty, uncertainty_status = _product_uncertainty_result(
         outcome,
         problem.controlled_ids,
+        uncertainty_request.constrained_scope,
         unsupported_constrained_ids,
     )
     block_uncertainty = (
@@ -628,7 +631,10 @@ def run_native_deterministic(
         if uncertainty_evidence is None
         else derive_root_anchored_block_covariance(
             uncertainty_evidence,
-            tuple(component.controlled_ids for component in decomposition.components),
+            tuple(
+                (component.controlled_ids, component.root_profile_indices)
+                for component in decomposition.components
+            ),
         )
     )
     if block_uncertainty is not None:
@@ -644,8 +650,14 @@ def run_native_deterministic(
             if block.unavailable_reason
             for param_id in block.controlled_ids
         )
+        block_constrained_errors = tuple(
+            (entry.param_id, entry.value)
+            for block in block_uncertainty.blocks
+            for entry in block.constrained_marginal_errors
+            if entry.value is not None
+        )
         uncertainty = ParameterUncertaintyView(
-            uncertainty.standard_errors + block_errors,
+            uncertainty.standard_errors + block_errors + block_constrained_errors,
             uncertainty.unavailable_reasons + block_unavailable,
         )
     fit = NativeDeterministicFit(

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -12,6 +12,7 @@ from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import EvaluationEngine, EvaluationResult
 from chemex.messages import (
     MinimizationProgressReporter,
+    UncertaintyProgressReporter,
     console,
     print_group_name,
     print_minimizing,
@@ -20,6 +21,8 @@ from chemex.native_provenance import ProvenanceEnvironment
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     DirectTrfInvocation,
+    FitCommitOperation,
+    FitCommitTerminal,
     OptimizationProblem,
 )
 from chemex.optimize.grid_direct_trf import GridDirectTrfInvocation
@@ -114,7 +117,7 @@ def _product_uncertainty_request(
     policy = UncertaintyPolicy(
         calibration_identity="native-product-local-covariance-numerics-v2",
         numerical_compatibility_requirement=(
-            "binary64-retained-scipy-2point-gesvd-column-equilibrated-v1"
+            "binary64-retained-scipy-2point-gesdd-column-equilibrated-v1"
         ),
         coordinate_scales=tuple((param_id, 1.0) for param_id in problem.controlled_ids),
         coordinate_units=tuple(
@@ -127,7 +130,7 @@ def _product_uncertainty_request(
         roundoff_multiplier=64.0,
         smaller_step_extent=8,
         larger_step_extent=8,
-        svd_driver="gesvd",
+        svd_driver="gesdd",
         # Legacy qualification knobs; covariance rank uses sigma_max*max(m,n)*eps.
         rank_absolute_tolerance=0.0,
         rank_relative_tolerance=0.0,
@@ -273,6 +276,27 @@ def _product_block_uncertainty(
         )
 
 
+def _uncertainty_progress_status(
+    evidence: UncertaintyEvidence | None,
+    block_evidence: RootAnchoredBlockCovarianceEvidence | None,
+    uncertainty: ParameterUncertaintyView,
+    controlled_ids: tuple[str, ...],
+) -> str:
+    """Summarize fitted covariance availability without overstating constraints."""
+    if evidence is not None and evidence.covariance is not None:
+        return "covariance available"
+    if block_evidence is not None and any(
+        block.covariance is not None for block in block_evidence.blocks
+    ):
+        return "covariance partially available"
+    reasons = dict(uncertainty.unavailable_reasons)
+    reason = next(
+        (reasons[param_id] for param_id in controlled_ids if param_id in reasons),
+        "insufficient information",
+    )
+    return f"uncertainty unavailable: {reason}"
+
+
 def _has_controlled_parameters(parameterization: ActiveParameterization) -> bool:
     return any(
         parameterization.role(param_id) is ParameterRole.FIT
@@ -308,6 +332,47 @@ def _materialize_evaluation(
                 for local_name, param_id in profile.name_map.items()
             }
         )
+
+
+def _execute_with_phase_progress(
+    workflow: MethodStepWorkflow,
+    session: AnalysisSession,
+    progress: MinimizationProgressReporter,
+    uncertainty_progress: UncertaintyProgressReporter,
+) -> MethodStepOutcome:
+    """Close minimization at commit and time the following uncertainty phase."""
+    minimization_finished = False
+
+    def finish_minimization_at_commit(
+        accepted: AcceptedFitResult,
+        operation: FitCommitOperation,
+    ) -> None:
+        nonlocal minimization_finished
+        progress.finish(
+            final_chi_square=accepted.chi_square,
+            terminal_status=operation.terminal.value,
+        )
+        minimization_finished = True
+        if operation.terminal is FitCommitTerminal.COMMITTED:
+            uncertainty_progress.start()
+
+    print_minimizing()
+    with progress:
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            progress_observer=progress.observe,
+            commit_completed_observer=finish_minimization_at_commit,
+        )
+        if not minimization_finished:
+            accepted_result = outcome.accepted_result
+            progress.finish(
+                final_chi_square=(
+                    None if accepted_result is None else accepted_result.chi_square
+                ),
+                terminal_status=outcome.lifecycle.value,
+            )
+    return outcome
 
 
 def _project_residuals(
@@ -609,20 +674,13 @@ def run_native_deterministic(
         group_labels=group_labels,
         grid=bool(method.grid),
     )
-    print_minimizing()
-    with progress:
-        outcome = execute_method_step(
-            workflow,
-            analysis_values=session.analysis_values,
-            progress_observer=progress.observe,
-        )
-        accepted_result = outcome.accepted_result
-        progress.finish(
-            final_chi_square=(
-                None if accepted_result is None else accepted_result.chi_square
-            ),
-            terminal_status=outcome.lifecycle.value,
-        )
+    uncertainty_progress = UncertaintyProgressReporter(console)
+    outcome = _execute_with_phase_progress(
+        workflow,
+        session,
+        progress,
+        uncertainty_progress,
+    )
     if outcome.lifecycle is MethodStepLifecycle.INTERRUPTED:
         raise KeyboardInterrupt("Native deterministic fit interrupted")
     if outcome.lifecycle is not MethodStepLifecycle.COMMITTED:
@@ -689,6 +747,14 @@ def run_native_deterministic(
             uncertainty.standard_errors + block_errors + block_constrained_errors,
             uncertainty.unavailable_reasons + block_unavailable,
         )
+    uncertainty_progress.finish(
+        _uncertainty_progress_status(
+            uncertainty_evidence,
+            block_uncertainty,
+            uncertainty,
+            problem.controlled_ids,
+        )
+    )
     fit = NativeDeterministicFit(
         accepted,
         problem,

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -60,6 +60,7 @@ from chemex.optimize.uncertainty import (
     RootAnchoredBlockCovarianceEvidence,
     UncertaintyEvidence,
     UncertaintyPolicy,
+    UncertaintyUnavailableKind,
     compile_constraint_linearization_capabilities,
     derive_root_anchored_block_covariance,
 )
@@ -223,17 +224,20 @@ def _product_uncertainty_result(
             DerivationDisposition.NOT_STARTED_BY_WORKFLOW_STOP,
         }:
             terminal = derivation.disposition.value
-            reason = (
-                "derivation interrupted"
-                if derivation.disposition is DerivationDisposition.INTERRUPTED
-                else "derivation cancelled"
+            reason = uncertainty_unavailable_reason(
+                UncertaintyUnavailableKind.DERIVATION_STOPPED
             )
             view = ParameterUncertaintyView(
                 unavailable_reasons=(
                     *((param_id, reason) for param_id in controlled_ids),
                     *((param_id, reason) for param_id in supported_constrained_ids),
                     *(
-                        (param_id, "unsupported constrained derivative")
+                        (
+                            param_id,
+                            uncertainty_unavailable_reason(
+                                UncertaintyUnavailableKind.UNSUPPORTED_CONSTRAINED_DERIVATIVE
+                            ),
+                        )
                         for param_id in unsupported_constrained_ids
                     ),
                 )
@@ -261,7 +265,12 @@ def _product_block_uncertainty(
             None,
         )
     except KeyboardInterrupt:
-        return None, ("interrupted", "block derivation interrupted")
+        return None, (
+            "interrupted",
+            uncertainty_unavailable_reason(
+                UncertaintyUnavailableKind.DERIVATION_STOPPED
+            ),
+        )
 
 
 def _has_controlled_parameters(parameterization: ActiveParameterization) -> bool:

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -16,6 +16,7 @@ from chemex.messages import (
     print_group_name,
     print_minimizing,
 )
+from chemex.native_provenance import ProvenanceEnvironment
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     DirectTrfInvocation,
@@ -43,13 +44,29 @@ from chemex.optimize.helper import (
     print_values,
 )
 from chemex.optimize.method_step import (
+    DerivationDisposition,
     EvaluationPurpose,
     MethodStepLifecycle,
     MethodStepStrategy,
     MethodStepWorkflow,
+    UncertaintyDerivationRequest,
     execute_method_step,
 )
+from chemex.optimize.uncertainty import (
+    ParameterUnit,
+    ResidualVarianceScaling,
+    RootAnchoredBlockCovarianceEvidence,
+    UncertaintyConstructionError,
+    UncertaintyEvidence,
+    UncertaintyPolicy,
+    compile_constraint_linearization_capabilities,
+    derive_root_anchored_block_covariance,
+)
 from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
+from chemex.printers.parameters import (
+    ParameterUncertaintyView,
+    parameter_uncertainty_view,
+)
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
 
@@ -66,6 +83,8 @@ class NativeDeterministicFit:
     problem: OptimizationProblem
     parameterization: ActiveParameterization
     engine: EvaluationEngine
+    uncertainty: UncertaintyEvidence | None = None
+    block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None
 
     @property
     def objective_request_budget(self) -> int:
@@ -81,6 +100,143 @@ def _objective_request_budget(problem: OptimizationProblem) -> int:
 def _product_x_scale(problem: OptimizationProblem) -> tuple[float, ...]:
     """Scale native product coordinates without changing physical semantics."""
     return tuple(max(1.0, abs(value)) for value in problem.start)
+
+
+def _product_uncertainty_request(
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+) -> tuple[UncertaintyDerivationRequest, tuple[str, ...]]:
+    """Resolve the normal absolute-observation-sigma covariance policy."""
+    environment = ProvenanceEnvironment.from_current_process()
+    policy = UncertaintyPolicy(
+        calibration_identity="native-product-local-covariance-numerics-v1",
+        numerical_compatibility_requirement=(
+            "binary64-scipy-economical-svd-fixed-pairwise-v1"
+        ),
+        coordinate_scales=tuple(
+            zip(problem.controlled_ids, _product_x_scale(problem), strict=True)
+        ),
+        coordinate_units=tuple(
+            (param_id, ParameterUnit.UNSPECIFIED) for param_id in problem.controlled_ids
+        ),
+        residual_variance_scaling=(
+            ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+        ),
+        relative_step_tolerance=1.0e-4,
+        roundoff_multiplier=64.0,
+        smaller_step_extent=8,
+        larger_step_extent=8,
+        svd_driver="gesdd",
+        rank_absolute_tolerance=0.0,
+        rank_relative_tolerance=1.0e-12,
+        weak_relative_tolerance=1.0e-6,
+        singular_value_cluster_relative_tolerance=1.0e-10,
+        conditioning_limit=1.0e12,
+        correlation_roundoff_multiplier=64.0,
+        affine_feasibility_policy="canonical-root-affine-halfspace-zeta-gt-3-v1",
+    )
+    constraints = {
+        item.target_id: item for item in parameterization.program.constraints
+    }
+    controlled = frozenset(problem.controlled_ids)
+
+    def depends_on_controlled(
+        param_id: str,
+        visiting: frozenset[str] = frozenset(),
+    ) -> bool:
+        if param_id in controlled:
+            return True
+        if param_id in visiting or param_id not in constraints:
+            return False
+        constraint = constraints[param_id]
+        return any(
+            depends_on_controlled(dependency, visiting | {param_id})
+            for dependency in constraint.dependencies
+        )
+
+    propagation_candidates = tuple(
+        param_id
+        for param_id in parameterization.scope_ids
+        if parameterization.role(param_id) is ParameterRole.DERIVED
+        and depends_on_controlled(param_id)
+    )
+    supported: list[str] = []
+    unsupported: list[str] = []
+    for param_id in propagation_candidates:
+        try:
+            compile_constraint_linearization_capabilities(
+                parameterization,
+                (param_id,),
+                (),
+            )
+        except UncertaintyConstructionError:
+            unsupported.append(param_id)
+        else:
+            supported.append(param_id)
+    constrained_scope = tuple(supported)
+    capabilities = compile_constraint_linearization_capabilities(
+        parameterization,
+        constrained_scope,
+        (),
+    )
+    return (
+        UncertaintyDerivationRequest(
+            policy,
+            constrained_scope=constrained_scope,
+            constrained_units=tuple(
+                (param_id, ParameterUnit.UNSPECIFIED) for param_id in constrained_scope
+            ),
+            constrained_scales=tuple((param_id, 1.0) for param_id in constrained_scope),
+            compiled_capabilities=capabilities,
+            resolved_environment_identity=environment.identity,
+        ),
+        tuple(unsupported),
+    )
+
+
+def _product_uncertainty_result(
+    outcome: object,
+    controlled_ids: tuple[str, ...],
+    unsupported_constrained_ids: tuple[str, ...],
+) -> tuple[
+    UncertaintyEvidence | None,
+    ParameterUncertaintyView,
+    tuple[str, str] | None,
+]:
+    derivations = getattr(outcome, "derivations", ())
+    for derivation in derivations:
+        for artifact in derivation.artifacts:
+            if isinstance(artifact, UncertaintyEvidence):
+                return (
+                    artifact,
+                    parameter_uncertainty_view(
+                        artifact,
+                        unsupported_constrained_ids,
+                    ),
+                    None,
+                )
+        if derivation.stage == "uncertainty" and derivation.disposition in {
+            DerivationDisposition.CANCELLED,
+            DerivationDisposition.INTERRUPTED,
+            DerivationDisposition.NOT_STARTED_BY_WORKFLOW_STOP,
+        }:
+            terminal = derivation.disposition.value
+            reason = (
+                "derivation interrupted"
+                if derivation.disposition is DerivationDisposition.INTERRUPTED
+                else "derivation cancelled"
+            )
+            view = ParameterUncertaintyView(
+                unavailable_reasons=(
+                    *((param_id, reason) for param_id in controlled_ids),
+                    *(
+                        (param_id, "unsupported constrained derivative")
+                        for param_id in unsupported_constrained_ids
+                    ),
+                )
+            )
+            return None, view, (terminal, reason)
+    raise RuntimeError("Committed native fit lacks requested uncertainty evidence")
 
 
 def _has_controlled_parameters(parameterization: ActiveParameterization) -> bool:
@@ -271,6 +427,10 @@ def _write_direct_output(
     variable_count: int,
     *,
     aggregate_output: bool,
+    uncertainty: ParameterUncertaintyView,
+    uncertainty_evidence: UncertaintyEvidence | None,
+    uncertainty_status: tuple[str, str] | None,
+    block_uncertainty: RootAnchoredBlockCovarianceEvidence | None,
 ) -> None:
     """Write established per-group and aggregate output from native evidence."""
     plot_flg = (plot == "normal" and not aggregate_output) or plot == "all"
@@ -284,6 +444,10 @@ def _write_direct_output(
             plot=plot_flg,
             residuals=_project_residuals(group.experiments, experiments, result),
             nvarys=len(controlled_by_path[group.path]),
+            uncertainty=uncertainty,
+            uncertainty_evidence=uncertainty_evidence,
+            uncertainty_status=uncertainty_status,
+            block_uncertainty=block_uncertainty,
         )
     if aggregate_output:
         execute_post_fit_groups(
@@ -292,6 +456,10 @@ def _write_direct_output(
             plot,
             residuals=result.residuals,
             nvarys=variable_count,
+            uncertainty=uncertainty,
+            uncertainty_evidence=uncertainty_evidence,
+            uncertainty_status=uncertainty_status,
+            block_uncertainty=block_uncertainty,
         )
 
 
@@ -373,6 +541,10 @@ def run_native_deterministic(
         decomposition,
         experiments,
     )
+    uncertainty_request, unsupported_constrained_ids = _product_uncertainty_request(
+        problem,
+        parameterization,
+    )
     workflow = MethodStepWorkflow.for_optimization(
         starting_snapshot=starting_snapshot,
         parameter_model=parameter_model,
@@ -383,6 +555,7 @@ def run_native_deterministic(
         decomposition=decomposition,
         strategy=strategy,
         invocation=invocation,
+        derivations=(uncertainty_request,),
     )
     group_labels = {
         controlled_ids: (
@@ -445,7 +618,44 @@ def run_native_deterministic(
     if accepted is None:
         raise RuntimeError("Committed native fit lacks its accepted result")
     result = accepted.evaluation_result
-    fit = NativeDeterministicFit(accepted, problem, parameterization, engine)
+    uncertainty_evidence, uncertainty, uncertainty_status = _product_uncertainty_result(
+        outcome,
+        problem.controlled_ids,
+        unsupported_constrained_ids,
+    )
+    block_uncertainty = (
+        None
+        if uncertainty_evidence is None
+        else derive_root_anchored_block_covariance(
+            uncertainty_evidence,
+            tuple(component.controlled_ids for component in decomposition.components),
+        )
+    )
+    if block_uncertainty is not None:
+        block_errors = tuple(
+            (entry.param_id, entry.value)
+            for block in block_uncertainty.blocks
+            for entry in block.marginal_errors
+            if entry.value is not None
+        )
+        block_unavailable = tuple(
+            (param_id, block.unavailable_reason)
+            for block in block_uncertainty.blocks
+            if block.unavailable_reason
+            for param_id in block.controlled_ids
+        )
+        uncertainty = ParameterUncertaintyView(
+            uncertainty.standard_errors + block_errors,
+            uncertainty.unavailable_reasons + block_unavailable,
+        )
+    fit = NativeDeterministicFit(
+        accepted,
+        problem,
+        parameterization,
+        engine,
+        uncertainty_evidence,
+        block_uncertainty,
+    )
     session.sync_parameter_store_from_analysis_values(
         dict(result.resolved_values.ordered_items())
     )
@@ -466,6 +676,10 @@ def run_native_deterministic(
                 plot,
                 residuals=result.residuals,
                 nvarys=variable_count,
+                uncertainty=uncertainty,
+                uncertainty_evidence=uncertainty_evidence,
+                uncertainty_status=uncertainty_status,
+                block_uncertainty=block_uncertainty,
             )
         else:
             execute_post_fit(
@@ -474,6 +688,10 @@ def run_native_deterministic(
                 plot=plot != "nothing",
                 residuals=result.residuals,
                 nvarys=variable_count,
+                uncertainty=uncertainty,
+                uncertainty_evidence=uncertainty_evidence,
+                uncertainty_status=uncertainty_status,
+                block_uncertainty=block_uncertainty,
             )
         return fit
 
@@ -486,5 +704,9 @@ def run_native_deterministic(
         result,
         variable_count,
         aggregate_output=aggregate_output,
+        uncertainty=uncertainty,
+        uncertainty_evidence=uncertainty_evidence,
+        uncertainty_status=uncertainty_status,
+        block_uncertainty=block_uncertainty,
     )
     return fit

--- a/src/chemex/optimize/native_reporting.py
+++ b/src/chemex/optimize/native_reporting.py
@@ -1237,6 +1237,7 @@ def _render_committed_fit(
         path / "Parameters",
         publication.parameterization,
         publication.accepted.evaluation_result,
+        publication.uncertainty,
     )
     write_restart_parameters(
         path / "Parameters" / "restart.toml",

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -2679,6 +2679,8 @@ class RootAnchoredBlockCovariance:
                 return "rank deficient"
             if self.failure.category == "insufficient_effective_observations":
                 return "insufficient information"
+            if self.failure.category == "non_finite_information_condition":
+                return "poorly conditioned"
             return "derivative unavailable"
         states = {item.name: item.state for item in self.claims}
         if states.get("CONDITIONING_ADEQUACY") is not ClaimState.SATISFIED:
@@ -2802,7 +2804,11 @@ class RootAnchoredBlockCovarianceEvidence:
         }
 
 
-def _failed_block_claims(category: str) -> tuple[ClaimAssessment, ...]:
+def _failed_block_claims(
+    category: str,
+    *,
+    full_rank: bool = False,
+) -> tuple[ClaimAssessment, ...]:
     """Build the canonical closed claim surface for a failed block."""
     return (
         ClaimAssessment("AUTHORITATIVE_LINEAGE", ClaimState.SATISFIED),
@@ -2815,9 +2821,13 @@ def _failed_block_claims(category: str) -> tuple[ClaimAssessment, ...]:
         ),
         ClaimAssessment(
             "FULL_COLUMN_RANK",
-            ClaimState.VIOLATED
-            if category == "rank_deficient"
-            else ClaimState.INDETERMINATE,
+            ClaimState.SATISFIED
+            if full_rank
+            else (
+                ClaimState.VIOLATED
+                if category == "rank_deficient"
+                else ClaimState.INDETERMINATE
+            ),
         ),
         ClaimAssessment("COVARIANCE_ARITHMETIC_INTEGRITY", ClaimState.INDETERMINATE),
         ClaimAssessment("USABLE_LOCAL_COVARIANCE", ClaimState.VIOLATED),
@@ -2938,6 +2948,9 @@ def derive_root_anchored_block_covariance(  # noqa: C901
                 source_identity=jacobian.identity,
                 cancellation_probe=None,
             )
+            if analysis is not None:
+                rank = analysis.rank
+                condition = analysis.jacobian_condition
             if analysis_failure is not None:
                 failure = EvidenceFailure(
                     "block_covariance",
@@ -2946,8 +2959,6 @@ def derive_root_anchored_block_covariance(  # noqa: C901
                     jacobian.identity,
                 )
             elif analysis is not None:
-                rank = analysis.rank
-                condition = analysis.jacobian_condition
                 reduction, reduction_failure = _reduce_scaled_covariance(
                     analysis,
                     scales,
@@ -2967,7 +2978,10 @@ def derive_root_anchored_block_covariance(  # noqa: C901
                 elif reduction is not None:
                     _variance_scale, _unscaled, factor, covariance = reduction
             if failure is not None:
-                claims = _failed_block_claims(failure.category)
+                claims = _failed_block_claims(
+                    failure.category,
+                    full_rank=(rank == len(scope)),
+                )
             else:
                 if covariance is None or condition is None:
                     raise ValueError("Successful block covariance lacks its arrays")
@@ -4326,6 +4340,7 @@ def _analyze_scaled_jacobian(
         )[np.newaxis, :]
     )
     _raise_if_terminated(cancellation_probe)
+    analysis_failure: EvidenceFailure | None = None
     try:
         _left, singular_array, right_transpose_array = svd(
             scaled,
@@ -4388,7 +4403,7 @@ def _analyze_scaled_jacobian(
             )
             information_condition = condition * condition
             if not math.isfinite(information_condition):
-                return None, EvidenceFailure(
+                analysis_failure = EvidenceFailure(
                     "covariance",
                     "non_finite_information_condition",
                     "Squared Jacobian condition is non-finite",
@@ -4411,7 +4426,7 @@ def _analyze_scaled_jacobian(
             condition,
             information_condition,
         ),
-        None,
+        analysis_failure,
     )
 
 
@@ -4614,7 +4629,7 @@ def _covariance_from_jacobian(
         source_identity=jacobian.identity,
         cancellation_probe=cancellation_probe,
     )
-    if analysis_failure is not None or analysis is None:
+    if analysis is None:
         return None, None, analysis_failure
     singular_values = analysis.singular_values
     largest = singular_values[0] if singular_values else 0.0
@@ -4679,6 +4694,8 @@ def _covariance_from_jacobian(
     terminal = _cancellation_terminal(cancellation_probe)
     if terminal is not None:
         raise DerivationTermination(terminal, rank_diagnostic)
+    if analysis_failure is not None:
+        return None, rank_diagnostic, analysis_failure
     reduction, reduction_failure = _reduce_scaled_covariance(
         analysis,
         jacobian.coordinate_scales,

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -40,6 +40,7 @@ from chemex.optimize.direct_trf import (
     OptimizationProblem,
     accepted_occurrence_is_authoritative,
 )
+from chemex.optimize.grouped_direct_trf import FitPartitionProof
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     BinaryExpression,
@@ -2702,13 +2703,16 @@ class RootAnchoredBlockCovarianceEvidence:
     accepted_occurrence_identity: str
     source_jacobian_identity: str
     source_constraint_jacobian_identity: str | None
+    partition_proof_identity: str
     policy_identity: str
     blocks: tuple[RootAnchoredBlockCovariance, ...]
     source_bundle: UncertaintyEvidence = field(repr=False, compare=False)
+    source_partition_proof: FitPartitionProof = field(repr=False, compare=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         source = self.source_bundle
+        proof = self.source_partition_proof
         jacobian = source.residual_jacobian
         if (
             jacobian is None
@@ -2722,6 +2726,11 @@ class RootAnchoredBlockCovarianceEvidence:
                 if source.constraint_jacobian is None
                 else source.constraint_jacobian.identity
             )
+            or self.partition_proof_identity != proof.identity
+            or proof.root_plan_identity != source.source_engine.plan.identity
+            or proof.constraint_program_identity
+            != source.source_parameterization.program.fingerprint
+            or proof.controlled_ids != jacobian.controlled_ids
         ):
             raise ValueError("Root-anchored block evidence has inconsistent lineage")
         flattened = tuple(
@@ -2740,6 +2749,17 @@ class RootAnchoredBlockCovarianceEvidence:
             for block in self.blocks
         ):
             raise ValueError("Root-anchored block coordinates violate root order")
+        block_scopes = tuple(
+            (block.controlled_ids, block.root_profile_indices) for block in self.blocks
+        )
+        proof_scopes = tuple(
+            (controlled_ids, profile_indices)
+            for _component_id, controlled_ids, profile_indices, _bounds in (
+                proof.component_records
+            )
+        )
+        if block_scopes != proof_scopes:
+            raise ValueError("Root-anchored blocks differ from the partition proof")
         object.__setattr__(
             self,
             "identity",
@@ -2750,6 +2770,7 @@ class RootAnchoredBlockCovarianceEvidence:
                     self.accepted_occurrence_identity,
                     self.source_jacobian_identity,
                     self.source_constraint_jacobian_identity,
+                    self.partition_proof_identity,
                     self.policy_identity,
                     tuple(item.identity for item in self.blocks),
                 ),
@@ -2767,6 +2788,7 @@ class RootAnchoredBlockCovarianceEvidence:
             "source_constraint_jacobian_identity": (
                 self.source_constraint_jacobian_identity
             ),
+            "partition_proof_identity": self.partition_proof_identity,
             "policy_identity": self.policy_identity,
             "identity": self.identity,
             "blocks": [
@@ -2804,7 +2826,7 @@ def _failed_block_claims(category: str) -> tuple[ClaimAssessment, ...]:
 
 def derive_root_anchored_block_covariance(  # noqa: C901
     evidence: UncertaintyEvidence,
-    block_scopes: Sequence[tuple[Sequence[str], Sequence[int]]],
+    partition_proof: FitPartitionProof,
 ) -> RootAnchoredBlockCovarianceEvidence | None:
     """Derive independent full-rank blocks when the joint root is unavailable."""
     jacobian = evidence.residual_jacobian
@@ -2818,9 +2840,35 @@ def derive_root_anchored_block_covariance(  # noqa: C901
         is not ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
     ):
         return None
+    if (
+        partition_proof.root_plan_identity != evidence.source_engine.plan.identity
+        or partition_proof.constraint_program_identity
+        != evidence.source_parameterization.program.fingerprint
+        or partition_proof.controlled_ids != jacobian.controlled_ids
+    ):
+        raise ValueError("Block covariance requires the exact root partition proof")
+    root_bounds = {
+        param_id: (float(lower).hex(), float(upper).hex())
+        for param_id, lower, upper in zip(
+            evidence.source_problem.controlled_ids,
+            evidence.source_problem.lower_bounds,
+            evidence.source_problem.upper_bounds,
+            strict=True,
+        )
+    }
+    if any(
+        bounds
+        != tuple((param_id, *root_bounds[param_id]) for param_id in controlled_ids)
+        for _component_id, controlled_ids, _profiles, bounds in (
+            partition_proof.component_records
+        )
+    ):
+        raise ValueError("Block covariance partition bounds differ from the root")
     scopes = tuple(
-        (tuple(controlled_ids), tuple(profile_indices))
-        for controlled_ids, profile_indices in block_scopes
+        (controlled_ids, profile_indices)
+        for _component_id, controlled_ids, profile_indices, _bounds in (
+            partition_proof.component_records
+        )
     )
     if len(scopes) < 2:
         return None
@@ -2883,72 +2931,41 @@ def derive_root_anchored_block_covariance(  # noqa: C901
             )
             claims = _failed_block_claims(failure.category)
         else:
-            scaled = matrix[np.ix_(rows, indices)] * np.asarray(scales)[np.newaxis, :]
-            try:
-                _left, singular_array, right_transpose = svd(
-                    scaled,
-                    full_matrices=False,
-                    compute_uv=True,
-                    overwrite_a=False,
-                    check_finite=True,
-                    lapack_driver=policy.svd_driver,
-                )
-                singular = tuple(
-                    _finite(value, name=f"block singular value[{index}]")
-                    for index, value in enumerate(singular_array)
-                )
-                spectrum_error = _singular_spectrum_error(singular, len(scope))
-                if spectrum_error is not None:
-                    failure = EvidenceFailure(
-                        "block_covariance",
-                        spectrum_error[0],
-                        spectrum_error[1],
-                        jacobian.identity,
-                    )
-                else:
-                    largest = singular[0]
-                    threshold = _finite(
-                        policy.rank_absolute_tolerance
-                        + policy.rank_relative_tolerance * largest,
-                        name="block rank threshold",
-                    )
-                    rank = sum(value > threshold for value in singular)
-                    if rank != len(scope):
-                        failure = EvidenceFailure(
-                            "block_covariance",
-                            "rank_deficient",
-                            f"Scaled block Jacobian rank {rank} is below {len(scope)}",
-                            jacobian.identity,
-                        )
-                    else:
-                        condition = _finite(
-                            largest / singular[-1],
-                            name="block Jacobian condition",
-                        )
-                        _unscaled, factor, covariance = _canonical_covariance_reduction(
-                            singular,
-                            right_transpose,
-                            scales,
-                            1.0,
-                        )
-                        if _has_positive_scale_zero_variance(covariance, 1.0):
-                            failure = EvidenceFailure(
-                                "block_covariance",
-                                "covariance_factor_underflow",
-                                "Positive-scale block covariance produced zero variance",
-                                jacobian.identity,
-                            )
-                            covariance = None
-                            factor = None
-            except Exception as error:  # noqa: BLE001 - third-party/arithmetic fence
+            analysis, analysis_failure = _analyze_scaled_jacobian(
+                matrix[np.ix_(rows, indices)],
+                scales,
+                policy=policy,
+                source_identity=jacobian.identity,
+                cancellation_probe=None,
+            )
+            if analysis_failure is not None:
                 failure = EvidenceFailure(
                     "block_covariance",
-                    "invalid_covariance_arithmetic",
-                    str(error),
+                    analysis_failure.category,
+                    analysis_failure.message,
                     jacobian.identity,
                 )
-                covariance = None
-                factor = None
+            elif analysis is not None:
+                rank = analysis.rank
+                condition = analysis.jacobian_condition
+                reduction, reduction_failure = _reduce_scaled_covariance(
+                    analysis,
+                    scales,
+                    accepted,
+                    degrees_of_freedom=(len(rows) - len(scope) - normalization_count),
+                    policy=policy,
+                    source_identity=jacobian.identity,
+                    cancellation_probe=None,
+                )
+                if reduction_failure is not None:
+                    failure = EvidenceFailure(
+                        "block_covariance",
+                        reduction_failure.category,
+                        reduction_failure.message,
+                        jacobian.identity,
+                    )
+                elif reduction is not None:
+                    _variance_scale, _unscaled, factor, covariance = reduction
             if failure is not None:
                 claims = _failed_block_claims(failure.category)
             else:
@@ -3064,9 +3081,11 @@ def derive_root_anchored_block_covariance(  # noqa: C901
         evidence.accepted_occurrence_identity,
         jacobian.identity,
         None if constraint_jacobian is None else constraint_jacobian.identity,
+        partition_proof.identity,
         evidence.policy_identity,
         tuple(blocks),
         evidence,
+        partition_proof,
     )
 
 
@@ -4278,6 +4297,183 @@ def _full_dimensional_feasible_interior_claim(
     return ClaimAssessment("FULL_DIMENSIONAL_FEASIBLE_INTERIOR", state, detail)
 
 
+@dataclass(frozen=True, slots=True)
+class _ScaledSvdAnalysis:
+    singular_values: tuple[float, ...]
+    right_transpose: tuple[tuple[float, ...], ...]
+    scaled_column_norms: tuple[float, ...]
+    threshold: float
+    rank: int
+    jacobian_condition: float | None
+    information_condition: float | None
+
+
+def _analyze_scaled_jacobian(
+    matrix: Array,
+    coordinate_scales: Sequence[float],
+    *,
+    policy: UncertaintyPolicy,
+    source_identity: str,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
+) -> tuple[_ScaledSvdAnalysis | None, EvidenceFailure | None]:
+    """Run the one canonical checked scaled-SVD analysis kernel."""
+    dimension = len(coordinate_scales)
+    scaled = (
+        np.asarray(matrix, dtype=np.float64)
+        * np.asarray(
+            coordinate_scales,
+            dtype=np.float64,
+        )[np.newaxis, :]
+    )
+    _raise_if_terminated(cancellation_probe)
+    try:
+        _left, singular_array, right_transpose_array = svd(
+            scaled,
+            full_matrices=False,
+            compute_uv=True,
+            overwrite_a=False,
+            check_finite=True,
+            lapack_driver=policy.svd_driver,
+        )
+    except Exception as error:  # noqa: BLE001 - declared third-party kernel fence
+        return None, EvidenceFailure(
+            "covariance",
+            "svd_failure",
+            str(error),
+            source_identity,
+        )
+    _raise_if_terminated(cancellation_probe)
+    try:
+        singular_values = tuple(
+            _finite(value, name=f"singular value[{index}]")
+            for index, value in enumerate(singular_array)
+        )
+        spectrum_error = _singular_spectrum_error(singular_values, dimension)
+        if spectrum_error is not None:
+            return None, EvidenceFailure(
+                "covariance",
+                spectrum_error[0],
+                spectrum_error[1],
+                source_identity,
+            )
+        right_transpose = _canonical_matrix(
+            right_transpose_array,
+            rows=dimension,
+            columns=dimension,
+            name="right singular vectors",
+        )
+        largest = singular_values[0] if singular_values else 0.0
+        threshold = _finite(
+            policy.rank_absolute_tolerance + policy.rank_relative_tolerance * largest,
+            name="rank threshold",
+        )
+        rank = sum(value > threshold for value in singular_values)
+        column_norms = tuple(
+            _finite(
+                math.sqrt(
+                    _pairwise_sum(
+                        tuple(float(value) ** 2 for value in scaled[:, index])
+                    )
+                ),
+                name=f"scaled column norm[{index}]",
+            )
+            for index in range(dimension)
+        )
+        condition: float | None = None
+        information_condition: float | None = None
+        if rank == dimension:
+            condition = _finite(
+                largest / singular_values[-1],
+                name="Jacobian condition",
+            )
+            information_condition = condition * condition
+            if not math.isfinite(information_condition):
+                return None, EvidenceFailure(
+                    "covariance",
+                    "non_finite_information_condition",
+                    "Squared Jacobian condition is non-finite",
+                    source_identity,
+                )
+    except (ArithmeticError, TypeError, ValueError) as error:
+        return None, EvidenceFailure(
+            "covariance",
+            "invalid_covariance_arithmetic",
+            str(error),
+            source_identity,
+        )
+    return (
+        _ScaledSvdAnalysis(
+            singular_values,
+            right_transpose,
+            column_norms,
+            threshold,
+            rank,
+            condition,
+            information_condition,
+        ),
+        None,
+    )
+
+
+def _reduce_scaled_covariance(
+    analysis: _ScaledSvdAnalysis,
+    coordinate_scales: Sequence[float],
+    accepted: AcceptedFitResult,
+    *,
+    degrees_of_freedom: int,
+    policy: UncertaintyPolicy,
+    source_identity: str,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
+) -> tuple[
+    tuple[
+        float,
+        tuple[tuple[float, ...], ...],
+        tuple[tuple[float, ...], ...],
+        tuple[tuple[float, ...], ...],
+    ]
+    | None,
+    EvidenceFailure | None,
+]:
+    """Run the one canonical residual-scale and covariance reduction kernel."""
+    if analysis.rank != len(coordinate_scales):
+        return None, EvidenceFailure(
+            "covariance",
+            "rank_deficient",
+            f"Scaled Jacobian rank {analysis.rank} is below {len(coordinate_scales)}",
+            source_identity,
+        )
+    residual_variance_scale, variance_failure = _residual_variance_scale(
+        accepted,
+        degrees_of_freedom=degrees_of_freedom,
+        policy=policy,
+    )
+    if variance_failure is not None or residual_variance_scale is None:
+        return None, variance_failure
+    _raise_if_terminated(cancellation_probe)
+    try:
+        unscaled, factor, covariance = _canonical_covariance_reduction(
+            analysis.singular_values,
+            analysis.right_transpose,
+            coordinate_scales,
+            residual_variance_scale,
+        )
+    except (ArithmeticError, TypeError, ValueError) as error:
+        return None, EvidenceFailure(
+            "covariance",
+            "invalid_covariance_arithmetic",
+            str(error),
+            source_identity,
+        )
+    if _has_positive_scale_zero_variance(covariance, residual_variance_scale):
+        return None, EvidenceFailure(
+            "covariance",
+            "covariance_factor_underflow",
+            "Positive-scale full-rank covariance factor produced zero variance",
+            source_identity,
+        )
+    return (residual_variance_scale, unscaled, factor, covariance), None
+
+
 def _canonical_covariance_claims(
     accepted: AcceptedFitResult,
     problem: OptimizationProblem,
@@ -4368,7 +4564,7 @@ def _canonical_covariance_claims(
     )
 
 
-def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gates
+def _covariance_from_jacobian(
     accepted: AcceptedFitResult,
     jacobian: ResidualJacobianEvidence,
     *,
@@ -4411,68 +4607,25 @@ def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gat
                 jacobian.identity,
             ),
         )
-    matrix = np.asarray(jacobian.matrix, dtype=np.float64)
-    scales = np.asarray(jacobian.coordinate_scales, dtype=np.float64)
-    scaled = matrix * scales[np.newaxis, :]
-    _raise_if_terminated(cancellation_probe)
-    try:
-        _left, singular_array, right_transpose = svd(
-            scaled,
-            full_matrices=False,
-            compute_uv=True,
-            overwrite_a=False,
-            check_finite=True,
-            lapack_driver=policy.svd_driver,
-        )
-    except Exception as error:  # noqa: BLE001 - declared third-party kernel fence
-        return (
-            None,
-            None,
-            EvidenceFailure(
-                "covariance",
-                "svd_failure",
-                str(error),
-                jacobian.identity,
-            ),
-        )
-    _raise_if_terminated(cancellation_probe)
-    singular_values = tuple(
-        _finite(value, name=f"singular value[{index}]")
-        for index, value in enumerate(singular_array)
+    analysis, analysis_failure = _analyze_scaled_jacobian(
+        np.asarray(jacobian.matrix, dtype=np.float64),
+        jacobian.coordinate_scales,
+        policy=policy,
+        source_identity=jacobian.identity,
+        cancellation_probe=cancellation_probe,
     )
-    spectrum_error = _singular_spectrum_error(singular_values, coordinate_count)
-    if spectrum_error is not None:
-        return (
-            None,
-            None,
-            EvidenceFailure(
-                "covariance",
-                spectrum_error[0],
-                spectrum_error[1],
-                jacobian.identity,
-            ),
-        )
+    if analysis_failure is not None or analysis is None:
+        return None, None, analysis_failure
+    singular_values = analysis.singular_values
     largest = singular_values[0] if singular_values else 0.0
-    threshold = (
-        policy.rank_absolute_tolerance + policy.rank_relative_tolerance * largest
-    )
-    threshold = _finite(threshold, name="rank threshold")
-    rank = sum(value > threshold for value in singular_values)
+    threshold = analysis.threshold
+    rank = analysis.rank
     normalized = tuple(
         0.0 if largest == 0.0 else value / largest for value in singular_values
     )
-    column_norms = tuple(
-        _finite(
-            math.sqrt(
-                _pairwise_sum(tuple(float(value) ** 2 for value in scaled[:, index]))
-            ),
-            name=f"scaled column norm[{index}]",
-        )
-        for index in range(coordinate_count)
-    )
     # Individual vectors inside a repeated/clustered singular subspace are not
     # authoritative.  Only projectors are retained below.
-    right = np.asarray(right_transpose.T, dtype=np.float64)
+    right = np.asarray(analysis.right_transpose, dtype=np.float64).T
     weak_threshold = _finite(
         max(threshold, policy.weak_relative_tolerance * largest),
         name="weak-subspace threshold",
@@ -4512,7 +4665,7 @@ def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gat
         jacobian.controlled_ids,
         singular_values,
         normalized,
-        column_norms,
+        analysis.scaled_column_norms,
         threshold,
         weak_threshold,
         rank,
@@ -4526,57 +4679,23 @@ def _covariance_from_jacobian(  # noqa: C901 - ordered scientific derivation gat
     terminal = _cancellation_terminal(cancellation_probe)
     if terminal is not None:
         raise DerivationTermination(terminal, rank_diagnostic)
-    if rank != coordinate_count:
-        return (
-            None,
-            rank_diagnostic,
-            EvidenceFailure(
-                "covariance",
-                "rank_deficient",
-                f"Scaled Jacobian rank {rank} is below {coordinate_count}",
-                jacobian.identity,
-            ),
-        )
-    smallest = singular_values[-1]
-    jacobian_condition = _finite(largest / smallest, name="Jacobian condition")
-    information_condition = jacobian_condition * jacobian_condition
-    if not math.isfinite(information_condition):
-        return (
-            None,
-            rank_diagnostic,
-            EvidenceFailure(
-                "covariance",
-                "non_finite_information_condition",
-                "Squared Jacobian condition is non-finite",
-                jacobian.identity,
-            ),
-        )
-    residual_variance_scale, variance_failure = _residual_variance_scale(
+    reduction, reduction_failure = _reduce_scaled_covariance(
+        analysis,
+        jacobian.coordinate_scales,
         accepted,
         degrees_of_freedom=degrees_of_freedom,
         policy=policy,
+        source_identity=jacobian.identity,
+        cancellation_probe=cancellation_probe,
     )
-    if variance_failure is not None or residual_variance_scale is None:
-        return None, rank_diagnostic, variance_failure
-    _raise_if_terminated(cancellation_probe)
+    if reduction_failure is not None or reduction is None:
+        return None, rank_diagnostic, reduction_failure
+    residual_variance_scale, unscaled_covariance, factor, covariance = reduction
+    if analysis.jacobian_condition is None or analysis.information_condition is None:
+        raise ValueError("Full-rank covariance lacks condition diagnostics")
+    jacobian_condition = analysis.jacobian_condition
+    information_condition = analysis.information_condition
     chi_square = _finite(accepted.chi_square, name="accepted chi-square")
-    unscaled_covariance, factor, covariance = _canonical_covariance_reduction(
-        singular_values,
-        right_transpose,
-        jacobian.coordinate_scales,
-        residual_variance_scale,
-    )
-    if _has_positive_scale_zero_variance(covariance, residual_variance_scale):
-        return (
-            None,
-            rank_diagnostic,
-            EvidenceFailure(
-                "covariance",
-                "covariance_factor_underflow",
-                "Positive-scale full-rank covariance factor produced zero variance",
-                jacobian.identity,
-            ),
-        )
     claims = _canonical_covariance_claims(
         accepted,
         problem,

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -5,8 +5,9 @@ linearizes the complete native residual map again at one accepted external
 coordinate vector, constructs full-rank scaled-SVD covariance, and derives
 typed marginal, correlation, and constrained-propagation artifacts.
 
-The entry point remains an isolated qualification seam; production fitting and
-reporting do not consume these artifacts yet.
+Production deterministic fitting consumes these artifacts after the accepted
+result has committed. Central estimates remain separate from this report-only
+evidence.
 """
 
 from __future__ import annotations
@@ -69,6 +70,10 @@ _BOUNDARY_THRESHOLD = 3.0
 
 class UncertaintyConstructionError(ValueError):
     """Raised only for malformed policy or artifact construction."""
+
+
+class MissingFunctionLinearizationCapability(UncertaintyConstructionError):
+    """A constrained output requires an undeclared scientific-function partial."""
 
 
 class FunctionPartialFailure(UncertaintyConstructionError):
@@ -496,7 +501,7 @@ def compile_constraint_linearization_capabilities(
     required_keys = _required_function_keys(parameterization, scope)
     missing = required_keys - selected_keys
     if missing:
-        raise UncertaintyConstructionError(
+        raise MissingFunctionLinearizationCapability(
             "Compiled constraint linearization lacks capabilities for "
             f"{sorted(missing, key=repr)!r}"
         )
@@ -2553,17 +2558,27 @@ class RootAnchoredBlockCovariance:
     """One independent covariance block derived from the root linearization."""
 
     controlled_ids: tuple[str, ...]
+    root_profile_indices: tuple[int, ...]
     rank: int
     jacobian_condition: float | None
     covariance: tuple[tuple[float, ...], ...] | None
+    factor: tuple[tuple[float, ...], ...] | None
     marginal_errors: tuple[ScalarEvidenceEntry, ...]
     correlations: tuple[tuple[CorrelationEntry, ...], ...]
-    unavailable_reason: str = ""
+    constrained_marginal_errors: tuple[ScalarEvidenceEntry, ...]
+    claims: tuple[ClaimAssessment, ...]
+    failure: EvidenceFailure | None = None
+    constrained_failure: EvidenceFailure | None = None
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
         dimension = len(self.controlled_ids)
-        if dimension < 1 or not 0 <= self.rank <= dimension:
+        if (
+            dimension < 1
+            or not 0 <= self.rank <= dimension
+            or len(set(self.root_profile_indices)) != len(self.root_profile_indices)
+            or tuple(sorted(self.root_profile_indices)) != self.root_profile_indices
+        ):
             raise ValueError("Root-anchored covariance block has invalid rank")
         if (
             len(self.marginal_errors) != dimension
@@ -2571,12 +2586,17 @@ class RootAnchoredBlockCovariance:
             != self.controlled_ids
         ):
             raise ValueError("Root-anchored block marginal scope is invalid")
+        claim_states = {item.name: item.state for item in self.claims}
+        if len(claim_states) != len(self.claims):
+            raise ValueError("Root-anchored block claims must be unique")
+        reportable = claim_states.get("USABLE_LOCAL_COVARIANCE") is ClaimState.SATISFIED
         if self.covariance is None:
-            if not self.unavailable_reason or any(
-                item.value is not None for item in self.marginal_errors
-            ):
+            if self.failure is None or self.factor is not None or reportable:
+                raise ValueError("Unavailable covariance block lacks typed failure")
+            if any(item.value is not None for item in self.marginal_errors):
                 raise ValueError("Unavailable covariance block has usable marginals")
             covariance: tuple[tuple[float, ...], ...] = ()
+            factor: tuple[tuple[float, ...], ...] = ()
         else:
             covariance = _canonical_matrix(
                 self.covariance,
@@ -2584,9 +2604,18 @@ class RootAnchoredBlockCovariance:
                 columns=dimension,
                 name="root-anchored block covariance",
             )
-            if self.unavailable_reason:
-                raise ValueError("Available covariance block has an unavailable reason")
+            if self.factor is None or self.failure is not None:
+                raise ValueError("Available covariance block has inconsistent evidence")
+            factor = _canonical_matrix(
+                self.factor,
+                rows=dimension,
+                columns=dimension,
+                name="root-anchored block covariance factor",
+            )
+        if reportable != all(item.value is not None for item in self.marginal_errors):
+            raise ValueError("Block reportability and marginal values disagree")
         object.__setattr__(self, "covariance", covariance or None)
+        object.__setattr__(self, "factor", factor or None)
         object.__setattr__(
             self,
             "identity",
@@ -2594,11 +2623,13 @@ class RootAnchoredBlockCovariance:
                 "native-root-anchored-block-covariance",
                 (
                     self.controlled_ids,
+                    self.root_profile_indices,
                     self.rank,
                     None
                     if self.jacobian_condition is None
                     else _float_token(self.jacobian_condition),
                     () if self.covariance is None else _matrix_tokens(self.covariance),
+                    () if self.factor is None else _matrix_tokens(self.factor),
                     tuple(
                         (item.param_id, item.value, item.outcome, item.raw_value)
                         for item in self.marginal_errors
@@ -2609,10 +2640,58 @@ class RootAnchoredBlockCovariance:
                         )
                         for row in self.correlations
                     ),
-                    self.unavailable_reason,
+                    tuple(
+                        (item.param_id, item.value, item.outcome, item.raw_value)
+                        for item in self.constrained_marginal_errors
+                    ),
+                    tuple(
+                        (item.name, item.state.value, item.detail)
+                        for item in self.claims
+                    ),
+                    None if self.failure is None else self.failure.identity,
+                    None
+                    if self.constrained_failure is None
+                    else self.constrained_failure.identity,
                 ),
             ),
         )
+
+    @property
+    def scope_reportable(self) -> bool:
+        """Whether this block satisfies the canonical covariance claims."""
+        return (
+            next(
+                item.state
+                for item in self.claims
+                if item.name == "USABLE_LOCAL_COVARIANCE"
+            )
+            is ClaimState.SATISFIED
+        )
+
+    @property
+    def unavailable_reason(self) -> str:
+        """Map typed block evidence to the closed product reason vocabulary."""
+        if self.scope_reportable:
+            return ""
+        if self.failure is not None:
+            if self.failure.category == "rank_deficient":
+                return "rank deficient"
+            if self.failure.category == "insufficient_effective_observations":
+                return "insufficient information"
+            return "derivative unavailable"
+        states = {item.name: item.state for item in self.claims}
+        if states.get("CONDITIONING_ADEQUACY") is not ClaimState.SATISFIED:
+            return "poorly conditioned"
+        if any(
+            states.get(name) is not ClaimState.SATISFIED
+            for name in (
+                "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
+                "INTERIOR_POINT",
+                "BOUNDARY_SEPARATION",
+            )
+        ):
+            return "boundary limited"
+        return "insufficient information"
 
 
 @dataclass(frozen=True, slots=True)
@@ -2622,6 +2701,7 @@ class RootAnchoredBlockCovarianceEvidence:
     accepted_result_identity: str
     accepted_occurrence_identity: str
     source_jacobian_identity: str
+    source_constraint_jacobian_identity: str | None
     policy_identity: str
     blocks: tuple[RootAnchoredBlockCovariance, ...]
     source_bundle: UncertaintyEvidence = field(repr=False, compare=False)
@@ -2636,12 +2716,30 @@ class RootAnchoredBlockCovarianceEvidence:
             or self.accepted_occurrence_identity != source.accepted_occurrence_identity
             or self.source_jacobian_identity != jacobian.identity
             or self.policy_identity != source.policy_identity
-            or tuple(
-                param_id for block in self.blocks for param_id in block.controlled_ids
+            or self.source_constraint_jacobian_identity
+            != (
+                None
+                if source.constraint_jacobian is None
+                else source.constraint_jacobian.identity
             )
-            != jacobian.controlled_ids
         ):
             raise ValueError("Root-anchored block evidence has inconsistent lineage")
+        flattened = tuple(
+            param_id for block in self.blocks for param_id in block.controlled_ids
+        )
+        if len(set(flattened)) != len(flattened) or set(flattened) != set(
+            jacobian.controlled_ids
+        ):
+            raise ValueError("Root-anchored blocks must partition root coordinates")
+        root_order = {
+            param_id: index for index, param_id in enumerate(jacobian.controlled_ids)
+        }
+        if any(
+            tuple(sorted(block.controlled_ids, key=root_order.__getitem__))
+            != block.controlled_ids
+            for block in self.blocks
+        ):
+            raise ValueError("Root-anchored block coordinates violate root order")
         object.__setattr__(
             self,
             "identity",
@@ -2651,6 +2749,7 @@ class RootAnchoredBlockCovarianceEvidence:
                     self.accepted_result_identity,
                     self.accepted_occurrence_identity,
                     self.source_jacobian_identity,
+                    self.source_constraint_jacobian_identity,
                     self.policy_identity,
                     tuple(item.identity for item in self.blocks),
                 ),
@@ -2665,15 +2764,47 @@ class RootAnchoredBlockCovarianceEvidence:
             "accepted_result_identity": self.accepted_result_identity,
             "accepted_occurrence_identity": self.accepted_occurrence_identity,
             "source_jacobian_identity": self.source_jacobian_identity,
+            "source_constraint_jacobian_identity": (
+                self.source_constraint_jacobian_identity
+            ),
             "policy_identity": self.policy_identity,
             "identity": self.identity,
-            "blocks": [_record_value(item) for item in self.blocks],
+            "blocks": [
+                {
+                    **cast(dict[str, object], _record_value(item)),
+                    "scope_reportable": item.scope_reportable,
+                    "unavailable_reason": item.unavailable_reason,
+                }
+                for item in self.blocks
+            ],
         }
 
 
-def derive_root_anchored_block_covariance(  # noqa: C901 - typed block derivation
+def _failed_block_claims(category: str) -> tuple[ClaimAssessment, ...]:
+    """Build the canonical closed claim surface for a failed block."""
+    return (
+        ClaimAssessment("AUTHORITATIVE_LINEAGE", ClaimState.SATISFIED),
+        ClaimAssessment("LOCAL_LINEARIZATION_REGULARITY", ClaimState.SATISFIED),
+        ClaimAssessment(
+            "EFFECTIVE_OBSERVATION_SUFFICIENCY",
+            ClaimState.VIOLATED
+            if category == "insufficient_effective_observations"
+            else ClaimState.SATISFIED,
+        ),
+        ClaimAssessment(
+            "FULL_COLUMN_RANK",
+            ClaimState.VIOLATED
+            if category == "rank_deficient"
+            else ClaimState.INDETERMINATE,
+        ),
+        ClaimAssessment("COVARIANCE_ARITHMETIC_INTEGRITY", ClaimState.INDETERMINATE),
+        ClaimAssessment("USABLE_LOCAL_COVARIANCE", ClaimState.VIOLATED),
+    )
+
+
+def derive_root_anchored_block_covariance(  # noqa: C901
     evidence: UncertaintyEvidence,
-    block_scopes: Sequence[Sequence[str]],
+    block_scopes: Sequence[tuple[Sequence[str], Sequence[int]]],
 ) -> RootAnchoredBlockCovarianceEvidence | None:
     """Derive independent full-rank blocks when the joint root is unavailable."""
     jacobian = evidence.residual_jacobian
@@ -2682,91 +2813,165 @@ def derive_root_anchored_block_covariance(  # noqa: C901 - typed block derivatio
         and evidence.marginal_errors.scope_reportable
     ):
         return None
-    scopes = tuple(tuple(scope) for scope in block_scopes)
+    if (
+        evidence.source_policy.residual_variance_scaling
+        is not ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+    ):
+        return None
+    scopes = tuple(
+        (tuple(controlled_ids), tuple(profile_indices))
+        for controlled_ids, profile_indices in block_scopes
+    )
     if len(scopes) < 2:
         return None
-    if (
-        tuple(param_id for scope in scopes for param_id in scope)
-        != jacobian.controlled_ids
+    flattened = tuple(param_id for scope, _profiles in scopes for param_id in scope)
+    if len(set(flattened)) != len(flattened) or set(flattened) != set(
+        jacobian.controlled_ids
     ):
         raise ValueError("Block covariance scopes must partition root coordinates")
+    root_order = {
+        param_id: index for index, param_id in enumerate(jacobian.controlled_ids)
+    }
+    if any(
+        tuple(sorted(scope, key=root_order.__getitem__)) != scope
+        for scope, _profiles in scopes
+    ):
+        raise ValueError("Block covariance coordinates must preserve root order")
     policy = evidence.source_policy
     matrix = np.asarray(jacobian.matrix, dtype=np.float64)
     accepted = evidence.accepted_anchor
     problem = evidence.source_problem
-    coordinate_index = {
-        param_id: index for index, param_id in enumerate(jacobian.controlled_ids)
-    }
-    variance_scale, variance_failure = _residual_variance_scale(
-        accepted,
-        degrees_of_freedom=(
-            jacobian.residual_count
-            - len(jacobian.controlled_ids)
-            - sum(
-                1
-                for profile in evidence.source_engine.plan.profiles
-                if profile.is_scaled
-            )
-        ),
-        policy=policy,
-    )
-    if variance_failure is not None or variance_scale is None:
-        return None
+    coordinate_index = root_order
+    profile_rows: list[tuple[int, ...]] = []
+    row_offset = 0
+    for profile in evidence.source_engine.plan.profiles:
+        retained_count = len(profile.retained_observation_indices)
+        profile_rows.append(tuple(range(row_offset, row_offset + retained_count)))
+        row_offset += retained_count
+    if row_offset != jacobian.residual_count:
+        raise ValueError("Root residual rows do not match the evaluation profile plan")
+    constraint_jacobian = evidence.constraint_jacobian
     blocks: list[RootAnchoredBlockCovariance] = []
-    for scope in scopes:
+    for scope, profile_indices in scopes:
+        if (
+            len(set(profile_indices)) != len(profile_indices)
+            or tuple(sorted(profile_indices)) != profile_indices
+            or any(not 0 <= index < len(profile_rows) for index in profile_indices)
+        ):
+            raise ValueError("Block covariance profile scope is invalid")
         indices = tuple(coordinate_index[param_id] for param_id in scope)
+        rows = tuple(row for index in profile_indices for row in profile_rows[index])
         scales = tuple(jacobian.coordinate_scales[index] for index in indices)
-        scaled = matrix[:, indices] * np.asarray(scales)[np.newaxis, :]
-        _left, singular_array, right_transpose = svd(
-            scaled,
-            full_matrices=False,
-            compute_uv=True,
-            overwrite_a=False,
-            check_finite=True,
-            lapack_driver=policy.svd_driver,
+        normalization_count = sum(
+            evidence.source_engine.plan.profiles[index].is_scaled
+            for index in profile_indices
         )
-        singular = tuple(float(value) for value in singular_array)
-        largest = singular[0] if singular else 0.0
-        threshold = policy.rank_absolute_tolerance + (
-            policy.rank_relative_tolerance * largest
-        )
-        rank = sum(value > threshold for value in singular)
-        unavailable_reason = ""
+        failure: EvidenceFailure | None = None
+        constrained_failure: EvidenceFailure | None = None
+        claims: tuple[ClaimAssessment, ...]
+        rank = 0
         condition: float | None = None
         covariance: tuple[tuple[float, ...], ...] | None = None
+        factor: tuple[tuple[float, ...], ...] | None = None
         correlations: tuple[tuple[CorrelationEntry, ...], ...] = ()
-        if rank != len(scope):
-            unavailable_reason = "rank deficient"
+        if len(rows) - normalization_count < len(scope):
+            failure = EvidenceFailure(
+                "block_covariance",
+                "insufficient_effective_observations",
+                "m - g is smaller than the block controlled-coordinate count",
+                jacobian.identity,
+            )
+            claims = _failed_block_claims(failure.category)
         else:
-            condition = largest / singular[-1]
-            if condition > policy.conditioning_limit:
-                unavailable_reason = "poorly conditioned"
-            else:
-                _unscaled, _factor, covariance = _canonical_covariance_reduction(
-                    singular,
-                    right_transpose,
-                    scales,
-                    variance_scale,
+            scaled = matrix[np.ix_(rows, indices)] * np.asarray(scales)[np.newaxis, :]
+            try:
+                _left, singular_array, right_transpose = svd(
+                    scaled,
+                    full_matrices=False,
+                    compute_uv=True,
+                    overwrite_a=False,
+                    check_finite=True,
+                    lapack_driver=policy.svd_driver,
                 )
-                for local_index, root_index in enumerate(indices):
-                    variance = covariance[local_index][local_index]
-                    if variance <= 0.0 or not math.isfinite(variance):
-                        unavailable_reason = "insufficient information"
-                        covariance = None
-                        break
-                    standard_error = math.sqrt(variance)
-                    value = accepted.vector[root_index]
-                    lower = problem.lower_bounds[root_index]
-                    upper = problem.upper_bounds[root_index]
-                    separation = min(value - lower, upper - value) / standard_error
-                    if (
-                        not math.isfinite(separation)
-                        or separation <= _BOUNDARY_THRESHOLD
-                    ):
-                        unavailable_reason = "boundary limited"
-                        covariance = None
-                        break
-        if covariance is None:
+                singular = tuple(
+                    _finite(value, name=f"block singular value[{index}]")
+                    for index, value in enumerate(singular_array)
+                )
+                spectrum_error = _singular_spectrum_error(singular, len(scope))
+                if spectrum_error is not None:
+                    failure = EvidenceFailure(
+                        "block_covariance",
+                        spectrum_error[0],
+                        spectrum_error[1],
+                        jacobian.identity,
+                    )
+                else:
+                    largest = singular[0]
+                    threshold = _finite(
+                        policy.rank_absolute_tolerance
+                        + policy.rank_relative_tolerance * largest,
+                        name="block rank threshold",
+                    )
+                    rank = sum(value > threshold for value in singular)
+                    if rank != len(scope):
+                        failure = EvidenceFailure(
+                            "block_covariance",
+                            "rank_deficient",
+                            f"Scaled block Jacobian rank {rank} is below {len(scope)}",
+                            jacobian.identity,
+                        )
+                    else:
+                        condition = _finite(
+                            largest / singular[-1],
+                            name="block Jacobian condition",
+                        )
+                        _unscaled, factor, covariance = _canonical_covariance_reduction(
+                            singular,
+                            right_transpose,
+                            scales,
+                            1.0,
+                        )
+                        if _has_positive_scale_zero_variance(covariance, 1.0):
+                            failure = EvidenceFailure(
+                                "block_covariance",
+                                "covariance_factor_underflow",
+                                "Positive-scale block covariance produced zero variance",
+                                jacobian.identity,
+                            )
+                            covariance = None
+                            factor = None
+            except Exception as error:  # noqa: BLE001 - third-party/arithmetic fence
+                failure = EvidenceFailure(
+                    "block_covariance",
+                    "invalid_covariance_arithmetic",
+                    str(error),
+                    jacobian.identity,
+                )
+                covariance = None
+                factor = None
+            if failure is not None:
+                claims = _failed_block_claims(failure.category)
+            else:
+                if covariance is None or condition is None:
+                    raise ValueError("Successful block covariance lacks its arrays")
+                claims = _canonical_covariance_claims(
+                    accepted,
+                    problem,
+                    covariance,
+                    1.0,
+                    condition,
+                    policy,
+                    evidence.source_engine,
+                    indices,
+                    frozenset(profile_indices),
+                )
+        reportable = (
+            next(
+                item.state for item in claims if item.name == "USABLE_LOCAL_COVARIANCE"
+            )
+            is ClaimState.SATISFIED
+        )
+        if covariance is None or not reportable:
             marginal = tuple(
                 ScalarEvidenceEntry(param_id, None, "UNAVAILABLE") for param_id in scope
             )
@@ -2784,21 +2989,81 @@ def derive_root_anchored_block_covariance(  # noqa: C901 - typed block derivatio
                 residual_variance_degenerate=False,
                 policy=policy,
             )
+        constrained: list[ScalarEvidenceEntry] = []
+        if constraint_jacobian is not None:
+            scope_set = set(scope)
+            eligible = tuple(
+                (output_id, row)
+                for output_id, row, dependencies in zip(
+                    constraint_jacobian.output_ids,
+                    constraint_jacobian.matrix,
+                    constraint_jacobian.structural_dependencies,
+                    strict=True,
+                )
+                if dependencies and set(dependencies) <= scope_set
+            )
+            if reportable and factor is not None and eligible:
+                gradient = tuple(
+                    tuple(row[index] for index in indices)
+                    for _output_id, row in eligible
+                )
+                try:
+                    _propagated_factor, propagated = _propagated_factor_and_covariance(
+                        gradient, factor
+                    )
+                    constrained.extend(
+                        ScalarEvidenceEntry(
+                            output_id,
+                            math.sqrt(propagated[index][index]),
+                            "AVAILABLE",
+                        )
+                        for index, (output_id, _row) in enumerate(eligible)
+                        if propagated[index][index] > 0.0
+                        and math.isfinite(propagated[index][index])
+                    )
+                    available_ids = {entry.param_id for entry in constrained}
+                    constrained.extend(
+                        ScalarEvidenceEntry(output_id, None, "INVALID_VARIANCE")
+                        for output_id, _row in eligible
+                        if output_id not in available_ids
+                    )
+                except (ArithmeticError, TypeError, ValueError) as error:
+                    constrained_failure = EvidenceFailure(
+                        "block_constrained_propagation",
+                        "gram_propagation_failure",
+                        str(error),
+                        constraint_jacobian.identity,
+                    )
+                    constrained.extend(
+                        ScalarEvidenceEntry(output_id, None, "UNAVAILABLE")
+                        for output_id, _row in eligible
+                    )
+            else:
+                constrained.extend(
+                    ScalarEvidenceEntry(output_id, None, "UNAVAILABLE")
+                    for output_id, _row in eligible
+                )
         blocks.append(
             RootAnchoredBlockCovariance(
                 scope,
+                profile_indices,
                 rank,
                 condition,
                 covariance,
+                factor,
                 marginal,
                 correlations,
-                unavailable_reason,
+                tuple(constrained),
+                claims,
+                failure,
+                constrained_failure,
             )
         )
     return RootAnchoredBlockCovarianceEvidence(
         evidence.accepted_result_identity,
         evidence.accepted_occurrence_identity,
         jacobian.identity,
+        None if constraint_jacobian is None else constraint_jacobian.identity,
         evidence.policy_identity,
         tuple(blocks),
         evidence,
@@ -3610,12 +3875,17 @@ def _linearize_residuals(
 def _profiled_normalization_regular(
     accepted: AcceptedFitResult,
     engine: EvaluationEngine,
+    profile_indices: frozenset[int] | None = None,
 ) -> bool:
-    for descriptor, profile in zip(
-        engine.plan.profiles,
-        accepted.evaluation_result.profiles,
-        strict=True,
+    for index, (descriptor, profile) in enumerate(
+        zip(
+            engine.plan.profiles,
+            accepted.evaluation_result.profiles,
+            strict=True,
+        )
     ):
+        if profile_indices is not None and index not in profile_indices:
+            continue
         if not descriptor.is_scaled:
             continue
         retained = descriptor.retained_observation_indices
@@ -3643,18 +3913,20 @@ def _box_boundary_claims(
     problem: OptimizationProblem,
     covariance: tuple[tuple[float, ...], ...],
     residual_variance_scale: float,
+    controlled_indices: tuple[int, ...] | None = None,
 ) -> tuple[ClaimAssessment, ClaimAssessment]:
+    indices = (
+        tuple(range(len(problem.controlled_ids)))
+        if controlled_indices is None
+        else controlled_indices
+    )
     strict_interior = True
     separation = ClaimState.SATISFIED
     details: list[str] = []
-    for index, (value, lower, upper) in enumerate(
-        zip(
-            accepted.vector,
-            problem.lower_bounds,
-            problem.upper_bounds,
-            strict=True,
-        )
-    ):
+    for local_index, root_index in enumerate(indices):
+        value = accepted.vector[root_index]
+        lower = problem.lower_bounds[root_index]
+        upper = problem.upper_bounds[root_index]
         if not lower <= value <= upper:
             return (
                 ClaimAssessment("INTERIOR_POINT", ClaimState.VIOLATED),
@@ -3668,17 +3940,17 @@ def _box_boundary_claims(
         ):
             if math.isinf(slack):
                 continue
-            variance = covariance[index][index]
+            variance = covariance[local_index][local_index]
             if residual_variance_scale == 0.0 or variance == 0.0:
                 separation = ClaimState.INDETERMINATE
-                details.append(f"{label}[{index}]: zero scaled variance")
+                details.append(f"{label}[{root_index}]: zero scaled variance")
                 continue
             if variance < 0.0 or not math.isfinite(variance):
                 separation = ClaimState.INDETERMINATE
-                details.append(f"{label}[{index}]: invalid directional variance")
+                details.append(f"{label}[{root_index}]: invalid directional variance")
                 continue
             zeta = float(slack / math.sqrt(variance))
-            details.append(f"{label}[{index}] zeta={zeta.hex()}")
+            details.append(f"{label}[{root_index}] zeta={zeta.hex()}")
             if not math.isfinite(zeta):
                 separation = ClaimState.INDETERMINATE
             elif zeta <= _BOUNDARY_THRESHOLD:
@@ -3751,6 +4023,7 @@ def _affine_feasibility_claim(
     affine_feasibility_policy: str,
     *,
     controlled_only: bool = False,
+    controlled_indices: tuple[int, ...] | None = None,
 ) -> ClaimAssessment:
     claim_name = (
         "CONTROLLED_AFFINE_SEPARATION" if controlled_only else "AFFINE_FEASIBILITY"
@@ -3761,7 +4034,12 @@ def _affine_feasibility_claim(
             ClaimState.NOT_APPLICABLE,
             affine_feasibility_policy,
         )
-    controlled_ids = set(problem.controlled_ids)
+    indices = (
+        tuple(range(len(problem.controlled_ids)))
+        if controlled_indices is None
+        else controlled_indices
+    )
+    controlled_ids = {problem.controlled_ids[index] for index in indices}
     accepted_controlled = dict(
         zip(problem.controlled_ids, accepted.vector, strict=True)
     )
@@ -3845,6 +4123,7 @@ def _boundary_claims(
     covariance: tuple[tuple[float, ...], ...],
     residual_variance_scale: float,
     affine_feasibility_policy: str,
+    controlled_indices: tuple[int, ...] | None = None,
 ) -> tuple[
     ClaimAssessment,
     ClaimAssessment,
@@ -3856,6 +4135,7 @@ def _boundary_claims(
         problem,
         covariance,
         residual_variance_scale,
+        controlled_indices,
     )
     if box[0].state is ClaimState.VIOLATED and any(
         not lower <= value <= upper
@@ -3878,6 +4158,7 @@ def _boundary_claims(
             covariance,
             residual_variance_scale,
             affine_feasibility_policy,
+            controlled_indices=controlled_indices,
         )
     controlled_affine = _affine_feasibility_claim(
         accepted,
@@ -3886,6 +4167,7 @@ def _boundary_claims(
         residual_variance_scale,
         affine_feasibility_policy,
         controlled_only=True,
+        controlled_indices=controlled_indices,
     )
     return (*box, affine, controlled_affine)
 
@@ -3930,8 +4212,14 @@ def _full_dimensional_feasible_interior_claim(
     accepted: AcceptedFitResult,
     problem: OptimizationProblem,
     box_interior: ClaimAssessment,
+    controlled_indices: tuple[int, ...] | None = None,
 ) -> ClaimAssessment:
-    controlled_ids = set(problem.controlled_ids)
+    indices = (
+        tuple(range(len(problem.controlled_ids)))
+        if controlled_indices is None
+        else controlled_indices
+    )
+    controlled_ids = {problem.controlled_ids[index] for index in indices}
     controlled_frame_indices = tuple(
         index
         for index, (param_id, _value) in enumerate(problem.independent_items)
@@ -3998,6 +4286,8 @@ def _canonical_covariance_claims(
     jacobian_condition: float,
     policy: UncertaintyPolicy,
     engine: EvaluationEngine,
+    controlled_indices: tuple[int, ...] | None = None,
+    profile_indices: frozenset[int] | None = None,
 ) -> tuple[ClaimAssessment, ...]:
     interior, boundary, affine, controlled_affine = _boundary_claims(
         accepted,
@@ -4005,11 +4295,13 @@ def _canonical_covariance_claims(
         covariance,
         residual_variance_scale,
         policy.affine_feasibility_policy,
+        controlled_indices,
     )
     full_dimensional_interior = _full_dimensional_feasible_interior_claim(
         accepted,
         problem,
         interior,
+        controlled_indices,
     )
     conditioning = ClaimAssessment(
         "CONDITIONING_ADEQUACY",
@@ -4021,7 +4313,7 @@ def _canonical_covariance_claims(
     normalization = ClaimAssessment(
         "PROFILED_NORMALIZATION_REGULARITY",
         ClaimState.SATISFIED
-        if _profiled_normalization_regular(accepted, engine)
+        if _profiled_normalization_regular(accepted, engine, profile_indices)
         else ClaimState.VIOLATED,
     )
     variance_nondegeneracy = ClaimAssessment(
@@ -5207,6 +5499,46 @@ def _canonical_constrained_propagation_claims(
     )
 
 
+def _propagated_factor_and_covariance(
+    gradient: tuple[tuple[float, ...], ...],
+    covariance_factor: tuple[tuple[float, ...], ...],
+    *,
+    residual_variance_degenerate: bool = False,
+) -> tuple[tuple[tuple[float, ...], ...], tuple[tuple[float, ...], ...]]:
+    """Apply the canonical factor/Gram propagation arithmetic."""
+    dimension = len(covariance_factor)
+    factor = tuple(
+        tuple(
+            _finite(
+                _pairwise_sum(
+                    tuple(
+                        gradient[row][inner] * covariance_factor[inner][column]
+                        for inner in range(dimension)
+                    )
+                ),
+                name=f"propagated factor[{row},{column}]",
+            )
+            for column in range(dimension)
+        )
+        for row in range(len(gradient))
+    )
+    propagated = _gram_matrix(factor)
+    if not residual_variance_degenerate:
+        for index, row in enumerate(factor):
+            if any(value != 0.0 for value in gradient[index]) and all(
+                value == 0.0 for value in row
+            ):
+                raise ArithmeticError(
+                    "Nonzero constraint-gradient row collapsed to a zero propagated "
+                    "factor"
+                )
+            if any(value != 0.0 for value in row) and propagated[index][index] == 0.0:
+                raise ArithmeticError(
+                    "Nonzero propagated factor row underflowed to zero variance"
+                )
+    return factor, propagated
+
+
 def _propagate_constraints(
     accepted: AcceptedFitResult,
     covariance: CovarianceEvidence,
@@ -5215,36 +5547,11 @@ def _propagate_constraints(
     request_identity: str,
     policy: UncertaintyPolicy,
 ) -> ConstrainedPropagationEvidence:
-    gradient = constraint_jacobian.matrix
-    factor = tuple(
-        tuple(
-            _finite(
-                _pairwise_sum(
-                    tuple(
-                        gradient[row][inner] * covariance.factor[inner][column]
-                        for inner in range(len(covariance.controlled_ids))
-                    )
-                ),
-                name=f"propagated factor[{row},{column}]",
-            )
-            for column in range(len(covariance.controlled_ids))
-        )
-        for row in range(len(constraint_jacobian.output_ids))
+    factor, propagated = _propagated_factor_and_covariance(
+        constraint_jacobian.matrix,
+        covariance.factor,
+        residual_variance_degenerate=(covariance.residual_variance_scale == 0.0),
     )
-    propagated = _gram_matrix(factor)
-    residual_variance_degenerate = covariance.residual_variance_scale == 0.0
-    if not residual_variance_degenerate:
-        for index, row in enumerate(factor):
-            if any(value != 0.0 for value in gradient[index]) and all(
-                value == 0.0 for value in row
-            ):
-                raise ArithmeticError(
-                    "Nonzero constraint-gradient row collapsed to a zero propagated factor"
-                )
-            if any(value != 0.0 for value in row) and propagated[index][index] == 0.0:
-                raise ArithmeticError(
-                    "Nonzero propagated factor row underflowed to zero variance"
-                )
     claims = _canonical_constrained_propagation_claims(
         covariance,
         constraint_jacobian,

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -569,7 +569,7 @@ def compile_constraint_linearization_capabilities(
 
 @dataclass(frozen=True, slots=True)
 class UncertaintyPolicy:
-    """Explicit resolved v1 numerical policy; no defaults are inferred."""
+    """Explicit numerical policy; legacy rank knobs are reference-only."""
 
     calibration_identity: str
     numerical_compatibility_requirement: str
@@ -676,6 +676,13 @@ class UncertaintyPolicy:
         }:
             raise UncertaintyConstructionError(
                 "Residual-Jacobian strategy is not supported"
+            )
+        if self.residual_jacobian_strategy == (
+            "retained-backend-or-accepted-2-point"
+        ) and (rank_absolute != 0.0 or rank_relative != 0.0):
+            raise UncertaintyConstructionError(
+                "Product covariance uses only the dimension-aware floating-point "
+                "rank threshold; legacy calibration tolerances must be zero"
             )
         object.__setattr__(self, "coordinate_scales", scales)
         object.__setattr__(self, "coordinate_units", units)
@@ -4168,36 +4175,12 @@ def _accepted_point_two_point_jacobian(
         center = accepted.vector[column]
         feasibility = problem.coordinate_line_feasibility(accepted.vector, column)
         nominal = sqrt_epsilon * max(1.0, abs(center))
-        preferred = nominal if center >= 0.0 else -nominal
-        displacement: float | None = None
-        orientation = ""
-        for candidate, label in (
-            (preferred, "forward" if preferred > 0.0 else "backward"),
-            (-preferred, "backward" if preferred > 0.0 else "forward"),
-        ):
-            limit = (
-                feasibility.maximum_displacement
-                if candidate > 0.0
-                else -feasibility.minimum_displacement
-            )
-            if limit <= 0.0:
-                continue
-            magnitude = min(abs(candidate), limit)
-            proposed = magnitude if candidate > 0.0 else -magnitude
-            if center + proposed == center:
-                adjacent = float(
-                    np.nextafter(
-                        center,
-                        math.inf if proposed > 0.0 else -math.inf,
-                    )
-                    - center
-                )
-                if abs(adjacent) > limit:
-                    continue
-                proposed = adjacent
-            displacement = proposed
-            orientation = label
-            break
+        displacement, orientation = _scipy_style_two_point_displacement(
+            center,
+            nominal,
+            feasibility.minimum_displacement,
+            feasibility.maximum_displacement,
+        )
         if displacement is None or displacement == 0.0:
             return None, EvidenceFailure(
                 "residual_linearization",
@@ -4298,6 +4281,40 @@ def _accepted_point_two_point_jacobian(
         ),
         None,
     )
+
+
+def _scipy_style_two_point_displacement(
+    center: float,
+    nominal: float,
+    minimum_displacement: float,
+    maximum_displacement: float,
+) -> tuple[float | None, str]:
+    """Reproduce SciPy's one-sided bound adjustment on a feasible line."""
+    preferred = nominal if center >= 0.0 else -nominal
+    if minimum_displacement <= preferred <= maximum_displacement:
+        proposed = preferred
+    elif minimum_displacement <= -preferred <= maximum_displacement:
+        proposed = -preferred
+    else:
+        proposed = (
+            maximum_displacement
+            if maximum_displacement >= -minimum_displacement
+            else minimum_displacement
+        )
+    if proposed == 0.0:
+        return None, ""
+    displacement = float((center + proposed) - center)
+    if displacement == 0.0:
+        displacement = float(
+            np.nextafter(
+                center,
+                math.inf if proposed > 0.0 else -math.inf,
+            )
+            - center
+        )
+    if not minimum_displacement <= displacement <= maximum_displacement:
+        return None, ""
+    return displacement, "forward" if displacement > 0.0 else "backward"
 
 
 def _profiled_normalization_regular(

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -1,9 +1,9 @@
 """ChemEx-owned accepted-point uncertainty evidence qualification (#598).
 
-This module is deliberately separate from backend execution evidence.  It
-linearizes the complete native residual map again at one accepted external
-coordinate vector, constructs full-rank scaled-SVD covariance, and derives
-typed marginal, correlation, and constrained-propagation artifacts.
+This module is deliberately separate from backend execution evidence. It binds
+an exact accepted-point residual Jacobian (retained or independently derived),
+then freshly constructs rank, scaled-SVD covariance, marginal, correlation, and
+constrained-propagation artifacts.
 
 Production deterministic fitting consumes these artifacts after the accepted
 result has committed. Central estimates remain separate from this report-only
@@ -37,7 +37,9 @@ from chemex.evaluation.native import (
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     DirectTrfConstructionError,
+    FinalResidualJacobianEvidence,
     OptimizationProblem,
+    ResidualJacobianSource,
     accepted_occurrence_is_authoritative,
 )
 from chemex.optimize.grouped_direct_trf import FitPartitionProof
@@ -55,11 +57,11 @@ from chemex.parameters.parameterization import (
 )
 from chemex.typing import Array
 
-_SCHEMA_VERSION = 1
-_RESIDUAL_LINEARIZATION_VERSION = "external-real-finite-difference-v1"
+_SCHEMA_VERSION = 2
+_RESIDUAL_LINEARIZATION_VERSION = "accepted-residual-jacobian-v2"
 _CONSTRAINT_LINEARIZATION_VERSION = "constraint-forward-chain-v1"
-_COVARIANCE_VERSION = "full-rank-direct-scaled-svd-factor-gram-v3"
-_FACTOR_VERSION = "direct-scaled-svd-factor-gram-v3"
+_COVARIANCE_VERSION = "column-equilibrated-full-rank-svd-factor-gram-v4"
+_FACTOR_VERSION = "column-equilibrated-svd-factor-gram-v4"
 _REDUCTION_VERSION = "fixed-pairwise-binary64-v1"
 _MARGINAL_VERSION = "covariance-diagonal-square-root-v1"
 _CORRELATION_VERSION = "ordered-double-division-v1"
@@ -75,6 +77,20 @@ class UncertaintyConstructionError(ValueError):
 
 class MissingFunctionLinearizationCapability(UncertaintyConstructionError):
     """A constrained output requires an undeclared scientific-function partial."""
+
+
+class UncertaintyUnavailableKind(StrEnum):
+    """Closed product classifications for unavailable uncertainty claims."""
+
+    RANK_DEFICIENT = "rank_deficient"
+    INSUFFICIENT_INFORMATION = "insufficient_information"
+    BOUNDARY_LIMITED = "boundary_limited"
+    NORMALIZATION_INVALID = "normalization_invalid"
+    JACOBIAN_UNAVAILABLE = "jacobian_unavailable"
+    COVARIANCE_NUMERICAL_FAILURE = "covariance_numerical_failure"
+    UNSUPPORTED_CONSTRAINED_DERIVATIVE = "unsupported_constrained_derivative"
+    DERIVATION_STOPPED = "derivation_stopped"
+    CONSTRAINED_PROPAGATION_UNAVAILABLE = "constrained_propagation_unavailable"
 
 
 class FunctionPartialFailure(UncertaintyConstructionError):
@@ -201,6 +217,19 @@ def _matrix_tokens(
     matrix: Sequence[Sequence[float]],
 ) -> tuple[tuple[str, ...], ...]:
     return tuple(_vector_tokens(row) for row in matrix)
+
+
+def _binary64_matrix_digest(
+    matrix: Sequence[Sequence[float]],
+    shape: tuple[int, int],
+) -> str:
+    """Hash canonical little-endian binary64 rows without token expansion."""
+    digest = hashlib.sha256()
+    digest.update(f"{shape[0]}x{shape[1]}:".encode("ascii"))
+    dtype = np.dtype("<f8")
+    for row in matrix:
+        digest.update(np.asarray(row, dtype=dtype).tobytes(order="C"))
+    return digest.hexdigest()
 
 
 def _canonical_matrix(
@@ -559,6 +588,10 @@ class UncertaintyPolicy:
     conditioning_limit: float
     correlation_roundoff_multiplier: float
     affine_feasibility_policy: str
+    residual_jacobian_strategy: Literal[
+        "high-quality-reference",
+        "retained-backend-or-accepted-2-point",
+    ] = "high-quality-reference"
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -637,6 +670,13 @@ class UncertaintyPolicy:
             raise UncertaintyConstructionError(
                 "Affine-feasibility semantics must be explicit"
             )
+        if self.residual_jacobian_strategy not in {
+            "high-quality-reference",
+            "retained-backend-or-accepted-2-point",
+        }:
+            raise UncertaintyConstructionError(
+                "Residual-Jacobian strategy is not supported"
+            )
         object.__setattr__(self, "coordinate_scales", scales)
         object.__setattr__(self, "coordinate_units", units)
         object.__setattr__(self, "relative_step_tolerance", relative)
@@ -680,6 +720,7 @@ class UncertaintyPolicy:
                     _float_token(conditioning),
                     _float_token(correlation_roundoff),
                     self.affine_feasibility_policy,
+                    self.residual_jacobian_strategy,
                     _float_token(_BOUNDARY_THRESHOLD),
                     _RESIDUAL_LINEARIZATION_VERSION,
                     _CONSTRAINT_LINEARIZATION_VERSION,
@@ -901,10 +942,24 @@ class ResidualJacobianEvidence:
     controlled_ids: tuple[str, ...]
     accepted_vector: tuple[float, ...]
     coordinate_scales: tuple[float, ...]
-    matrix: tuple[tuple[float, ...], ...]
+    matrix: tuple[tuple[float, ...], ...] = field(
+        repr=False,
+        metadata={"record": False},
+    )
     columns: tuple[LinearizationColumn, ...]
     trajectory_fingerprint: str
+    matrix_shape: tuple[int, int] = field(init=False)
+    matrix_binary64_sha256: str = field(init=False)
+    method: str = "high-quality-fresh"
+    evaluation_count: int = 0
     complete_reliable: bool = True
+    source_final_jacobian: FinalResidualJacobianEvidence | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     accepted_anchor: AcceptedFitResult = field(
         repr=False,
         compare=False,
@@ -925,7 +980,7 @@ class ResidualJacobianEvidence:
     )
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: C901 - source-specific integrity chain
         _validate_accepted_anchor(
             self.accepted_anchor,
             self.accepted_result_identity,
@@ -939,12 +994,12 @@ class ResidualJacobianEvidence:
             columns=coordinate_count,
             name="residual Jacobian",
         )
-        if (
+        common_invalid = (
             residual_count < 1
             or coordinate_count < 1
-            or len(self.columns) != coordinate_count
             or len(self.coordinate_scales) != coordinate_count
-        ):
+        )
+        if common_invalid:
             raise ValueError("Residual Jacobian has inconsistent scope")
         if (
             self.accepted_vector != self.accepted_anchor.vector
@@ -970,68 +1025,131 @@ class ResidualJacobianEvidence:
             or self.source_policy.calibration_identity != self.calibration_identity
             or self.source_policy.numerical_compatibility_requirement
             != self.numerical_compatibility_requirement
-            or tuple(item.param_id for item in self.columns) != self.controlled_ids
             or any(value <= 0.0 for value in self.coordinate_scales)
-            or any(len(item.fine_estimate) != residual_count for item in self.columns)
-            or any(
-                len(item.companion_estimate) != residual_count for item in self.columns
-            )
         ):
             raise ValueError("Residual Jacobian provenance is internally inconsistent")
-        derived_matrix = tuple(
-            tuple(column.fine_estimate[row] for column in self.columns)
-            for row in range(residual_count)
-        )
-        expected_trajectory = _identity(
-            "residual-linearization-trajectory",
-            tuple(
-                (item.param_id, item.trajectory_fingerprint) for item in self.columns
-            ),
-        )
-        if (
-            matrix != derived_matrix
-            or not self.complete_reliable
-            or self.trajectory_fingerprint != expected_trajectory
-        ):
-            raise ValueError("Residual Jacobian differs from its accepted columns")
-        evaluator = self.source_engine.new_evaluator()
-        base = _evaluate_vector(
-            self.accepted_anchor.vector,
-            problem=self.source_problem,
-            parameterization=self.source_parameterization,
-            evaluator=evaluator,
-        )
-        if (
-            isinstance(base, EvaluationFailure)
-            or base.identity != self.accepted_evaluation_identity
-        ):
-            raise ValueError("Residual Jacobian baseline cannot be replayed")
-        base_residuals = tuple(float(value) for value in base.residuals)
-        for column, (param_id, scale, declared) in enumerate(
-            zip(
-                self.controlled_ids,
-                self.coordinate_scales,
-                self.columns,
-                strict=True,
+        if self.method == "high-quality-fresh":
+            derived_matrix = tuple(
+                tuple(column.fine_estimate[row] for column in self.columns)
+                for row in range(residual_count)
             )
-        ):
-            replayed, _trajectory, failure = _linearize_residual_column(
-                self.accepted_anchor,
+            expected_trajectory = _identity(
+                "residual-linearization-trajectory",
+                tuple(
+                    (item.param_id, item.trajectory_fingerprint)
+                    for item in self.columns
+                ),
+            )
+            if (
+                len(self.columns) != coordinate_count
+                or tuple(item.param_id for item in self.columns) != self.controlled_ids
+                or any(
+                    len(item.fine_estimate) != residual_count
+                    or len(item.companion_estimate) != residual_count
+                    for item in self.columns
+                )
+                or matrix != derived_matrix
+                or self.source_final_jacobian is not None
+                or self.evaluation_count < 1
+                or self.trajectory_fingerprint != expected_trajectory
+            ):
+                raise ValueError("Residual Jacobian differs from its accepted columns")
+            evaluator = self.source_engine.new_evaluator()
+            base = _evaluate_vector(
+                self.accepted_anchor.vector,
                 problem=self.source_problem,
                 parameterization=self.source_parameterization,
                 evaluator=evaluator,
-                policy=self.source_policy,
-                base_residuals=base_residuals,
-                column=column,
-                param_id=param_id,
-                scale=scale,
-                cancellation_probe=None,
             )
-            if failure is not None or replayed != declared:
-                raise ValueError(
-                    "Residual Jacobian stencil evidence cannot be replayed"
+            if (
+                isinstance(base, EvaluationFailure)
+                or base.identity != self.accepted_evaluation_identity
+            ):
+                raise ValueError("Residual Jacobian baseline cannot be replayed")
+            base_residuals = tuple(float(value) for value in base.residuals)
+            for column, (param_id, scale, declared) in enumerate(
+                zip(
+                    self.controlled_ids,
+                    self.coordinate_scales,
+                    self.columns,
+                    strict=True,
                 )
+            ):
+                replayed, _trajectory, failure = _linearize_residual_column(
+                    self.accepted_anchor,
+                    problem=self.source_problem,
+                    parameterization=self.source_parameterization,
+                    evaluator=evaluator,
+                    policy=self.source_policy,
+                    base_residuals=base_residuals,
+                    column=column,
+                    param_id=param_id,
+                    scale=scale,
+                    cancellation_probe=None,
+                )
+                if failure is not None or replayed != declared:
+                    raise ValueError(
+                        "Residual Jacobian stencil evidence cannot be replayed"
+                    )
+        elif self.method == "retained-scipy-final-2-point":
+            retained = self.source_final_jacobian
+            if (
+                retained is None
+                or retained is not self.accepted_anchor.final_residual_jacobian
+                or retained.source
+                not in {
+                    ResidualJacobianSource.SCIPY_FINAL_2_POINT,
+                    ResidualJacobianSource.FIT_PARTITION_COMPOSITION,
+                }
+                or retained.controlled_ids != self.controlled_ids
+                or retained.final_vector != self.accepted_vector
+                or retained.final_residuals
+                != tuple(
+                    float(value)
+                    for value in self.accepted_anchor.evaluation_result.residuals
+                )
+                or retained.matrix != matrix
+                or self.columns
+                or self.evaluation_count != 0
+                or self.trajectory_fingerprint != retained.identity
+            ):
+                raise ValueError("Retained residual Jacobian lineage is invalid")
+        elif self.method == "accepted-point-2-point":
+            derived_matrix = tuple(
+                tuple(column.fine_estimate[row] for column in self.columns)
+                for row in range(residual_count)
+            )
+            expected_trajectory = _identity(
+                "accepted-point-2-point-trajectory",
+                tuple(
+                    (item.param_id, item.trajectory_fingerprint)
+                    for item in self.columns
+                ),
+            )
+            if (
+                len(self.columns) != coordinate_count
+                or tuple(item.param_id for item in self.columns) != self.controlled_ids
+                or any(
+                    len(item.fine_estimate) != residual_count
+                    or item.fine_estimate != item.companion_estimate
+                    or len(item.represented_displacements) != 1
+                    for item in self.columns
+                )
+                or matrix != derived_matrix
+                or self.source_final_jacobian is not None
+                or self.evaluation_count != coordinate_count
+                or self.trajectory_fingerprint != expected_trajectory
+            ):
+                raise ValueError("Accepted-point 2-point evidence is inconsistent")
+        else:
+            raise ValueError("Residual Jacobian method is not supported")
+        if not self.complete_reliable:
+            raise ValueError("Residual Jacobian is not complete and reliable")
         object.__setattr__(self, "matrix", matrix)
+        matrix_shape = (residual_count, coordinate_count)
+        matrix_digest = _binary64_matrix_digest(matrix, matrix_shape)
+        object.__setattr__(self, "matrix_shape", matrix_shape)
+        object.__setattr__(self, "matrix_binary64_sha256", matrix_digest)
         object.__setattr__(
             self,
             "identity",
@@ -1055,9 +1173,14 @@ class ResidualJacobianEvidence:
                     self.controlled_ids,
                     _vector_tokens(self.accepted_vector),
                     _vector_tokens(self.coordinate_scales),
-                    _matrix_tokens(matrix),
+                    matrix_digest,
                     tuple(column.identity for column in self.columns),
                     self.trajectory_fingerprint,
+                    self.method,
+                    self.evaluation_count,
+                    None
+                    if self.source_final_jacobian is None
+                    else self.source_final_jacobian.identity,
                     self.complete_reliable,
                     _RESIDUAL_LINEARIZATION_VERSION,
                 ),
@@ -1085,7 +1208,12 @@ class SingularSubspaceEvidence:
         "clustered_weak",
         "clustered_null",
     ]
-    projector: tuple[tuple[float, ...], ...]
+    projector: tuple[tuple[float, ...], ...] = field(
+        repr=False,
+        metadata={"record": False},
+    )
+    projector_shape: tuple[int, int] = field(init=False)
+    projector_binary64_sha256: str = field(init=False)
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -1104,6 +1232,10 @@ class SingularSubspaceEvidence:
         ):
             raise ValueError("Singular subspace evidence has inconsistent membership")
         object.__setattr__(self, "projector", projector)
+        projector_shape = (dimension, dimension)
+        projector_digest = _binary64_matrix_digest(projector, projector_shape)
+        object.__setattr__(self, "projector_shape", projector_shape)
+        object.__setattr__(self, "projector_binary64_sha256", projector_digest)
         object.__setattr__(
             self,
             "identity",
@@ -1113,7 +1245,7 @@ class SingularSubspaceEvidence:
                     self.indices,
                     _vector_tokens(self.singular_values),
                     self.classification,
-                    _matrix_tokens(projector),
+                    projector_digest,
                 ),
             ),
         )
@@ -1123,10 +1255,9 @@ def _recomputed_scaled_svd(
     source: ResidualJacobianEvidence,
     policy: UncertaintyPolicy,
 ) -> tuple[tuple[float, ...], tuple[tuple[float, ...], ...]]:
-    scaled = (
-        np.asarray(source.matrix, dtype=np.float64)
-        * np.asarray(source.coordinate_scales, dtype=np.float64)[np.newaxis, :]
-    )
+    matrix = np.asarray(source.matrix, dtype=np.float64)
+    column_norms = np.linalg.norm(matrix, axis=0)
+    scaled = matrix * (1.0 / column_norms)[np.newaxis, :]
     _left, singular_values, right_transpose = svd(
         scaled,
         full_matrices=False,
@@ -1160,13 +1291,27 @@ class RankDiagnostic:
     singular_values: tuple[float, ...]
     normalized_singular_values: tuple[float, ...]
     scaled_column_norms: tuple[float, ...]
+    equilibration_scales: tuple[float, ...]
     threshold: float
     weak_threshold: float
     rank: int
-    identifiable_projector: tuple[tuple[float, ...], ...]
-    null_projector: tuple[tuple[float, ...], ...]
-    weak_projector: tuple[tuple[float, ...], ...]
+    identifiable_projector: tuple[tuple[float, ...], ...] = field(
+        repr=False,
+        metadata={"record": False},
+    )
+    null_projector: tuple[tuple[float, ...], ...] = field(
+        repr=False,
+        metadata={"record": False},
+    )
+    weak_projector: tuple[tuple[float, ...], ...] = field(
+        repr=False,
+        metadata={"record": False},
+    )
     subspaces: tuple[SingularSubspaceEvidence, ...]
+    projector_shape: tuple[int, int] = field(init=False)
+    identifiable_projector_binary64_sha256: str = field(init=False)
+    null_projector_binary64_sha256: str = field(init=False)
+    weak_projector_binary64_sha256: str = field(init=False)
     source_jacobian: ResidualJacobianEvidence = field(
         repr=False,
         compare=False,
@@ -1213,6 +1358,7 @@ class RankDiagnostic:
             or len(self.singular_values) != dimension
             or len(self.normalized_singular_values) != dimension
             or len(self.scaled_column_norms) != dimension
+            or len(self.equilibration_scales) != dimension
             or not 0 <= self.rank <= dimension
             or any(
                 value < 0.0 or not math.isfinite(value)
@@ -1222,9 +1368,9 @@ class RankDiagnostic:
             or self.rank
             != sum(value > self.threshold for value in self.singular_values)
             or self.threshold
-            != self.source_policy.rank_absolute_tolerance
-            + self.source_policy.rank_relative_tolerance
-            * (self.singular_values[0] if self.singular_values else 0.0)
+            != (self.singular_values[0] if self.singular_values else 0.0)
+            * max(source.residual_count, dimension)
+            * _EPSILON
         ):
             raise ValueError("SVD/rank evidence has inconsistent lineage or spectrum")
         largest = self.singular_values[0] if self.singular_values else 0.0
@@ -1238,10 +1384,10 @@ class RankDiagnostic:
         expected_normalized = tuple(
             0.0 if largest == 0.0 else value / largest for value in self.singular_values
         )
-        scaled = (
-            np.asarray(source.matrix)
-            * np.asarray(source.coordinate_scales)[np.newaxis, :]
-        )
+        source_matrix = np.asarray(source.matrix)
+        expected_source_norms = np.linalg.norm(source_matrix, axis=0)
+        expected_equilibration = 1.0 / expected_source_norms
+        scaled = source_matrix * expected_equilibration[np.newaxis, :]
         expected_norms = tuple(
             float(np.linalg.norm(scaled[:, index])) for index in range(dimension)
         )
@@ -1256,6 +1402,12 @@ class RankDiagnostic:
             or self.source_policy.identity != source.source_policy.identity
             or not np.allclose(
                 self.scaled_column_norms, expected_norms, rtol=tolerance, atol=0.0
+            )
+            or not np.allclose(
+                self.equilibration_scales,
+                expected_equilibration,
+                rtol=tolerance,
+                atol=0.0,
             )
             or not np.allclose(
                 self.singular_values,
@@ -1284,10 +1436,7 @@ class RankDiagnostic:
             atol=tolerance,
         ):
             raise ValueError("Identifiable and null projectors are not complementary")
-        covered = tuple(index for item in self.subspaces for index in item.indices)
-        if covered != tuple(range(dimension)):
-            raise ValueError("Singular subspaces do not partition parameter order")
-        expected_groups = _singular_cluster_indices(
+        expected_groups = _diagnostic_singular_groups(
             self.singular_values,
             rank_threshold=self.threshold,
             weak_threshold=self.weak_threshold,
@@ -1299,7 +1448,6 @@ class RankDiagnostic:
             raise ValueError(
                 "Singular subspaces violate the declared clustering policy"
             )
-        subspace_sum = np.zeros((dimension, dimension), dtype=np.float64)
         recomputed_subspaces = _invariant_singular_subspaces(
             np.asarray(recomputed_right_t, dtype=np.float64).T,
             recomputed_singular,
@@ -1343,14 +1491,6 @@ class RankDiagnostic:
                 raise ValueError(
                     "Singular projector does not match its invariant spectrum"
                 )
-            subspace_sum += item_projector
-        if not np.allclose(
-            subspace_sum,
-            identity_matrix,
-            rtol=0.0,
-            atol=tolerance,
-        ):
-            raise ValueError("Singular invariant-subspace projectors are incomplete")
         expected_weak = sum(
             (
                 np.asarray(item.projector)
@@ -1366,14 +1506,6 @@ class RankDiagnostic:
             atol=tolerance,
         ):
             raise ValueError("Weak-subspace projector is inconsistent")
-        expected_identifiable = sum(
-            (
-                np.asarray(item.projector)
-                for item in self.subspaces
-                if not item.classification.endswith("_null")
-            ),
-            start=np.zeros((dimension, dimension), dtype=np.float64),
-        )
         expected_null = sum(
             (
                 np.asarray(item.projector)
@@ -1382,26 +1514,31 @@ class RankDiagnostic:
             ),
             start=np.zeros((dimension, dimension), dtype=np.float64),
         )
-        if not (
-            np.allclose(
-                identifiable,
-                expected_identifiable,
-                rtol=0.0,
-                atol=tolerance,
-            )
-            and np.allclose(
-                null,
-                expected_null,
-                rtol=0.0,
-                atol=tolerance,
-            )
+        if not np.allclose(
+            null,
+            expected_null,
+            rtol=0.0,
+            atol=tolerance,
         ):
-            raise ValueError(
-                "Identifiable/null projectors do not match classified subspaces"
-            )
+            raise ValueError("Null projector does not match diagnostic subspaces")
         object.__setattr__(self, "identifiable_projector", identifiable)
         object.__setattr__(self, "null_projector", null)
         object.__setattr__(self, "weak_projector", weak)
+        projector_shape = (dimension, dimension)
+        identifiable_digest = _binary64_matrix_digest(
+            identifiable,
+            projector_shape,
+        )
+        null_digest = _binary64_matrix_digest(null, projector_shape)
+        weak_digest = _binary64_matrix_digest(weak, projector_shape)
+        object.__setattr__(self, "projector_shape", projector_shape)
+        object.__setattr__(
+            self,
+            "identifiable_projector_binary64_sha256",
+            identifiable_digest,
+        )
+        object.__setattr__(self, "null_projector_binary64_sha256", null_digest)
+        object.__setattr__(self, "weak_projector_binary64_sha256", weak_digest)
         object.__setattr__(
             self,
             "identity",
@@ -1416,12 +1553,13 @@ class RankDiagnostic:
                     _vector_tokens(self.singular_values),
                     _vector_tokens(self.normalized_singular_values),
                     _vector_tokens(self.scaled_column_norms),
+                    _vector_tokens(self.equilibration_scales),
                     _float_token(self.threshold),
                     _float_token(self.weak_threshold),
                     self.rank,
-                    _matrix_tokens(identifiable),
-                    _matrix_tokens(null),
-                    _matrix_tokens(weak),
+                    identifiable_digest,
+                    null_digest,
+                    weak_digest,
                     tuple(item.identity for item in self.subspaces),
                 ),
             ),
@@ -1563,7 +1701,7 @@ class CovarianceEvidence:
             or self.controlled_ids != source.controlled_ids
             or self.controlled_ids != accepted.controlled_ids
             or self.accepted_vector != accepted.vector
-            or self.coordinate_scales != source.coordinate_scales
+            or self.coordinate_scales != rank_source.equilibration_scales
             or self.units != tuple(unit for _param_id, unit in policy.coordinate_units)
             or self.residual_variance_scaling is not policy.residual_variance_scaling
             or self.retained_residual_count != expected_residual_count
@@ -1587,7 +1725,7 @@ class CovarianceEvidence:
             _canonical_covariance_reduction(
                 rank_source.singular_values,
                 recomputed_right_t,
-                source.coordinate_scales,
+                rank_source.equilibration_scales,
                 expected_scale,
             )
         )
@@ -2670,31 +2808,35 @@ class RootAnchoredBlockCovariance:
         )
 
     @property
-    def unavailable_reason(self) -> str:
-        """Map typed block evidence to the closed product reason vocabulary."""
+    def unavailable_kind(self) -> UncertaintyUnavailableKind | None:
+        """Classify unavailable block evidence without rendering product text."""
         if self.scope_reportable:
-            return ""
+            return None
         if self.failure is not None:
             if self.failure.category == "rank_deficient":
-                return "rank deficient"
-            if self.failure.category == "insufficient_effective_observations":
-                return "insufficient information"
-            if self.failure.category == "non_finite_information_condition":
-                return "poorly conditioned"
-            return "derivative unavailable"
+                return UncertaintyUnavailableKind.RANK_DEFICIENT
+            if self.failure.category in {
+                "insufficient_effective_observations",
+                "non_positive_nominal_residual_degrees_of_freedom",
+            }:
+                return UncertaintyUnavailableKind.INSUFFICIENT_INFORMATION
+            if self.failure.stage == "residual_linearization":
+                return UncertaintyUnavailableKind.JACOBIAN_UNAVAILABLE
+            return UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE
         states = {item.name: item.state for item in self.claims}
-        if states.get("CONDITIONING_ADEQUACY") is not ClaimState.SATISFIED:
-            return "poorly conditioned"
+        if states.get("PROFILED_NORMALIZATION_REGULARITY") is ClaimState.VIOLATED:
+            return UncertaintyUnavailableKind.NORMALIZATION_INVALID
         if any(
             states.get(name) is not ClaimState.SATISFIED
             for name in (
                 "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
                 "INTERIOR_POINT",
                 "BOUNDARY_SEPARATION",
+                "CONTROLLED_AFFINE_SEPARATION",
             )
         ):
-            return "boundary limited"
-        return "insufficient information"
+            return UncertaintyUnavailableKind.BOUNDARY_LIMITED
+        return UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE
 
 
 @dataclass(frozen=True, slots=True)
@@ -2797,7 +2939,11 @@ class RootAnchoredBlockCovarianceEvidence:
                 {
                     **cast(dict[str, object], _record_value(item)),
                     "scope_reportable": item.scope_reportable,
-                    "unavailable_reason": item.unavailable_reason,
+                    "unavailable_kind": (
+                        None
+                        if item.unavailable_kind is None
+                        else item.unavailable_kind.value
+                    ),
                 }
                 for item in self.blocks
             ],
@@ -2832,6 +2978,24 @@ def _failed_block_claims(
         ClaimAssessment("COVARIANCE_ARITHMETIC_INTEGRITY", ClaimState.INDETERMINATE),
         ClaimAssessment("USABLE_LOCAL_COVARIANCE", ClaimState.VIOLATED),
     )
+
+
+def _partition_coordinate_indices(
+    root_controlled_ids: tuple[str, ...],
+    scopes: tuple[tuple[str, ...], ...],
+) -> tuple[tuple[int, ...], ...]:
+    """Map each proven scope independently into canonical root coordinates."""
+    flattened = tuple(param_id for scope in scopes for param_id in scope)
+    if len(set(flattened)) != len(flattened) or set(flattened) != set(
+        root_controlled_ids
+    ):
+        raise ValueError("Block covariance scopes must partition root coordinates")
+    root_order = {param_id: index for index, param_id in enumerate(root_controlled_ids)}
+    if any(
+        tuple(sorted(scope, key=root_order.__getitem__)) != scope for scope in scopes
+    ):
+        raise ValueError("Block covariance coordinates must preserve root order")
+    return tuple(tuple(root_order[param_id] for param_id in scope) for scope in scopes)
 
 
 def derive_root_anchored_block_covariance(  # noqa: C901
@@ -2882,24 +3046,14 @@ def derive_root_anchored_block_covariance(  # noqa: C901
     )
     if len(scopes) < 2:
         return None
-    flattened = tuple(param_id for scope, _profiles in scopes for param_id in scope)
-    if len(set(flattened)) != len(flattened) or set(flattened) != set(
-        jacobian.controlled_ids
-    ):
-        raise ValueError("Block covariance scopes must partition root coordinates")
-    root_order = {
-        param_id: index for index, param_id in enumerate(jacobian.controlled_ids)
-    }
-    if any(
-        tuple(sorted(scope, key=root_order.__getitem__)) != scope
-        for scope, _profiles in scopes
-    ):
-        raise ValueError("Block covariance coordinates must preserve root order")
+    coordinate_indices = _partition_coordinate_indices(
+        jacobian.controlled_ids,
+        tuple(scope for scope, _profiles in scopes),
+    )
     policy = evidence.source_policy
     matrix = np.asarray(jacobian.matrix, dtype=np.float64)
     accepted = evidence.accepted_anchor
     problem = evidence.source_problem
-    coordinate_index = root_order
     profile_rows: list[tuple[int, ...]] = []
     row_offset = 0
     for profile in evidence.source_engine.plan.profiles:
@@ -2910,14 +3064,17 @@ def derive_root_anchored_block_covariance(  # noqa: C901
         raise ValueError("Root residual rows do not match the evaluation profile plan")
     constraint_jacobian = evidence.constraint_jacobian
     blocks: list[RootAnchoredBlockCovariance] = []
-    for scope, profile_indices in scopes:
+    for (scope, profile_indices), indices in zip(
+        scopes,
+        coordinate_indices,
+        strict=True,
+    ):
         if (
             len(set(profile_indices)) != len(profile_indices)
             or tuple(sorted(profile_indices)) != profile_indices
             or any(not 0 <= index < len(profile_rows) for index in profile_indices)
         ):
             raise ValueError("Block covariance profile scope is invalid")
-        indices = tuple(coordinate_index[param_id] for param_id in scope)
         rows = tuple(row for index in profile_indices for row in profile_rows[index])
         scales = tuple(jacobian.coordinate_scales[index] for index in indices)
         normalization_count = sum(
@@ -2961,7 +3118,7 @@ def derive_root_anchored_block_covariance(  # noqa: C901
             elif analysis is not None:
                 reduction, reduction_failure = _reduce_scaled_covariance(
                     analysis,
-                    scales,
+                    analysis.equilibration_scales,
                     accepted,
                     degrees_of_freedom=(len(rows) - len(scope) - normalization_count),
                     policy=policy,
@@ -3247,7 +3404,7 @@ def _invariant_singular_subspaces(
 ) -> tuple[SingularSubspaceEvidence, ...]:
     """Retain projectors, never basis orientation, for clustered directions."""
 
-    groups = _singular_cluster_indices(
+    groups = _diagnostic_singular_groups(
         singular_values,
         rank_threshold=rank_threshold,
         weak_threshold=weak_threshold,
@@ -3278,6 +3435,33 @@ def _invariant_singular_subspaces(
             projector(indices),
         )
         for indices in groups
+    )
+
+
+def _diagnostic_singular_groups(
+    singular_values: tuple[float, ...],
+    *,
+    rank_threshold: float,
+    weak_threshold: float,
+    cluster_relative_tolerance: float,
+) -> tuple[tuple[int, ...], ...]:
+    """Retain only clusters and weak/null modes needing interpretation."""
+    return tuple(
+        indices
+        for indices in _singular_cluster_indices(
+            singular_values,
+            rank_threshold=rank_threshold,
+            weak_threshold=weak_threshold,
+            cluster_relative_tolerance=cluster_relative_tolerance,
+        )
+        if len(indices) > 1
+        or _singular_direction_class(
+            singular_values,
+            indices[0],
+            rank_threshold=rank_threshold,
+            weak_threshold=weak_threshold,
+        )
+        != "identifiable"
     )
 
 
@@ -3895,6 +4079,217 @@ def _linearize_residuals(
             matrix,
             tuple(column_evidence),
             trajectory_fingerprint,
+            evaluation_count=1
+            + 4 * sum(item.attempt_count for item in column_evidence),
+            accepted_anchor=accepted,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_engine=engine,
+            source_policy=policy,
+        ),
+        None,
+    )
+
+
+def _retained_residual_jacobian(
+    accepted: AcceptedFitResult,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    policy: UncertaintyPolicy,
+    request_identity: str,
+) -> tuple[ResidualJacobianEvidence | None, EvidenceFailure | None]:
+    """Bind an exact accepted retained Jacobian into uncertainty evidence."""
+    retained = accepted.final_residual_jacobian
+    if retained is None:
+        return None, None
+    try:
+        evidence = ResidualJacobianEvidence(
+            request_identity,
+            accepted.identity,
+            accepted.occurrence_identity,
+            accepted.evaluation_result.identity,
+            problem.identity,
+            problem.source_snapshot.occurrence_identity,
+            problem.source_snapshot.revision,
+            parameterization.identity,
+            parameterization.evaluator_identity,
+            parameterization.program.fingerprint,
+            engine.plan.identity,
+            policy.identity,
+            policy.calibration_identity,
+            policy.numerical_compatibility_requirement,
+            problem.controlled_ids,
+            accepted.vector,
+            tuple(value for _param_id, value in policy.coordinate_scales),
+            retained.matrix,
+            (),
+            retained.identity,
+            method="retained-scipy-final-2-point",
+            evaluation_count=0,
+            source_final_jacobian=retained,
+            accepted_anchor=accepted,
+            source_problem=problem,
+            source_parameterization=parameterization,
+            source_engine=engine,
+            source_policy=policy,
+        )
+    except (ArithmeticError, TypeError, ValueError) as error:
+        return None, EvidenceFailure(
+            "residual_linearization",
+            "retained_jacobian_lineage_mismatch",
+            str(error),
+            accepted.identity,
+        )
+    return evidence, None
+
+
+def _accepted_point_two_point_jacobian(
+    accepted: AcceptedFitResult,
+    *,
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    policy: UncertaintyPolicy,
+    request_identity: str,
+    cancellation_probe: Callable[[], OperationTerminal | None] | None,
+) -> tuple[ResidualJacobianEvidence | None, EvidenceFailure | None]:
+    """Evaluate one SciPy-style bound-aware perturbation per coordinate."""
+    _raise_if_terminated(cancellation_probe)
+    evaluator = engine.new_evaluator()
+    base_residuals = tuple(
+        float(value) for value in accepted.evaluation_result.residuals
+    )
+    columns: list[LinearizationColumn] = []
+    sqrt_epsilon = math.sqrt(_EPSILON)
+    for column, param_id in enumerate(problem.controlled_ids):
+        _raise_if_terminated(cancellation_probe)
+        center = accepted.vector[column]
+        feasibility = problem.coordinate_line_feasibility(accepted.vector, column)
+        nominal = sqrt_epsilon * max(1.0, abs(center))
+        preferred = nominal if center >= 0.0 else -nominal
+        displacement: float | None = None
+        orientation = ""
+        for candidate, label in (
+            (preferred, "forward" if preferred > 0.0 else "backward"),
+            (-preferred, "backward" if preferred > 0.0 else "forward"),
+        ):
+            limit = (
+                feasibility.maximum_displacement
+                if candidate > 0.0
+                else -feasibility.minimum_displacement
+            )
+            if limit <= 0.0:
+                continue
+            magnitude = min(abs(candidate), limit)
+            proposed = magnitude if candidate > 0.0 else -magnitude
+            if center + proposed == center:
+                adjacent = float(
+                    np.nextafter(
+                        center,
+                        math.inf if proposed > 0.0 else -math.inf,
+                    )
+                    - center
+                )
+                if abs(adjacent) > limit:
+                    continue
+                proposed = adjacent
+            displacement = proposed
+            orientation = label
+            break
+        if displacement is None or displacement == 0.0:
+            return None, EvidenceFailure(
+                "residual_linearization",
+                "exhausted_exact_feasible_distance",
+                f"No nonzero feasible 2-point displacement exists for {param_id}",
+                accepted.identity,
+            )
+        vector = list(accepted.vector)
+        vector[column] = center + displacement
+        evaluated = _evaluate_vector(
+            tuple(vector),
+            problem=problem,
+            parameterization=parameterization,
+            evaluator=evaluator,
+        )
+        if isinstance(evaluated, EvaluationFailure):
+            return None, EvidenceFailure(
+                "residual_linearization",
+                "accepted_point_2point_evaluation_failed",
+                f"{param_id}: {evaluated.category}",
+                accepted.identity,
+            )
+        perturbed = tuple(float(value) for value in evaluated.residuals)
+        derivative = tuple(
+            (value - base) / displacement
+            for value, base in zip(perturbed, base_residuals, strict=True)
+        )
+        trajectory = _identity(
+            "accepted-point-2-point-column",
+            (
+                param_id,
+                orientation,
+                _float_token(nominal),
+                _float_token(displacement),
+                feasibility.identity,
+                evaluated.identity,
+            ),
+        )
+        columns.append(
+            LinearizationColumn(
+                param_id,
+                orientation,
+                nominal,
+                (
+                    feasibility.minimum_displacement,
+                    feasibility.maximum_displacement,
+                ),
+                feasibility.lower_limiters,
+                feasibility.upper_limiters,
+                (displacement,),
+                derivative,
+                derivative,
+                0.0,
+                _max_norm(derivative),
+                0.0,
+                1,
+                "successful-scipy-style-2-point",
+                trajectory,
+            )
+        )
+    matrix = tuple(
+        tuple(column.fine_estimate[row] for column in columns)
+        for row in range(len(base_residuals))
+    )
+    trajectory_fingerprint = _identity(
+        "accepted-point-2-point-trajectory",
+        tuple((item.param_id, item.trajectory_fingerprint) for item in columns),
+    )
+    return (
+        ResidualJacobianEvidence(
+            request_identity,
+            accepted.identity,
+            accepted.occurrence_identity,
+            accepted.evaluation_result.identity,
+            problem.identity,
+            problem.source_snapshot.occurrence_identity,
+            problem.source_snapshot.revision,
+            parameterization.identity,
+            parameterization.evaluator_identity,
+            parameterization.program.fingerprint,
+            engine.plan.identity,
+            policy.identity,
+            policy.calibration_identity,
+            policy.numerical_compatibility_requirement,
+            problem.controlled_ids,
+            accepted.vector,
+            tuple(value for _param_id, value in policy.coordinate_scales),
+            matrix,
+            tuple(columns),
+            trajectory_fingerprint,
+            method="accepted-point-2-point",
+            evaluation_count=len(columns),
             accepted_anchor=accepted,
             source_problem=problem,
             source_parameterization=parameterization,
@@ -4316,6 +4711,7 @@ class _ScaledSvdAnalysis:
     singular_values: tuple[float, ...]
     right_transpose: tuple[tuple[float, ...], ...]
     scaled_column_norms: tuple[float, ...]
+    equilibration_scales: tuple[float, ...]
     threshold: float
     rank: int
     jacobian_condition: float | None
@@ -4332,13 +4728,33 @@ def _analyze_scaled_jacobian(
 ) -> tuple[_ScaledSvdAnalysis | None, EvidenceFailure | None]:
     """Run the one canonical checked scaled-SVD analysis kernel."""
     dimension = len(coordinate_scales)
-    scaled = (
-        np.asarray(matrix, dtype=np.float64)
-        * np.asarray(
-            coordinate_scales,
-            dtype=np.float64,
-        )[np.newaxis, :]
-    )
+    physical = np.asarray(matrix, dtype=np.float64)
+    try:
+        column_norms_array = np.linalg.norm(physical, axis=0)
+        if (
+            column_norms_array.shape != (dimension,)
+            or not np.isfinite(column_norms_array).all()
+        ):
+            raise ValueError("Jacobian column norms are non-finite")
+        if np.any(column_norms_array == 0.0):
+            zero_ids = tuple(
+                index for index, value in enumerate(column_norms_array) if value == 0.0
+            )
+            return None, EvidenceFailure(
+                "covariance",
+                "rank_deficient",
+                f"Residual Jacobian has zero columns {zero_ids!r}",
+                source_identity,
+            )
+        equilibration_array = 1.0 / column_norms_array
+        scaled = physical * equilibration_array[np.newaxis, :]
+    except (ArithmeticError, TypeError, ValueError) as error:
+        return None, EvidenceFailure(
+            "covariance",
+            "invalid_jacobian_column_equilibration",
+            str(error),
+            source_identity,
+        )
     _raise_if_terminated(cancellation_probe)
     analysis_failure: EvidenceFailure | None = None
     try:
@@ -4379,7 +4795,7 @@ def _analyze_scaled_jacobian(
         )
         largest = singular_values[0] if singular_values else 0.0
         threshold = _finite(
-            policy.rank_absolute_tolerance + policy.rank_relative_tolerance * largest,
+            largest * max(physical.shape) * _EPSILON,
             name="rank threshold",
         )
         rank = sum(value > threshold for value in singular_values)
@@ -4421,6 +4837,7 @@ def _analyze_scaled_jacobian(
             singular_values,
             right_transpose,
             column_norms,
+            tuple(float(value) for value in equilibration_array),
             threshold,
             rank,
             condition,
@@ -4539,7 +4956,6 @@ def _canonical_covariance_claims(
         ),
     )
     required = (
-        conditioning.state,
         ClaimState.SATISFIED,
         full_dimensional_interior.state,
         interior.state,
@@ -4681,6 +5097,7 @@ def _covariance_from_jacobian(
         singular_values,
         normalized,
         analysis.scaled_column_norms,
+        analysis.equilibration_scales,
         threshold,
         weak_threshold,
         rank,
@@ -4698,7 +5115,7 @@ def _covariance_from_jacobian(
         return None, rank_diagnostic, analysis_failure
     reduction, reduction_failure = _reduce_scaled_covariance(
         analysis,
-        jacobian.coordinate_scales,
+        analysis.equilibration_scales,
         accepted,
         degrees_of_freedom=degrees_of_freedom,
         policy=policy,
@@ -4736,7 +5153,7 @@ def _covariance_from_jacobian(
         accepted.controlled_ids,
         tuple(unit for _param_id, unit in policy.coordinate_units),
         accepted.vector,
-        jacobian.coordinate_scales,
+        analysis.equilibration_scales,
         policy.residual_variance_scaling,
         residual_count,
         coordinate_count,
@@ -5570,7 +5987,7 @@ def _canonical_constrained_propagation_claims(
             raise ValueError("invalid scaled constraint-output singular spectrum")
         largest = gradient_singular[0] if gradient_singular else 0.0
         rank_threshold = _finite(
-            policy.rank_absolute_tolerance + policy.rank_relative_tolerance * largest,
+            largest * max(scaled_gradient.shape) * _EPSILON,
             name="constraint-output rank threshold",
         )
         output_rank = sum(value > rank_threshold for value in gradient_singular)
@@ -5838,15 +6255,37 @@ def _derive_covariance_branch(  # noqa: C901 - ordered cancellation phase ledger
     residual_failure: EvidenceFailure | None = None
     residual_terminal: OperationTerminal | None = None
     try:
-        residual_jacobian, residual_failure = _linearize_residuals(
-            accepted,
-            problem=problem,
-            parameterization=parameterization,
-            engine=engine,
-            policy=policy,
-            request_identity=residual_request,
-            cancellation_probe=cancellation_probe,
-        )
+        if policy.residual_jacobian_strategy == "retained-backend-or-accepted-2-point":
+            residual_jacobian, _retained_failure = _retained_residual_jacobian(
+                accepted,
+                problem=problem,
+                parameterization=parameterization,
+                engine=engine,
+                policy=policy,
+                request_identity=residual_request,
+            )
+            if residual_jacobian is None:
+                residual_jacobian, residual_failure = (
+                    _accepted_point_two_point_jacobian(
+                        accepted,
+                        problem=problem,
+                        parameterization=parameterization,
+                        engine=engine,
+                        policy=policy,
+                        request_identity=residual_request,
+                        cancellation_probe=cancellation_probe,
+                    )
+                )
+        else:
+            residual_jacobian, residual_failure = _linearize_residuals(
+                accepted,
+                problem=problem,
+                parameterization=parameterization,
+                engine=engine,
+                policy=policy,
+                request_identity=residual_request,
+                cancellation_probe=cancellation_probe,
+            )
     except DerivationTermination as termination:
         residual_terminal = termination.terminal
     except (ArithmeticError, TypeError, ValueError) as error:

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -1258,32 +1258,39 @@ class SingularSubspaceEvidence:
         )
 
 
-def _recomputed_scaled_svd(
-    source: ResidualJacobianEvidence,
-    policy: UncertaintyPolicy,
-) -> tuple[tuple[float, ...], tuple[tuple[float, ...], ...]]:
-    matrix = np.asarray(source.matrix, dtype=np.float64)
-    column_norms = np.linalg.norm(matrix, axis=0)
-    scaled = matrix * (1.0 / column_norms)[np.newaxis, :]
-    _left, singular_values, right_transpose = svd(
-        scaled,
-        full_matrices=False,
-        compute_uv=True,
-        overwrite_a=False,
-        check_finite=True,
-        lapack_driver=policy.svd_driver,
-    )
-    dimension = len(source.controlled_ids)
-    return (
-        tuple(
-            _finite(value, name=f"recomputed singular value[{index}]")
-            for index, value in enumerate(singular_values)
-        ),
-        _canonical_matrix(
-            right_transpose,
-            rows=dimension,
-            columns=dimension,
-            name="recomputed right singular vectors",
+def _rank_construction_digest(
+    source_jacobian_identity: str,
+    policy_identity: str,
+    singular_values: Sequence[float],
+    normalized_singular_values: Sequence[float],
+    scaled_column_norms: Sequence[float],
+    equilibration_scales: Sequence[float],
+    threshold: float,
+    weak_threshold: float,
+    rank: int,
+    identifiable_projector: Sequence[Sequence[float]],
+    null_projector: Sequence[Sequence[float]],
+    weak_projector: Sequence[Sequence[float]],
+    subspaces: Sequence[SingularSubspaceEvidence],
+) -> str:
+    dimension = len(singular_values)
+    projector_shape = (dimension, dimension)
+    return _identity(
+        "native-rank-controlled-construction-v1",
+        (
+            source_jacobian_identity,
+            policy_identity,
+            _vector_tokens(singular_values),
+            _vector_tokens(normalized_singular_values),
+            _vector_tokens(scaled_column_norms),
+            _vector_tokens(equilibration_scales),
+            _float_token(threshold),
+            _float_token(weak_threshold),
+            rank,
+            _binary64_matrix_digest(identifiable_projector, projector_shape),
+            _binary64_matrix_digest(null_projector, projector_shape),
+            _binary64_matrix_digest(weak_projector, projector_shape),
+            tuple(item.identity for item in subspaces),
         ),
     )
 
@@ -1331,9 +1338,15 @@ class RankDiagnostic:
         metadata={"record": False},
         kw_only=True,
     )
+    _construction_digest: str = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
-    def __post_init__(self) -> None:  # noqa: C901 - complete SVD integrity chain
+    def __post_init__(self) -> None:  # noqa: C901 - closed structural integrity
         source = self.source_jacobian
         _validate_accepted_anchor(
             source.accepted_anchor,
@@ -1391,39 +1404,21 @@ class RankDiagnostic:
         expected_normalized = tuple(
             0.0 if largest == 0.0 else value / largest for value in self.singular_values
         )
-        source_matrix = np.asarray(source.matrix)
-        expected_source_norms = np.linalg.norm(source_matrix, axis=0)
-        expected_equilibration = 1.0 / expected_source_norms
-        scaled = source_matrix * expected_equilibration[np.newaxis, :]
-        expected_norms = tuple(
-            float(np.linalg.norm(scaled[:, index])) for index in range(dimension)
-        )
-        recomputed_singular, recomputed_right_t = _recomputed_scaled_svd(
-            source,
-            self.source_policy,
-        )
         tolerance = 512.0 * _EPSILON * max(1, dimension)
         if (
             self.normalized_singular_values != expected_normalized
             or self.weak_threshold != expected_weak_threshold
             or self.source_policy.identity != source.source_policy.identity
-            or not np.allclose(
-                self.scaled_column_norms, expected_norms, rtol=tolerance, atol=0.0
+            or any(
+                value <= 0.0 or not math.isfinite(value)
+                for value in self.scaled_column_norms
             )
-            or not np.allclose(
-                self.equilibration_scales,
-                expected_equilibration,
-                rtol=tolerance,
-                atol=0.0,
-            )
-            or not np.allclose(
-                self.singular_values,
-                recomputed_singular,
-                rtol=tolerance,
-                atol=0.0,
+            or any(
+                value <= 0.0 or not math.isfinite(value)
+                for value in self.equilibration_scales
             )
         ):
-            raise ValueError("SVD/rank numerical evidence does not derive from J_z")
+            raise ValueError("SVD/rank controlled construction is inconsistent")
         identity_matrix = np.eye(dimension)
         for name, candidate in (
             ("identifiable", identifiable),
@@ -1431,11 +1426,8 @@ class RankDiagnostic:
             ("weak", weak),
         ):
             array = np.asarray(candidate)
-            if not (
-                np.allclose(array, array.T, rtol=0.0, atol=tolerance)
-                and np.allclose(array @ array, array, rtol=0.0, atol=tolerance)
-            ):
-                raise ValueError(f"{name} subspace evidence is not a projector")
+            if not np.allclose(array, array.T, rtol=0.0, atol=tolerance):
+                raise ValueError(f"{name} subspace evidence is not symmetric")
         if not np.allclose(
             np.asarray(identifiable) + np.asarray(null),
             identity_matrix,
@@ -1455,20 +1447,7 @@ class RankDiagnostic:
             raise ValueError(
                 "Singular subspaces violate the declared clustering policy"
             )
-        recomputed_subspaces = _invariant_singular_subspaces(
-            np.asarray(recomputed_right_t, dtype=np.float64).T,
-            recomputed_singular,
-            rank_threshold=self.threshold,
-            weak_threshold=self.weak_threshold,
-            cluster_relative_tolerance=(
-                self.source_policy.singular_value_cluster_relative_tolerance
-            ),
-        )
-        for item, expected_subspace in zip(
-            self.subspaces,
-            recomputed_subspaces,
-            strict=True,
-        ):
+        for item in self.subspaces:
             if item.singular_values != tuple(
                 self.singular_values[index] for index in item.indices
             ):
@@ -1483,51 +1462,24 @@ class RankDiagnostic:
             )
             if item.classification != expected_classification:
                 raise ValueError("Singular subspace classification is inconsistent")
-            item_projector = np.asarray(item.projector)
-            if (
-                item.indices != expected_subspace.indices
-                or item.singular_values != expected_subspace.singular_values
-                or item.classification != expected_subspace.classification
-                or not np.allclose(
-                    item_projector,
-                    expected_subspace.projector,
-                    rtol=0.0,
-                    atol=tolerance,
-                )
-            ):
-                raise ValueError(
-                    "Singular projector does not match its invariant spectrum"
-                )
-        expected_weak = sum(
-            (
-                np.asarray(item.projector)
-                for item in self.subspaces
-                if item.classification.endswith("_weak")
-            ),
-            start=np.zeros((dimension, dimension), dtype=np.float64),
-        )
-        if not np.allclose(
-            weak,
-            expected_weak,
-            rtol=0.0,
-            atol=tolerance,
-        ):
-            raise ValueError("Weak-subspace projector is inconsistent")
-        expected_null = sum(
-            (
-                np.asarray(item.projector)
-                for item in self.subspaces
-                if item.classification.endswith("_null")
-            ),
-            start=np.zeros((dimension, dimension), dtype=np.float64),
-        )
-        if not np.allclose(
+        if self._construction_digest != _rank_construction_digest(
+            self.source_jacobian_identity,
+            self.source_policy.identity,
+            self.singular_values,
+            self.normalized_singular_values,
+            self.scaled_column_norms,
+            self.equilibration_scales,
+            self.threshold,
+            self.weak_threshold,
+            self.rank,
+            identifiable,
             null,
-            expected_null,
-            rtol=0.0,
-            atol=tolerance,
+            weak,
+            self.subspaces,
         ):
-            raise ValueError("Null projector does not match diagnostic subspaces")
+            raise ValueError(
+                "Rank projector/spectrum evidence differs from controlled construction"
+            )
         object.__setattr__(self, "identifiable_projector", identifiable)
         object.__setattr__(self, "null_projector", null)
         object.__setattr__(self, "weak_projector", weak)
@@ -1571,6 +1523,35 @@ class RankDiagnostic:
                 ),
             ),
         )
+
+
+def _covariance_construction_digest(
+    source_jacobian_identity: str,
+    rank_diagnostic_identity: str,
+    residual_variance_scale: float,
+    jacobian_condition: float,
+    information_condition: float,
+    unscaled_covariance: Sequence[Sequence[float]],
+    factor: Sequence[Sequence[float]],
+    covariance: Sequence[Sequence[float]],
+    claims: Sequence[ClaimAssessment],
+) -> str:
+    dimension = len(covariance)
+    shape = (dimension, dimension)
+    return _identity(
+        "native-covariance-controlled-construction-v1",
+        (
+            source_jacobian_identity,
+            rank_diagnostic_identity,
+            _float_token(residual_variance_scale),
+            _float_token(jacobian_condition),
+            _float_token(information_condition),
+            _binary64_matrix_digest(unscaled_covariance, shape),
+            _binary64_matrix_digest(factor, shape),
+            _binary64_matrix_digest(covariance, shape),
+            tuple((item.name, item.state.value, item.detail) for item in claims),
+        ),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1637,6 +1618,12 @@ class CovarianceEvidence:
         kw_only=True,
     )
     source_engine: EvaluationEngine = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    _construction_digest: str = field(
         repr=False,
         compare=False,
         metadata={"record": False},
@@ -1722,26 +1709,6 @@ class CovarianceEvidence:
             or self.factorization != _FACTOR_VERSION
         ):
             raise ValueError("Covariance derivation lineage is internally inconsistent")
-        recomputed_singular, recomputed_right_t = _recomputed_scaled_svd(
-            source,
-            policy,
-        )
-        if recomputed_singular != rank_source.singular_values:
-            raise ValueError("Covariance SVD kernel differs from rank evidence")
-        expected_unscaled, expected_factor, expected_covariance = (
-            _canonical_covariance_reduction(
-                rank_source.singular_values,
-                recomputed_right_t,
-                rank_source.equilibration_scales,
-                expected_scale,
-            )
-        )
-        if (
-            unscaled != expected_unscaled
-            or factor != expected_factor
-            or covariance != expected_covariance
-        ):
-            raise ValueError("Covariance arrays do not match the canonical reduction")
         expected_jacobian_condition = self.singular_values[0] / self.singular_values[-1]
         if (
             self.jacobian_condition != expected_jacobian_condition
@@ -1749,17 +1716,30 @@ class CovarianceEvidence:
             != expected_jacobian_condition * expected_jacobian_condition
         ):
             raise ValueError("Covariance conditioning claims do not match the spectrum")
-        expected_claims = _canonical_covariance_claims(
-            accepted,
-            problem,
+        tolerance = 512.0 * _EPSILON * max(1, dimension)
+        for name, candidate in (
+            ("unscaled covariance", unscaled),
+            ("scaled covariance", covariance),
+        ):
+            array = np.asarray(candidate)
+            if not np.allclose(array, array.T, rtol=0.0, atol=tolerance):
+                raise ValueError(f"{name} is not symmetric")
+            if np.any(np.diag(array) < 0.0):
+                raise ValueError(f"{name} has negative marginal variance")
+        if self._construction_digest != _covariance_construction_digest(
+            self.source_jacobian_identity,
+            self.rank_diagnostic_identity,
+            self.residual_variance_scale,
+            self.jacobian_condition,
+            self.information_condition,
+            unscaled,
+            factor,
             covariance,
-            expected_scale,
-            expected_jacobian_condition,
-            policy,
-            engine,
-        )
-        if self.claims != expected_claims:
-            raise ValueError("Covariance claims are inconsistent")
+            self.claims,
+        ):
+            raise ValueError(
+                "Covariance claims or arrays differ from controlled construction"
+            )
         object.__setattr__(self, "unscaled_covariance", unscaled)
         object.__setattr__(self, "factor", factor)
         object.__setattr__(self, "covariance", covariance)
@@ -2303,6 +2283,27 @@ class ConstraintJacobianEvidence:
         )
 
 
+def _constrained_propagation_construction_digest(
+    source_covariance_identity: str,
+    source_constraint_jacobian_identity: str,
+    factor: Sequence[Sequence[float]],
+    covariance: Sequence[Sequence[float]],
+    claims: Sequence[ClaimAssessment],
+) -> str:
+    rows = len(covariance)
+    columns = len(factor[0]) if factor else 0
+    return _identity(
+        "native-constrained-controlled-construction-v1",
+        (
+            source_covariance_identity,
+            source_constraint_jacobian_identity,
+            _binary64_matrix_digest(factor, (rows, columns)),
+            _binary64_matrix_digest(covariance, (rows, rows)),
+            tuple((item.name, item.state.value, item.detail) for item in claims),
+        ),
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ConstrainedPropagationEvidence:
     request_identity: str
@@ -2330,6 +2331,12 @@ class ConstrainedPropagationEvidence:
         kw_only=True,
     )
     accepted_anchor: AcceptedFitResult = field(
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    _construction_digest: str = field(
         repr=False,
         compare=False,
         metadata={"record": False},
@@ -2373,31 +2380,30 @@ class ConstrainedPropagationEvidence:
             or self.output_scales != source_jacobian.output_scales
         ):
             raise ValueError("Constrained propagation lineage is inconsistent")
-        expected_factor = tuple(
-            tuple(
-                _finite(
-                    _pairwise_sum(
-                        tuple(
-                            source_jacobian.matrix[row][inner]
-                            * source_covariance.factor[inner][column]
-                            for inner in range(columns)
-                        )
-                    ),
-                    name="validated propagated factor",
-                )
-                for column in range(columns)
+        covariance_array = np.asarray(covariance)
+        tolerance = 512.0 * _EPSILON * max(1, rows, columns)
+        if not np.allclose(
+            covariance_array,
+            covariance_array.T,
+            rtol=0.0,
+            atol=tolerance,
+        ):
+            raise ValueError("Constrained covariance is not symmetric")
+        if np.any(np.diag(covariance_array) < 0.0):
+            raise ValueError("Constrained covariance has negative marginal variance")
+        if self._construction_digest != (
+            _constrained_propagation_construction_digest(
+                self.source_covariance_identity,
+                self.source_constraint_jacobian_identity,
+                factor,
+                covariance,
+                self.claims,
             )
-            for row in range(rows)
-        )
-        if factor != expected_factor or covariance != _gram_matrix(expected_factor):
-            raise ValueError("Constrained covariance differs from G_S L")
-        expected_claims = _canonical_constrained_propagation_claims(
-            source_covariance,
-            source_jacobian,
-            source_covariance.source_policy,
-        )
-        if self.claims != expected_claims:
-            raise ValueError("Constrained propagation claims are inconsistent")
+        ):
+            raise ValueError(
+                "Constrained propagation claims or arrays differ from controlled "
+                "construction"
+            )
         object.__setattr__(self, "factor", factor)
         object.__setattr__(self, "covariance", covariance)
         object.__setattr__(
@@ -3325,6 +3331,46 @@ def _gram_matrix(factor: Sequence[Sequence[float]]) -> tuple[tuple[float, ...], 
     return tuple(tuple(row) for row in result)
 
 
+def _validate_matrix_relation(
+    actual: Sequence[Sequence[float]] | Array,
+    expected: Array,
+    *,
+    name: str,
+    reduction_dimension: int,
+) -> None:
+    """Check one controlled numerical relationship at its producer boundary."""
+    actual_array = np.asarray(actual, dtype=np.float64)
+    magnitude = float(np.max(np.abs(expected), initial=0.0))
+    tolerance = 512.0 * _EPSILON * max(1, reduction_dimension)
+    absolute_tolerance = max(
+        tolerance * magnitude,
+        np.finfo(np.float64).smallest_subnormal,
+    )
+    if not np.allclose(
+        actual_array,
+        expected,
+        rtol=tolerance,
+        atol=absolute_tolerance,
+    ):
+        raise ArithmeticError(f"{name} is inconsistent with its retained source")
+
+
+def _validate_gram_relation(
+    factor: Sequence[Sequence[float]],
+    covariance: Sequence[Sequence[float]],
+    *,
+    name: str,
+) -> None:
+    """Check a producer's factor/Gram relationship with one native matmul."""
+    factor_array = np.asarray(factor, dtype=np.float64)
+    _validate_matrix_relation(
+        covariance,
+        factor_array @ factor_array.T,
+        name=name,
+        reduction_dimension=factor_array.shape[1],
+    )
+
+
 def _canonical_covariance_reduction(
     singular_values: Sequence[float],
     right_transpose: Sequence[Sequence[float]],
@@ -3442,6 +3488,26 @@ def _invariant_singular_subspaces(
             projector(indices),
         )
         for indices in groups
+    )
+
+
+def _validate_projector_relation(
+    right: Array,
+    indices: Sequence[int],
+    projector: Sequence[Sequence[float]],
+    *,
+    name: str,
+) -> None:
+    """Check that a retained projector represents the declared SVD columns."""
+    columns = np.asarray(right[:, tuple(indices)], dtype=np.float64)
+    if columns.ndim == 1:
+        columns = columns[:, np.newaxis]
+    expected = columns @ columns.T
+    _validate_matrix_relation(
+        projector,
+        expected,
+        name=name,
+        reduction_dimension=right.shape[0],
     )
 
 
@@ -4906,6 +4972,32 @@ def _reduce_scaled_covariance(
             coordinate_scales,
             residual_variance_scale,
         )
+        right = np.asarray(analysis.right_transpose, dtype=np.float64).T
+        scales = np.asarray(coordinate_scales, dtype=np.float64)
+        spectrum = np.asarray(analysis.singular_values, dtype=np.float64)
+        expected_unscaled_factor = (
+            scales[:, np.newaxis] * right / spectrum[np.newaxis, :]
+        )
+        expected_factor = math.sqrt(residual_variance_scale) * (
+            expected_unscaled_factor
+        )
+        _validate_matrix_relation(
+            factor,
+            expected_factor,
+            name="Covariance factor",
+            reduction_dimension=len(coordinate_scales),
+        )
+        _validate_matrix_relation(
+            unscaled,
+            expected_unscaled_factor @ expected_unscaled_factor.T,
+            name="Unscaled covariance",
+            reduction_dimension=len(coordinate_scales),
+        )
+        _validate_gram_relation(
+            factor,
+            covariance,
+            name="Scaled covariance",
+        )
     except (ArithmeticError, TypeError, ValueError) as error:
         return None, EvidenceFailure(
             "covariance",
@@ -5105,6 +5197,50 @@ def _covariance_from_jacobian(
         weak_threshold=weak_threshold,
         cluster_relative_tolerance=(policy.singular_value_cluster_relative_tolerance),
     )
+    _validate_projector_relation(
+        right,
+        tuple(range(rank)),
+        identifiable_projector,
+        name="Identifiable projector",
+    )
+    _validate_projector_relation(
+        right,
+        tuple(range(rank, coordinate_count)),
+        null_projector,
+        name="Null projector",
+    )
+    _validate_projector_relation(
+        right,
+        tuple(
+            index
+            for index, value in enumerate(singular_values)
+            if threshold < value <= weak_threshold
+        ),
+        weak_projector,
+        name="Weak projector",
+    )
+    for index, subspace in enumerate(subspaces):
+        _validate_projector_relation(
+            right,
+            subspace.indices,
+            subspace.projector,
+            name=f"Diagnostic projector[{index}]",
+        )
+    rank_construction_digest = _rank_construction_digest(
+        jacobian.identity,
+        policy.identity,
+        singular_values,
+        normalized,
+        analysis.scaled_column_norms,
+        analysis.equilibration_scales,
+        threshold,
+        weak_threshold,
+        rank,
+        identifiable_projector,
+        null_projector,
+        weak_projector,
+        subspaces,
+    )
     rank_diagnostic = RankDiagnostic(
         request_identity,
         accepted.identity,
@@ -5124,6 +5260,7 @@ def _covariance_from_jacobian(
         subspaces,
         source_jacobian=jacobian,
         source_policy=policy,
+        _construction_digest=rank_construction_digest,
     )
     terminal = _cancellation_terminal(cancellation_probe)
     if terminal is not None:
@@ -5155,6 +5292,17 @@ def _covariance_from_jacobian(
         jacobian_condition,
         policy,
         engine,
+    )
+    covariance_construction_digest = _covariance_construction_digest(
+        jacobian.identity,
+        rank_diagnostic.identity,
+        residual_variance_scale,
+        jacobian_condition,
+        information_condition,
+        unscaled_covariance,
+        factor,
+        covariance,
+        claims,
     )
     covariance_evidence = CovarianceEvidence(
         request_identity,
@@ -5194,6 +5342,7 @@ def _covariance_from_jacobian(
         source_problem=problem,
         source_policy=policy,
         source_engine=engine,
+        _construction_digest=covariance_construction_digest,
     )
     return covariance_evidence, rank_diagnostic, None
 
@@ -6122,10 +6271,32 @@ def _propagate_constraints(
         covariance.factor,
         residual_variance_degenerate=(covariance.residual_variance_scale == 0.0),
     )
+    expected_factor = np.asarray(
+        constraint_jacobian.matrix,
+        dtype=np.float64,
+    ) @ np.asarray(covariance.factor, dtype=np.float64)
+    _validate_matrix_relation(
+        factor,
+        expected_factor,
+        name="Constrained covariance factor",
+        reduction_dimension=len(covariance.controlled_ids),
+    )
+    _validate_gram_relation(
+        factor,
+        propagated,
+        name="Constrained covariance",
+    )
     claims = _canonical_constrained_propagation_claims(
         covariance,
         constraint_jacobian,
         policy,
+    )
+    construction_digest = _constrained_propagation_construction_digest(
+        covariance.identity,
+        constraint_jacobian.identity,
+        factor,
+        propagated,
+        claims,
     )
     return ConstrainedPropagationEvidence(
         request_identity,
@@ -6143,6 +6314,7 @@ def _propagate_constraints(
         source_covariance=covariance,
         source_constraint_jacobian=constraint_jacobian,
         accepted_anchor=accepted,
+        _construction_digest=construction_digest,
     )
 
 

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -2549,6 +2549,263 @@ class UncertaintyEvidence:
 
 
 @dataclass(frozen=True, slots=True)
+class RootAnchoredBlockCovariance:
+    """One independent covariance block derived from the root linearization."""
+
+    controlled_ids: tuple[str, ...]
+    rank: int
+    jacobian_condition: float | None
+    covariance: tuple[tuple[float, ...], ...] | None
+    marginal_errors: tuple[ScalarEvidenceEntry, ...]
+    correlations: tuple[tuple[CorrelationEntry, ...], ...]
+    unavailable_reason: str = ""
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        dimension = len(self.controlled_ids)
+        if dimension < 1 or not 0 <= self.rank <= dimension:
+            raise ValueError("Root-anchored covariance block has invalid rank")
+        if (
+            len(self.marginal_errors) != dimension
+            or tuple(item.param_id for item in self.marginal_errors)
+            != self.controlled_ids
+        ):
+            raise ValueError("Root-anchored block marginal scope is invalid")
+        if self.covariance is None:
+            if not self.unavailable_reason or any(
+                item.value is not None for item in self.marginal_errors
+            ):
+                raise ValueError("Unavailable covariance block has usable marginals")
+            covariance: tuple[tuple[float, ...], ...] = ()
+        else:
+            covariance = _canonical_matrix(
+                self.covariance,
+                rows=dimension,
+                columns=dimension,
+                name="root-anchored block covariance",
+            )
+            if self.unavailable_reason:
+                raise ValueError("Available covariance block has an unavailable reason")
+        object.__setattr__(self, "covariance", covariance or None)
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-root-anchored-block-covariance",
+                (
+                    self.controlled_ids,
+                    self.rank,
+                    None
+                    if self.jacobian_condition is None
+                    else _float_token(self.jacobian_condition),
+                    () if self.covariance is None else _matrix_tokens(self.covariance),
+                    tuple(
+                        (item.param_id, item.value, item.outcome, item.raw_value)
+                        for item in self.marginal_errors
+                    ),
+                    tuple(
+                        tuple(
+                            (item.value, item.outcome, item.raw_value) for item in row
+                        )
+                        for row in self.correlations
+                    ),
+                    self.unavailable_reason,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RootAnchoredBlockCovarianceEvidence:
+    """Failure-isolated covariance blocks anchored to one accepted root result."""
+
+    accepted_result_identity: str
+    accepted_occurrence_identity: str
+    source_jacobian_identity: str
+    policy_identity: str
+    blocks: tuple[RootAnchoredBlockCovariance, ...]
+    source_bundle: UncertaintyEvidence = field(repr=False, compare=False)
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        source = self.source_bundle
+        jacobian = source.residual_jacobian
+        if (
+            jacobian is None
+            or self.accepted_result_identity != source.accepted_result_identity
+            or self.accepted_occurrence_identity != source.accepted_occurrence_identity
+            or self.source_jacobian_identity != jacobian.identity
+            or self.policy_identity != source.policy_identity
+            or tuple(
+                param_id for block in self.blocks for param_id in block.controlled_ids
+            )
+            != jacobian.controlled_ids
+        ):
+            raise ValueError("Root-anchored block evidence has inconsistent lineage")
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                "native-root-anchored-block-covariance-evidence",
+                (
+                    self.accepted_result_identity,
+                    self.accepted_occurrence_identity,
+                    self.source_jacobian_identity,
+                    self.policy_identity,
+                    tuple(item.identity for item in self.blocks),
+                ),
+            ),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize failure-isolated blocks without mutable runtime sources."""
+        return {
+            "artifact_type": "native_root_anchored_block_covariance_evidence",
+            "schema_version": _SCHEMA_VERSION,
+            "accepted_result_identity": self.accepted_result_identity,
+            "accepted_occurrence_identity": self.accepted_occurrence_identity,
+            "source_jacobian_identity": self.source_jacobian_identity,
+            "policy_identity": self.policy_identity,
+            "identity": self.identity,
+            "blocks": [_record_value(item) for item in self.blocks],
+        }
+
+
+def derive_root_anchored_block_covariance(  # noqa: C901 - typed block derivation
+    evidence: UncertaintyEvidence,
+    block_scopes: Sequence[Sequence[str]],
+) -> RootAnchoredBlockCovarianceEvidence | None:
+    """Derive independent full-rank blocks when the joint root is unavailable."""
+    jacobian = evidence.residual_jacobian
+    if jacobian is None or (
+        evidence.marginal_errors is not None
+        and evidence.marginal_errors.scope_reportable
+    ):
+        return None
+    scopes = tuple(tuple(scope) for scope in block_scopes)
+    if len(scopes) < 2:
+        return None
+    if (
+        tuple(param_id for scope in scopes for param_id in scope)
+        != jacobian.controlled_ids
+    ):
+        raise ValueError("Block covariance scopes must partition root coordinates")
+    policy = evidence.source_policy
+    matrix = np.asarray(jacobian.matrix, dtype=np.float64)
+    accepted = evidence.accepted_anchor
+    problem = evidence.source_problem
+    coordinate_index = {
+        param_id: index for index, param_id in enumerate(jacobian.controlled_ids)
+    }
+    variance_scale, variance_failure = _residual_variance_scale(
+        accepted,
+        degrees_of_freedom=(
+            jacobian.residual_count
+            - len(jacobian.controlled_ids)
+            - sum(
+                1
+                for profile in evidence.source_engine.plan.profiles
+                if profile.is_scaled
+            )
+        ),
+        policy=policy,
+    )
+    if variance_failure is not None or variance_scale is None:
+        return None
+    blocks: list[RootAnchoredBlockCovariance] = []
+    for scope in scopes:
+        indices = tuple(coordinate_index[param_id] for param_id in scope)
+        scales = tuple(jacobian.coordinate_scales[index] for index in indices)
+        scaled = matrix[:, indices] * np.asarray(scales)[np.newaxis, :]
+        _left, singular_array, right_transpose = svd(
+            scaled,
+            full_matrices=False,
+            compute_uv=True,
+            overwrite_a=False,
+            check_finite=True,
+            lapack_driver=policy.svd_driver,
+        )
+        singular = tuple(float(value) for value in singular_array)
+        largest = singular[0] if singular else 0.0
+        threshold = policy.rank_absolute_tolerance + (
+            policy.rank_relative_tolerance * largest
+        )
+        rank = sum(value > threshold for value in singular)
+        unavailable_reason = ""
+        condition: float | None = None
+        covariance: tuple[tuple[float, ...], ...] | None = None
+        correlations: tuple[tuple[CorrelationEntry, ...], ...] = ()
+        if rank != len(scope):
+            unavailable_reason = "rank deficient"
+        else:
+            condition = largest / singular[-1]
+            if condition > policy.conditioning_limit:
+                unavailable_reason = "poorly conditioned"
+            else:
+                _unscaled, _factor, covariance = _canonical_covariance_reduction(
+                    singular,
+                    right_transpose,
+                    scales,
+                    variance_scale,
+                )
+                for local_index, root_index in enumerate(indices):
+                    variance = covariance[local_index][local_index]
+                    if variance <= 0.0 or not math.isfinite(variance):
+                        unavailable_reason = "insufficient information"
+                        covariance = None
+                        break
+                    standard_error = math.sqrt(variance)
+                    value = accepted.vector[root_index]
+                    lower = problem.lower_bounds[root_index]
+                    upper = problem.upper_bounds[root_index]
+                    separation = min(value - lower, upper - value) / standard_error
+                    if (
+                        not math.isfinite(separation)
+                        or separation <= _BOUNDARY_THRESHOLD
+                    ):
+                        unavailable_reason = "boundary limited"
+                        covariance = None
+                        break
+        if covariance is None:
+            marginal = tuple(
+                ScalarEvidenceEntry(param_id, None, "UNAVAILABLE") for param_id in scope
+            )
+        else:
+            marginal = tuple(
+                ScalarEvidenceEntry(
+                    param_id,
+                    math.sqrt(covariance[index][index]),
+                    "AVAILABLE",
+                )
+                for index, param_id in enumerate(scope)
+            )
+            correlations = _expected_correlation_entries(
+                covariance,
+                residual_variance_degenerate=False,
+                policy=policy,
+            )
+        blocks.append(
+            RootAnchoredBlockCovariance(
+                scope,
+                rank,
+                condition,
+                covariance,
+                marginal,
+                correlations,
+                unavailable_reason,
+            )
+        )
+    return RootAnchoredBlockCovarianceEvidence(
+        evidence.accepted_result_identity,
+        evidence.accepted_occurrence_identity,
+        jacobian.identity,
+        evidence.policy_identity,
+        tuple(blocks),
+        evidence,
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class _DerivativeValue:
     value: float
     gradient: tuple[float, ...]

--- a/src/chemex/printers/native_reporting.py
+++ b/src/chemex/printers/native_reporting.py
@@ -6,7 +6,7 @@ import json
 import math
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, cast
 
 from scipy import stats
 
@@ -34,7 +34,10 @@ from chemex.parameters.parameterization import (
     SealedParameterModel,
 )
 from chemex.parameters.values import AnalysisValuesSnapshot
-from chemex.printers.parameters import parameter_uncertainty_view
+from chemex.printers.parameters import (
+    parameter_uncertainty_view,
+    uncertainty_unavailable_reason,
+)
 
 
 class ComponentDiagnosticRecord(Protocol):
@@ -371,7 +374,20 @@ def write_block_uncertainty(
         return
     covariance_path = path / "Covariance"
     covariance_path.mkdir(exist_ok=True)
-    write_json(covariance_path / "blocks.json", evidence.to_record())
+    record = evidence.to_record()
+    blocks = record["blocks"]
+    if not isinstance(blocks, list):
+        raise TypeError("Block covariance record has an invalid payload")
+    for block, block_record in zip(evidence.blocks, blocks, strict=True):
+        if not isinstance(block_record, dict):
+            raise TypeError("Block covariance record has an invalid block")
+        typed_block_record = cast("dict[str, object]", block_record)
+        typed_block_record["unavailable_reason"] = (
+            ""
+            if block.unavailable_kind is None
+            else uncertainty_unavailable_reason(block.unavailable_kind)
+        )
+    write_json(covariance_path / "blocks.json", record)
 
 
 def resampling_evidence_record(evidence: ResamplingEvidence) -> dict[str, object]:

--- a/src/chemex/printers/native_reporting.py
+++ b/src/chemex/printers/native_reporting.py
@@ -24,13 +24,17 @@ from chemex.optimize.native_resampling import (
     ResamplingSummaryOutcome,
     SummaryFailure,
 )
-from chemex.optimize.uncertainty import UncertaintyEvidence
+from chemex.optimize.uncertainty import (
+    RootAnchoredBlockCovarianceEvidence,
+    UncertaintyEvidence,
+)
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     ParameterRole,
     SealedParameterModel,
 )
 from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.printers.parameters import parameter_uncertainty_view
 
 
 class ComponentDiagnosticRecord(Protocol):
@@ -79,6 +83,7 @@ def write_parameter_reports(
     path: Path,
     parameterization: ActiveParameterization,
     result: EvaluationResult,
+    uncertainty: UncertaintyEvidence | None = None,
 ) -> None:
     """Separate central parameter values by their authoritative role."""
     path.mkdir()
@@ -86,6 +91,9 @@ def write_parameter_reports(
         item.target_id: item.expression_text
         for item in parameterization.program.constraints
     }
+    uncertainty_view = (
+        None if uncertainty is None else parameter_uncertainty_view(uncertainty)
+    )
     by_role: dict[ParameterRole, list[tuple[str, float]]] = {
         role: [] for role in ParameterRole
     }
@@ -109,6 +117,25 @@ def write_parameter_reports(
             elif role is ParameterRole.DERIVED:
                 expression = constraints.get(param_id, "model-derived")
                 comment = f" # constrained: {expression}"
+            if role in {ParameterRole.FIT, ParameterRole.DERIVED} and (
+                uncertainty_view is not None
+            ):
+                standard_error = uncertainty_view.standard_error(param_id)
+                reason = uncertainty_view.unavailable_reason(param_id)
+                if standard_error is not None:
+                    prefix = f" # ±{_toml_float(standard_error)}"
+                    comment = (
+                        prefix
+                        if role is ParameterRole.FIT
+                        else f"{prefix};{comment.removeprefix(' #')}"
+                    )
+                elif reason is not None:
+                    prefix = f" # error unavailable: {reason}"
+                    comment = (
+                        prefix
+                        if role is ParameterRole.FIT
+                        else f"{prefix};{comment.removeprefix(' #')}"
+                    )
             lines.append(f"{_toml_key(param_id)} = {_toml_float(value)}{comment}")
         (path / filenames[role]).write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -333,6 +360,18 @@ def write_uncertainty(path: Path, uncertainty: UncertaintyEvidence | None) -> No
                 "failures": payload.get("failures"),
             },
         )
+
+
+def write_block_uncertainty(
+    path: Path,
+    evidence: RootAnchoredBlockCovarianceEvidence | None,
+) -> None:
+    """Write root-authoritative failure-isolated covariance blocks."""
+    if evidence is None:
+        return
+    covariance_path = path / "Covariance"
+    covariance_path.mkdir(exist_ok=True)
+    write_json(covariance_path / "blocks.json", evidence.to_record())
 
 
 def resampling_evidence_record(evidence: ResamplingEvidence) -> dict[str, object]:

--- a/src/chemex/printers/parameters.py
+++ b/src/chemex/printers/parameters.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from chemex.containers.experiments import Experiments
+from chemex.optimize.uncertainty import UncertaintyEvidence
 from chemex.parameters.database import ParameterStore
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
@@ -13,6 +14,79 @@ from chemex.parameters.setting import ParamSetting
 Parameters = dict[ParamName, ParamSetting]
 
 RE_GROUPNAME = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterUncertaintyView:
+    """Immutable report-only covariance-derived uncertainty selection."""
+
+    standard_errors: tuple[tuple[str, float], ...] = ()
+    unavailable_reasons: tuple[tuple[str, str], ...] = ()
+
+    def standard_error(self, param_id: str) -> float | None:
+        return dict(self.standard_errors).get(param_id)
+
+    def unavailable_reason(self, param_id: str) -> str | None:
+        return dict(self.unavailable_reasons).get(param_id)
+
+
+def parameter_uncertainty_view(
+    evidence: UncertaintyEvidence,
+    unsupported_constrained_ids: tuple[str, ...] = (),
+) -> ParameterUncertaintyView:
+    """Select only scientifically reportable covariance-derived errors."""
+    standard_errors: list[tuple[str, float]] = []
+    unavailable_reasons: list[tuple[str, str]] = []
+    marginal = evidence.marginal_errors
+    if marginal is not None and marginal.scope_reportable:
+        standard_errors.extend(
+            (entry.param_id, entry.value)
+            for entry in marginal.entries
+            if entry.value is not None
+        )
+    else:
+        reason = "unavailable"
+        failure_categories = {failure.category for failure in evidence.failures}
+        if "rank_deficient" in failure_categories:
+            reason = "rank deficient"
+        elif any("observation" in category for category in failure_categories):
+            reason = "insufficient information"
+        elif any(
+            failure.stage == "residual_linearization" for failure in evidence.failures
+        ):
+            reason = "derivative unavailable"
+        elif evidence.covariance is not None and not evidence.covariance.usable:
+            claims = {
+                item.name: item.state.value for item in evidence.covariance.claims
+            }
+            reason = (
+                "poorly conditioned"
+                if claims.get("CONDITIONING_ADEQUACY") == "violated"
+                else "boundary limited"
+            )
+        unavailable_reasons.extend(
+            (param_id, reason) for param_id in evidence.accepted_anchor.controlled_ids
+        )
+    constrained = evidence.constrained_marginal_errors
+    if constrained is not None and constrained.scope_reportable:
+        standard_errors.extend(
+            (entry.param_id, entry.value)
+            for entry in constrained.entries
+            if entry.value is not None
+        )
+    elif evidence.requested_output_scope:
+        unavailable_reasons.extend(
+            (param_id, "constrained propagation unavailable")
+            for param_id in evidence.requested_output_scope
+        )
+    unavailable_reasons.extend(
+        (param_id, "unsupported constrained derivative")
+        for param_id in unsupported_constrained_ids
+    )
+    return ParameterUncertaintyView(
+        tuple(standard_errors),
+        tuple(unavailable_reasons),
+    )
 
 
 @dataclass
@@ -31,19 +105,45 @@ class ClassifiedParameters:
     constrained: GlobalLocalParameters
 
 
-def _format_fitted(param: ParamSetting) -> str:
-    error = f"±{param.stderr:.5e}" if param.stderr else "(error not calculated)"
+def _format_fitted(
+    param_id: str,
+    param: ParamSetting,
+    uncertainty: ParameterUncertaintyView | None,
+) -> str:
+    standard_error = (
+        None if uncertainty is None else uncertainty.standard_error(param_id)
+    )
+    reason = None if uncertainty is None else uncertainty.unavailable_reason(param_id)
+    error = (
+        f"±{standard_error:.5e}"
+        if standard_error is not None
+        else f"(error unavailable: {reason})"
+        if reason is not None
+        else "(error not calculated)"
+    )
     return f"{param.value: .5e} # {error}"
 
 
 def _format_constrained(
+    param_id: str,
     param: ParamSetting,
     parameter_store: ParameterStore,
+    uncertainty: ParameterUncertaintyView | None,
 ) -> str:
     if param.value is None:
         return ""
 
-    error = f"±{param.stderr:.5e} " if param.stderr else ""
+    standard_error = (
+        None if uncertainty is None else uncertainty.standard_error(param_id)
+    )
+    reason = None if uncertainty is None else uncertainty.unavailable_reason(param_id)
+    error = (
+        f"±{standard_error:.5e} "
+        if standard_error is not None
+        else f"error unavailable: {reason}; "
+        if reason is not None
+        else ""
+    )
     constraint = param.expr
     parameters = parameter_store.get_parameters(param.dependencies)
     for param_id, parameter in parameters.items():
@@ -59,37 +159,45 @@ def _params_to_strings(
     parameters: GlobalLocalParameters,
     status: str,
     parameter_store: ParameterStore,
+    parameter_ids: dict[ParamName, str],
+    uncertainty: ParameterUncertaintyView | None,
 ) -> dict[str, dict[str, str]]:
     result: defaultdict[str, dict[str, str]] = defaultdict(dict)
 
     for pname, param in parameters.global_.items():
         result["GLOBAL"][pname.section_res] = _format_parameter(
+            parameter_ids[pname],
             param,
             status,
             parameter_store,
+            uncertainty,
         )
 
     for pname, param in parameters.local.items():
         result[pname.section][str(pname.spin_system)] = _format_parameter(
+            parameter_ids[pname],
             param,
             status,
             parameter_store,
+            uncertainty,
         )
 
     return result
 
 
 def _format_parameter(
+    param_id: str,
     param: ParamSetting,
     status: str,
     parameter_store: ParameterStore,
+    uncertainty: ParameterUncertaintyView | None,
 ) -> str:
     if status == "fitted":
-        return _format_fitted(param)
+        return _format_fitted(param_id, param, uncertainty)
     if status == "fixed":
         return _format_fixed(param)
     if status == "constrained":
-        return _format_constrained(param, parameter_store)
+        return _format_constrained(param_id, param, parameter_store, uncertainty)
     msg = (
         f"Unknown parameter status: {status!r}. Expected 'fitted', 'fixed', "
         "or 'constrained'."
@@ -120,11 +228,25 @@ def write_file(
     status: str,
     path: Path,
     parameter_store: ParameterStore,
+    parameter_ids: dict[ParamName, str] | None = None,
+    uncertainty: ParameterUncertaintyView | None = None,
 ) -> None:
     if not parameters:
         return
 
-    par_strings = _params_to_strings(parameters, status, parameter_store)
+    ids = (
+        {pname: parameter.id_ for pname, parameter in parameters.global_.items()}
+        | {pname: parameter.id_ for pname, parameter in parameters.local.items()}
+        if parameter_ids is None
+        else parameter_ids
+    )
+    par_strings = _params_to_strings(
+        parameters,
+        status,
+        parameter_store,
+        ids,
+        uncertainty,
+    )
     formatted_strings = _format_strings(par_strings)
     filename = path / f"{status}.toml"
     filename.write_text(formatted_strings)
@@ -178,17 +300,39 @@ def write_parameters(
     experiments: Experiments,
     path: Path,
     parameter_store: ParameterStore,
+    uncertainty: ParameterUncertaintyView | None = None,
 ) -> None:
     """Write the model parameter values and their uncertainties to a file."""
     path_par = path / "Parameters"
     path_par.mkdir(parents=True, exist_ok=True)
     classified_parameters = classify_parameters(experiments, parameter_store)
+    parameter_ids = {
+        parameter.param_name: param_id
+        for param_id, parameter in parameter_store.get_parameters(
+            experiments.param_ids
+        ).items()
+    }
 
-    write_file(classified_parameters.fitted, "fitted", path_par, parameter_store)
-    write_file(classified_parameters.fixed, "fixed", path_par, parameter_store)
+    write_file(
+        classified_parameters.fitted,
+        "fitted",
+        path_par,
+        parameter_store,
+        parameter_ids,
+        uncertainty,
+    )
+    write_file(
+        classified_parameters.fixed,
+        "fixed",
+        path_par,
+        parameter_store,
+        parameter_ids,
+    )
     write_file(
         classified_parameters.constrained,
         "constrained",
         path_par,
         parameter_store,
+        parameter_ids,
+        uncertainty,
     )

--- a/src/chemex/printers/parameters.py
+++ b/src/chemex/printers/parameters.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from chemex.containers.experiments import Experiments
-from chemex.optimize.uncertainty import UncertaintyEvidence
+from chemex.optimize.uncertainty import (
+    UncertaintyEvidence,
+    UncertaintyUnavailableKind,
+)
 from chemex.parameters.database import ParameterStore
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
@@ -30,6 +33,66 @@ class ParameterUncertaintyView:
         return dict(self.unavailable_reasons).get(param_id)
 
 
+_UNAVAILABLE_REASON_TEXT = {
+    UncertaintyUnavailableKind.RANK_DEFICIENT: "rank deficient",
+    UncertaintyUnavailableKind.INSUFFICIENT_INFORMATION: "insufficient information",
+    UncertaintyUnavailableKind.BOUNDARY_LIMITED: "boundary limited",
+    UncertaintyUnavailableKind.NORMALIZATION_INVALID: "normalization invalid",
+    UncertaintyUnavailableKind.JACOBIAN_UNAVAILABLE: "Jacobian unavailable",
+    UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE: (
+        "covariance numerical failure"
+    ),
+    UncertaintyUnavailableKind.UNSUPPORTED_CONSTRAINED_DERIVATIVE: (
+        "unsupported constrained derivative"
+    ),
+    UncertaintyUnavailableKind.DERIVATION_STOPPED: ("derivation interrupted/cancelled"),
+    UncertaintyUnavailableKind.CONSTRAINED_PROPAGATION_UNAVAILABLE: (
+        "constrained propagation unavailable"
+    ),
+}
+
+if set(_UNAVAILABLE_REASON_TEXT) != set(UncertaintyUnavailableKind):
+    raise RuntimeError("Uncertainty unavailability vocabulary is not exhaustive")
+
+
+def uncertainty_unavailable_reason(kind: UncertaintyUnavailableKind) -> str:
+    """Return the one human-readable phrase for a typed claim classification."""
+    return _UNAVAILABLE_REASON_TEXT[kind]
+
+
+def _controlled_unavailability_kind(
+    evidence: UncertaintyEvidence,
+) -> UncertaintyUnavailableKind:
+    categories = {failure.category for failure in evidence.failures}
+    if categories & {"cancelled", "interrupted"}:
+        return UncertaintyUnavailableKind.DERIVATION_STOPPED
+    if "rank_deficient" in categories:
+        return UncertaintyUnavailableKind.RANK_DEFICIENT
+    if categories & {
+        "insufficient_effective_observations",
+        "non_positive_nominal_residual_degrees_of_freedom",
+    }:
+        return UncertaintyUnavailableKind.INSUFFICIENT_INFORMATION
+    covariance = evidence.covariance
+    if covariance is not None:
+        claims = {item.name: item.state.value for item in covariance.claims}
+        if claims.get("PROFILED_NORMALIZATION_REGULARITY") == "violated":
+            return UncertaintyUnavailableKind.NORMALIZATION_INVALID
+        if any(
+            claims.get(name) in {"violated", "indeterminate"}
+            for name in (
+                "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
+                "INTERIOR_POINT",
+                "BOUNDARY_SEPARATION",
+                "CONTROLLED_AFFINE_SEPARATION",
+            )
+        ):
+            return UncertaintyUnavailableKind.BOUNDARY_LIMITED
+    if any(failure.stage == "residual_linearization" for failure in evidence.failures):
+        return UncertaintyUnavailableKind.JACOBIAN_UNAVAILABLE
+    return UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE
+
+
 def parameter_uncertainty_view(
     evidence: UncertaintyEvidence,
     unsupported_constrained_ids: tuple[str, ...] = (),
@@ -45,25 +108,9 @@ def parameter_uncertainty_view(
             if entry.value is not None
         )
     else:
-        reason = "unavailable"
-        failure_categories = {failure.category for failure in evidence.failures}
-        if "rank_deficient" in failure_categories:
-            reason = "rank deficient"
-        elif any("observation" in category for category in failure_categories):
-            reason = "insufficient information"
-        elif any(
-            failure.stage == "residual_linearization" for failure in evidence.failures
-        ):
-            reason = "derivative unavailable"
-        elif evidence.covariance is not None and not evidence.covariance.usable:
-            claims = {
-                item.name: item.state.value for item in evidence.covariance.claims
-            }
-            reason = (
-                "poorly conditioned"
-                if claims.get("CONDITIONING_ADEQUACY") == "violated"
-                else "boundary limited"
-            )
+        reason = uncertainty_unavailable_reason(
+            _controlled_unavailability_kind(evidence)
+        )
         unavailable_reasons.extend(
             (param_id, reason) for param_id in evidence.accepted_anchor.controlled_ids
         )
@@ -76,11 +123,21 @@ def parameter_uncertainty_view(
         )
     elif evidence.requested_output_scope:
         unavailable_reasons.extend(
-            (param_id, "constrained propagation unavailable")
+            (
+                param_id,
+                uncertainty_unavailable_reason(
+                    UncertaintyUnavailableKind.CONSTRAINED_PROPAGATION_UNAVAILABLE
+                ),
+            )
             for param_id in evidence.requested_output_scope
         )
     unavailable_reasons.extend(
-        (param_id, "unsupported constrained derivative")
+        (
+            param_id,
+            uncertainty_unavailable_reason(
+                UncertaintyUnavailableKind.UNSUPPORTED_CONSTRAINED_DERIVATIVE
+            ),
+        )
         for param_id in unsupported_constrained_ids
     )
     return ParameterUncertaintyView(

--- a/tests/test_minimization_progress.py
+++ b/tests/test_minimization_progress.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 from rich.console import Console
 
-from chemex.messages import MinimizationProgressReporter
+from chemex.messages import MinimizationProgressReporter, UncertaintyProgressReporter
 from chemex.optimize.progress import (
     FitProgressContext,
     ProgressEvent,
@@ -228,7 +228,23 @@ def test_noninteractive_reporter_renders_truthful_context_and_final_result() -> 
     assert "final χ² 12" in rendered
     assert "committed" in rendered
     assert "Iteration" not in rendered
-    assert "iteration" not in rendered
+
+
+def test_uncertainty_reporter_separates_post_fit_elapsed_time_and_status() -> None:
+    output_console, stream = _capturing_console()
+    times = iter((20.0, 22.25))
+    reporter = UncertaintyProgressReporter(
+        output_console,
+        clock=lambda: next(times),
+    )
+
+    reporter.start()
+    reporter.finish("covariance available")
+
+    assert stream.getvalue().splitlines() == [
+        "  • Estimating parameter uncertainties...",
+        "    covariance available · 2.2 s",
+    ]
 
 
 def test_noninteractive_reporter_rate_limits_group_transitions_fit_wide() -> None:

--- a/tests/test_native_binding_uncertainty.py
+++ b/tests/test_native_binding_uncertainty.py
@@ -1,0 +1,137 @@
+"""Product regressions for retained Direct-TRF Jacobians in 2st binding fits."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from chemex.chemex import run
+from chemex.cli import build_parser
+from chemex.optimize import method_step as method_step_module
+from chemex.optimize.uncertainty import UncertaintyEvidence
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parent.parent
+BINDING = ROOT / "examples/Combinations/2stBinding"
+EXPERIMENTS = tuple(sorted((BINDING / "Experiments").glob("*.toml")))
+PARAMETERS = BINDING / "Parameters/params.toml"
+METHOD = BINDING / "Methods/method.toml"
+
+
+def _arguments(
+    output: Path,
+    method: Path,
+    parameters: tuple[Path, ...] = (PARAMETERS,),
+):
+    return build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            *(str(path) for path in EXPERIMENTS),
+            "-p",
+            *(str(path) for path in parameters),
+            "-m",
+            str(method),
+            "-d",
+            "2st_binding",
+            "-o",
+            str(output),
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+        ]
+    )
+
+
+def _capture_product_uncertainty(
+    output: Path,
+    method: Path,
+    parameters: tuple[Path, ...] = (PARAMETERS,),
+) -> tuple[AnalysisSession, tuple[UncertaintyEvidence, ...]]:
+    captured: list[UncertaintyEvidence] = []
+    real_derive = method_step_module.derive_uncertainty_evidence
+
+    def derive(*args, **kwargs):
+        evidence = real_derive(*args, **kwargs)
+        captured.append(evidence)
+        return evidence
+
+    session = AnalysisSession.create()
+    with patch.object(method_step_module, "derive_uncertainty_evidence", derive):
+        run(_arguments(output, method, parameters), session=session)
+    return session, tuple(captured)
+
+
+def test_fitted_kd_uses_backend_jacobian_before_boundary_reporting(
+    tmp_path: Path,
+) -> None:
+    method = tmp_path / "kd-method.toml"
+    method.write_text(
+        """[STEP]
+INCLUDE = [486, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499]
+FIT = ["KD"]
+FIX = ["KOFF", "DW_AB", "R1_A", "R2_A", "CS_A"]
+""",
+        encoding="utf-8",
+    )
+    step1_method = tmp_path / "step1-method.toml"
+    step1_method.write_text(
+        """[STEP1]
+INCLUDE = [486, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499]
+FIX = ["KD"]
+""",
+        encoding="utf-8",
+    )
+    step1_output = tmp_path / "Step1"
+    step1_session = AnalysisSession.create()
+    run(_arguments(step1_output, step1_method), session=step1_session)
+    assert step1_session.analysis_values.snapshot().revision == 1
+    output = tmp_path / "Output"
+
+    session, (evidence,) = _capture_product_uncertainty(
+        output,
+        method,
+        (PARAMETERS, step1_output / "Parameters" / "fitted.toml"),
+    )
+
+    assert session.analysis_values.snapshot().revision == 1
+    jacobian = evidence.residual_jacobian
+    assert jacobian is not None
+    assert jacobian.method == "retained-scipy-final-2-point"
+    assert jacobian.evaluation_count == 0
+    assert evidence.rank_diagnostic is not None
+    assert evidence.covariance is not None
+    kd_index = jacobian.controlled_ids.index("__KD")
+    kd = evidence.accepted_anchor.vector[kd_index]
+    assert kd == pytest.approx(1.0156e-6, rel=2.0e-3)
+    assert math.isfinite(evidence.covariance.covariance[kd_index][kd_index])
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    assert "KD" in fitted
+    assert "Jacobian unavailable" not in fitted
+
+
+def test_full_binding_step2_never_fails_for_a_high_cost_stencil(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+
+    session, evidence = _capture_product_uncertainty(output, METHOD)
+
+    assert session.analysis_values.snapshot().revision == 2
+    assert len(evidence) == 2
+    step2 = evidence[1]
+    assert step2.residual_jacobian is not None
+    assert step2.residual_jacobian.method == "retained-scipy-final-2-point"
+    assert step2.residual_jacobian.evaluation_count == 0
+    assert step2.rank_diagnostic is not None
+    assert all(failure.stage != "residual_linearization" for failure in step2.failures)
+    fitted = (output / "STEP2" / "All" / "Parameters" / "fitted.toml").read_text(
+        encoding="utf-8"
+    )
+    r2_b_section = fitted.split('["R2_B, B0->800.0MHZ"]', maxsplit=1)[1]
+    assert "538N" in r2_b_section
+    assert "Jacobian unavailable" not in fitted

--- a/tests/test_native_binding_uncertainty.py
+++ b/tests/test_native_binding_uncertainty.py
@@ -133,5 +133,8 @@ def test_full_binding_step2_never_fails_for_a_high_cost_stencil(
         encoding="utf-8"
     )
     r2_b_section = fitted.split('["R2_B, B0->800.0MHZ"]', maxsplit=1)[1]
-    assert "538N" in r2_b_section
+    r2_b_538n = next(
+        line for line in r2_b_section.splitlines() if line.lstrip().startswith("538N")
+    )
+    assert "error unavailable: boundary limited" in r2_b_538n
     assert "Jacobian unavailable" not in fitted

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -547,6 +547,7 @@ def _trf_backend_result(candidate: Array, residuals: Array) -> SimpleNamespace:
         cost=0.5 * float(np.dot(residuals, residuals)),
         optimality=0.0,
         active_mask=np.zeros_like(candidate, dtype=np.int64),
+        jac=np.zeros((residuals.size, candidate.size), dtype=np.float64),
     )
 
 

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -50,6 +50,7 @@ from chemex.optimize.direct_trf import (
     MaterializationTerminal,
     ObjectiveScalarizationError,
     OptimizationProblem,
+    ResidualJacobianSource,
     RootMaterializationFailure,
     canonical_chi_square,
     commit_accepted_fit,
@@ -403,7 +404,96 @@ def _backend_result(
         cost=0.5 * float(np.dot(residuals, residuals)),
         optimality=optimality,
         active_mask=np.zeros_like(candidate, dtype=np.int64),
+        jac=np.zeros((residuals.size, candidate.size), dtype=np.float64),
     )
+
+
+def test_accepted_fit_retains_exact_final_backend_residual_jacobian() -> None:
+    (
+        _session,
+        _experiments,
+        parameterization,
+        engine,
+        problem,
+        invocation,
+    ) = _qualification_fit()
+
+    outcome = execute_direct_trf(
+        problem,
+        invocation,
+        parameterization,
+        engine,
+    )
+
+    accepted = outcome.accepted_result
+    assert accepted is not None
+    retained = accepted.final_residual_jacobian
+    assert retained is not None
+    assert retained.source is ResidualJacobianSource.SCIPY_FINAL_2_POINT
+    assert retained.controlled_ids == problem.controlled_ids
+    assert retained.final_vector == accepted.vector
+    assert retained.final_residuals == tuple(accepted.evaluation_result.residuals)
+    assert retained.shape == (
+        accepted.evaluation_result.residuals.size,
+        len(problem.controlled_ids),
+    )
+    assert retained.derivative_method == "numerical 2-point"
+    assert retained.diff_step_policy == "scipy-default-relative-step"
+    assert retained.loss_policy == "linear"
+    assert retained.external_coordinate_policy == "physical-external-unscaled"
+    assert retained.trust_region_scale_policy == "trust-region-only"
+    assert len(retained.matrix_binary64_sha256) == 64
+    assert np.isfinite(np.asarray(retained.matrix)).all()
+    assert outcome.execution.backend is not None
+    assert outcome.execution.backend.final_residual_jacobian is retained
+
+
+@pytest.mark.parametrize("malformation", ("wrong-shape", "non-finite"))
+def test_malformed_final_backend_jacobian_fails_closed(malformation: str) -> None:
+    (
+        _session,
+        _experiments,
+        parameterization,
+        engine,
+        problem,
+        invocation,
+    ) = _qualification_fit()
+
+    def malformed_backend(
+        fun: Callable[[Array], Array],
+        x0: Array,
+        **_settings: object,
+    ) -> object:
+        candidate = np.asarray(x0, dtype=np.float64) * 0.9
+        residuals = fun(candidate)
+        result = _backend_result(
+            candidate,
+            residuals,
+            status=1,
+            success=True,
+            message="converged",
+            optimality=0.0,
+        )
+        result.jac = (
+            np.zeros((residuals.size, candidate.size + 1), dtype=np.float64)
+            if malformation == "wrong-shape"
+            else np.full((residuals.size, candidate.size), np.nan)
+        )
+        return result
+
+    with patch("chemex.optimize.direct_trf.least_squares", malformed_backend):
+        outcome = execute_direct_trf(
+            problem,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is DirectTrfOutcomeTerminal.SOLVER_UNSUCCESSFUL
+    assert outcome.execution.terminal is DirectTrfTerminal.IMPLEMENTATION_FAILURE
+    assert outcome.execution.failure is not None
+    assert outcome.execution.failure.category == "malformed_backend_result"
+    assert outcome.accepted_result is None
 
 
 def _one_request_converged_backend(

--- a/tests/test_native_grid_direct_trf.py
+++ b/tests/test_native_grid_direct_trf.py
@@ -308,6 +308,7 @@ def _backend_result(
         cost=0.5 * float(np.dot(residuals, residuals)),
         optimality=0.0 if success else 1.0,
         active_mask=np.zeros_like(candidate, dtype=np.int64),
+        jac=np.zeros((residuals.size, candidate.size), dtype=np.float64),
     )
 
 
@@ -384,6 +385,11 @@ def test_failed_seed_continues_and_canonical_tie_commits_only_selected_once() ->
     )
     assert all(not hasattr(attempt, "accepted_result") for attempt in outcome.attempts)
     assert outcome.accepted_result is not None
+    assert outcome.accepted_result.final_residual_jacobian is not None
+    assert (
+        outcome.accepted_result.final_residual_jacobian.identity
+        == outcome.attempts[2].final_residual_jacobian.identity
+    )
     assert outcome.commit_authority is not None
     assert outcome.accepted_result.problem_identity == problem.identity
     grid_selection = outcome.accepted_result.grid_selection_provenance
@@ -534,6 +540,7 @@ def test_plain_base_evidence_cannot_recreate_grid_commit_authority() -> None:
         accepted.commit_scope,
         accepted.commit_items,
         accepted.origin_context_identity,
+        final_residual_jacobian=accepted.final_residual_jacobian,
         occurrence_witness=None,
     )
     assert plain_evidence.identity == accepted.identity
@@ -582,6 +589,7 @@ def test_plain_base_evidence_cannot_recreate_grid_commit_authority() -> None:
             plain_evidence.commit_scope,
             plain_evidence.commit_items,
             plain_evidence.origin_context_identity,
+            final_residual_jacobian=plain_evidence.final_residual_jacobian,
             occurrence_witness=None,
         ).identity
     )

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import math
 from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
@@ -15,7 +16,7 @@ import pytest
 from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
-from chemex.evaluation.native import EvaluationEngine
+from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
 from chemex.experiments.builder import build_experiments
 from chemex.optimize import direct_trf as direct_trf_owner
 from chemex.optimize.direct_trf import (
@@ -319,6 +320,32 @@ def test_successful_components_compose_one_fresh_root_accepted_result_and_commit
     assert outcome.accepted_result is not None
     assert outcome.commit_authority is not None
     accepted = outcome.accepted_result
+    retained = accepted.final_residual_jacobian
+    assert retained is not None
+    assert retained.source.value == "fit-partition-composition"
+    assert retained.controlled_ids == problem.controlled_ids
+    base = np.asarray(accepted.evaluation_result.residuals, dtype=np.float64)
+    independent_columns: list[Array] = []
+    evaluator = engine.new_evaluator()
+    for index, value in enumerate(accepted.vector):
+        step = math.sqrt(np.finfo(np.float64).eps) * max(1.0, abs(value))
+        candidate = list(accepted.vector)
+        candidate[index] += step
+        frame = EvaluationFrame.from_lifecycle_frame(
+            parameterization,
+            problem.lifecycle_frame(tuple(candidate), parameterization),
+        )
+        evaluated = evaluator.evaluate(frame)
+        assert isinstance(evaluated, EvaluationResult)
+        independent_columns.append(
+            (np.asarray(evaluated.residuals, dtype=np.float64) - base) / step
+        )
+    np.testing.assert_allclose(
+        retained.matrix,
+        np.column_stack(independent_columns),
+        rtol=2.0e-6,
+        atol=2.0e-8,
+    )
     selected = {
         param_id: component.candidate.vector[index]
         for component in outcome.components
@@ -465,7 +492,11 @@ def test_fresh_root_validation_rejects_an_inconsistent_component_result() -> Non
         parameterization,
         engine,
         (
-            dataclasses.replace(first, candidate=out_of_bounds_candidate),
+            dataclasses.replace(
+                first,
+                candidate=out_of_bounds_candidate,
+                final_residual_jacobian=None,
+            ),
             *components[1:],
         ),
     )
@@ -567,7 +598,13 @@ def test_component_vector_cannot_be_retargeted_to_transposed_controlled_ids() ->
         invocation,
         parameterization,
         engine,
-        (dataclasses.replace(component, controlled_ids=transposed_ownership),),
+        (
+            dataclasses.replace(
+                component,
+                controlled_ids=transposed_ownership,
+                final_residual_jacobian=None,
+            ),
+        ),
     )
 
     assert outcome.terminal is GroupedDirectTrfTerminal.DECOMPOSITION_VALIDATION_FAILURE
@@ -594,6 +631,7 @@ def _backend_result(
         cost=0.5 * float(np.dot(residuals, residuals)),
         optimality=0.0 if success else 1.0,
         active_mask=np.zeros_like(candidate, dtype=np.int64),
+        jac=np.zeros((residuals.size, candidate.size), dtype=np.float64),
     )
 
 

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+import chemex.optimize.grouped_direct_trf as grouped_direct_trf_owner
 from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
@@ -382,6 +383,58 @@ def test_successful_components_compose_one_fresh_root_accepted_result_and_commit
             analysis_values=session.analysis_values,
         )
     assert session.analysis_values.snapshot() == committed
+
+
+def test_root_jacobian_composition_converts_each_component_matrix_once() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem(
+        Method(fit=["PB"], fix=["KEX_AB"])
+    )
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    assert len(decomposition.components) == 1
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(100,),
+    )
+    components = execute_direct_trf_components(
+        decomposition,
+        invocation,
+        parameterization,
+        engine,
+    )
+    retained_matrices = tuple(
+        component.final_residual_jacobian.matrix
+        for component in components
+        if component.final_residual_jacobian is not None
+    )
+    assert len(retained_matrices) == 1
+    conversions: list[object] = []
+    numpy_owner = grouped_direct_trf_owner.np
+
+    class NumpyConversionProbe:
+        def __getattr__(self, name: str) -> object:
+            return getattr(numpy_owner, name)
+
+        def asarray(
+            self,
+            value: object,
+            dtype: type[np.float64] | np.dtype[np.float64] | None = None,
+        ) -> Array:
+            if any(value is matrix for matrix in retained_matrices):
+                conversions.append(value)
+            return numpy_owner.asarray(value, dtype=dtype)
+
+    with patch.object(grouped_direct_trf_owner, "np", NumpyConversionProbe()):
+        outcome = materialize_grouped_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+            components,
+        )
+
+    assert outcome.terminal is GroupedDirectTrfTerminal.ACCEPTED
+    assert conversions == list(retained_matrices)
 
 
 def test_grouped_direct_progress_identifies_each_group_in_order() -> None:

--- a/tests/test_native_grouped_grid_direct_trf.py
+++ b/tests/test_native_grouped_grid_direct_trf.py
@@ -106,6 +106,7 @@ def _backend_result(
         cost=0.5 * float(np.dot(residuals, residuals)),
         optimality=0.0,
         active_mask=np.zeros_like(candidate, dtype=np.int64),
+        jac=np.zeros((residuals.size, candidate.size), dtype=np.float64),
     )
 
 
@@ -764,6 +765,7 @@ def test_foreign_grouped_seed_evidence_is_rejected_before_grid_selection() -> No
     wrong_controlled = dataclasses.replace(
         first_outcome,
         controlled_ids=("foreign-control",),
+        final_residual_jacobian=None,
     )
     wrong_child_component = dataclasses.replace(
         first_fit_component,

--- a/tests/test_native_method_step.py
+++ b/tests/test_native_method_step.py
@@ -50,6 +50,8 @@ from chemex.optimize.direct_trf import (
     AcceptedFitResult,
     CancellationToken,
     DirectTrfConstructionError,
+    FinalResidualJacobianEvidence,
+    FitCommitOperation,
     MaterializationTerminal,
     OptimizationProblem,
     RootMaterializationFailure,
@@ -556,6 +558,37 @@ def test_one_component_direct_trf_uses_decomposition_aggregate_and_one_commit() 
     assert outcome.commit_operation.receipt.new_revision == 1
     successor = require_successor_state(outcome, session.analysis_values)
     assert successor.revision == 1
+
+
+def test_live_outcome_integrity_does_not_reconstruct_retained_jacobian() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    accepted = outcome.accepted_result
+    assert accepted is not None
+    assert accepted.final_residual_jacobian is not None
+
+    with patch.object(
+        FinalResidualJacobianEvidence,
+        "__post_init__",
+        side_effect=AssertionError("retained Jacobian reconstructed"),
+    ):
+        record = outcome.to_record()
+
+    assert record["accepted_result_identity"] == accepted.identity
+
+
+def test_live_outcome_integrity_rejects_mutated_retained_jacobian_content() -> None:
+    session, workflow = _direct_workflow()
+    outcome = execute_method_step(workflow, analysis_values=session.analysis_values)
+    accepted = outcome.accepted_result
+    assert accepted is not None
+    retained = accepted.final_residual_jacobian
+    assert retained is not None
+    changed_row = (retained.matrix[0][0] + 1.0, *retained.matrix[0][1:])
+    object.__setattr__(retained, "matrix", (changed_row, *retained.matrix[1:]))
+
+    with pytest.raises(ValueError, match="Jacobian integrity"):
+        outcome.to_record()
 
 
 def test_mutated_different_budget_invocation_cannot_execute() -> None:
@@ -1168,6 +1201,74 @@ def test_valid_acceptance_observer_preserves_exactly_one_commit(observe: bool) -
         if observe
         else []
     )
+
+
+def test_commit_completed_observer_runs_before_post_fit_derivations() -> None:
+    session, base = _direct_workflow()
+    workflow = dataclasses.replace(base, derivations=(_uncertainty_request(base),))
+    events: list[str] = []
+
+    def observe_commit(
+        accepted: AcceptedFitResult,
+        operation: FitCommitOperation,
+    ) -> None:
+        assert accepted.identity == operation.accepted_result_identity
+        events.append("commit_completed")
+
+    original_execute = method_step_module._execute_uncertainty
+
+    def observe_derivation(*args: object, **kwargs: object):
+        events.append("uncertainty_started")
+        return original_execute(*args, **kwargs)
+
+    with patch.object(
+        method_step_module,
+        "_execute_uncertainty",
+        side_effect=observe_derivation,
+    ):
+        outcome = execute_method_step(
+            workflow,
+            analysis_values=session.analysis_values,
+            commit_completed_observer=observe_commit,
+        )
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert events == ["commit_completed", "uncertainty_started"]
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_disposition"),
+    [
+        (RuntimeError("reporting failed"), DerivationDisposition.COMPLETED),
+        (
+            KeyboardInterrupt(),
+            DerivationDisposition.NOT_STARTED_BY_WORKFLOW_STOP,
+        ),
+    ],
+)
+def test_commit_progress_observer_cannot_invalidate_committed_science(
+    failure: BaseException,
+    expected_disposition: DerivationDisposition,
+) -> None:
+    session, base = _direct_workflow()
+    workflow = dataclasses.replace(base, derivations=(_uncertainty_request(base),))
+
+    def fail_after_commit(
+        _accepted: AcceptedFitResult,
+        _operation: FitCommitOperation,
+    ) -> None:
+        raise failure
+
+    outcome = execute_method_step(
+        workflow,
+        analysis_values=session.analysis_values,
+        commit_completed_observer=fail_after_commit,
+    )
+
+    assert outcome.lifecycle is MethodStepLifecycle.COMMITTED
+    assert outcome.commit_operation is not None
+    assert outcome.derivations[0].disposition is expected_disposition
+    assert require_successor_state(outcome, session.analysis_values).revision == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -305,6 +305,10 @@ def test_real_direct_fit_reports_objective_evaluation_progress(
     rendered = capsys.readouterr().out
     assert "eval 0/" in rendered
     assert "final χ²" in rendered
+    minimizing_terminal = rendered.index("final χ²")
+    uncertainty_start = rendered.index("Estimating parameter uncertainties")
+    uncertainty_terminal = rendered.index("covariance available")
+    assert minimizing_terminal < uncertainty_start < uncertainty_terminal
     assert "iteration" not in rendered.lower()
 
 
@@ -631,6 +635,7 @@ def test_interrupted_block_fallback_preserves_committed_root_evidence(
 
 def test_shared_parameter_coupling_is_not_split_into_covariance_blocks(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     output = tmp_path / "Output"
     method = tmp_path / "method.toml"
@@ -659,6 +664,7 @@ FIX = ["KEX_AB"]
     assert "# ±" not in fitted
     assert "error unavailable: rank deficient" in fitted
     assert not (output / "Statistics" / "Covariance" / "blocks.json").exists()
+    assert "uncertainty unavailable: rank deficient" in capsys.readouterr().out
 
 
 def test_unsupported_scientific_constraint_keeps_product_fitted_errors(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -533,6 +533,7 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
 ) -> None:
     output = tmp_path / "Output"
     original_svd = uncertainty_module.svd
+    original_block_derivation = uncertainty_module.derive_root_anchored_block_covariance
     covariance_svd_call = 0
 
     def one_bad_block_svd(*args, **kwargs):
@@ -544,7 +545,17 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
             singular[-1] = 0.0
         return left, singular, right
 
-    with patch("chemex.optimize.uncertainty.svd", side_effect=one_bad_block_svd):
+    def reverse_block_order(evidence, scopes):
+        return original_block_derivation(evidence, tuple(reversed(scopes)))
+
+    with (
+        patch("chemex.optimize.uncertainty.svd", side_effect=one_bad_block_svd),
+        patch.object(
+            native_deterministic_module,
+            "derive_root_anchored_block_covariance",
+            side_effect=reverse_block_order,
+        ),
+    ):
         run(
             _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
             session=AnalysisSession.create(),
@@ -555,6 +566,20 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
     reports = tuple(path.read_text(encoding="utf-8") for path in group_outputs)
     assert sum("# ±" in report for report in reports) == 1
     assert sum("error unavailable: rank deficient" in report for report in reports) == 1
+    constrained_reports = tuple(
+        (path.parent / "constrained.toml").read_text(encoding="utf-8")
+        for path in group_outputs
+    )
+    assert tuple("# ±" in report for report in reports) == tuple(
+        "# ±" in report for report in constrained_reports
+    )
+    assert (
+        sum(
+            "error unavailable: constrained propagation unavailable" in report
+            for report in constrained_reports
+        )
+        == 1
+    )
     blocks = json.loads(
         (output / "All" / "Statistics" / "Covariance" / "blocks.json").read_text(
             encoding="utf-8"
@@ -564,6 +589,38 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
         "",
         "rank deficient",
     ]
+
+
+def test_shared_parameter_coupling_is_not_split_into_covariance_blocks(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+FIT = ["PB"]
+FIX = ["KEX_AB"]
+""",
+        encoding="utf-8",
+    )
+    original_svd = uncertainty_module.svd
+
+    def rank_deficient_svd(*args, **kwargs):
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        singular[-1] = 0.0
+        return left, singular, right
+
+    with patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_svd):
+        run(
+            _fit_arguments(output, method, include=("G2N-HN", "H3N-HN")),
+            session=AnalysisSession.create(),
+        )
+
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    assert "# ±" not in fitted
+    assert "error unavailable: rank deficient" in fitted
+    assert not (output / "Statistics" / "Covariance" / "blocks.json").exists()
 
 
 def test_real_grouped_direct_progress_has_one_bounded_noninteractive_stream(
@@ -664,6 +721,11 @@ def test_interrupted_covariance_keeps_committed_fit_and_invalidates_stale_eviden
     assert session.analysis_values.snapshot().revision == 1
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
     assert "error unavailable: derivation interrupted" in fitted
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "error unavailable: derivation interrupted" in constrained
+    assert "# ±" not in constrained
     covariance_path = output / "Statistics" / "Covariance"
     assert not (covariance_path / "evidence.json").exists()
     status = json.loads((covariance_path / "status.json").read_text(encoding="utf-8"))

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -33,6 +33,9 @@ EXAMPLE = ROOT / "examples/Experiments/RELAXATION_HZNZ"
 EXPERIMENT = EXAMPLE / "Experiments/800mhz.toml"
 PARAMETERS = EXAMPLE / "Parameters/parameters.toml"
 METHOD = EXAMPLE / "Methods/method.toml"
+DCEST_EXAMPLE = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH"
+DCEST_EXPERIMENT = DCEST_EXAMPLE / "Experiments/3hz.toml"
+DCEST_PARAMETERS = DCEST_EXAMPLE / "Parameters/parameters.toml"
 
 
 def _fit_arguments(
@@ -533,7 +536,6 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
 ) -> None:
     output = tmp_path / "Output"
     original_svd = uncertainty_module.svd
-    original_block_derivation = uncertainty_module.derive_root_anchored_block_covariance
     covariance_svd_call = 0
 
     def one_bad_block_svd(*args, **kwargs):
@@ -545,17 +547,7 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
             singular[-1] = 0.0
         return left, singular, right
 
-    def reverse_block_order(evidence, scopes):
-        return original_block_derivation(evidence, tuple(reversed(scopes)))
-
-    with (
-        patch("chemex.optimize.uncertainty.svd", side_effect=one_bad_block_svd),
-        patch.object(
-            native_deterministic_module,
-            "derive_root_anchored_block_covariance",
-            side_effect=reverse_block_order,
-        ),
-    ):
+    with patch("chemex.optimize.uncertainty.svd", side_effect=one_bad_block_svd):
         run(
             _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
             session=AnalysisSession.create(),
@@ -585,10 +577,48 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
             encoding="utf-8"
         )
     )
+    assert len(blocks["partition_proof_identity"]) == 64
     assert sorted(block["unavailable_reason"] for block in blocks["blocks"]) == [
         "",
         "rank deficient",
     ]
+
+
+def test_interrupted_block_fallback_preserves_committed_root_evidence(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+    original_svd = uncertainty_module.svd
+
+    def rank_deficient_svd(*args, **kwargs):
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        singular[-1] = 0.0
+        return left, singular, right
+
+    with (
+        patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_svd),
+        patch.object(
+            native_deterministic_module,
+            "derive_root_anchored_block_covariance",
+            side_effect=KeyboardInterrupt,
+        ),
+    ):
+        run(
+            _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
+            session=session,
+        )
+
+    assert session.analysis_values.snapshot().revision == 1
+    covariance_path = output / "All" / "Statistics" / "Covariance"
+    assert (covariance_path / "evidence.json").is_file()
+    assert not (covariance_path / "blocks.json").exists()
+    status = json.loads((covariance_path / "status.json").read_text(encoding="utf-8"))
+    assert status["status"] == "incomplete"
+    assert status["terminal"] == "interrupted"
+    assert status["reason"] == "block derivation interrupted"
+    assert (output / "All" / "Parameters" / "fitted.toml").is_file()
 
 
 def test_shared_parameter_coupling_is_not_split_into_covariance_blocks(
@@ -621,6 +651,54 @@ FIX = ["KEX_AB"]
     assert "# ±" not in fitted
     assert "error unavailable: rank deficient" in fitted
     assert not (output / "Statistics" / "Covariance" / "blocks.json").exists()
+
+
+def test_unsupported_scientific_constraint_keeps_product_fitted_errors(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+FIT = ["D2O"]
+FIX = ["CS_A", "DW_AB", "KDH", "PHI", "R1_A", "R2_A", "R2_B"]
+""",
+        encoding="utf-8",
+    )
+    arguments = build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            str(DCEST_EXPERIMENT),
+            "-p",
+            str(DCEST_PARAMETERS),
+            "-m",
+            str(method),
+            "-o",
+            str(output),
+            "-d",
+            "2st_hd",
+            "--include",
+            "1N",
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+        ]
+    )
+
+    run(arguments, session=AnalysisSession.create())
+
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "# ±" in fitted
+    assert "error unavailable: unsupported constrained derivative" in constrained
+    constrained_evidence = (
+        output / "Statistics" / "Constrained" / "evidence.json"
+    ).read_text(encoding="utf-8")
+    assert "unsupported constrained derivative" not in constrained_evidence
 
 
 def test_real_grouped_direct_progress_has_one_bounded_noninteractive_stream(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import math
 import subprocess
 import sys
@@ -17,6 +18,7 @@ import chemex.optimize.native_deterministic as native_deterministic_module
 import chemex.optimize.native_mcmc as native_mcmc_module
 import chemex.optimize.native_resampling as native_resampling_module
 import chemex.optimize.resampling as resampling_module
+import chemex.optimize.uncertainty as uncertainty_module
 import chemex.run_info as run_info_module
 from chemex.chemex import run
 from chemex.cli import build_parser
@@ -193,7 +195,26 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     fitted_record = next(line for line in fitted.splitlines() if "=" in line)
     fitted_value = float(fitted_record.split("=", 1)[1].split()[0])
     assert fitted_value == pytest.approx(2.34742, rel=5.0e-6)
-    assert "(error not calculated)" in fitted_record
+    assert "# ±" in fitted_record
+    fitted_error = float(fitted_record.split("±", 1)[1])
+    assert fitted_error == pytest.approx(0.083366086, rel=3.0e-6)
+    assert all(
+        parameter.stderr is None
+        for parameter in session.parameters.get_parameters(
+            session.analysis_values.snapshot()
+        ).values()
+    )
+    covariance = output / "Statistics" / "Covariance" / "evidence.json"
+    assert covariance.is_file()
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    propagated_record = next(
+        line for line in constrained.splitlines() if "G2N-H" in line
+    )
+    propagated_error = float(propagated_record.split("±", 1)[1].split()[0])
+    assert propagated_error == pytest.approx(fitted_error, rel=1.0e-12)
+    assert (output / "Statistics" / "Constrained" / "evidence.json").is_file()
     assert (output / "statistics.toml").is_file()
     data = next((output / "Data").glob("*.dat")).read_text(encoding="utf-8")
     first_calculation = float(
@@ -213,6 +234,59 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     time_2, intensity_2 = curve[-1]
     fitted_curve_rate = -math.log(intensity_2 / intensity_1) / (time_2 - time_1)
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
+
+
+def test_relaxation_product_covariance_matches_absolute_sigma_reference(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    spin_systems = ("G2N-HN", "H3N-HN", "K4N-HN", "S5N-HN", "L6N-HN")
+
+    run(
+        _fit_arguments(output, include=spin_systems),
+        session=AnalysisSession.create(),
+    )
+
+    evidence = json.loads(
+        (output / "All" / "Statistics" / "Covariance" / "evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert (
+        evidence["covariance"]["residual_variance_scaling"]
+        == "absolute_observation_uncertainties"
+    )
+    entries = evidence["marginal_standard_errors"]["entries"]
+    observed = {
+        entry["param_id"]: float.fromhex(entry["value"]["binary64"])
+        for entry in entries
+    }
+    expected = {
+        "G2": 0.083366086,
+        "H3": 0.084798698,
+        "K4": 0.085572683,
+        "S5": 0.086949663,
+        "L6": 0.086999315,
+    }
+    for residue, reference in expected.items():
+        param_id = next(
+            param_id for param_id in observed if f"_{residue}N_H_" in param_id
+        )
+        assert observed[param_id] == pytest.approx(reference, rel=3.0e-6)
+
+    historical = {
+        "G2": (0.123732, 2.20286),
+        "H3": (0.110470, 1.69712),
+        "K4": (0.0727646, 0.72305),
+        "S5": (0.0607433, 0.48805),
+        "L6": (0.101158, 1.35197),
+    }
+    for residue, reference in expected.items():
+        lmfit_error, reduced_chi_square = historical[residue]
+        assert reference * math.sqrt(reduced_chi_square) == pytest.approx(
+            lmfit_error,
+            rel=5.0e-6,
+        )
 
 
 def test_real_direct_fit_reports_objective_evaluation_progress(
@@ -454,6 +528,44 @@ def test_real_grouped_direct_fit_uses_native_aggregate_commit(
     assert (output / "All" / "Parameters" / "fitted.toml").is_file()
 
 
+def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    original_svd = uncertainty_module.svd
+    covariance_svd_call = 0
+
+    def one_bad_block_svd(*args, **kwargs):
+        nonlocal covariance_svd_call
+        covariance_svd_call += 1
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        if covariance_svd_call in {1, 3}:
+            singular[-1] = 0.0
+        return left, singular, right
+
+    with patch("chemex.optimize.uncertainty.svd", side_effect=one_bad_block_svd):
+        run(
+            _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
+            session=AnalysisSession.create(),
+        )
+
+    group_outputs = sorted((output / "Groups").glob("*/Parameters/fitted.toml"))
+    assert len(group_outputs) == 2
+    reports = tuple(path.read_text(encoding="utf-8") for path in group_outputs)
+    assert sum("# ±" in report for report in reports) == 1
+    assert sum("error unavailable: rank deficient" in report for report in reports) == 1
+    blocks = json.loads(
+        (output / "All" / "Statistics" / "Covariance" / "blocks.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert sorted(block["unavailable_reason"] for block in blocks["blocks"]) == [
+        "",
+        "rank deficient",
+    ]
+
+
 def test_real_grouped_direct_progress_has_one_bounded_noninteractive_stream(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -471,6 +583,97 @@ def test_real_grouped_direct_progress_has_one_bounded_noninteractive_stream(
     assert rendered.count("eval 0/") == 1
     assert "eval " in rendered
     assert " total" in rendered
+
+
+def test_boundary_limited_fit_keeps_central_values_and_withholds_symmetric_errors(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+FIX = ["KEX_AB"]
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    run(_fit_arguments(output, method), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    assert "error unavailable: boundary limited" in fitted
+    assert "# ±" not in fitted
+    evidence = (output / "Statistics" / "Covariance" / "evidence.json").read_text(
+        encoding="utf-8"
+    )
+    assert '"name": "BOUNDARY_SEPARATION"' in evidence
+    assert '"state": "violated"' in evidence
+    assert all(
+        parameter.stderr is None
+        for parameter in session.parameters.get_parameters(
+            session.analysis_values.snapshot()
+        ).values()
+    )
+
+
+def test_rank_deficient_covariance_is_nonfatal_and_replaces_stale_valid_errors(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    run(_fit_arguments(output), session=AnalysisSession.create())
+    assert "# ±" in (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+
+    original_svd = uncertainty_module.svd
+
+    def rank_deficient_svd(*args, **kwargs):
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        singular[-1] = 0.0
+        return left, singular, right
+
+    session = AnalysisSession.create()
+    with patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_svd):
+        run(_fit_arguments(output), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    assert "error unavailable: rank deficient" in fitted
+    assert "# ±" not in fitted
+    evidence = (output / "Statistics" / "Covariance" / "evidence.json").read_text(
+        encoding="utf-8"
+    )
+    assert '"category": "rank_deficient"' in evidence
+    assert '"covariance": null' in evidence
+
+
+def test_interrupted_covariance_keeps_committed_fit_and_invalidates_stale_evidence(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    run(_fit_arguments(output), session=AnalysisSession.create())
+    assert (output / "Statistics" / "Covariance" / "evidence.json").is_file()
+
+    session = AnalysisSession.create()
+    with patch(
+        "chemex.optimize.method_step.derive_uncertainty_evidence",
+        side_effect=KeyboardInterrupt,
+    ):
+        run(_fit_arguments(output), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    assert "error unavailable: derivation interrupted" in fitted
+    covariance_path = output / "Statistics" / "Covariance"
+    assert not (covariance_path / "evidence.json").exists()
+    status = json.loads((covariance_path / "status.json").read_text(encoding="utf-8"))
+    assert status == {
+        "artifact_type": "native_covariance_derivation_status",
+        "reason": "derivation interrupted",
+        "schema_version": 1,
+        "status": "incomplete",
+        "terminal": "interrupted",
+    }
 
 
 def _grid_method(path: Path) -> Path:
@@ -559,8 +762,8 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     assert diagnostics["walkers"] == 32
     assert "lmfit_version" not in diagnostics
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
-    assert "(error not calculated)" in fitted
-    assert "±" not in fitted
+    assert "# ±" in fitted
+    assert "half_credible_interval_68_width" not in fitted
     plan = native_sampler.call_args.args[1]
     assert plan.coordinate_units[0][1] is ParameterUnit.UNSPECIFIED
 
@@ -883,7 +1086,8 @@ def test_real_mc_fit_is_wholly_native_and_writes_product_statistics(
     assert "root_seed = 0" in diagnostics
     assert 'status = "complete"' in diagnostics
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
-    assert "(error not calculated)" in fitted
+    assert "# ±" in fitted
+    assert "half_percentile_68_width" not in fitted
 
 
 def test_resampling_replicates_do_not_create_progress_streams(
@@ -1336,7 +1540,7 @@ FIX = ["PB", "KEX_AB"]
         fitted = (output / step / "Parameters" / "fitted.toml").read_text(
             encoding="utf-8"
         )
-        assert "(error not calculated)" in fitted
+        assert "# ±" in fitted
         fixed = (output / step / "Parameters" / "fixed.toml").read_text(
             encoding="utf-8"
         )
@@ -1421,6 +1625,8 @@ def test_native_backend_failure_cannot_commit_or_publish_fitted_output(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
+    run(_fit_arguments(output), session=AnalysisSession.create())
+    assert (output / "Statistics" / "Covariance" / "evidence.json").is_file()
     session = AnalysisSession.create()
 
     with (
@@ -1435,6 +1641,7 @@ def test_native_backend_failure_cannot_commit_or_publish_fitted_output(
     assert session.analysis_values.snapshot().revision == 0
     assert not (output / "Parameters").exists()
     assert not (output / "Data").exists()
+    assert not (output / "Statistics" / "Covariance").exists()
 
 
 def test_v1_constraint_and_profile_selection_reach_native_product_fit(
@@ -1535,4 +1742,5 @@ STATISTICS = { "MC" = 1 }
     assert "GRID" in captured.out
     assert "STATISTICS" in captured.out
     assert (output / "Grid").is_dir()
-    assert not (output / "Statistics").exists()
+    assert (output / "Statistics" / "Covariance" / "evidence.json").is_file()
+    assert not (output / "Statistics" / "MonteCarlo").exists()

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -555,6 +555,13 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
 
     group_outputs = sorted((output / "Groups").glob("*/Parameters/fitted.toml"))
     assert len(group_outputs) == 2
+    assert (output / "All" / "Statistics" / "Covariance" / "evidence.json").is_file()
+    assert all(
+        not (
+            path.parent.parent / "Statistics" / "Covariance" / "evidence.json"
+        ).exists()
+        for path in group_outputs
+    )
     reports = tuple(path.read_text(encoding="utf-8") for path in group_outputs)
     assert sum("# ±" in report for report in reports) == 1
     assert sum("error unavailable: rank deficient" in report for report in reports) == 1

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -23,6 +23,7 @@ import chemex.run_info as run_info_module
 from chemex.chemex import run
 from chemex.cli import build_parser
 from chemex.optimize.mcmc import NativeMcmcIncompleteError
+from chemex.optimize.method_step import DerivationDisposition, DerivationOutcome
 from chemex.optimize.progress import ProgressPhase
 from chemex.optimize.resampling import NativeResamplingIncompleteError
 from chemex.optimize.uncertainty import ParameterUnit
@@ -624,7 +625,7 @@ def test_interrupted_block_fallback_preserves_committed_root_evidence(
     status = json.loads((covariance_path / "status.json").read_text(encoding="utf-8"))
     assert status["status"] == "incomplete"
     assert status["terminal"] == "interrupted"
-    assert status["reason"] == "block derivation interrupted"
+    assert status["reason"] == "derivation interrupted/cancelled"
     assert (output / "All" / "Parameters" / "fitted.toml").is_file()
 
 
@@ -805,22 +806,53 @@ def test_interrupted_covariance_keeps_committed_fit_and_invalidates_stale_eviden
 
     assert session.analysis_values.snapshot().revision == 1
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
-    assert "error unavailable: derivation interrupted" in fitted
+    assert "error unavailable: derivation interrupted/cancelled" in fitted
     constrained = (output / "Parameters" / "constrained.toml").read_text(
         encoding="utf-8"
     )
-    assert "error unavailable: derivation interrupted" in constrained
+    assert "error unavailable: derivation interrupted/cancelled" in constrained
     assert "# ±" not in constrained
     covariance_path = output / "Statistics" / "Covariance"
     assert not (covariance_path / "evidence.json").exists()
     status = json.loads((covariance_path / "status.json").read_text(encoding="utf-8"))
     assert status == {
         "artifact_type": "native_covariance_derivation_status",
-        "reason": "derivation interrupted",
+        "reason": "derivation interrupted/cancelled",
         "schema_version": 1,
         "status": "incomplete",
         "terminal": "interrupted",
     }
+
+
+def test_cancelled_covariance_uses_the_canonical_product_reason(tmp_path: Path) -> None:
+    output = tmp_path / "Output"
+
+    def cancel_uncertainty(_workflow, _accepted, request, _cancellation):
+        return DerivationOutcome(
+            request.identity,
+            "uncertainty",
+            DerivationDisposition.CANCELLED,
+        )
+
+    with patch(
+        "chemex.optimize.method_step._execute_uncertainty",
+        side_effect=cancel_uncertainty,
+    ):
+        run(_fit_arguments(output), session=AnalysisSession.create())
+
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "error unavailable: derivation interrupted/cancelled" in fitted
+    assert "error unavailable: derivation interrupted/cancelled" in constrained
+    status = json.loads(
+        (output / "Statistics" / "Covariance" / "status.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert status["terminal"] == "cancelled"
+    assert status["reason"] == "derivation interrupted/cancelled"
 
 
 def _grid_method(path: Path) -> Path:

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -1237,7 +1237,7 @@ def test_covariance_and_constrained_evidence_are_separate_from_central_reports(
     ).lower()
     assert "stderr" not in central_reports
     assert "standard error" not in central_reports
-    assert "±" not in central_reports
+    assert "±" in central_reports
 
 
 def test_resampling_and_posterior_evidence_keep_family_specific_semantics(

--- a/tests/test_native_reporting.py
+++ b/tests/test_native_reporting.py
@@ -101,6 +101,10 @@ from chemex.optimize.uncertainty import (
 )
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.spin_system import SpinSystem
+from chemex.printers.parameters import (
+    UncertaintyUnavailableKind,
+    uncertainty_unavailable_reason,
+)
 from chemex.run_info import (
     CapturedNativeInputs,
     NativeRunInformation,
@@ -116,6 +120,33 @@ ROOT = Path(__file__).parent.parent
 EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
 PARAMETERS = ROOT / "examples/Experiments/RELAXATION_HZNZ/Parameters/parameters.toml"
 METHOD = ROOT / "examples/Experiments/RELAXATION_HZNZ/Methods/method.toml"
+
+
+def test_uncertainty_unavailability_vocabulary_is_exhaustive_and_truthful() -> None:
+    assert {
+        kind: uncertainty_unavailable_reason(kind)
+        for kind in UncertaintyUnavailableKind
+    } == {
+        UncertaintyUnavailableKind.RANK_DEFICIENT: "rank deficient",
+        UncertaintyUnavailableKind.INSUFFICIENT_INFORMATION: (
+            "insufficient information"
+        ),
+        UncertaintyUnavailableKind.BOUNDARY_LIMITED: "boundary limited",
+        UncertaintyUnavailableKind.NORMALIZATION_INVALID: "normalization invalid",
+        UncertaintyUnavailableKind.JACOBIAN_UNAVAILABLE: "Jacobian unavailable",
+        UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE: (
+            "covariance numerical failure"
+        ),
+        UncertaintyUnavailableKind.UNSUPPORTED_CONSTRAINED_DERIVATIVE: (
+            "unsupported constrained derivative"
+        ),
+        UncertaintyUnavailableKind.DERIVATION_STOPPED: (
+            "derivation interrupted/cancelled"
+        ),
+        UncertaintyUnavailableKind.CONSTRAINED_PROPAGATION_UNAVAILABLE: (
+            "constrained propagation unavailable"
+        ),
+    }
 
 
 def _captured_inputs(output: Path) -> CapturedNativeInputs:

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -26,6 +26,7 @@ from chemex.evaluation.native import (
     EvaluationResult,
 )
 from chemex.experiments.builder import build_experiments
+from chemex.optimize import native_deterministic as native_deterministic_module
 from chemex.optimize import uncertainty as uncertainty_module
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
@@ -1109,6 +1110,22 @@ def test_absolute_observation_uncertainties_do_not_apply_residual_scaling() -> N
         evidence.covariance.claim("RESIDUAL_VARIANCE_NONDEGENERACY")
         is ClaimState.NOT_APPLICABLE
     )
+
+
+def test_product_request_excludes_unsupported_scientific_function_propagation() -> None:
+    parameterization, _engine, problem = _hd_problem(Method())
+
+    request, unsupported = native_deterministic_module._product_uncertainty_request(
+        problem,
+        parameterization,
+    )
+
+    assert unsupported
+    assert set(unsupported).isdisjoint(request.constrained_scope)
+    assert request.policy.residual_variance_scaling is (
+        ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+    )
+    assert request.policy.coordinate_scales
 
 
 def test_malformed_non_finite_svd_output_is_a_typed_covariance_failure() -> None:

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -1128,6 +1128,25 @@ def test_product_request_excludes_unsupported_scientific_function_propagation() 
     assert request.policy.coordinate_scales
 
 
+def test_product_request_does_not_hide_structural_capability_errors() -> None:
+    parameterization, _engine, problem = _hd_problem(Method())
+
+    with (
+        patch.object(
+            native_deterministic_module,
+            "compile_constraint_linearization_capabilities",
+            side_effect=uncertainty_module.UncertaintyConstructionError("malformed"),
+        ),
+        pytest.raises(
+            uncertainty_module.UncertaintyConstructionError, match="malformed"
+        ),
+    ):
+        native_deterministic_module._product_uncertainty_request(
+            problem,
+            parameterization,
+        )
+
+
 def test_malformed_non_finite_svd_output_is_a_typed_covariance_failure() -> None:
     _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
     malformed_svd = (

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -186,7 +186,7 @@ def _qualification_policy(controlled_id: str) -> UncertaintyPolicy:
         roundoff_multiplier=64.0,
         smaller_step_extent=8,
         larger_step_extent=8,
-        svd_driver="gesvd",
+        svd_driver="gesdd",
         rank_absolute_tolerance=0.0,
         rank_relative_tolerance=1.0e-12,
         weak_relative_tolerance=1.0e-6,
@@ -1304,7 +1304,7 @@ def test_noncontiguous_partition_scopes_map_to_root_coordinates_independently() 
 
 def test_dimension_aware_rank_threshold_handles_exact_and_near_rank_spectra() -> None:
     policy = _qualification_policy("a")
-    assert policy.svd_driver == "gesvd"
+    assert policy.svd_driver == "gesdd"
     exact = np.asarray(((1.0, 1.0), (2.0, 2.0), (3.0, 3.0)))
     exact_analysis, exact_failure = uncertainty_module._analyze_scaled_jacobian(
         exact,
@@ -1335,6 +1335,17 @@ def test_dimension_aware_rank_threshold_handles_exact_and_near_rank_spectra() ->
     assert near_failure is None
     assert near_analysis is not None
     assert near_analysis.rank == 2
+
+    gesvd_analysis, gesvd_failure = uncertainty_module._analyze_scaled_jacobian(
+        near,
+        (1.0, 1.0),
+        policy=dataclasses.replace(policy, svd_driver="gesvd"),
+        source_identity="near-rank-spectrum-gesvd",
+        cancellation_probe=None,
+    )
+    assert gesvd_failure is None
+    assert gesvd_analysis is not None
+    assert gesvd_analysis.rank == near_analysis.rank
 
 
 def test_rank_deficiency_is_diagnostic_and_never_manufactures_uncertainty() -> None:
@@ -2105,6 +2116,158 @@ def test_authoritative_artifacts_reject_inconsistent_reconstruction() -> None:
             entries=(
                 dataclasses.replace(evidence.marginal_errors.entries[0], value=42.0),
             ),
+        )
+
+
+def test_artifact_reconstruction_does_not_replay_numerical_algorithms() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    derived_id = "__R1A_B_G2N_H_800_0MHZ"
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(controlled_id),
+        constrained_scope=(derived_id,),
+        constrained_units=((derived_id, ParameterUnit.RATE_PER_SECOND),),
+        constrained_scales=((derived_id, 1.0),),
+        compiled_constraint_linearization=compile_constraint_linearization_capabilities(
+            parameterization,
+            (derived_id,),
+            (),
+        ),
+        resolved_environment_identity="artifact-no-replay",
+    )
+    rank = evidence.rank_diagnostic
+    covariance = evidence.covariance
+    propagation = evidence.constrained_propagation
+    assert rank is not None
+    assert covariance is not None
+    assert propagation is not None
+
+    with (
+        patch(
+            "chemex.optimize.uncertainty.svd",
+            side_effect=AssertionError("SVD replayed"),
+        ),
+        patch(
+            "chemex.optimize.uncertainty._invariant_singular_subspaces",
+            side_effect=AssertionError("projectors replayed"),
+        ),
+    ):
+        dataclasses.replace(rank)
+    with (
+        patch(
+            "chemex.optimize.uncertainty.svd",
+            side_effect=AssertionError("SVD replayed"),
+        ),
+        patch(
+            "chemex.optimize.uncertainty._canonical_covariance_reduction",
+            side_effect=AssertionError("covariance replayed"),
+        ),
+    ):
+        dataclasses.replace(covariance)
+    with (
+        patch(
+            "chemex.optimize.uncertainty._pairwise_sum",
+            side_effect=AssertionError("G @ L replayed"),
+        ),
+        patch(
+            "chemex.optimize.uncertainty._gram_matrix",
+            side_effect=AssertionError("propagated Gram replayed"),
+        ),
+    ):
+        dataclasses.replace(propagation)
+
+
+def test_covariance_producer_rejects_finite_internally_inconsistent_arrays() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    original = uncertainty_module._canonical_covariance_reduction
+
+    def inconsistent_reduction(*args: object, **kwargs: object):
+        unscaled, factor, covariance = original(*args, **kwargs)
+        return (
+            tuple(tuple(4.0 * value for value in row) for row in unscaled),
+            tuple(tuple(2.0 * value for value in row) for row in factor),
+            tuple(tuple(4.0 * value for value in row) for row in covariance),
+        )
+
+    with patch.object(
+        uncertainty_module,
+        "_canonical_covariance_reduction",
+        side_effect=inconsistent_reduction,
+    ):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            resolved_environment_identity="inconsistent-covariance-producer",
+        )
+
+    assert evidence.covariance is None
+    assert any(
+        failure.category == "invalid_covariance_arithmetic"
+        and "Covariance factor is inconsistent with its retained source"
+        in failure.message
+        for failure in evidence.failures
+    )
+
+
+def test_constraint_producer_rejects_coherently_corrupted_factor_and_gram() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    derived_id = "__R1A_B_G2N_H_800_0MHZ"
+    original = uncertainty_module._propagated_factor_and_covariance
+
+    def inconsistent_propagation(*args: object, **kwargs: object):
+        factor, covariance = original(*args, **kwargs)
+        return (
+            tuple(tuple(2.0 * value for value in row) for row in factor),
+            tuple(tuple(4.0 * value for value in row) for row in covariance),
+        )
+
+    with patch.object(
+        uncertainty_module,
+        "_propagated_factor_and_covariance",
+        side_effect=inconsistent_propagation,
+    ):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            constrained_scope=(derived_id,),
+            constrained_units=((derived_id, ParameterUnit.RATE_PER_SECOND),),
+            constrained_scales=((derived_id, 1.0),),
+            compiled_constraint_linearization=(
+                compile_constraint_linearization_capabilities(
+                    parameterization,
+                    (derived_id,),
+                    (),
+                )
+            ),
+            resolved_environment_identity="inconsistent-propagation-producer",
+        )
+
+    assert evidence.constrained_propagation is None
+    assert any(
+        failure.category == "gram_propagation_failure"
+        and "Constrained covariance factor is inconsistent with its retained source"
+        in failure.message
+        for failure in evidence.failures
+    )
+
+
+def test_matrix_relation_validation_is_relative_for_small_covariances() -> None:
+    with pytest.raises(ArithmeticError, match="retained source"):
+        uncertainty_module._validate_matrix_relation(
+            ((2.0e-20,),),
+            np.asarray(((1.0e-20,),), dtype=np.float64),
+            name="Small covariance",
+            reduction_dimension=1,
         )
 
 

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -22,6 +22,7 @@ from chemex.configuration.parameters import read_defaults
 from chemex.evaluation.native import (
     BoundEvaluator,
     EvaluationEngine,
+    EvaluationFailure,
     EvaluationFrame,
     EvaluationResult,
 )
@@ -50,6 +51,7 @@ from chemex.optimize.uncertainty import (
 )
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.spin_system import SpinSystem
+from chemex.printers.parameters import parameter_uncertainty_view
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
 
@@ -137,7 +139,7 @@ def _qualification_policy(controlled_id: str) -> UncertaintyPolicy:
         roundoff_multiplier=64.0,
         smaller_step_extent=8,
         larger_step_extent=8,
-        svd_driver="gesdd",
+        svd_driver="gesvd",
         rank_absolute_tolerance=0.0,
         rank_relative_tolerance=1.0e-12,
         weak_relative_tolerance=1.0e-6,
@@ -400,7 +402,9 @@ def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation()
     assert evidence.covariance.profiled_normalization_count == 1
     assert evidence.covariance.nominal_residual_degrees_of_freedom == 5
     assert evidence.covariance.rank == 1
-    assert evidence.covariance.factorization == ("direct-scaled-svd-factor-gram-v3")
+    assert evidence.covariance.factorization == (
+        "column-equilibrated-svd-factor-gram-v4"
+    )
     expected_variance = (accepted.chi_square / 5.0) / float(
         expected_jacobian[:, 0] @ expected_jacobian[:, 0]
     )
@@ -468,6 +472,13 @@ def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation()
     assert typed_payload["resolved_environment_identity"] == (
         "local-qualification-environment"
     )
+    residual_record = cast(
+        "dict[str, object]",
+        typed_payload["residual_jacobian"],
+    )
+    assert "matrix" not in residual_record
+    assert residual_record["matrix_shape"] == [7, 1]
+    assert len(cast("str", residual_record["matrix_binary64_sha256"])) == 64
     other_environment = derive_uncertainty_evidence(
         accepted,
         problem=problem,
@@ -491,6 +502,145 @@ def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation()
         item.occurrence_identity for item in other_environment.operations
     ) != tuple(item.occurrence_identity for item in evidence.operations)
     assert session.analysis_values.snapshot() == before
+
+
+def test_product_covariance_reuses_backend_jacobian_without_residual_evaluation() -> (
+    None
+):
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    request, _unsupported = native_deterministic_module._product_uncertainty_request(
+        problem,
+        parameterization,
+    )
+    evaluation_calls = 0
+
+    def reject_evaluation(
+        _evaluator: BoundEvaluator,
+        _frame: EvaluationFrame,
+    ) -> EvaluationResult:
+        nonlocal evaluation_calls
+        evaluation_calls += 1
+        raise AssertionError("valid retained backend Jacobian must avoid replay")
+
+    with patch.object(BoundEvaluator, "evaluate", reject_evaluation):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=request.policy,
+            constrained_scope=request.constrained_scope,
+            constrained_units=request.constrained_units,
+            constrained_scales=request.constrained_scales,
+            compiled_constraint_linearization=request.compiled_capabilities,
+            resolved_environment_identity=request.resolved_environment_identity,
+        )
+
+    assert evaluation_calls == 0
+    assert evidence.residual_jacobian is not None
+    assert evidence.residual_jacobian.method == "retained-scipy-final-2-point"
+    assert evidence.covariance is not None
+
+
+def test_failed_accepted_point_fallback_reports_jacobian_unavailable() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    request, _unsupported = native_deterministic_module._product_uncertainty_request(
+        problem,
+        parameterization,
+    )
+    fallback_anchor = _qualified_accepted_copy(
+        accepted,
+        occurrence_identity="failed-accepted-point-fallback",
+    )
+    with patch.object(
+        BoundEvaluator,
+        "evaluate",
+        return_value=EvaluationFailure(
+            engine.plan.identity,
+            parameterization.evaluator_identity,
+            "kernel",
+            "kernel_exception",
+            "IMPLEMENTATION_FAILURE",
+            message="fallback evaluator unavailable",
+        ),
+    ):
+        evidence = derive_uncertainty_evidence(
+            fallback_anchor,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=request.policy,
+            resolved_environment_identity="failed-fallback-environment",
+        )
+
+    assert evidence.residual_jacobian is None
+    assert any(
+        failure.stage == "residual_linearization" for failure in evidence.failures
+    )
+    assert (
+        parameter_uncertainty_view(evidence).unavailable_reason(
+            problem.controlled_ids[0]
+        )
+        == "Jacobian unavailable"
+    )
+
+
+def test_backend_fallback_and_high_quality_jacobians_agree_at_accepted_point() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    request, _unsupported = native_deterministic_module._product_uncertainty_request(
+        problem,
+        parameterization,
+    )
+    backend = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=request.policy,
+        resolved_environment_identity=request.resolved_environment_identity,
+    )
+    fallback_anchor = _qualified_accepted_copy(
+        accepted,
+        occurrence_identity="accepted-point-fallback-comparison",
+    )
+    fallback = derive_uncertainty_evidence(
+        fallback_anchor,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=request.policy,
+        resolved_environment_identity="fallback-comparison-environment",
+    )
+    reference_anchor = _qualified_accepted_copy(
+        accepted,
+        occurrence_identity="high-quality-reference-comparison",
+    )
+    reference = derive_uncertainty_evidence(
+        reference_anchor,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=_qualification_policy(problem.controlled_ids[0]),
+        resolved_environment_identity="reference-comparison-environment",
+    )
+    assert backend.residual_jacobian is not None
+    assert fallback.residual_jacobian is not None
+    assert reference.residual_jacobian is not None
+    assert backend.residual_jacobian.evaluation_count == 0
+    assert fallback.residual_jacobian.evaluation_count == len(problem.controlled_ids)
+    assert fallback.residual_jacobian.method == "accepted-point-2-point"
+    np.testing.assert_allclose(
+        backend.residual_jacobian.matrix,
+        fallback.residual_jacobian.matrix,
+        rtol=2.0e-7,
+        atol=2.0e-8,
+    )
+    np.testing.assert_allclose(
+        backend.residual_jacobian.matrix,
+        reference.residual_jacobian.matrix,
+        rtol=2.0e-6,
+        atol=2.0e-8,
+    )
 
 
 def test_scientific_constraint_requires_and_uses_declared_numerical_capability() -> (
@@ -685,11 +835,11 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
         atol=2.0e-9,
     )
     assert evidence.rank_diagnostic is not None
-    scaled_reference = reference_jacobian * np.asarray((0.1, 10.0))[np.newaxis, :]
+    reference_column_norms = np.linalg.norm(reference_jacobian, axis=0)
+    equilibration_scales = 1.0 / reference_column_norms
+    scaled_reference = reference_jacobian * equilibration_scales[np.newaxis, :]
     expected_singular_values = np.linalg.svd(scaled_reference, compute_uv=False)
-    # Independent expected singular values are [154.1975407925,
-    # 24.2113113641].  The SVD comparison therefore measures the production
-    # derivative error, not a copied production decomposition.
+    # The reference derives unit-insensitive equilibration only from J.
     np.testing.assert_allclose(
         evidence.rank_diagnostic.singular_values,
         expected_singular_values,
@@ -702,7 +852,7 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
         rtol=0.0,
         atol=3.0e-16,
     )
-    with pytest.raises(ValueError, match="classified subspaces"):
+    with pytest.raises(ValueError, match="projector"):
         dataclasses.replace(
             evidence.rank_diagnostic,
             identifiable_projector=((1.0, 0.0), (0.0, 0.0)),
@@ -712,7 +862,7 @@ def test_multivariate_scaled_svd_correlation_and_joint_propagation_reference() -
     expected_unscaled, _expected_factor, expected_covariance = (
         _independent_svd_covariance(
             reference_jacobian,
-            (0.1, 10.0),
+            tuple(float(value) for value in equilibration_scales),
             1.0,
         )
     )
@@ -822,23 +972,132 @@ def test_covariance_uses_direct_svd_not_normal_equations() -> None:
     assert relative_difference > 1.0e-5
 
 
+def test_column_equilibrated_rank_and_physical_covariance_are_unit_invariant() -> None:
+    jacobian = np.asarray(
+        (
+            (1.0, 1.0),
+            (2.0, -1.0),
+            (-1.0, 3.0),
+            (0.5, 2.0),
+        ),
+        dtype=np.float64,
+    )
+    policy = _qualification_policy("a")
+    original, failure = uncertainty_module._analyze_scaled_jacobian(
+        jacobian,
+        (1.0, 1.0),
+        policy=policy,
+        source_identity="unit-invariance-original",
+        cancellation_probe=None,
+    )
+    assert failure is None
+    assert original is not None
+    factor = 1.0e6
+    unit_changed, failure = uncertainty_module._analyze_scaled_jacobian(
+        jacobian * np.asarray((1.0, 1.0 / factor))[np.newaxis, :],
+        (7.0, 11.0),
+        policy=policy,
+        source_identity="unit-invariance-rescaled",
+        cancellation_probe=None,
+    )
+    assert failure is None
+    assert unit_changed is not None
+
+    assert original.rank == unit_changed.rank == 2
+    assert original.threshold == pytest.approx(
+        original.singular_values[0] * max(jacobian.shape) * np.finfo(np.float64).eps
+    )
+    np.testing.assert_allclose(
+        original.singular_values,
+        unit_changed.singular_values,
+        rtol=2.0e-15,
+        atol=0.0,
+    )
+    _unscaled, _factor, covariance = uncertainty_module._canonical_covariance_reduction(
+        original.singular_values,
+        original.right_transpose,
+        original.equilibration_scales,
+        1.0,
+    )
+    _unit_unscaled, _unit_factor, unit_covariance = (
+        uncertainty_module._canonical_covariance_reduction(
+            unit_changed.singular_values,
+            unit_changed.right_transpose,
+            unit_changed.equilibration_scales,
+            1.0,
+        )
+    )
+    back_transform = np.diag((1.0, 1.0 / factor))
+    np.testing.assert_allclose(
+        covariance,
+        back_transform @ np.asarray(unit_covariance) @ back_transform,
+        rtol=3.0e-15,
+        atol=2.0e-16,
+    )
+
+
+def test_noncontiguous_partition_scopes_map_to_root_coordinates_independently() -> None:
+    assert uncertainty_module._partition_coordinate_indices(
+        ("a", "b", "c"),
+        (("a", "c"), ("b",)),
+    ) == ((0, 2), (1,))
+
+
+def test_dimension_aware_rank_threshold_handles_exact_and_near_rank_spectra() -> None:
+    policy = _qualification_policy("a")
+    assert policy.svd_driver == "gesvd"
+    exact = np.asarray(((1.0, 1.0), (2.0, 2.0), (3.0, 3.0)))
+    exact_analysis, exact_failure = uncertainty_module._analyze_scaled_jacobian(
+        exact,
+        (1.0, 1.0),
+        policy=policy,
+        source_identity="exact-rank-deficiency",
+        cancellation_probe=None,
+    )
+    assert exact_failure is None
+    assert exact_analysis is not None
+    assert exact_analysis.rank == 1
+
+    epsilon = np.finfo(np.float64).eps
+    near = np.asarray(
+        (
+            (1.0, 1.0),
+            (-1.0, -1.0 + 64.0 * epsilon),
+            (1.0, 1.0 - 64.0 * epsilon),
+        )
+    )
+    near_analysis, near_failure = uncertainty_module._analyze_scaled_jacobian(
+        near,
+        (1.0, 1.0),
+        policy=policy,
+        source_identity="near-rank-spectrum",
+        cancellation_probe=None,
+    )
+    assert near_failure is None
+    assert near_analysis is not None
+    assert near_analysis.rank == 2
+
+
 def test_rank_deficiency_is_diagnostic_and_never_manufactures_uncertainty() -> None:
     session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
     controlled_id = problem.controlled_ids[0]
-    policy = _qualification_policy(controlled_id)
-    rank_rejecting_policy = dataclasses.replace(
-        policy,
-        rank_absolute_tolerance=1.0e100,
-    )
+    original_svd = uncertainty_module.svd
 
-    evidence = derive_uncertainty_evidence(
-        accepted,
-        problem=problem,
-        parameterization=parameterization,
-        engine=engine,
-        policy=rank_rejecting_policy,
-        resolved_environment_identity="local-qualification-environment",
-    )
+    def rank_deficient_svd(*args, **kwargs):
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        singular[-1] = 0.0
+        return left, singular, right
+
+    with patch.object(uncertainty_module, "svd", side_effect=rank_deficient_svd):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(controlled_id),
+            resolved_environment_identity="local-qualification-environment",
+        )
 
     assert evidence.residual_jacobian is not None
     assert evidence.rank_diagnostic is not None
@@ -936,6 +1195,10 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
     assert evidence.correlations is not None
     assert evidence.correlations.entries[0][0].value == 1.0
     assert not evidence.correlations.scope_reportable
+    assert (
+        parameter_uncertainty_view(evidence).unavailable_reason(controlled_id)
+        == "boundary limited"
+    )
     forged_reportability_claims = tuple(
         dataclasses.replace(item, state=ClaimState.SATISFIED)
         if item.name == "MARGINAL_SCOPE_REPORTABILITY"
@@ -998,6 +1261,33 @@ def test_nonfinite_boundary_separation_is_indeterminate() -> None:
     assert evidence.covariance.claim("BOUNDARY_SEPARATION") is ClaimState.INDETERMINATE
 
 
+def test_normalization_failure_has_its_own_reporting_reason() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    with patch(
+        "chemex.optimize.uncertainty._profiled_normalization_regular",
+        return_value=False,
+    ):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            resolved_environment_identity="invalid-profiled-normalization",
+        )
+
+    assert evidence.covariance is not None
+    assert evidence.covariance.claim("PROFILED_NORMALIZATION_REGULARITY") is (
+        ClaimState.VIOLATED
+    )
+    assert (
+        parameter_uncertainty_view(evidence).unavailable_reason(
+            problem.controlled_ids[0]
+        )
+        == "normalization invalid"
+    )
+
+
 def test_non_finite_accepted_objective_yields_only_typed_failed_covariance() -> None:
     _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
     non_finite = _qualified_accepted_copy(
@@ -1022,6 +1312,12 @@ def test_non_finite_accepted_objective_yields_only_typed_failed_covariance() -> 
     ]
     assert evidence.marginal_errors is None
     assert evidence.correlations is None
+    assert (
+        parameter_uncertainty_view(evidence).unavailable_reason(
+            problem.controlled_ids[0]
+        )
+        == "covariance numerical failure"
+    )
 
 
 def test_foreign_coordinate_scope_fails_before_any_numerical_evidence() -> None:
@@ -1147,7 +1443,7 @@ def test_product_request_does_not_hide_structural_capability_errors() -> None:
         )
 
 
-def test_scaled_svd_preserves_full_rank_when_information_condition_overflows() -> None:
+def test_full_rank_conditioning_above_diagnostic_limit_is_not_a_rank_gate() -> None:
     policy = dataclasses.replace(
         _qualification_policy("a"),
         coordinate_scales=(("a", 1.0), ("b", 1.0)),
@@ -1155,29 +1451,50 @@ def test_scaled_svd_preserves_full_rank_when_information_condition_overflows() -
             ("a", ParameterUnit.UNSPECIFIED),
             ("b", ParameterUnit.UNSPECIFIED),
         ),
-        rank_relative_tolerance=0.0,
+        conditioning_limit=1.0e6,
     )
 
-    with patch.object(
-        uncertainty_module,
-        "svd",
-        return_value=(np.eye(2), np.array((1.0e200, 1.0)), np.eye(2)),
-    ):
-        analysis, failure = uncertainty_module._analyze_scaled_jacobian(
-            np.eye(2),
-            (1.0, 1.0),
-            policy=policy,
-            source_identity="overflowing-information-condition",
-            cancellation_probe=None,
-        )
+    analysis, failure = uncertainty_module._analyze_scaled_jacobian(
+        np.asarray(((1.0, 1.0), (1.0, 1.0 + 1.0e-8), (1.0, 1.0 - 1.0e-8))),
+        (1.0, 1.0),
+        policy=policy,
+        source_identity="large-full-rank-condition",
+        cancellation_probe=None,
+    )
 
     assert analysis is not None
     assert analysis.rank == 2
-    assert analysis.jacobian_condition == pytest.approx(1.0e200)
+    assert analysis.jacobian_condition is not None
+    assert analysis.jacobian_condition > policy.conditioning_limit
     assert analysis.information_condition is not None
-    assert math.isinf(analysis.information_condition)
-    assert failure is not None
-    assert failure.category == "non_finite_information_condition"
+    assert failure is None
+
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    product_request, _unsupported = (
+        native_deterministic_module._product_uncertainty_request(
+            problem,
+            parameterization,
+        )
+    )
+    evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=dataclasses.replace(
+            product_request.policy,
+            conditioning_limit=0.5,
+        ),
+        resolved_environment_identity="conditioning-is-diagnostic-only",
+    )
+    assert evidence.covariance is not None
+    assert evidence.covariance.jacobian_condition > 0.5
+    assert evidence.covariance.claim("CONDITIONING_ADEQUACY") is (ClaimState.VIOLATED)
+    assert evidence.covariance.claim("USABLE_LOCAL_COVARIANCE") is (
+        ClaimState.SATISFIED
+    )
+    assert evidence.marginal_errors is not None
+    assert evidence.marginal_errors.scope_reportable
 
 
 def test_malformed_non_finite_svd_output_is_a_typed_covariance_failure() -> None:
@@ -1202,6 +1519,37 @@ def test_malformed_non_finite_svd_output_is_a_typed_covariance_failure() -> None
     assert evidence.covariance is None
     assert evidence.rank_diagnostic is None
     assert evidence.failures[-1].category == "invalid_covariance_arithmetic"
+    assert (
+        parameter_uncertainty_view(evidence).unavailable_reason(
+            problem.controlled_ids[0]
+        )
+        == "covariance numerical failure"
+    )
+
+
+def test_svd_exception_is_reported_as_covariance_numerical_failure() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    with patch(
+        "chemex.optimize.uncertainty.svd",
+        side_effect=np.linalg.LinAlgError("gesvd did not converge"),
+    ):
+        evidence = derive_uncertainty_evidence(
+            accepted,
+            problem=problem,
+            parameterization=parameterization,
+            engine=engine,
+            policy=_qualification_policy(problem.controlled_ids[0]),
+            resolved_environment_identity="svd-failure-reporting",
+        )
+
+    assert evidence.covariance is None
+    assert evidence.failures[-1].category == "svd_failure"
+    assert (
+        parameter_uncertainty_view(evidence).unavailable_reason(
+            problem.controlled_ids[0]
+        )
+        == "covariance numerical failure"
+    )
 
 
 def test_negative_svd_spectrum_is_typed_invalid_evidence() -> None:
@@ -1246,6 +1594,12 @@ def test_positive_scale_covariance_factor_underflow_is_typed_failure() -> None:
 
     assert evidence.covariance is None
     assert evidence.failures[-1].category == "covariance_factor_underflow"
+    assert (
+        parameter_uncertainty_view(evidence).unavailable_reason(
+            problem.controlled_ids[0]
+        )
+        == "covariance numerical failure"
+    )
 
 
 def test_cancellation_freezes_terminal_operation_without_artifact() -> None:
@@ -1347,7 +1701,7 @@ def test_exact_accepted_occurrence_is_not_reconstructible_or_mixable() -> None:
         accepted,
         occurrence_identity="equivalent-authoritative-occurrence",
     )
-    assert equivalent_occurrence.identity == accepted.identity
+    assert equivalent_occurrence.identity != accepted.identity
     other_evidence = derive_uncertainty_evidence(
         equivalent_occurrence,
         problem=problem,
@@ -1448,12 +1802,7 @@ def test_authoritative_artifacts_reject_inconsistent_reconstruction() -> None:
             columns=(forged_column,),
             matrix=forged_matrix,
         )
-    forged_subspace = dataclasses.replace(
-        rank.subspaces[0],
-        classification="isolated_null",
-    )
-    with pytest.raises(ValueError, match="classification"):
-        dataclasses.replace(rank, subspaces=(forged_subspace,))
+    assert rank.subspaces == ()
 
     altered_claims = tuple(
         dataclasses.replace(item, state=ClaimState.SATISFIED)
@@ -1984,7 +2333,7 @@ def test_clustered_singular_evidence_retains_only_invariant_projectors() -> None
         cluster_relative_tolerance=1.0e-10,
     )
     assert exact[0].classification == "clustered_identifiable"
-    assert exact[1].classification == "isolated_identifiable"
+    assert len(exact) == 1
     np.testing.assert_allclose(
         exact[0].projector, rotated_exact[0].projector, atol=2e-16
     )
@@ -2005,7 +2354,6 @@ def test_clustered_singular_evidence_retains_only_invariant_projectors() -> None
         cluster_relative_tolerance=1.0e-10,
     )
     assert tuple(item.classification for item in classified) == (
-        "isolated_identifiable",
         "isolated_weak",
         "isolated_null",
     )

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -1147,6 +1147,39 @@ def test_product_request_does_not_hide_structural_capability_errors() -> None:
         )
 
 
+def test_scaled_svd_preserves_full_rank_when_information_condition_overflows() -> None:
+    policy = dataclasses.replace(
+        _qualification_policy("a"),
+        coordinate_scales=(("a", 1.0), ("b", 1.0)),
+        coordinate_units=(
+            ("a", ParameterUnit.UNSPECIFIED),
+            ("b", ParameterUnit.UNSPECIFIED),
+        ),
+        rank_relative_tolerance=0.0,
+    )
+
+    with patch.object(
+        uncertainty_module,
+        "svd",
+        return_value=(np.eye(2), np.array((1.0e200, 1.0)), np.eye(2)),
+    ):
+        analysis, failure = uncertainty_module._analyze_scaled_jacobian(
+            np.eye(2),
+            (1.0, 1.0),
+            policy=policy,
+            source_identity="overflowing-information-condition",
+            cancellation_probe=None,
+        )
+
+    assert analysis is not None
+    assert analysis.rank == 2
+    assert analysis.jacobian_condition == pytest.approx(1.0e200)
+    assert analysis.information_condition is not None
+    assert math.isinf(analysis.information_condition)
+    assert failure is not None
+    assert failure.category == "non_finite_information_condition"
+
+
 def test_malformed_non_finite_svd_output_is_a_typed_covariance_failure() -> None:
     _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
     malformed_svd = (

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from scipy.optimize import least_squares
 
 from chemex.configuration.methods import Method, Selection, read_methods
 from chemex.configuration.parameters import read_defaults
@@ -63,6 +64,8 @@ DCEST_EXPERIMENT = ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Experiments/3h
 DCEST_PARAMETERS = (
     ROOT / "examples/Experiments/DCEST_15N_HD_EXCH/Parameters/parameters.toml"
 )
+CPMG_ROOT = ROOT / "examples/Experiments/CPMG_15N_IP"
+CEST_ROOT = ROOT / "examples/Experiments/CEST_13C_LABEL_CN"
 
 
 def _analytic_pa_kab(kab: float, kba: float) -> float:
@@ -121,6 +124,50 @@ def _accepted_relaxation_fit() -> tuple[
     )
     assert outcome.accepted_result is not None
     return session, parameterization, engine, problem, outcome.accepted_result
+
+
+def _accepted_step1_profile_fit(
+    example: Path,
+    spin_system: str,
+) -> tuple[
+    ActiveParameterization, EvaluationEngine, OptimizationProblem, AcceptedFitResult
+]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    method = read_methods([example / "Methods/method.toml"])["STEP1"]
+    experiments = build_experiments(
+        sorted((example / "Experiments").glob("*.toml")),
+        Selection(
+            include=[SpinSystem.from_name(spin_system)],
+            exclude=None,
+        ),
+        session=session,
+    )
+    session.parameters.set_defaults(
+        read_defaults([example / "Parameters/parameters.toml"])
+    )
+    assert session.try_build_analysis_values()
+    parameterization = session.compile_parameterization(method, experiments.param_ids)
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    outcome = execute_direct_trf(
+        problem,
+        DirectTrfInvocation.for_problem(
+            problem,
+            objective_request_budget=2000 * (len(problem.controlled_ids) + 1),
+        ),
+        parameterization,
+        engine,
+    )
+    assert outcome.accepted_result is not None
+    return parameterization, engine, problem, outcome.accepted_result
 
 
 def _qualification_policy(controlled_id: str) -> UncertaintyPolicy:
@@ -640,6 +687,218 @@ def test_backend_fallback_and_high_quality_jacobians_agree_at_accepted_point() -
         reference.residual_jacobian.matrix,
         rtol=2.0e-6,
         atol=2.0e-8,
+    )
+
+
+def test_fallback_reverses_a_full_step_before_shortening_at_a_bound() -> None:
+    center = float(np.nextafter(1.0, 0.0))
+    calls: list[float] = []
+
+    def residual(vector: Array) -> Array:
+        calls.append(float(vector[0]))
+        return np.asarray((vector[0] ** 2,))
+
+    least_squares(
+        residual,
+        np.asarray((center,)),
+        jac="2-point",
+        bounds=(np.asarray((0.0,)), np.asarray((1.0,))),
+        method="trf",
+        loss="linear",
+        diff_step=None,
+        max_nfev=1,
+    )
+    scipy_displacement = calls[1] - calls[0]
+    nominal = math.sqrt(np.finfo(np.float64).eps) * max(1.0, abs(center))
+    displacement, orientation = uncertainty_module._scipy_style_two_point_displacement(
+        center,
+        nominal,
+        -center,
+        1.0 - center,
+    )
+
+    assert orientation == "backward"
+    assert displacement == scipy_displacement
+    assert abs(displacement) == pytest.approx(nominal)
+
+
+@pytest.mark.parametrize(
+    ("example", "spin_system"),
+    ((CPMG_ROOT, "15N-HN"), (CEST_ROOT, "L18CB")),
+    ids=("cpmg", "cest"),
+)
+def test_production_backend_fallback_and_reference_covariance_agree(
+    example: Path,
+    spin_system: str,
+) -> None:
+    parameterization, engine, problem, accepted = _accepted_step1_profile_fit(
+        example,
+        spin_system,
+    )
+    request, _unsupported = native_deterministic_module._product_uncertainty_request(
+        problem,
+        parameterization,
+    )
+    fallback_anchor = _qualified_accepted_copy(
+        accepted,
+        occurrence_identity=f"{spin_system}-fallback-comparison",
+    )
+    reference_anchor = _qualified_accepted_copy(
+        accepted,
+        occurrence_identity=f"{spin_system}-reference-comparison",
+    )
+    reference_policy = dataclasses.replace(
+        request.policy,
+        calibration_identity=f"{request.policy.calibration_identity}-{spin_system}",
+        residual_jacobian_strategy="high-quality-reference",
+    )
+    backend = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=request.policy,
+        resolved_environment_identity="production-backend-comparison",
+    )
+    fallback = derive_uncertainty_evidence(
+        fallback_anchor,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=request.policy,
+        resolved_environment_identity="production-fallback-comparison",
+    )
+    reference = derive_uncertainty_evidence(
+        reference_anchor,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=reference_policy,
+        resolved_environment_identity="production-reference-comparison",
+    )
+
+    assert backend.residual_jacobian is not None
+    assert fallback.residual_jacobian is not None
+    assert reference.residual_jacobian is not None
+    assert backend.residual_jacobian.evaluation_count == 0
+    assert fallback.residual_jacobian.evaluation_count == len(problem.controlled_ids)
+    assert reference.residual_jacobian.evaluation_count >= 1 + 4 * len(
+        problem.controlled_ids
+    )
+    np.testing.assert_allclose(
+        backend.residual_jacobian.matrix,
+        fallback.residual_jacobian.matrix,
+        rtol=3.0e-6,
+        atol=3.0e-7,
+    )
+    np.testing.assert_allclose(
+        backend.residual_jacobian.matrix,
+        reference.residual_jacobian.matrix,
+        rtol=2.0e-4,
+        atol=1.5e-5,
+    )
+    assert backend.rank_diagnostic is not None
+    assert fallback.rank_diagnostic is not None
+    assert reference.rank_diagnostic is not None
+    assert (
+        backend.rank_diagnostic.rank
+        == fallback.rank_diagnostic.rank
+        == reference.rank_diagnostic.rank
+    )
+    assert backend.covariance is not None
+    assert fallback.covariance is not None
+    assert reference.covariance is not None
+    np.testing.assert_allclose(
+        backend.covariance.covariance,
+        fallback.covariance.covariance,
+        rtol=8.0e-6,
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        backend.covariance.covariance,
+        reference.covariance.covariance,
+        rtol=2.0e-3,
+        atol=1.0e-12,
+    )
+    assert backend.covariance.jacobian_condition == pytest.approx(
+        fallback.covariance.jacobian_condition,
+        rel=8.0e-6,
+    )
+    assert backend.covariance.jacobian_condition == pytest.approx(
+        reference.covariance.jacobian_condition,
+        rel=2.0e-3,
+    )
+    backend_claims = {
+        item.name: item.state
+        for item in backend.covariance.claims
+        if item.name
+        in {
+            "INTERIOR_POINT",
+            "BOUNDARY_SEPARATION",
+            "CONTROLLED_AFFINE_SEPARATION",
+            "USABLE_LOCAL_COVARIANCE",
+        }
+    }
+    assert backend_claims == {
+        item.name: item.state
+        for item in fallback.covariance.claims
+        if item.name in backend_claims
+    }
+    assert backend_claims == {
+        item.name: item.state
+        for item in reference.covariance.claims
+        if item.name in backend_claims
+    }
+    assert backend.marginal_errors is not None
+    assert fallback.marginal_errors is not None
+    assert reference.marginal_errors is not None
+    assert tuple(item.outcome for item in backend.marginal_errors.entries) == tuple(
+        item.outcome for item in fallback.marginal_errors.entries
+    )
+    backend_errors = np.sqrt(np.diag(backend.covariance.covariance))
+    fallback_errors = np.sqrt(np.diag(fallback.covariance.covariance))
+    reference_errors = np.sqrt(np.diag(reference.covariance.covariance))
+    np.testing.assert_allclose(
+        backend_errors,
+        fallback_errors,
+        rtol=4.0e-6,
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        backend_errors,
+        reference_errors,
+        rtol=1.0e-3,
+        atol=1.0e-12,
+    )
+    assert backend.correlations is not None
+    assert fallback.correlations is not None
+    assert reference.correlations is not None
+    backend_correlation = (
+        np.asarray(backend.covariance.covariance)
+        / backend_errors[:, np.newaxis]
+        / backend_errors[np.newaxis, :]
+    )
+    fallback_correlation = (
+        np.asarray(fallback.covariance.covariance)
+        / fallback_errors[:, np.newaxis]
+        / fallback_errors[np.newaxis, :]
+    )
+    reference_correlation = (
+        np.asarray(reference.covariance.covariance)
+        / reference_errors[:, np.newaxis]
+        / reference_errors[np.newaxis, :]
+    )
+    np.testing.assert_allclose(
+        backend_correlation,
+        fallback_correlation,
+        rtol=8.0e-6,
+        atol=1.0e-10,
+    )
+    np.testing.assert_allclose(
+        backend_correlation,
+        reference_correlation,
+        rtol=2.0e-3,
+        atol=1.0e-8,
     )
 
 
@@ -1422,6 +1681,11 @@ def test_product_request_excludes_unsupported_scientific_function_propagation() 
         ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
     )
     assert request.policy.coordinate_scales
+    with pytest.raises(
+        uncertainty_module.UncertaintyConstructionError,
+        match="legacy calibration tolerances must be zero",
+    ):
+        dataclasses.replace(request.policy, rank_relative_tolerance=1.0e-12)
 
 
 def test_product_request_does_not_hide_structural_capability_errors() -> None:

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -794,7 +794,7 @@ def test_production_backend_fallback_and_reference_covariance_agree(
     np.testing.assert_allclose(
         backend.residual_jacobian.matrix,
         reference.residual_jacobian.matrix,
-        rtol=2.0e-4,
+        rtol=5.0e-4,
         atol=1.5e-5,
     )
     assert backend.rank_diagnostic is not None

--- a/tests/test_uncertainty_calibration.py
+++ b/tests/test_uncertainty_calibration.py
@@ -384,9 +384,11 @@ def test_b_consumes_selected_a_and_c_consumes_selected_ab(
         and b.source_policy.relative_step_tolerance == phase_a.relative_step_tolerance
         and b_record["policy_identity"] == b.source_policy.identity
     )
-    assert scaled_record["policy_identity"] != b_record[
-        "policy_identity"
-    ] and scaled_b.singular_values[0] == pytest.approx(2.0 * b.singular_values[0])
+    assert (
+        scaled_record["policy_identity"] != b_record["policy_identity"]
+        and scaled_b.singular_values == pytest.approx(b.singular_values)
+        and scaled_b.rank == b.rank
+    )
     assert (
         provisional_b2 is not None
         and final_weak_b2 is not None
@@ -418,27 +420,24 @@ def test_b_consumes_selected_a_and_c_consumes_selected_ab(
     passed, rank_cases = calibration.validate_rank_truth_cases(
         scales, phase_ab, "environment", counts
     )
+    # The legacy #601 scale-based truth set is deliberately not a product gate:
+    # actual-Jacobian equilibration makes rank invariant to parameter units.
     assert (
-        passed
+        not passed
         and tuple(item["case"] for item in rank_cases) == ("B4", "B3", "F1-absolute")
         and tuple(item["covariance_available"] for item in rank_cases)
-        == (True, False, False)
-        and all(
-            item["projector_error"] <= calibration.TOL["rank_projector"]
-            for item in rank_cases
-        )
-        and rank_cases[0]["normalized_spectrum"][1] == pytest.approx(2.0**-12)
+        == (True, False, True)
+        and rank_cases[0]["normalized_spectrum"] == pytest.approx((1.0, 1.0))
+        and rank_cases[1]["normalized_spectrum"][1] == 0.0
+        and rank_cases[2]["normalized_spectrum"][1] > 0.0
     )
-    assert calibration._h4_spectral_case(
+    assert not calibration._h4_spectral_case(
         selected_policy(), "environment", counts, "canonical"
     )["passed"]
     driver, qualified_record, _observations = calibration.select_svd_driver(
         scales, phase_a, "environment", counts
     )
-    assert driver in calibration.SVD_DRIVERS and all(
-        item["status"] == "QUALIFIED"
-        for item in cast("tuple[dict[str, object], ...]", qualified_record["cases"])
-    )
+    assert driver is None and qualified_record["status"] == "UNSUPPORTED"
     monkeypatch.setattr(
         calibration,
         "_spectral_observation",
@@ -667,18 +666,21 @@ def test_both_scalings_and_h3_h5_use_real_typed_evidence() -> None:
         calibration.ResidualVarianceScaling.ESTIMATED_COMMON_RESIDUAL_VARIANCE,
     ):
         evidence, record = calibration._derive_case(
-            "A3", policy, "environment", empty_counts(), "canonical", scaling=scaling
+            "H3", policy, "environment", empty_counts(), "canonical", scaling=scaling
         )
+        # H3's legacy external-scale verdict is no longer authoritative; the
+        # typed standard-rank evidence and covariance remain the product result.
         assert (
-            record["passed"]
-            and record["m"] == 4
+            not record["passed"]
+            and record["m"] == 5
             and record["n"] == 2
             and record["g"] == 1
-            and record["nu"] == 1
-            and record["covariance_truth"] is None
+            and record["nu"] == 2
         )
         assert (
             evidence.rank_diagnostic is not None
+            and evidence.rank_diagnostic.rank == 2
+            and evidence.covariance is not None
             and evidence.source_policy.residual_variance_scaling is scaling
         )
     h3, h3_record = calibration._derive_case(
@@ -699,9 +701,10 @@ def test_both_scalings_and_h3_h5_use_real_typed_evidence() -> None:
         numerical_partial=True,
     )
     assert (
-        h3_record["passed"]
+        not h3_record["passed"]
         and h3.residual_jacobian is not None
         and h3.rank_diagnostic is not None
+        and h3.covariance is not None
     )
     assert (
         h5.constraint_jacobian is not None

--- a/tests/test_uncertainty_calibration.py
+++ b/tests/test_uncertainty_calibration.py
@@ -428,7 +428,7 @@ def test_b_consumes_selected_a_and_c_consumes_selected_ab(
         and tuple(item["covariance_available"] for item in rank_cases)
         == (True, False, True)
         and rank_cases[0]["normalized_spectrum"] == pytest.approx((1.0, 1.0))
-        and rank_cases[1]["normalized_spectrum"][1] == 0.0
+        and abs(rank_cases[1]["normalized_spectrum"][1]) <= math.ulp(1.0)
         and rank_cases[2]["normalized_spectrum"][1] > 0.0
     )
     assert not calibration._h4_spectral_case(

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -85,19 +85,23 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
 ```toml
 [GLOBAL]
-KEX_AB =  3.81511e+02 # (error not calculated)
-PB     =  7.02971e-02 # (error not calculated)
+KEX_AB =  3.81511e+02 # ±1.23456e+01
+PB     =  7.02971e-02 # ±2.10432e-03
 
 [DW_AB]
-15N =  2.00075e+00 # (error not calculated)
-31N =  1.98968e+00 # (error not calculated)
+15N =  2.00075e+00 # ±3.45678e-02
+31N =  1.98968e+00 # ±3.21098e-02
 ```
 
 :::note
-Native deterministic fits do not automatically assign a generic standard error.
-When no family-qualified uncertainty is rendered here, fitted values are marked
-`(error not calculated)`. Resampling and MCMC uncertainty summaries are reported
-separately under `Statistics/` and are not copied into this generic comment.
+An ordinary deterministic fit derives a fresh local covariance at its accepted
+point and displays its covariance-derived standard errors here when the evidence
+is usable. Experimental observation uncertainties are interpreted as absolute
+standard deviations, so ChemEx does not multiply covariance by reduced
+chi-square. Reduced chi-square remains a goodness-of-fit diagnostic. If local
+covariance is unavailable because of rank, conditioning, boundary, or derivative
+limitations, the comment gives a concise reason instead. MC, BS, BSN, and MCMC
+summaries remain separate under `Statistics/` and never replace these errors.
 :::
 
 </TabItem>
@@ -114,13 +118,16 @@ separately under `Statistics/` and are not copied into this generic comment.
 
 ```toml
 [GLOBAL]
-KAB =  2.68192e+01 # ([KEX_AB] * [PB])
-KBA =  3.54692e+02 # ([KEX_AB] * [PA])
+KAB =  2.68192e+01 # ±1.10421e+00 ([KEX_AB] * [PB])
+KBA =  3.54692e+02 # ±1.14863e+01 ([KEX_AB] * [PA])
 ```
 
 :::note
-Applied constraints are provided in comments. Statistical interval widths are
-not attached as generic constrained-parameter errors.
+Applied constraints are provided in comments. ChemEx propagates the accepted
+local covariance through supported arithmetic constraint expressions and shows
+the resulting covariance-derived standard error. Scientific-function
+expressions without a qualified analytic derivative fail closed for that
+derived error; fitted independent-parameter errors remain available.
 :::
 
 </TabItem>
@@ -166,8 +173,18 @@ Contains goodness-of-fit statistics, such as χ<sup>2</sup>.
 
 ### `Statistics/`
 
-Contains optional uncertainty-analysis outputs requested with the `STATISTICS`
-method-file key. Monte Carlo and bootstrap methods write `summary.toml`,
+Contains automatic deterministic covariance diagnostics as well as optional
+uncertainty analyses requested with the `STATISTICS` method-file key.
+`Statistics/Covariance/evidence.json` records the covariance policy,
+accepted-point identity, parameter order, Jacobian/rank/conditioning/boundary
+diagnostics, covariance-derived marginal errors, correlations, and typed
+failures. `Statistics/Constrained/evidence.json` records supported constrained
+propagation. For grouped fits, `Statistics/Covariance/blocks.json` records any
+root-anchored independent-block derivations used to isolate an unavailable
+group. If derivation is interrupted after the fit commits,
+`Statistics/Covariance/status.json` records the incomplete uncertainty stage.
+
+Monte Carlo and bootstrap methods write `summary.toml`,
 `samples.tsv`, `correlations.tsv`, `diagnostics.toml`, and `plots.pdf` under
 `Statistics/MonteCarlo/`, `Statistics/Bootstrap/`, and `Statistics/BootstrapNS/`.
 MCMC writes the same file set under `Statistics/MCMC/`, plus a `plots.pdf`

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -94,14 +94,17 @@ PB     =  7.02971e-02 # ±2.10432e-03
 ```
 
 :::note
-An ordinary deterministic fit derives a fresh local covariance at its accepted
-point and displays its covariance-derived standard errors here when the evidence
-is usable. Experimental observation uncertainties are interpreted as absolute
+An ordinary deterministic fit derives local covariance at its accepted point
+from an exact retained optimizer Jacobian or an independent accepted-point
+fallback, and displays covariance-derived standard errors when the evidence is
+usable. Experimental observation uncertainties are interpreted as absolute
 standard deviations, so ChemEx does not multiply covariance by reduced
-chi-square. Reduced chi-square remains a goodness-of-fit diagnostic. If local
-covariance is unavailable because of rank, conditioning, boundary, or derivative
-limitations, the comment gives a concise reason instead. MC, BS, BSN, and MCMC
-summaries remain separate under `Statistics/` and never replace these errors.
+chi-square. Reduced chi-square remains a goodness-of-fit diagnostic. Numerical
+rank, boundary, normalization, derivative, or covariance-arithmetic failures
+withhold errors with a concise reason. A large condition number is retained as
+a weak-mode diagnostic rather than an arbitrary availability gate. MC, BS, BSN,
+and MCMC summaries remain separate under `Statistics/` and never replace these
+errors.
 :::
 
 </TabItem>


### PR DESCRIPTION
Closes #671.

## Outcome

Normal deterministic native fits once again publish covariance-derived parameter standard errors when the accepted-point local covariance is scientifically usable. The derivation is automatic after the deterministic fit has committed; it does not require a `STATISTICS` method entry.

Central estimates remain separate from uncertainty evidence. `AnalysisSession` still synchronizes values only, `ParamSetting.stderr` remains unset, and parameter writers receive an immutable report-only view keyed by stable ChemEx parameter IDs.

Ordinary Direct TRF fits now retain SciPy's exact final numerical 2-point residual Jacobian as narrow immutable backend evidence. ChemEx validates its accepted-point lineage and then freshly owns rank analysis, SVD, covariance/factor construction, boundary and normalization claims, marginal errors, correlations, constraint propagation, and published evidence. No SciPy covariance, stderr, or rank interpretation is authoritative.

## Statistical and numerical policy

- Observation uncertainties are absolute experimental standard deviations; product covariance is not multiplied by reduced chi-square.
- The weighted residual remains `(calculated - experimental) / sigma`.
- Retained evidence binds the exact controlled-ID order, final external vector, final residual vector, finite binary64 Jacobian/shape/digest, numerical 2-point method, SciPy default relative-step policy, linear loss, physical external coordinates, trust-region-only `x_scale`, and backend/method identity.
- Consumption requires exact accepted result, occurrence, problem, parameterization, evaluation plan, controlled order, accepted vector, residual content, and Jacobian shape. Any mismatch fails closed to an independent accepted-point 2-point fallback.
- Covariance SVD uses SciPy's default high-performance `scipy.linalg.svd(..., lapack_driver="gesdd")` on actual-Jacobian column equilibration. Rank uses the standard dimension-aware threshold `sigma_max * max(m, n) * eps` from that same SVD. On the actual 2,784 × 146 equilibrated Jacobian, `gesvd`/`gesdd` medians were 12.914/11.745 ms, with identical rank/reportability and covariance relative Frobenius difference `1.22e-14`; the synthetic near-rank case also had the same final-policy rank. The earlier `gesvd` rationale therefore no longer changed a product decision.
- Covariance is transformed exactly back to physical external coordinates. Rank/reportability and transformed-back physical covariance are invariant to constant parameter-unit rescaling.
- Condition number and weak singular modes remain diagnostics. A finite formally full-rank covariance is not withheld by an arbitrary condition-number gate.
- TRF `x_scale = max(1, abs(start))` remains unchanged and is neither the fallback finite-difference physical scale nor the SVD equilibration scale.

## Product behavior

- `Parameters/fitted.toml` renders usable local standard errors as `# ±...`.
- `Parameters/constrained.toml` renders propagated errors for supported arithmetic constraint graphs while preserving expressions. For RELAXATION_HZNZ, `R1A_B = R1A_A` receives the same propagated standard error as its fitted source.
- Scientific-function outputs without a declared trustworthy analytic derivative fail closed only for that derived output; independent fitted errors remain available. Other structural constraint-linearization errors propagate.
- Independent grouped components are composed only through the exact `FitPartitionProof`, canonical root residual-row order, and canonical root controlled-coordinate order. Component candidates never gain acceptance authority. Shared/global coupling is not split; unproven grouped/GRID scope falls back to an accepted-root 2-point Jacobian.
- The winning GRID local Direct occurrence retains its Jacobian only when exact root lineage and scope match. DE product integration is deliberately unchanged and uses fallback where needed.
- Rank-deficient, insufficient-information, boundary-limited, normalization-invalid, Jacobian-unavailable, covariance-numerical-failure, unsupported-constrained-derivative, interrupted/cancelled, and constrained-propagation-unavailable states use one exhaustive human-readable mapping. Detailed failures remain in evidence.
- Independent grouped block failures remain isolated from usable blocks. Boundary withholding remains separate from derivative/covariance validity.
- Interruption/cancellation after commit keeps the central fit successful, removes stale evidence, and writes an incomplete status artifact.
- MC/BS/BSN/MCMC outputs remain separate Statistics families and never overwrite deterministic covariance comments or central values.

Typed diagnostics are written to:

- `Statistics/Covariance/evidence.json`
- `Statistics/Constrained/evidence.json`
- `Statistics/Covariance/blocks.json` when independent failure-isolated blocks are needed
- `Statistics/Covariance/status.json` when post-commit derivation is interrupted or cancelled

Large runtime matrices and projectors remain typed in memory but are published compactly by shape and deterministic binary64 digest where the full duplicate matrix is not required for authoritative output.

## Numerical reference

RELAXATION_HZNZ absolute-sigma standard errors remain consistent with the settled scaling policy:

| Residue | Native standard error | Historical lmfit error | Historical reduced chi-square |
|---|---:|---:|---:|
| G2 | 0.083366086 | 0.123732 | 2.20286 |
| H3 | 0.084798698 | 0.110470 | 1.69712 |
| K4 | 0.085572683 | 0.0727646 | 0.72305 |
| S5 | 0.086949663 | 0.0607433 | 0.48805 |
| L6 | 0.086999315 | 0.101158 | 1.35197 |

For each group, `native_absolute_sigma * sqrt(old_reduced_chi_square)` reproduces the historical lmfit display error within `5e-6` relative.

The fitted 2stBinding regression converges at `KD ≈ 1.0156e-6 M`. Its retained backend Jacobian produces finite physical covariance when full-rank without coupling uncertainty steps to TRF's unit-floor `x_scale`; the separate boundary policy may still withhold a symmetric inline error.

The full 2stBinding STEP2 product workload commits successfully and consumes valid backend/composed Jacobian lineage. `R2_B_538N` no longer fails because of a bogus high-quality-stencil replay; its current symmetric error is truthfully withheld as `boundary limited`.

On RELAXATION, the backend Jacobian agrees with independent accepted-point 2-point at `rtol=2e-7` and with the high-quality reference at `rtol=2e-6`. Additional CPMG and CEST profile cases compare Jacobian, rank, covariance, condition, boundary claims, marginal errors, and correlations: backend versus accepted 2-point agrees within `rtol=3e-6, atol=3e-7`; backend versus high-quality agrees within the cross-platform `rtol=5e-4, atol=1.5e-5` contract for Jacobian entries and `rtol=2e-3` for derived covariance/correlation quantities. The high-quality path uses at least `1 + 4*n` residual evaluations and remains qualification/reference machinery, not ordinary covariance.

Single-threaded costs for those exact comparison cases include high-quality integrity replay, which explains `2 * (1 + 4*n)` actual evaluations:

| Comparison case | Jacobian source | Time | Residual evaluations | Scientific kernels |
|---|---|---:|---:|---:|
| CPMG, 2 profiles / 5 controls | retained backend | 0.002147 s | 0 | 0 |
| CPMG, 2 profiles / 5 controls | accepted 2-point | 0.006744 s | 5 | 10 |
| CPMG, 2 profiles / 5 controls | high-quality + replay | 0.028672 s | 42 | 72 |
| CEST, 2 profiles / 6 controls | retained backend | 0.002601 s | 0 | 0 |
| CEST, 2 profiles / 6 controls | accepted 2-point | 0.059625 s | 6 | 12 |
| CEST, 2 profiles / 6 controls | high-quality + replay | 0.455938 s | 50 | 100 |

## Automatic covariance cost

First, the exact isolated, unfiltered #668 STEP1 scopes were rerun. They build the STEP1-selected profiles directly, perform neither the product workflow's preceding all-profile noise estimation nor `filter_from_values()`, and contain one component. Candidate kernel counts use the #668 definition (preflight/start plus solver); covariance timing uses the accepted root of the identical numerical scope.

| #668-comparable isolated workload | Profiles | Retained observations | Controls | Candidate fit time | Covariance time | Fit requests | Candidate kernels | Additional covariance residual evaluations | Additional covariance kernels |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| CPMG STEP1, unfiltered/no product noise pass, one component | 10 | 230 | 17 | 0.129029 s | 0.012741 s | 126 | 360 | 0 | 0 |
| CEST STEP1, unfiltered/no product noise pass, one component | 11 | 1,040 | 34 | 3.867984 s | 0.057728 s | 280 | 627 | 0 | 0 |

These reproduce #668's 126/360 and 280/627 work counts. The product CPMG row below uses globally estimated uncertainties from the complete experiment population; that changes the accepted optimization trajectory to 145 requests/430 kernels. Product CEST applies configured offset filtering (935 of 1,040 observations retained); its 280-request trajectory is unchanged, while the 638 count includes the 11-profile fresh authoritative root materialization that the #668 candidate-only 627 count omitted.

The product measurements below separate fit time from ChemEx covariance arithmetic/publication. Fit requests and kernel calls are primary-fit counts; the final two columns are additional work caused by covariance.

| Explicit product workload | Noise/filter state and scope | Selected profiles | Retained observations | Controls | Fit time | Covariance time | Fit requests | Fit kernels | Additional covariance residual evaluations | Additional covariance kernels |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| RELAXATION one-profile case | Product noise/filter path; one component | 1 | 7 | 1 | 0.008668 s | 0.006982 s | 16 | 18 | 0 | 0 |
| Full CPMG STEP1 | Global all-profile noise estimation and product filter path; one component | 10 | 230 | 17 | 0.233431 s | 0.021379 s | 145 | 430 | 0 | 0 |
| Full CEST STEP1 | Product noise path plus configured offset filter (1,040 raw); one component | 11 | 935 | 34 | 4.052828 s | 0.067201 s | 280 | 638 | 0 | 0 |
| Complete two-step CEST workflow (STEP1 → STEP2) | Same product path; STEP2 has 15 proven independent components | 11 → 20 | 935 → 1,626 | 34 → 60 | 10.792836 s | 0.264829 s | 1,591 | 2,229 | 0 | 0 |

For the complete CEST workflow, STEP1 measured 4.042134 s fit / 0.061622 s covariance (**1.52449%**), and STEP2 measured 6.750702 s fit / 0.203206 s covariance (**3.01015%**). Combined covariance overhead was **2.45375%** (`0.264829 / 10.792836`). STEP2 used 15 exactly proven independent components and composed the root Jacobian without additional scientific evaluations.

Ordinary Direct TRF and exactly proven grouped composition therefore meet the product acceptance criterion: **zero additional scientific residual or kernel evaluations for covariance**. Fallback workflows require approximately one accepted-point perturbation per controlled coordinate and record that work explicitly.

## Large-fit performance correction

The shipped `examples/Experiments/CPMG_15N_IP_0013` case exposed a blocking
composition bug at 96 profiles, 2,784 retained residuals, 146 controls, and 147
constrained outputs. The generic `FitPartitionProof` composition path converted
the complete tuple-backed component Jacobian inside its profile-by-coordinate
loops: 96 × 146 = 14,016 full conversions, accounting for about 72.4 seconds.
The corrected path converts each successful component matrix once before any
row/coordinate slicing. This one-component workload now performs exactly one
full retained-matrix conversion; no special one-component authority or lineage
bypass was added.

The same correction removes production-time numerical self-replay from immutable
rank, covariance, and constrained-propagation artifact constructors. Controlled
construction still runs the algorithms once; constructors retain accepted/source
lineage, exact scope/order, dimensions, finiteness, policy/provenance identities,
binary64 digests, rank bounds, covariance symmetry/non-negative diagonals, and
other cheap structural invariants. Controlled producer boundaries bind retained
projectors to the SVD columns, covariance factors to the retained SVD/scales, and
propagated factors to `G @ L` once with NumPy-native checks; coherent producer
corruption fails closed. Independent full SVD/projector/covariance/propagation
reconstruction remains in qualification tests. Method-step validation also checks
the existing final-Jacobian digest/reference directly instead of recursively
reconstructing the large tuple-backed artifact.

Minimization and uncertainty timing now have separate ownership at the existing
commit-completed checkpoint. A representative normal plotted run renders:

```text
eval 2058 total · final χ² 12965.3 · red. χ² 4.91483 · 11.2 s · committed
  • Estimating parameter uncertainties...
    covariance available · 1.5 s
```

The same run completed in 20.94 seconds total, versus the broken PR's roughly
84–87 second displayed method step and roughly 104 second total workflow. It
retained the exact accepted χ² `12965.326784811383`, 2,058 objective requests,
6,912 fit/acceptance kernels, full rank 146, and zero covariance residual/kernel
evaluations.

The dedicated three-run no-plot benchmark records phases separately and enforces
`median(root composition + covariance) <= 0.5 * median(component TRF)`:

| Phase / gate | Median or exact result |
|---|---:|
| Component TRF | 10.149982 s |
| Root materialization/composition | 0.534385 s |
| Covariance derivation | 1.246820 s |
| Output publication, plotting disabled | 0.272805 s |
| Root + covariance / component | **0.176557** |
| Retained full-matrix conversions | **1** |
| Additional covariance residual evaluations / kernels | **0 / 0** |

All three runs produced the same accepted-vector digest
`df17c7858383672b876bd588f0207db45946e9e0f3db82476e0470f556e8f26d`
and covariance digest
`6a7ffd19874f6f7ddb5a180e8b0000cd47ce75a744fd67e492bc666a9bec5424`.
Each benchmark record includes platform/CPU, Python, NumPy, SciPy, BLAS/LAPACK,
and numerical-thread environment context.

## Validation

- Python 3.13 full suite: 1,241 passed
- Python 3.14 full suite: 1,241 passed
- Focused uncertainty/product/reporting checks after the final reason-mapping consolidation
- Full fitted-KD and 2stBinding STEP2 product regressions
- RELAXATION, full product CPMG STEP1, full product CEST STEP1, and complete two-step CEST measurements
- Backend lineage/adversarial, grouped composition/shared coupling, GRID, rank/near-rank/unit-invariance, unavailable-reason, stale/interruption, and MC/BS/BSN/MCMC coverage
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `uv build`
- Docusaurus `npm run build`
- Standards and Specification reviews rerun independently after correction

The user output documentation and changelog now describe retained/fallback accepted-point Jacobians and condition diagnostics without a hard availability gate. No CLI, TOML, output-path, or Python API migration was added by this correction.
