### PR TITLE
Report local covariance errors with boundary warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 - Covariance-derived local standard errors are now reported when an otherwise
   valid covariance lies within the existing three-sigma boundary threshold,
   including at a bound. Boundary evidence and the threshold remain unchanged,
-  while parameter reports and the terminal carry a concise warning that the
-  local error may be asymmetric. Genuinely invalid covariance remains
-  unavailable.
+  while the terminal retains an aggregate warning. Inline warnings are limited
+  to fitted coordinates near their own simple bounds and constrained outputs
+  structurally depending on them. Genuinely invalid covariance remains unavailable.
 - Unified deterministic fit presentation and output around the authoritative
   aggregate method-step result. Interactive Rich output now shows one transient
   fit-component progress table, followed by one aggregate minimization summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 ## [Unreleased]
 
 ### Changed
+- Covariance-derived local standard errors are now reported when an otherwise
+  valid covariance lies within the existing three-sigma boundary threshold,
+  including at a bound. Boundary evidence and the threshold remain unchanged,
+  while parameter reports and the terminal carry a concise warning that the
+  local error may be asymmetric. Genuinely invalid covariance remains
+  unavailable.
 - Unified deterministic fit presentation and output around the authoritative
   aggregate method-step result. Interactive Rich output now shows one transient
   fit-component progress table, followed by one aggregate minimization summary
@@ -23,8 +29,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   `Parameters/fitted.toml`. Observation uncertainties are treated as absolute
   experimental standard deviations, so covariance is not scaled by reduced
   chi-square. Supported arithmetic constraints receive propagated errors;
-  rank, boundary, normalization, derivative, or covariance-arithmetic failures
-  withhold errors with a concise reason while preserving fitted central values.
+  rank, normalization, derivative, or covariance-arithmetic failures withhold
+  errors with a concise reason while preserving fitted central values.
   Condition and weak-mode diagnostics do not impose an arbitrary hard gate. Full covariance,
   correlation, constrained, and independent-block diagnostics are written
   under `Statistics/` without populating the legacy generic `stderr` field or

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -70,6 +70,7 @@ from chemex.parameters.parameterization import ActiveParameterization, Parameter
 from chemex.printers.parameters import (
     BOUNDARY_WARNING_TEXT,
     ParameterUncertaintyView,
+    constrained_boundary_warning_ids,
     parameter_uncertainty_view,
     uncertainty_unavailable_reason,
 )
@@ -282,7 +283,15 @@ def _uncertainty_progress_status(
     controlled_ids: tuple[str, ...],
 ) -> str:
     """Summarize fitted covariance availability without overstating constraints."""
-    if uncertainty.warnings:
+    root_boundary_warning = (
+        evidence is not None
+        and evidence.covariance is not None
+        and evidence.covariance.boundary_warning
+    )
+    block_boundary_warning = block_evidence is not None and any(
+        block.boundary_warning for block in block_evidence.blocks
+    )
+    if root_boundary_warning or block_boundary_warning:
         return "covariance available with boundary warnings"
     available_ids = {param_id for param_id, _value in uncertainty.standard_errors}
     if (
@@ -668,12 +677,23 @@ def run_native_deterministic(
             for entry in block.constrained_marginal_errors
             if entry.value is not None
         )
+        block_controlled_warning_ids = block_uncertainty.simple_bound_warning_ids
+        block_constrained_warning_ids = constrained_boundary_warning_ids(
+            block_uncertainty.source_bundle,
+            block_controlled_warning_ids,
+        )
         block_warnings = tuple(
             (entry.param_id, BOUNDARY_WARNING_TEXT)
             for block in block_uncertainty.blocks
-            if block.boundary_warning
-            for entry in (*block.marginal_errors, *block.constrained_marginal_errors)
+            for entry in block.marginal_errors
             if entry.value is not None
+            and entry.param_id in block_controlled_warning_ids
+        ) + tuple(
+            (entry.param_id, BOUNDARY_WARNING_TEXT)
+            for block in block_uncertainty.blocks
+            for entry in block.constrained_marginal_errors
+            if entry.value is not None
+            and entry.param_id in block_constrained_warning_ids
         )
         recovered_ids = {
             param_id for param_id, _value in (*block_errors, *block_constrained_errors)

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -68,6 +68,7 @@ from chemex.optimize.uncertainty import (
 )
 from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
 from chemex.printers.parameters import (
+    BOUNDARY_WARNING_TEXT,
     ParameterUncertaintyView,
     parameter_uncertainty_view,
     uncertainty_unavailable_reason,
@@ -281,7 +282,14 @@ def _uncertainty_progress_status(
     controlled_ids: tuple[str, ...],
 ) -> str:
     """Summarize fitted covariance availability without overstating constraints."""
-    if evidence is not None and evidence.covariance is not None:
+    if uncertainty.warnings:
+        return "covariance available with boundary warnings"
+    available_ids = {param_id for param_id, _value in uncertainty.standard_errors}
+    if (
+        evidence is not None
+        and evidence.covariance is not None
+        and all(param_id in available_ids for param_id in controlled_ids)
+    ):
         return "covariance available"
     if block_evidence is not None and any(
         block.covariance is not None for block in block_evidence.blocks
@@ -660,9 +668,29 @@ def run_native_deterministic(
             for entry in block.constrained_marginal_errors
             if entry.value is not None
         )
+        block_warnings = tuple(
+            (entry.param_id, BOUNDARY_WARNING_TEXT)
+            for block in block_uncertainty.blocks
+            if block.boundary_warning
+            for entry in (*block.marginal_errors, *block.constrained_marginal_errors)
+            if entry.value is not None
+        )
+        recovered_ids = {
+            param_id for param_id, _value in (*block_errors, *block_constrained_errors)
+        }
         uncertainty = ParameterUncertaintyView(
-            uncertainty.standard_errors + block_errors + block_constrained_errors,
-            uncertainty.unavailable_reasons + block_unavailable,
+            standard_errors=(
+                uncertainty.standard_errors + block_errors + block_constrained_errors
+            ),
+            warnings=uncertainty.warnings + block_warnings,
+            unavailable_reasons=(
+                tuple(
+                    (param_id, reason)
+                    for param_id, reason in uncertainty.unavailable_reasons
+                    if param_id not in recovered_ids
+                )
+                + block_unavailable
+            ),
         )
     uncertainty_progress.finish(
         _uncertainty_progress_status(

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -77,6 +77,39 @@ _BOUNDARY_DIAGNOSTIC_CLAIMS = (
 )
 
 
+def _simple_bound_warning_ids(
+    controlled_ids: Sequence[str],
+    accepted_vector: Sequence[float],
+    lower_bounds: Sequence[float],
+    upper_bounds: Sequence[float],
+    standard_errors: Mapping[str, float | None],
+) -> frozenset[str]:
+    """Attribute the boundary threshold only to each coordinate's box bounds."""
+    warned: set[str] = set()
+    for param_id, value, lower, upper in zip(
+        controlled_ids,
+        accepted_vector,
+        lower_bounds,
+        upper_bounds,
+        strict=True,
+    ):
+        standard_error = standard_errors.get(param_id)
+        if (
+            standard_error is None
+            or standard_error <= 0.0
+            or not math.isfinite(standard_error)
+        ):
+            continue
+        separations = tuple(
+            distance / standard_error
+            for distance in (value - lower, upper - value)
+            if math.isfinite(distance)
+        )
+        if separations and min(separations) <= _BOUNDARY_THRESHOLD:
+            warned.add(param_id)
+    return frozenset(warned)
+
+
 class UncertaintyConstructionError(ValueError):
     """Raised only for malformed policy or artifact construction."""
 
@@ -1812,6 +1845,23 @@ class CovarianceEvidence:
             for name in _BOUNDARY_DIAGNOSTIC_CLAIMS
         )
 
+    @property
+    def simple_bound_warning_ids(self) -> frozenset[str]:
+        """Controlled coordinates within the threshold of their own box bounds."""
+        standard_errors = {
+            param_id: math.sqrt(self.covariance[index][index])
+            if self.covariance[index][index] > 0.0
+            else None
+            for index, param_id in enumerate(self.controlled_ids)
+        }
+        return _simple_bound_warning_ids(
+            self.controlled_ids,
+            self.accepted_vector,
+            self.source_problem.lower_bounds,
+            self.source_problem.upper_bounds,
+            standard_errors,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class ScalarEvidenceEntry:
@@ -2975,6 +3025,23 @@ class RootAnchoredBlockCovarianceEvidence:
                 for item in self.blocks
             ],
         }
+
+    @property
+    def simple_bound_warning_ids(self) -> frozenset[str]:
+        """Recovered controlled coordinates near their own root box bounds."""
+        source = self.source_bundle
+        standard_errors = {
+            entry.param_id: entry.value
+            for block in self.blocks
+            for entry in block.marginal_errors
+        }
+        return _simple_bound_warning_ids(
+            source.source_problem.controlled_ids,
+            source.accepted_anchor.vector,
+            source.source_problem.lower_bounds,
+            source.source_problem.upper_bounds,
+            standard_errors,
+        )
 
 
 def _failed_block_claims(

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -60,7 +60,7 @@ from chemex.typing import Array
 _SCHEMA_VERSION = 2
 _RESIDUAL_LINEARIZATION_VERSION = "accepted-residual-jacobian-v2"
 _CONSTRAINT_LINEARIZATION_VERSION = "constraint-forward-chain-v1"
-_COVARIANCE_VERSION = "column-equilibrated-full-rank-svd-factor-gram-v4"
+_COVARIANCE_VERSION = "column-equilibrated-full-rank-svd-factor-gram-v5"
 _FACTOR_VERSION = "column-equilibrated-svd-factor-gram-v4"
 _REDUCTION_VERSION = "fixed-pairwise-binary64-v1"
 _MARGINAL_VERSION = "covariance-diagonal-square-root-v1"
@@ -69,6 +69,12 @@ _PROPAGATION_VERSION = "constraint-gram-factor-v1"
 _EPSILON = float(np.finfo(np.float64).eps)
 _NOMINAL_STEP_FACTOR = _EPSILON ** (1.0 / 3.0)
 _BOUNDARY_THRESHOLD = 3.0
+_BOUNDARY_DIAGNOSTIC_CLAIMS = (
+    "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
+    "INTERIOR_POINT",
+    "BOUNDARY_SEPARATION",
+    "CONTROLLED_AFFINE_SEPARATION",
+)
 
 
 class UncertaintyConstructionError(ValueError):
@@ -1797,6 +1803,15 @@ class CovarianceEvidence:
     def usable(self) -> bool:
         return self.claim("USABLE_LOCAL_COVARIANCE") is ClaimState.SATISFIED
 
+    @property
+    def boundary_warning(self) -> bool:
+        """Whether boundary evidence cautions against symmetric interpretation."""
+        states = {item.name: item.state for item in self.claims}
+        return any(
+            states.get(name) in {ClaimState.VIOLATED, ClaimState.INDETERMINATE}
+            for name in _BOUNDARY_DIAGNOSTIC_CLAIMS
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class ScalarEvidenceEntry:
@@ -2821,6 +2836,15 @@ class RootAnchoredBlockCovariance:
         )
 
     @property
+    def boundary_warning(self) -> bool:
+        """Whether this block carries a boundary-interpretation caveat."""
+        states = {item.name: item.state for item in self.claims}
+        return any(
+            states.get(name) in {ClaimState.VIOLATED, ClaimState.INDETERMINATE}
+            for name in _BOUNDARY_DIAGNOSTIC_CLAIMS
+        )
+
+    @property
     def unavailable_kind(self) -> UncertaintyUnavailableKind | None:
         """Classify unavailable block evidence without rendering product text."""
         if self.scope_reportable:
@@ -2839,16 +2863,6 @@ class RootAnchoredBlockCovariance:
         states = {item.name: item.state for item in self.claims}
         if states.get("PROFILED_NORMALIZATION_REGULARITY") is ClaimState.VIOLATED:
             return UncertaintyUnavailableKind.NORMALIZATION_INVALID
-        if any(
-            states.get(name) is not ClaimState.SATISFIED
-            for name in (
-                "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
-                "INTERIOR_POINT",
-                "BOUNDARY_SEPARATION",
-                "CONTROLLED_AFFINE_SEPARATION",
-            )
-        ):
-            return UncertaintyUnavailableKind.BOUNDARY_LIMITED
         return UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE
 
 
@@ -5065,13 +5079,6 @@ def _canonical_covariance_claims(
         ),
     )
     required = (
-        ClaimState.SATISFIED,
-        full_dimensional_interior.state,
-        interior.state,
-        boundary.state,
-        controlled_affine.state
-        if controlled_affine.state is not ClaimState.NOT_APPLICABLE
-        else ClaimState.SATISFIED,
         normalization.state,
         variance_nondegeneracy.state
         if variance_nondegeneracy.state is not ClaimState.NOT_APPLICABLE

--- a/src/chemex/printers/parameters.py
+++ b/src/chemex/printers/parameters.py
@@ -66,7 +66,7 @@ _UNAVAILABLE_REASON_TEXT = {
     ),
 }
 
-BOUNDARY_WARNING_TEXT = "boundary may make local error asymmetric"
+BOUNDARY_WARNING_TEXT = "boundary may make uncertainty asymmetric"
 
 if set(_UNAVAILABLE_REASON_TEXT) != set(UncertaintyUnavailableKind):
     raise RuntimeError("Uncertainty unavailability vocabulary is not exhaustive")
@@ -100,6 +100,25 @@ def _controlled_unavailability_kind(
     return UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE
 
 
+def constrained_boundary_warning_ids(
+    evidence: UncertaintyEvidence,
+    controlled_warning_ids: frozenset[str],
+) -> frozenset[str]:
+    """Derived outputs structurally depending on a directly warned coordinate."""
+    constraint_jacobian = evidence.constraint_jacobian
+    if constraint_jacobian is None or not controlled_warning_ids:
+        return frozenset()
+    return frozenset(
+        output_id
+        for output_id, dependencies in zip(
+            constraint_jacobian.output_ids,
+            constraint_jacobian.structural_dependencies,
+            strict=True,
+        )
+        if controlled_warning_ids.intersection(dependencies)
+    )
+
+
 def parameter_uncertainty_view(
     evidence: UncertaintyEvidence,
     unsupported_constrained_ids: tuple[str, ...] = (),
@@ -108,6 +127,11 @@ def parameter_uncertainty_view(
     standard_errors: list[tuple[str, float]] = []
     warnings: list[tuple[str, str]] = []
     unavailable_reasons: list[tuple[str, str]] = []
+    controlled_warning_ids = (
+        frozenset()
+        if evidence.covariance is None
+        else evidence.covariance.simple_bound_warning_ids
+    )
     marginal = evidence.marginal_errors
     if marginal is not None and marginal.scope_reportable:
         standard_errors.extend(
@@ -115,12 +139,11 @@ def parameter_uncertainty_view(
             for entry in marginal.entries
             if entry.value is not None
         )
-        if evidence.covariance is not None and evidence.covariance.boundary_warning:
-            warnings.extend(
-                (entry.param_id, BOUNDARY_WARNING_TEXT)
-                for entry in marginal.entries
-                if entry.value is not None
-            )
+        warnings.extend(
+            (entry.param_id, BOUNDARY_WARNING_TEXT)
+            for entry in marginal.entries
+            if entry.value is not None and entry.param_id in controlled_warning_ids
+        )
     else:
         reason = uncertainty_unavailable_reason(
             _controlled_unavailability_kind(evidence)
@@ -135,12 +158,15 @@ def parameter_uncertainty_view(
             for entry in constrained.entries
             if entry.value is not None
         )
-        if evidence.covariance is not None and evidence.covariance.boundary_warning:
-            warnings.extend(
-                (entry.param_id, BOUNDARY_WARNING_TEXT)
-                for entry in constrained.entries
-                if entry.value is not None
-            )
+        constrained_warning_ids = constrained_boundary_warning_ids(
+            evidence,
+            controlled_warning_ids,
+        )
+        warnings.extend(
+            (entry.param_id, BOUNDARY_WARNING_TEXT)
+            for entry in constrained.entries
+            if entry.value is not None and entry.param_id in constrained_warning_ids
+        )
     elif evidence.requested_output_scope:
         unavailable_reasons.extend(
             (

--- a/src/chemex/printers/parameters.py
+++ b/src/chemex/printers/parameters.py
@@ -24,10 +24,25 @@ class ParameterUncertaintyView:
     """Immutable report-only covariance-derived uncertainty selection."""
 
     standard_errors: tuple[tuple[str, float], ...] = ()
+    warnings: tuple[tuple[str, str], ...] = ()
     unavailable_reasons: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        error_ids = {param_id for param_id, _value in self.standard_errors}
+        warning_ids = {param_id for param_id, _warning in self.warnings}
+        unavailable_ids = {param_id for param_id, _reason in self.unavailable_reasons}
+        if warning_ids - error_ids:
+            raise ValueError("Uncertainty warnings require an available standard error")
+        if error_ids & unavailable_ids:
+            raise ValueError(
+                "A parameter uncertainty cannot be available and unavailable"
+            )
 
     def standard_error(self, param_id: str) -> float | None:
         return dict(self.standard_errors).get(param_id)
+
+    def warning(self, param_id: str) -> str | None:
+        return dict(self.warnings).get(param_id)
 
     def unavailable_reason(self, param_id: str) -> str | None:
         return dict(self.unavailable_reasons).get(param_id)
@@ -50,6 +65,8 @@ _UNAVAILABLE_REASON_TEXT = {
         "constrained propagation unavailable"
     ),
 }
+
+BOUNDARY_WARNING_TEXT = "boundary may make local error asymmetric"
 
 if set(_UNAVAILABLE_REASON_TEXT) != set(UncertaintyUnavailableKind):
     raise RuntimeError("Uncertainty unavailability vocabulary is not exhaustive")
@@ -78,16 +95,6 @@ def _controlled_unavailability_kind(
         claims = {item.name: item.state.value for item in covariance.claims}
         if claims.get("PROFILED_NORMALIZATION_REGULARITY") == "violated":
             return UncertaintyUnavailableKind.NORMALIZATION_INVALID
-        if any(
-            claims.get(name) in {"violated", "indeterminate"}
-            for name in (
-                "FULL_DIMENSIONAL_FEASIBLE_INTERIOR",
-                "INTERIOR_POINT",
-                "BOUNDARY_SEPARATION",
-                "CONTROLLED_AFFINE_SEPARATION",
-            )
-        ):
-            return UncertaintyUnavailableKind.BOUNDARY_LIMITED
     if any(failure.stage == "residual_linearization" for failure in evidence.failures):
         return UncertaintyUnavailableKind.JACOBIAN_UNAVAILABLE
     return UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE
@@ -99,6 +106,7 @@ def parameter_uncertainty_view(
 ) -> ParameterUncertaintyView:
     """Select only scientifically reportable covariance-derived errors."""
     standard_errors: list[tuple[str, float]] = []
+    warnings: list[tuple[str, str]] = []
     unavailable_reasons: list[tuple[str, str]] = []
     marginal = evidence.marginal_errors
     if marginal is not None and marginal.scope_reportable:
@@ -107,6 +115,12 @@ def parameter_uncertainty_view(
             for entry in marginal.entries
             if entry.value is not None
         )
+        if evidence.covariance is not None and evidence.covariance.boundary_warning:
+            warnings.extend(
+                (entry.param_id, BOUNDARY_WARNING_TEXT)
+                for entry in marginal.entries
+                if entry.value is not None
+            )
     else:
         reason = uncertainty_unavailable_reason(
             _controlled_unavailability_kind(evidence)
@@ -121,6 +135,12 @@ def parameter_uncertainty_view(
             for entry in constrained.entries
             if entry.value is not None
         )
+        if evidence.covariance is not None and evidence.covariance.boundary_warning:
+            warnings.extend(
+                (entry.param_id, BOUNDARY_WARNING_TEXT)
+                for entry in constrained.entries
+                if entry.value is not None
+            )
     elif evidence.requested_output_scope:
         unavailable_reasons.extend(
             (
@@ -141,8 +161,9 @@ def parameter_uncertainty_view(
         for param_id in unsupported_constrained_ids
     )
     return ParameterUncertaintyView(
-        tuple(standard_errors),
-        tuple(unavailable_reasons),
+        standard_errors=tuple(standard_errors),
+        warnings=tuple(warnings),
+        unavailable_reasons=tuple(unavailable_reasons),
     )
 
 
@@ -170,9 +191,10 @@ def _format_fitted(
     standard_error = (
         None if uncertainty is None else uncertainty.standard_error(param_id)
     )
+    warning = None if uncertainty is None else uncertainty.warning(param_id)
     reason = None if uncertainty is None else uncertainty.unavailable_reason(param_id)
     error = (
-        f"±{standard_error:.5e}"
+        f"±{standard_error:.5e}" + (f" ({warning})" if warning is not None else "")
         if standard_error is not None
         else f"(error unavailable: {reason})"
         if reason is not None
@@ -193,9 +215,10 @@ def _format_constrained(
     standard_error = (
         None if uncertainty is None else uncertainty.standard_error(param_id)
     )
+    warning = None if uncertainty is None else uncertainty.warning(param_id)
     reason = None if uncertainty is None else uncertainty.unavailable_reason(param_id)
     error = (
-        f"±{standard_error:.5e} "
+        f"±{standard_error:.5e}" + (f" ({warning}); " if warning is not None else " ")
         if standard_error is not None
         else f"error unavailable: {reason}; "
         if reason is not None

--- a/tests/test_native_binding_uncertainty.py
+++ b/tests/test_native_binding_uncertainty.py
@@ -114,7 +114,7 @@ FIX = ["KD"]
     assert "Jacobian unavailable" not in fitted
 
 
-def test_full_binding_step2_never_fails_for_a_high_cost_stencil(
+def test_full_binding_step2_reports_boundary_warning_with_retained_jacobian(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -136,5 +136,7 @@ def test_full_binding_step2_never_fails_for_a_high_cost_stencil(
     r2_b_538n = next(
         line for line in r2_b_section.splitlines() if line.lstrip().startswith("538N")
     )
-    assert "error unavailable: boundary limited" in r2_b_538n
+    assert "# ±" in r2_b_538n
+    assert "boundary may make local error asymmetric" in r2_b_538n
+    assert "error unavailable: boundary limited" not in fitted
     assert "Jacobian unavailable" not in fitted

--- a/tests/test_native_binding_uncertainty.py
+++ b/tests/test_native_binding_uncertainty.py
@@ -132,11 +132,18 @@ def test_full_binding_step2_reports_boundary_warning_with_retained_jacobian(
     fitted = (output / "STEP2" / "Parameters" / "fitted.toml").read_text(
         encoding="utf-8"
     )
-    r2_b_section = fitted.split('["R2_B, B0->800.0MHZ"]', maxsplit=1)[1]
-    r2_b_538n = next(
-        line for line in r2_b_section.splitlines() if line.lstrip().startswith("538N")
-    )
-    assert "# ±" in r2_b_538n
-    assert "boundary may make local error asymmetric" in r2_b_538n
+    fitted_uncertainties = [line for line in fitted.splitlines() if "# ±" in line]
+    warned_uncertainties = [
+        line
+        for line in fitted_uncertainties
+        if "boundary may make uncertainty asymmetric" in line
+    ]
+    unavailable_uncertainties = [
+        line for line in fitted.splitlines() if "error unavailable" in line
+    ]
+    assert step2.covariance is not None
+    assert len(warned_uncertainties) == len(step2.covariance.simple_bound_warning_ids)
+    assert 0 < len(warned_uncertainties) < len(fitted_uncertainties)
+    assert unavailable_uncertainties == []
     assert "error unavailable: boundary limited" not in fitted
     assert "Jacobian unavailable" not in fitted

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -570,8 +570,9 @@ def test_reused_output_removes_legacy_and_development_result_trees(
     assert (output / "run_info" / "outcome.toml").is_file()
 
 
-def test_grouped_covariance_reports_boundary_warning_in_valid_independent_block(
+def test_grouped_covariance_warns_only_near_bound_independent_coordinate(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     output = tmp_path / "Output"
     parameters = tmp_path / "parameters.toml"
@@ -592,7 +593,7 @@ G2N-H = [2.3, 2.18, 5.0]
         covariance_svd_call += 1
         left, singular, right = original_svd(*args, **kwargs)
         singular = np.array(singular, copy=True)
-        if covariance_svd_call in {1, 3}:
+        if covariance_svd_call == 1:
             singular[-1] = 0.0
         return left, singular, right
 
@@ -608,17 +609,22 @@ G2N-H = [2.3, 2.18, 5.0]
 
     assert (output / "Statistics" / "Covariance" / "evidence.json").is_file()
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
-    assert fitted.count("# ±") == 1
-    assert fitted.count("boundary may make local error asymmetric") == 1
-    assert fitted.count("error unavailable: rank deficient") == 1
+    assert fitted.count("# ±") == 2
+    assert fitted.count("boundary may make uncertainty asymmetric") == 1
+    g2_record = next(
+        line for line in fitted.splitlines() if line.lstrip().startswith("G2N-H")
+    )
+    h3_record = next(
+        line for line in fitted.splitlines() if line.lstrip().startswith("H3N-H")
+    )
+    assert "boundary may make uncertainty asymmetric" in g2_record
+    assert "boundary may make uncertainty asymmetric" not in h3_record
     constrained = (output / "Parameters" / "constrained.toml").read_text(
         encoding="utf-8"
     )
-    assert constrained.count("# ±") == 1
-    assert constrained.count("boundary may make local error asymmetric") == 1
-    assert (
-        constrained.count("error unavailable: constrained propagation unavailable") == 1
-    )
+    assert constrained.count("# ±") == 2
+    assert constrained.count("boundary may make uncertainty asymmetric") == 1
+    assert "error unavailable" not in constrained
     assert not (output / "All").exists()
     assert not (output / "Groups").exists()
     blocks = json.loads(
@@ -627,14 +633,77 @@ G2N-H = [2.3, 2.18, 5.0]
         )
     )
     assert len(blocks["partition_proof_identity"]) == 64
-    assert sorted(block["unavailable_reason"] for block in blocks["blocks"]) == [
-        "",
-        "rank deficient",
+    assert all(block["scope_reportable"] for block in blocks["blocks"])
+    claim_sets = [
+        {claim["name"]: claim["state"] for claim in block["claims"]}
+        for block in blocks["blocks"]
     ]
-    reportable = next(block for block in blocks["blocks"] if block["scope_reportable"])
-    claims = {claim["name"]: claim["state"] for claim in reportable["claims"]}
-    assert claims["BOUNDARY_SEPARATION"] == "violated"
-    assert claims["USABLE_LOCAL_COVARIANCE"] == "satisfied"
+    assert sorted(claims["BOUNDARY_SEPARATION"] for claims in claim_sets) == [
+        "satisfied",
+        "violated",
+    ]
+    assert all(
+        claims["USABLE_LOCAL_COVARIANCE"] == "satisfied" for claims in claim_sets
+    )
+    rendered = " ".join(capsys.readouterr().out.split())
+    assert rendered.count("covariance available with boundary warnings") == 1
+
+
+def test_multivariate_boundary_warning_product_is_coordinate_specific(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """[DEFAULT]
+FIT = ["D2O", "KDH"]
+FIX = ["CS_A", "DW_AB", "PHI", "R1_A", "R2_A", "R2_B"]
+""",
+        encoding="utf-8",
+    )
+    parameters = tmp_path / "parameters.toml"
+    parameters.write_text(
+        DCEST_PARAMETERS.read_text(encoding="utf-8").replace(
+            "KDH = 10.0",
+            "KDH = [10.0, 9.99, 10.0]",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    arguments = build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            str(DCEST_EXPERIMENT),
+            "-p",
+            str(parameters),
+            "-m",
+            str(method),
+            "-o",
+            str(output),
+            "-d",
+            "2st_hd",
+            "--include",
+            "1N",
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+        ]
+    )
+
+    run(arguments, session=AnalysisSession.create())
+
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    assert fitted.count("# ±") == 2
+    assert fitted.count("boundary may make uncertainty asymmetric") == 1
+    d2o_record = next(line for line in fitted.splitlines() if "D2O" in line)
+    kdh_record = next(line for line in fitted.splitlines() if line.startswith("1 ="))
+    assert "boundary may make uncertainty asymmetric" not in d2o_record
+    assert "boundary may make uncertainty asymmetric" in kdh_record
+    rendered = " ".join(capsys.readouterr().out.split())
+    assert rendered.count("covariance available with boundary warnings") == 1
 
 
 def test_interrupted_block_fallback_preserves_committed_root_evidence(
@@ -780,7 +849,7 @@ def test_real_grouped_direct_progress_has_one_bounded_noninteractive_stream(
     assert "Group " not in rendered
 
 
-def test_boundary_warning_fit_reports_local_errors_without_changing_central_values(
+def test_boundary_warning_fit_reports_uncertainty_without_changing_central_values(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -802,7 +871,7 @@ FIX = ["KEX_AB"]
         encoding="utf-8"
     )
     assert "# ±" in fitted
-    assert "boundary may make local error asymmetric" in fitted
+    assert "boundary may make uncertainty asymmetric" in fitted
     assert "error unavailable: boundary limited" not in fitted
     assert "error unavailable: boundary limited" not in constrained
     assert "error unavailable: constrained propagation unavailable" in constrained

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -570,10 +570,20 @@ def test_reused_output_removes_legacy_and_development_result_trees(
     assert (output / "run_info" / "outcome.toml").is_file()
 
 
-def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
+def test_grouped_covariance_reports_boundary_warning_in_valid_independent_block(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
+    parameters = tmp_path / "parameters.toml"
+    parameters.write_text(
+        PARAMETERS.read_text(encoding="utf-8")
+        + """
+
+[R1A_A]
+G2N-H = [2.3, 2.18, 5.0]
+""",
+        encoding="utf-8",
+    )
     original_svd = uncertainty_module.svd
     covariance_svd_call = 0
 
@@ -588,18 +598,24 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
 
     with patch("chemex.optimize.uncertainty.svd", side_effect=one_bad_block_svd):
         run(
-            _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
+            _fit_arguments(
+                output,
+                parameters=parameters,
+                include=("G2N-HN", "H3N-HN"),
+            ),
             session=AnalysisSession.create(),
         )
 
     assert (output / "Statistics" / "Covariance" / "evidence.json").is_file()
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
     assert fitted.count("# ±") == 1
+    assert fitted.count("boundary may make local error asymmetric") == 1
     assert fitted.count("error unavailable: rank deficient") == 1
     constrained = (output / "Parameters" / "constrained.toml").read_text(
         encoding="utf-8"
     )
     assert constrained.count("# ±") == 1
+    assert constrained.count("boundary may make local error asymmetric") == 1
     assert (
         constrained.count("error unavailable: constrained propagation unavailable") == 1
     )
@@ -615,6 +631,10 @@ def test_grouped_covariance_isolates_a_rank_deficient_independent_block(
         "",
         "rank deficient",
     ]
+    reportable = next(block for block in blocks["blocks"] if block["scope_reportable"])
+    claims = {claim["name"]: claim["state"] for claim in reportable["claims"]}
+    assert claims["BOUNDARY_SEPARATION"] == "violated"
+    assert claims["USABLE_LOCAL_COVARIANCE"] == "satisfied"
 
 
 def test_interrupted_block_fallback_preserves_committed_root_evidence(
@@ -760,8 +780,9 @@ def test_real_grouped_direct_progress_has_one_bounded_noninteractive_stream(
     assert "Group " not in rendered
 
 
-def test_boundary_limited_fit_keeps_central_values_and_withholds_symmetric_errors(
+def test_boundary_warning_fit_reports_local_errors_without_changing_central_values(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     output = tmp_path / "Output"
     method = tmp_path / "method.toml"
@@ -777,8 +798,14 @@ FIX = ["KEX_AB"]
 
     assert session.analysis_values.snapshot().revision == 1
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
-    assert "error unavailable: boundary limited" in fitted
-    assert "# ±" not in fitted
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "# ±" in fitted
+    assert "boundary may make local error asymmetric" in fitted
+    assert "error unavailable: boundary limited" not in fitted
+    assert "error unavailable: boundary limited" not in constrained
+    assert "error unavailable: constrained propagation unavailable" in constrained
     evidence = (output / "Statistics" / "Covariance" / "evidence.json").read_text(
         encoding="utf-8"
     )
@@ -790,6 +817,8 @@ FIX = ["KEX_AB"]
             session.analysis_values.snapshot()
         ).values()
     )
+    rendered = " ".join(capsys.readouterr().out.split())
+    assert rendered.count("covariance available with boundary warnings") == 1
 
 
 def test_rank_deficient_covariance_is_nonfatal_and_replaces_stale_valid_errors(

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -1419,7 +1419,7 @@ def test_stencil_exhaustion_retains_trajectory_and_each_search_extent() -> None:
     )
 
 
-def test_at_bound_covariance_reports_local_error_with_boundary_warning() -> None:
+def test_at_bound_covariance_reports_uncertainty_with_boundary_warning() -> None:
     _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
     controlled_id = problem.controlled_ids[0]
     derived_id = "__R1A_B_G2N_H_800_0MHZ"
@@ -1481,10 +1481,10 @@ def test_at_bound_covariance_reports_local_error_with_boundary_warning() -> None
     assert evidence.correlations.scope_reportable
     view = parameter_uncertainty_view(evidence)
     assert view.standard_error(controlled_id) is not None
-    assert view.warning(controlled_id) == "boundary may make local error asymmetric"
+    assert view.warning(controlled_id) == "boundary may make uncertainty asymmetric"
     assert view.unavailable_reason(controlled_id) is None
     assert view.standard_error(derived_id) is not None
-    assert view.warning(derived_id) == "boundary may make local error asymmetric"
+    assert view.warning(derived_id) == "boundary may make uncertainty asymmetric"
     assert view.unavailable_reason(derived_id) is None
     forged_reportability_claims = tuple(
         dataclasses.replace(item, state=ClaimState.VIOLATED)
@@ -1541,8 +1541,85 @@ def test_near_bound_covariance_reports_local_error_and_preserves_violation() -> 
     assert evidence.marginal_errors.scope_reportable
     view = parameter_uncertainty_view(evidence)
     assert view.standard_error(controlled_id) == pytest.approx(standard_error)
-    assert view.warning(controlled_id) == "boundary may make local error asymmetric"
+    assert view.warning(controlled_id) == "boundary may make uncertainty asymmetric"
     assert view.unavailable_reason(controlled_id) is None
+
+
+@pytest.mark.parametrize("zeta", (2.0, 0.0))
+def test_multivariate_simple_bound_warning_is_coordinate_specific(zeta: float) -> None:
+    method = Method(
+        fit=("D2O", "KDH"),
+        fix=("CS_A", "DW_AB", "PHI", "R1_A", "R2_A", "R2_B"),
+    )
+    parameterization, engine, problem = _hd_problem(method)
+    accepted = _accepted_reference_anchor(parameterization, engine, problem)
+    d2o_id, kdh_id = problem.controlled_ids
+    kab_id = "__KAB_1_0_1000"
+    policy = dataclasses.replace(
+        _qualification_policy(d2o_id),
+        coordinate_scales=((d2o_id, 0.1), (kdh_id, 10.0)),
+        coordinate_units=(
+            (d2o_id, ParameterUnit.FRACTION),
+            (kdh_id, ParameterUnit.RATE_PER_SECOND),
+        ),
+        residual_variance_scaling=(
+            ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
+        ),
+    )
+    baseline = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="coordinate-warning-baseline",
+    )
+    assert baseline.marginal_errors is not None
+    kdh_error = baseline.marginal_errors.entries[1].value
+    assert kdh_error is not None
+    boundary_problem = dataclasses.replace(
+        problem,
+        lower_bounds=(
+            problem.lower_bounds[0],
+            accepted.vector[1] - zeta * kdh_error,
+        ),
+    )
+    boundary_accepted = _qualified_accepted_copy(
+        accepted,
+        problem_identity=boundary_problem.identity,
+        occurrence_identity=f"coordinate-warning-{zeta.hex()}",
+    )
+
+    evidence = derive_uncertainty_evidence(
+        boundary_accepted,
+        problem=boundary_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        constrained_scope=(kab_id,),
+        constrained_units=((kab_id, ParameterUnit.RATE_PER_SECOND),),
+        constrained_scales=((kab_id, 10.0),),
+        compiled_constraint_linearization=(
+            compile_constraint_linearization_capabilities(
+                parameterization,
+                (kab_id,),
+                (),
+            )
+        ),
+        resolved_environment_identity="coordinate-warning",
+    )
+
+    assert evidence.covariance is not None
+    assert evidence.covariance.rank == 2
+    assert evidence.covariance.claim("BOUNDARY_SEPARATION") is ClaimState.VIOLATED
+    assert evidence.covariance.boundary_warning
+    view = parameter_uncertainty_view(evidence)
+    assert view.standard_error(d2o_id) is not None
+    assert view.standard_error(kdh_id) is not None
+    assert view.warning(d2o_id) is None
+    assert view.warning(kdh_id) == "boundary may make uncertainty asymmetric"
+    assert view.standard_error(kab_id) is not None
+    assert view.warning(kab_id) == "boundary may make uncertainty asymmetric"
 
 
 def test_unrepresentable_centered_interval_falls_back_to_inward_stencil() -> None:
@@ -2395,9 +2472,8 @@ def test_affine_directional_separation_uses_exact_full_frame_slack(
     assert evidence.covariance.usable
     view = parameter_uncertainty_view(evidence)
     assert view.standard_error(problem.controlled_ids[0]) is not None
-    assert (view.warning(problem.controlled_ids[0]) is not None) is (
-        expected is ClaimState.VIOLATED
-    )
+    assert view.warning(problem.controlled_ids[0]) is None
+    assert evidence.covariance.boundary_warning is (expected is ClaimState.VIOLATED)
 
 
 def test_active_affine_upper_uses_inward_stencil_without_off_feasible_calls() -> None:

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -502,6 +502,11 @@ def test_accepted_fit_yields_typed_covariance_and_joint_constraint_propagation()
     assert evidence.constrained_propagation.source_covariance_identity == (
         evidence.covariance.identity
     )
+    uncertainty_view = parameter_uncertainty_view(evidence)
+    assert uncertainty_view.standard_error(controlled_id) is not None
+    assert uncertainty_view.standard_error(derived_id) is not None
+    assert uncertainty_view.warning(controlled_id) is None
+    assert uncertainty_view.warning(derived_id) is None
     assert evidence.resolved_environment_identity == ("local-qualification-environment")
     assert all(
         item.resolved_environment_identity == "local-qualification-environment"
@@ -1414,9 +1419,10 @@ def test_stencil_exhaustion_retains_trajectory_and_each_search_extent() -> None:
     )
 
 
-def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> None:
+def test_at_bound_covariance_reports_local_error_with_boundary_warning() -> None:
     _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
     controlled_id = problem.controlled_ids[0]
+    derived_id = "__R1A_B_G2N_H_800_0MHZ"
     boundary_problem = dataclasses.replace(
         problem,
         lower_bounds=(accepted.vector[0],),
@@ -1432,6 +1438,14 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
         parameterization=parameterization,
         engine=engine,
         policy=_qualification_policy(controlled_id),
+        constrained_scope=(derived_id,),
+        constrained_units=((derived_id, ParameterUnit.RATE_PER_SECOND),),
+        constrained_scales=((derived_id, 1.0),),
+        compiled_constraint_linearization=compile_constraint_linearization_capabilities(
+            parameterization,
+            (derived_id,),
+            (),
+        ),
         resolved_environment_identity="local-qualification-environment",
     )
 
@@ -1458,19 +1472,22 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
     assert evidence.covariance is not None
     assert evidence.covariance.claim("INTERIOR_POINT") is ClaimState.VIOLATED
     assert evidence.covariance.claim("BOUNDARY_SEPARATION") is ClaimState.VIOLATED
-    assert evidence.covariance.claim("USABLE_LOCAL_COVARIANCE") is ClaimState.VIOLATED
+    assert evidence.covariance.claim("USABLE_LOCAL_COVARIANCE") is ClaimState.SATISFIED
     assert evidence.marginal_errors is not None
     assert evidence.marginal_errors.entries[0].value is not None
-    assert not evidence.marginal_errors.scope_reportable
+    assert evidence.marginal_errors.scope_reportable
     assert evidence.correlations is not None
     assert evidence.correlations.entries[0][0].value == 1.0
-    assert not evidence.correlations.scope_reportable
-    assert (
-        parameter_uncertainty_view(evidence).unavailable_reason(controlled_id)
-        == "boundary limited"
-    )
+    assert evidence.correlations.scope_reportable
+    view = parameter_uncertainty_view(evidence)
+    assert view.standard_error(controlled_id) is not None
+    assert view.warning(controlled_id) == "boundary may make local error asymmetric"
+    assert view.unavailable_reason(controlled_id) is None
+    assert view.standard_error(derived_id) is not None
+    assert view.warning(derived_id) == "boundary may make local error asymmetric"
+    assert view.unavailable_reason(derived_id) is None
     forged_reportability_claims = tuple(
-        dataclasses.replace(item, state=ClaimState.SATISFIED)
+        dataclasses.replace(item, state=ClaimState.VIOLATED)
         if item.name == "MARGINAL_SCOPE_REPORTABILITY"
         else item
         for item in evidence.marginal_errors.claims
@@ -1478,9 +1495,54 @@ def test_boundary_covariance_remains_diagnostic_but_reporting_fails_closed() -> 
     with pytest.raises(ValueError, match="reportability"):
         dataclasses.replace(
             evidence.marginal_errors,
-            scope_reportable=True,
+            scope_reportable=False,
             claims=forged_reportability_claims,
         )
+
+
+def test_near_bound_covariance_reports_local_error_and_preserves_violation() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
+    controlled_id = problem.controlled_ids[0]
+    policy = _qualification_policy(controlled_id)
+    interior_evidence = derive_uncertainty_evidence(
+        accepted,
+        problem=problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="near-bound-reference",
+    )
+    assert interior_evidence.marginal_errors is not None
+    standard_error = interior_evidence.marginal_errors.entries[0].value
+    assert standard_error is not None
+    near_problem = dataclasses.replace(
+        problem,
+        lower_bounds=(accepted.vector[0] - 2.0 * standard_error,),
+    )
+    near_accepted = _qualified_accepted_copy(
+        accepted,
+        problem_identity=near_problem.identity,
+    )
+
+    evidence = derive_uncertainty_evidence(
+        near_accepted,
+        problem=near_problem,
+        parameterization=parameterization,
+        engine=engine,
+        policy=policy,
+        resolved_environment_identity="near-bound-warning",
+    )
+
+    assert evidence.covariance is not None
+    assert evidence.covariance.claim("INTERIOR_POINT") is ClaimState.SATISFIED
+    assert evidence.covariance.claim("BOUNDARY_SEPARATION") is ClaimState.VIOLATED
+    assert evidence.covariance.claim("USABLE_LOCAL_COVARIANCE") is ClaimState.SATISFIED
+    assert evidence.marginal_errors is not None
+    assert evidence.marginal_errors.scope_reportable
+    view = parameter_uncertainty_view(evidence)
+    assert view.standard_error(controlled_id) == pytest.approx(standard_error)
+    assert view.warning(controlled_id) == "boundary may make local error asymmetric"
+    assert view.unavailable_reason(controlled_id) is None
 
 
 def test_unrepresentable_centered_interval_falls_back_to_inward_stencil() -> None:
@@ -2330,7 +2392,12 @@ def test_affine_directional_separation_uses_exact_full_frame_slack(
     )
     assert evidence.covariance is not None
     assert evidence.covariance.claim("AFFINE_FEASIBILITY") is expected
-    assert evidence.covariance.usable is (expected is ClaimState.SATISFIED)
+    assert evidence.covariance.usable
+    view = parameter_uncertainty_view(evidence)
+    assert view.standard_error(problem.controlled_ids[0]) is not None
+    assert (view.warning(problem.controlled_ids[0]) is not None) is (
+        expected is ClaimState.VIOLATED
+    )
 
 
 def test_active_affine_upper_uses_inward_stencil_without_off_feasible_calls() -> None:

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -208,10 +208,14 @@ diagnostics, covariance-derived marginal errors, correlations, and typed
 failures. `Statistics/Constrained/evidence.json` records supported constrained
 propagation. ChemEx reports covariance-derived local standard errors when the
 local covariance is otherwise valid, including when the accepted fit is near or
-at a parameter bound. In that case, parameter comments warn that the boundary
-may make the local error asymmetric because the symmetric Gaussian
+at a parameter bound. In that case, affected parameter comments warn that the
+boundary may make the uncertainty asymmetric because the symmetric Gaussian
 approximation can be imperfect. Profile likelihood or resampling may be more
-appropriate when accurate bounded confidence intervals are required.
+appropriate when accurate bounded confidence intervals are required. Inline
+warnings are attached only to fitted coordinates near their own simple bounds
+and to constrained outputs structurally depending on those coordinates;
+aggregate boundary and affine diagnostics remain available in the evidence and
+terminal status.
 
 For fits with independent fit components,
 `Statistics/Covariance/blocks.json` records any root-anchored independent-block

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -206,7 +206,14 @@ uncertainty analyses requested with the `STATISTICS` method-file key.
 accepted-point identity, parameter order, Jacobian/rank/conditioning/boundary
 diagnostics, covariance-derived marginal errors, correlations, and typed
 failures. `Statistics/Constrained/evidence.json` records supported constrained
-propagation. For fits with independent fit components,
+propagation. ChemEx reports covariance-derived local standard errors when the
+local covariance is otherwise valid, including when the accepted fit is near or
+at a parameter bound. In that case, parameter comments warn that the boundary
+may make the local error asymmetric because the symmetric Gaussian
+approximation can be imperfect. Profile likelihood or resampling may be more
+appropriate when accurate bounded confidence intervals are required.
+
+For fits with independent fit components,
 `Statistics/Covariance/blocks.json` records any root-anchored independent-block
 derivations used to isolate unavailable component covariance. If derivation is
 interrupted after the fit commits,


### PR DESCRIPTION
Closes #675

## Summary

- Keep the existing three-sigma boundary and interior evidence unchanged.
- Treat violated or indeterminate boundary claims as aggregate interpretation warnings rather than automatic local-covariance suppression.
- Report finite local standard errors and attach the inline warning `boundary may make uncertainty asymmetric` only to fitted coordinates within three local standard errors of their own simple box bounds.
- Propagate inline warnings to constrained outputs only through the existing structural dependency closure.
- Preserve aggregate affine/global evidence and terminal status without blanket per-parameter attribution.
- Preserve fail-closed behavior for rank, information, normalization, Jacobian, numerical, interruption, and unsupported constrained-derivative failures.

## Scientific rationale

The `zeta <= 3` boundary test remains useful evidence that a symmetric Gaussian interpretation may be unreliable or asymmetric. It does not, by itself, make an otherwise valid local-curvature covariance numerically unavailable. Aggregate diagnostics remain truthful, while inline attribution now uses each coordinate's accepted value, simple bounds, and covariance diagonal.

This does not change the optimizer, accepted fit, Jacobian, covariance calculation, threshold, scaling, or decomposition.

## Validation

- 55 native uncertainty tests passed.
- 3 directly affected product and recovered-block reporting tests passed.
- The full `examples/Combinations/2stBinding` STEP2 uncertainty/product test passed.
- STEP2 fitted uncertainties: 312 total; warnings reduced from 312 before attribution correction to 23; unavailable remained 0.
- STEP2 fitted central values matched the pre-attribution-correction #676 output exactly.
- Ruff lint and format checks passed.
- `ty check` passed.
- `git diff --check` passed.
- GitHub Python tests, website tests, and diagnostic numerical-lane checks passed on the final head.
