### PR TITLE
Implement canonical method-format planning (#681)

### DIFF
--- a/src/chemex/configuration/method_expressions.py
+++ b/src/chemex/configuration/method_expressions.py
@@ -92,18 +92,12 @@ def _parse_nucleus(
     start: int,
     end: int,
 ) -> str:
-    if re.fullmatch(r"[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+){0,2}", value_text) is None:
-        raise _error(
-            f"Invalid NUC spin-system selector {value_text!r}", source, start, end
-        )
     try:
-        spin_system = SpinSystem.from_name(value_text)
+        spin_system = SpinSystem.from_name_strict(value_text)
     except (TypeError, ValueError) as error:
         raise _error(
             f"Invalid NUC spin-system selector {value_text!r}", source, start, end
         ) from error
-    if not spin_system:
-        raise _error("NUC spin-system selector cannot be empty", source, start, end)
     return str(spin_system)
 
 

--- a/src/chemex/configuration/method_expressions.py
+++ b/src/chemex/configuration/method_expressions.py
@@ -1,0 +1,544 @@
+from __future__ import annotations
+
+import ast
+import io
+import math
+import re
+import tokenize
+from collections.abc import Callable
+from typing import cast
+
+from chemex.configuration.method_plan import (
+    BinaryExpression,
+    Constraint,
+    ConstraintExpression,
+    DeCoordinate,
+    DeRange,
+    GridAxis,
+    GridRange,
+    GridValues,
+    LiteralExpression,
+    MethodFormatError,
+    ParameterSelector,
+    SearchScale,
+    SelectorExpression,
+    SourceRef,
+    UnaryExpression,
+)
+from chemex.parameters.name import ParamName
+from chemex.parameters.spin_system import SpinSystem
+
+_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+_NUMBER = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+_QUALIFIER = re.compile(
+    r"(?P<key>NUC|T|B0|\[P\]|\[L\]|D2O)\s*->\s*(?P<value>.+)\Z",
+    re.IGNORECASE,
+)
+_NUMERIC_QUALIFIER = {
+    "T": re.compile(rf"(?P<number>{_NUMBER})(?P<unit>C)?\Z", re.IGNORECASE),
+    "B0": re.compile(
+        rf"(?P<number>{_NUMBER})(?P<unit>MHz)?\Z",
+        re.IGNORECASE,
+    ),
+    "[P]": re.compile(rf"(?P<number>{_NUMBER})(?P<unit>M)?\Z", re.IGNORECASE),
+    "[L]": re.compile(rf"(?P<number>{_NUMBER})(?P<unit>M)?\Z", re.IGNORECASE),
+    "D2O": re.compile(rf"(?P<number>{_NUMBER})\Z", re.IGNORECASE),
+}
+_PUBLIC_OPERATORS = {"+", "-", "*", "/", "(", ")"}
+_FIELD_FOR_QUALIFIER = {
+    "T": "temperature",
+    "B0": "h_larmor_frq",
+    "[P]": "p_total",
+    "[L]": "l_total",
+    "D2O": "d2o",
+}
+type _SelectorValues = dict[str, str | float | None]
+
+
+def parse_legacy_selector(text: str, source: SourceRef) -> ParameterSelector:
+    parsed = ParamName.from_section(text)
+    conditions = parsed.conditions
+    return ParameterSelector(
+        parsed.name,
+        str(parsed.spin_system) or None,
+        conditions.temperature,
+        conditions.h_larmor_frq,
+        conditions.p_total,
+        conditions.l_total,
+        conditions.d2o,
+        source,
+    )
+
+
+def _error(message: str, source: SourceRef, start: int, end: int) -> MethodFormatError:
+    return MethodFormatError(message, _span_source(source, start, end))
+
+
+def _span_source(source: SourceRef, start: int, end: int) -> SourceRef:
+    offset = source.start or 0
+    return SourceRef(
+        source.filename,
+        source.step,
+        source.field,
+        source.index,
+        offset + start,
+        offset + end,
+    )
+
+
+def _parse_nucleus(
+    value_text: str,
+    source: SourceRef,
+    start: int,
+    end: int,
+) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+){0,2}", value_text) is None:
+        raise _error(
+            f"Invalid NUC spin-system selector {value_text!r}", source, start, end
+        )
+    try:
+        spin_system = SpinSystem.from_name(value_text)
+    except (TypeError, ValueError) as error:
+        raise _error(
+            f"Invalid NUC spin-system selector {value_text!r}", source, start, end
+        ) from error
+    if not spin_system:
+        raise _error("NUC spin-system selector cannot be empty", source, start, end)
+    return str(spin_system)
+
+
+def _parse_numeric_qualifier(
+    key: str,
+    value_text: str,
+    source: SourceRef,
+    start: int,
+    end: int,
+) -> float:
+    numeric = _NUMERIC_QUALIFIER[key].fullmatch(value_text)
+    if numeric is None:
+        raise _error(
+            f"Invalid value or unit for selector qualifier {key}", source, start, end
+        )
+    value = float(numeric.group("number"))
+    if not math.isfinite(value):
+        raise _error(f"Selector qualifier {key} must be finite", source, start, end)
+    if key in {"B0", "[P]", "[L]"} and value < 0.0:
+        raise _error(
+            f"Selector qualifier {key} must be nonnegative", source, start, end
+        )
+    if key == "D2O" and not 0.0 < value < 1.0:
+        raise _error(
+            "Selector qualifier D2O must be between 0 and 1", source, start, end
+        )
+    return round(value, 1) if key in {"T", "B0"} else value
+
+
+def _parse_qualifier(
+    raw_fragment: str,
+    start: int,
+    source: SourceRef,
+    seen: set[str],
+    values: _SelectorValues,
+) -> None:
+    fragment = raw_fragment.strip()
+    content_start = start + len(raw_fragment) - len(raw_fragment.lstrip())
+    end = content_start + len(fragment)
+    if not fragment:
+        raise _error(
+            "Empty selector qualifier", source, start, start + len(raw_fragment)
+        )
+    match = _QUALIFIER.fullmatch(fragment)
+    if match is None:
+        raise _error(
+            f"Unknown or malformed selector qualifier {fragment!r}",
+            source,
+            content_start,
+            end,
+        )
+    key = match.group("key").upper()
+    if key in seen:
+        raise _error(f"Duplicate selector qualifier {key}", source, content_start, end)
+    seen.add(key)
+    value_text = match.group("value").strip()
+    if key == "NUC":
+        values["spin_system"] = _parse_nucleus(value_text, source, content_start, end)
+    else:
+        values[_FIELD_FOR_QUALIFIER[key]] = _parse_numeric_qualifier(
+            key, value_text, source, content_start, end
+        )
+
+
+def parse_strict_selector(text: str, source: SourceRef) -> ParameterSelector:
+    stripped = text.strip()
+    leading = len(text) - len(text.lstrip())
+    if not stripped:
+        raise _error("Parameter selector cannot be empty", source, 0, len(text))
+    fragments = stripped.split(",")
+    name = fragments[0].strip()
+    if not _NAME.fullmatch(name):
+        raise _error(
+            f"Invalid parameter-name token {name!r}",
+            source,
+            leading,
+            leading + len(fragments[0]),
+        )
+    values: _SelectorValues = dict.fromkeys(
+        ("spin_system", "temperature", "h_larmor_frq", "p_total", "l_total", "d2o")
+    )
+    cursor = len(fragments[0])
+    seen: set[str] = set()
+    for raw_fragment in fragments[1:]:
+        _parse_qualifier(raw_fragment, leading + cursor + 1, source, seen, values)
+        cursor += len(raw_fragment) + 1
+    source_offset = source.start or 0
+    selector_source = SourceRef(
+        source.filename,
+        source.step,
+        source.field,
+        source.index,
+        source_offset + leading,
+        source_offset + leading + len(stripped),
+    )
+    return ParameterSelector(
+        name.upper(),
+        cast("str | None", values["spin_system"]),
+        cast("float | None", values["temperature"]),
+        cast("float | None", values["h_larmor_frq"]),
+        cast("float | None", values["p_total"]),
+        cast("float | None", values["l_total"]),
+        cast("float | None", values["d2o"]),
+        selector_source,
+    )
+
+
+def _scan_bracketed_selectors(
+    text: str, source: SourceRef
+) -> tuple[tuple[int, int, str], ...]:
+    selectors: list[tuple[int, int, str]] = []
+    position = 0
+    while position < len(text):
+        if text[position] != "[":
+            position += 1
+            continue
+        start = position
+        depth = 1
+        position += 1
+        while position < len(text) and depth:
+            if text[position] == "[":
+                depth += 1
+            elif text[position] == "]":
+                depth -= 1
+            position += 1
+        if depth:
+            raise _error("Unclosed parameter selector", source, start, len(text))
+        selectors.append((start, position, text[start + 1 : position - 1]))
+    return tuple(selectors)
+
+
+def _compile_constraint_ast(
+    node: ast.AST,
+    references: dict[str, ParameterSelector],
+    source: SourceRef,
+) -> ConstraintExpression:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        try:
+            value = float(node.value)
+        except (OverflowError, ValueError):
+            value = math.inf
+        if math.isfinite(value):
+            return LiteralExpression(value)
+    if isinstance(node, ast.Name) and node.id in references:
+        return SelectorExpression(references[node.id])
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        operator = "+" if isinstance(node.op, ast.UAdd) else "-"
+        return UnaryExpression(
+            operator,
+            _compile_constraint_ast(node.operand, references, source),
+        )
+    if isinstance(node, ast.BinOp) and isinstance(
+        node.op,
+        (ast.Add, ast.Sub, ast.Mult, ast.Div),
+    ):
+        if isinstance(node.op, ast.Add):
+            operator = "+"
+        elif isinstance(node.op, ast.Sub):
+            operator = "-"
+        elif isinstance(node.op, ast.Mult):
+            operator = "*"
+        else:
+            operator = "/"
+        return BinaryExpression(
+            operator,
+            _compile_constraint_ast(node.left, references, source),
+            _compile_constraint_ast(node.right, references, source),
+        )
+    raise MethodFormatError(
+        f"Constraint contains unsupported scalar syntax {type(node).__name__}",
+        source,
+    )
+
+
+def _constraint_target(
+    left: str,
+    source: SourceRef,
+    selector_parser: Callable[[str, SourceRef], ParameterSelector],
+) -> ParameterSelector:
+    selectors = _scan_bracketed_selectors(left, source)
+    if (
+        len(selectors) != 1
+        or left[: selectors[0][0]].strip()
+        or left[selectors[0][1] :].strip()
+    ):
+        raise MethodFormatError(
+            "Constraint left side must be one bracketed selector",
+            _span_source(source, 0, len(left)),
+        )
+    start, end, text = selectors[0]
+    return selector_parser(
+        text,
+        SourceRef(
+            source.filename,
+            source.step,
+            source.field,
+            source.index,
+            start + 1,
+            end - 1,
+        ),
+    )
+
+
+def _constraint_python_source(
+    left: str,
+    right: str,
+    source: SourceRef,
+    selector_parser: Callable[[str, SourceRef], ParameterSelector],
+) -> tuple[str, dict[str, ParameterSelector]]:
+    references: dict[str, ParameterSelector] = {}
+    chunks: list[str] = []
+    cursor = 0
+    right_source = _span_source(source, len(left) + 1, len(left) + 1 + len(right))
+    for index, (start, end, selector_text) in enumerate(
+        _scan_bracketed_selectors(right, right_source)
+    ):
+        token = f"__ref_{index}"
+        chunks.extend((right[cursor:start], token))
+        references[token] = selector_parser(
+            selector_text,
+            SourceRef(
+                source.filename,
+                source.step,
+                source.field,
+                source.index,
+                len(left) + start + 2,
+                len(left) + end,
+            ),
+        )
+        cursor = end
+    chunks.append(right[cursor:])
+    return "".join(chunks).strip(), references
+
+
+def _parse_public_scalar_expression(
+    python_source: str,
+    references: dict[str, ParameterSelector],
+    source: SourceRef,
+) -> ConstraintExpression:
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(python_source).readline):
+            ignored = token.type in {
+                tokenize.NEWLINE,
+                tokenize.NL,
+                tokenize.ENDMARKER,
+                tokenize.ENCODING,
+            }
+            valid_number = token.type == tokenize.NUMBER and re.fullmatch(
+                _NUMBER, token.string
+            )
+            valid_reference = token.type == tokenize.NAME and token.string in references
+            valid_operator = (
+                token.type == tokenize.OP and token.string in _PUBLIC_OPERATORS
+            )
+            if ignored or valid_number or valid_reference or valid_operator:
+                continue
+            raise MethodFormatError(
+                f"Constraint contains unsupported token {token.string!r}",
+                source,
+            )
+        parsed = ast.parse(python_source, mode="eval")
+    except (IndentationError, SyntaxError, tokenize.TokenError, ValueError) as error:
+        raise MethodFormatError(
+            "Constraint is not a valid scalar expression", source
+        ) from error
+    return _compile_constraint_ast(parsed.body, references, source)
+
+
+def parse_constraint(
+    text: str,
+    source: SourceRef,
+    selector_parser: Callable[[str, SourceRef], ParameterSelector],
+) -> Constraint:
+    entry_source = _span_source(source, 0, len(text))
+    if text.count("=") != 1:
+        raise MethodFormatError("Constraint must contain exactly one '='", entry_source)
+    left, right = text.split("=", maxsplit=1)
+    if not right.strip():
+        raise MethodFormatError("Constraint right side cannot be empty", entry_source)
+    target = _constraint_target(left, source, selector_parser)
+    python_source, references = _constraint_python_source(
+        left, right, source, selector_parser
+    )
+    right_start = len(left) + 1 + len(right) - len(right.lstrip())
+    expression_source = _span_source(source, right_start, len(text))
+    return Constraint(
+        target,
+        _parse_public_scalar_expression(python_source, references, expression_source),
+        entry_source,
+    )
+
+
+def _search_parts(
+    text: str, source: SourceRef
+) -> tuple[str, SourceRef, str, list[str]]:
+    selectors = _scan_bracketed_selectors(text, source)
+    if len(selectors) != 1 or selectors[0][0] != 0:
+        raise MethodFormatError(
+            "V2 search entries must start with one bracketed selector",
+            source,
+        )
+    start, end, selector_text = selectors[0]
+    match = re.fullmatch(
+        r"=\s*(?P<function>[A-Za-z_][A-Za-z0-9_]*)\s*\((?P<arguments>.*)\)",
+        text[end:].strip(),
+    )
+    if match is None:
+        raise MethodFormatError("Malformed search expression", source)
+    arguments = [part.strip() for part in match.group("arguments").split(",")]
+    if not arguments or any(not argument for argument in arguments):
+        raise MethodFormatError("Search arguments cannot be empty", source)
+    selector_source = SourceRef(
+        source.filename,
+        source.step,
+        source.field,
+        source.index,
+        (source.start or 0) + start + 1,
+        (source.start or 0) + end - 1,
+    )
+    return selector_text, selector_source, match.group("function").lower(), arguments
+
+
+def _search_numbers(arguments: list[str], source: SourceRef) -> tuple[float, ...]:
+    if any(re.fullmatch(_NUMBER, argument) is None for argument in arguments):
+        raise MethodFormatError(
+            "Search arguments must be finite decimal literals",
+            source,
+        )
+    try:
+        values = tuple(float(argument) for argument in arguments)
+    except (OverflowError, ValueError) as error:
+        raise MethodFormatError("Search arguments must be finite", source) from error
+    if not all(math.isfinite(value) for value in values):
+        raise MethodFormatError("Search arguments must be finite", source)
+    return values
+
+
+def parse_strict_grid_axis(text: str, source: SourceRef) -> GridAxis:
+    leading = len(text) - len(text.lstrip())
+    text = text.strip()
+    entry_source = _span_source(source, leading, leading + len(text))
+    selector_text, selector_source, function, arguments = _search_parts(
+        text, entry_source
+    )
+    selector = parse_strict_selector(selector_text, selector_source)
+    values = _search_numbers(arguments, entry_source)
+    if function == "values":
+        if len(set(values)) != len(values):
+            raise MethodFormatError(
+                "GRID values cannot contain duplicates", entry_source
+            )
+        return GridAxis(selector, GridValues(values), entry_source)
+    if function not in {"lin", "log"} or len(arguments) != 3:
+        message = (
+            "GRID accepts only lin(low, high, count), log(low, high, count), "
+            "or values(...)"
+        )
+        raise MethodFormatError(message, entry_source)
+    if re.fullmatch(r"\d+", arguments[2]) is None:
+        raise MethodFormatError("GRID count must be an integer", entry_source)
+    low, high = values[:2]
+    try:
+        count = int(arguments[2])
+    except ValueError as error:
+        raise MethodFormatError(
+            "GRID count must be an integer", entry_source
+        ) from error
+    if low >= high:
+        raise MethodFormatError("GRID range must satisfy low < high", entry_source)
+    if count < 2:
+        raise MethodFormatError("GRID count must be at least 2", entry_source)
+    if function == "log" and low <= 0.0:
+        raise MethodFormatError(
+            "Logarithmic GRID endpoints must be positive", entry_source
+        )
+    scale = SearchScale.LINEAR if function == "lin" else SearchScale.LOGARITHMIC
+    return GridAxis(selector, GridRange(scale, low, high, count), entry_source)
+
+
+def parse_strict_de_coordinate(text: str, source: SourceRef) -> DeCoordinate:
+    leading = len(text) - len(text.lstrip())
+    text = text.strip()
+    entry_source = _span_source(source, leading, leading + len(text))
+    selector_text, selector_source, function, arguments = _search_parts(
+        text, entry_source
+    )
+    if function not in {"lin", "log"} or len(arguments) != 2:
+        raise MethodFormatError(
+            "DE accepts only lin(low, high) or log(low, high)",
+            entry_source,
+        )
+    low, high = _search_numbers(arguments, entry_source)
+    if low >= high:
+        raise MethodFormatError("DE range must satisfy low < high", entry_source)
+    if function == "log" and low <= 0.0:
+        raise MethodFormatError(
+            "Logarithmic DE endpoints must be positive", entry_source
+        )
+    scale = SearchScale.LINEAR if function == "lin" else SearchScale.LOGARITHMIC
+    return DeCoordinate(
+        parse_strict_selector(selector_text, selector_source),
+        DeRange(scale, low, high),
+        entry_source,
+    )
+
+
+def parse_legacy_grid_axis(text: str, source: SourceRef) -> GridAxis:
+    compact = text.replace(" ", "")
+    if compact.count("=") != 1:
+        raise MethodFormatError(
+            "Legacy GRID entry must contain exactly one '='", source
+        )
+    selector_text, expression = compact.split("=", maxsplit=1)
+    selector = parse_legacy_selector(selector_text, source)
+    function_match = re.fullmatch(
+        r"(?P<function>lin|log)\((?P<arguments>.*)\)",
+        expression,
+    )
+    if function_match is not None:
+        function = function_match.group("function")
+        arguments = function_match.group("arguments").split(",")
+        if len(arguments) != 3 or re.fullmatch(r"\d+", arguments[2]) is None:
+            raise MethodFormatError("Unsupported legacy GRID definition", source)
+        low, high, _ = _search_numbers(arguments, source)
+        scale = SearchScale.LINEAR if function == "lin" else SearchScale.LOGARITHMIC
+        try:
+            count = int(arguments[2])
+        except ValueError as error:
+            raise MethodFormatError(
+                "Unsupported legacy GRID definition", source
+            ) from error
+        return GridAxis(selector, GridRange(scale, low, high, count), source)
+    tuple_match = re.fullmatch(r"\((?P<arguments>.*)\)", expression)
+    if tuple_match is None:
+        raise MethodFormatError("Unsupported legacy GRID definition", source)
+    arguments = [part.strip() for part in tuple_match.group("arguments").split(",")]
+    values = _search_numbers(arguments, source)
+    return GridAxis(selector, GridValues(values), source)

--- a/src/chemex/configuration/method_plan.py
+++ b/src/chemex/configuration/method_plan.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from chemex.parameters.spin_system import SpinSystem
+
+if TYPE_CHECKING:
+    from chemex.parameters.parameterization import SealedParameterModel
+
+
+class FormatOrigin(StrEnum):
+    V1 = "v1"
+    V2 = "v2"
+
+
+class LocalFit(StrEnum):
+    TRF = "trf"
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRef:
+    filename: Path
+    step: str
+    field: str
+    index: int | None = None
+    start: int | None = None
+    end: int | None = None
+
+
+class MethodFormatError(ValueError):
+    def __init__(self, message: str, source: SourceRef) -> None:
+        super().__init__(message)
+        self.message = message
+        self.source = source
+
+    def __str__(self) -> str:
+        location = f"{self.source.filename}: [{self.source.step}] {self.source.field}"
+        if self.source.index is not None:
+            location += f"[{self.source.index}]"
+        if self.source.start is not None and self.source.end is not None:
+            location += f" characters {self.source.start}:{self.source.end}"
+        return f"{location}: {self.message}"
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterSelector:
+    name: str
+    spin_system: str | None = None
+    temperature: float | None = None
+    h_larmor_frq: float | None = None
+    p_total: float | None = None
+    l_total: float | None = None
+    d2o: float | None = None
+    source: SourceRef | None = field(default=None, compare=False, repr=False)
+
+    def render(self) -> str:
+        parts = [self.name]
+        if self.spin_system is not None:
+            parts.append(f"NUC->{self.spin_system}")
+        if self.temperature is not None:
+            parts.append(f"T->{self.temperature:.1f}C")
+        if self.h_larmor_frq is not None:
+            parts.append(f"B0->{self.h_larmor_frq:.1f}MHz")
+        if self.p_total is not None:
+            parts.append(f"[P]->{render_number(self.p_total)}M")
+        if self.l_total is not None:
+            parts.append(f"[L]->{render_number(self.l_total)}M")
+        if self.d2o is not None:
+            parts.append(f"D2O->{render_number(self.d2o)}")
+        return ", ".join(parts)
+
+
+@dataclass(frozen=True, slots=True)
+class LiteralExpression:
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class SelectorExpression:
+    selector: ParameterSelector
+
+
+@dataclass(frozen=True, slots=True)
+class UnaryExpression:
+    operator: Literal["+", "-"]
+    operand: ConstraintExpression
+
+
+@dataclass(frozen=True, slots=True)
+class BinaryExpression:
+    operator: Literal["+", "-", "*", "/"]
+    left: ConstraintExpression
+    right: ConstraintExpression
+
+
+type ConstraintExpression = (
+    LiteralExpression | SelectorExpression | UnaryExpression | BinaryExpression
+)
+
+
+def render_number(value: float) -> str:
+    normalized = 0.0 if value == 0.0 else value
+    rendered = repr(normalized)
+    if "e" not in rendered.lower() and "." not in rendered:
+        rendered += ".0"
+    return rendered
+
+
+def render_expression(expression: ConstraintExpression) -> str:
+    precedence = {"+": 1, "-": 1, "*": 2, "/": 2}
+
+    def render(node: ConstraintExpression) -> str:
+        if isinstance(node, LiteralExpression):
+            return render_number(node.value)
+        if isinstance(node, SelectorExpression):
+            return f"[{node.selector.render()}]"
+        if isinstance(node, UnaryExpression):
+            operand = render(node.operand)
+            if isinstance(node.operand, BinaryExpression):
+                operand = f"({operand})"
+            return f"{node.operator}{operand}"
+        node_precedence = precedence[node.operator]
+        left = render(node.left)
+        right_text = render(node.right)
+        if (
+            isinstance(node.left, BinaryExpression)
+            and precedence[node.left.operator] < node_precedence
+        ):
+            left = f"({left})"
+        if isinstance(node.right, BinaryExpression) and (
+            precedence[node.right.operator] < node_precedence
+            or precedence[node.right.operator] == node_precedence
+        ):
+            right_text = f"({right_text})"
+        return f"{left} {node.operator} {right_text}"
+
+    return render(expression)
+
+
+@dataclass(frozen=True, slots=True)
+class Constraint:
+    target: ParameterSelector
+    expression: ConstraintExpression
+    source: SourceRef = field(compare=False, repr=False)
+
+    def render(self) -> str:
+        return f"[{self.target.render()}] = {render_expression(self.expression)}"
+
+
+@dataclass(frozen=True, slots=True)
+class FitAction:
+    selectors: tuple[ParameterSelector, ...]
+    source: SourceRef = field(compare=False, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class FixAction:
+    selectors: tuple[ParameterSelector, ...]
+    source: SourceRef = field(compare=False, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConstrainAction:
+    constraints: tuple[Constraint, ...]
+    source: SourceRef = field(compare=False, repr=False)
+
+
+type RoleAction = FitAction | FixAction | ConstrainAction
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileSelection:
+    include: tuple[str, ...] | Literal["*"] | None = None
+    exclude: tuple[str, ...] | Literal["*"] | None = None
+
+
+class SearchScale(StrEnum):
+    LINEAR = "lin"
+    LOGARITHMIC = "log"
+
+
+@dataclass(frozen=True, slots=True)
+class GridRange:
+    scale: SearchScale
+    low: float
+    high: float
+    count: int
+
+    def render(self) -> str:
+        return (
+            f"{self.scale.value}({render_number(self.low)}, "
+            f"{render_number(self.high)}, {self.count})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GridValues:
+    values: tuple[float, ...]
+
+    def render(self) -> str:
+        return f"values({', '.join(render_number(value) for value in self.values)})"
+
+
+type GridSpacing = GridRange | GridValues
+
+
+@dataclass(frozen=True, slots=True)
+class GridAxis:
+    selector: ParameterSelector
+    spacing: GridSpacing
+    source: SourceRef = field(compare=False, repr=False)
+
+    def render(self) -> str:
+        return f"[{self.selector.render()}] = {self.spacing.render()}"
+
+
+@dataclass(frozen=True, slots=True)
+class GridSearch:
+    axes: tuple[GridAxis, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DeRange:
+    scale: SearchScale
+    low: float
+    high: float
+
+    def render(self) -> str:
+        return (
+            f"{self.scale.value}({render_number(self.low)}, {render_number(self.high)})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DeCoordinate:
+    selector: ParameterSelector
+    range: DeRange
+    source: SourceRef = field(compare=False, repr=False)
+
+    def render(self) -> str:
+        return f"[{self.selector.render()}] = {self.range.render()}"
+
+
+@dataclass(frozen=True, slots=True)
+class DeSearch:
+    seed: int
+    coordinates: tuple[DeCoordinate, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingRequest:
+    replicates: int
+    seed: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class McmcRequest:
+    steps: int
+    burn: int | None = None
+    seed: int | None = None
+    thin: int = 1
+    walkers: int | None = None
+    workers: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StatisticsPlan:
+    mc: ResamplingRequest | None = None
+    bs: ResamplingRequest | None = None
+    bsn: ResamplingRequest | None = None
+    mcmc: McmcRequest | None = None
+
+
+def profile_selection(
+    include: object = None,
+    exclude: object = None,
+) -> ProfileSelection:
+    def normalize(value: object) -> tuple[str, ...] | Literal["*"] | None:
+        if isinstance(value, str) and value.lower() in {"*", "all"}:
+            return "*"
+        if isinstance(value, list):
+            if any(
+                isinstance(item, str) and item.lower() in {"*", "all"} for item in value
+            ):
+                return "*"
+            if not all(isinstance(item, (int, str, SpinSystem)) for item in value):
+                msg = "Profile selections must contain only names or residue numbers"
+                raise TypeError(msg)
+            normalized: list[str] = []
+            for item in value:
+                if isinstance(item, SpinSystem):
+                    normalized.append(str(item))
+                elif isinstance(item, (int, str)):
+                    normalized.append(str(SpinSystem.from_name(item)))
+            return tuple(normalized)
+        return None
+
+    return ProfileSelection(normalize(include), normalize(exclude))
+
+
+@dataclass(frozen=True, slots=True)
+class StepPlan:
+    name: str
+    selection: ProfileSelection = ProfileSelection()
+    roles_from: str | None = None
+    role_actions: tuple[RoleAction, ...] = ()
+    search: GridSearch | DeSearch | None = None
+    statistics: StatisticsPlan | None = None
+    local_fit: LocalFit = LocalFit.TRF
+
+
+@dataclass(frozen=True, slots=True)
+class MethodPlan:
+    format_origin: FormatOrigin
+    steps: tuple[StepPlan, ...]
+
+    def render(self) -> str:
+        lines = ["FORMAT_VERSION = 2"]
+        for step in self.steps:
+            lines.extend(("", f"[{_toml_key(step.name)}]"))
+            lines.extend(_render_selection(step.selection))
+            if step.roles_from is not None:
+                lines.append(f"ROLES_FROM = {json.dumps(step.roles_from)}")
+            if step.role_actions:
+                lines.append("ROLES = [")
+                for action in step.role_actions:
+                    if isinstance(action, FixAction):
+                        key = "FIX"
+                        values = tuple(item.render() for item in action.selectors)
+                    elif isinstance(action, FitAction):
+                        key = "FIT"
+                        values = tuple(item.render() for item in action.selectors)
+                    else:
+                        key = "CONSTRAIN"
+                        values = tuple(item.render() for item in action.constraints)
+                    rendered = ", ".join(json.dumps(value) for value in values)
+                    lines.append(f"  {{ {key} = [{rendered}] }},")
+                lines.append("]")
+            if isinstance(step.search, GridSearch):
+                lines.extend(("", f"[{_toml_key(step.name)}.SEARCH.GRID]", "AXES = ["))
+                lines.extend(
+                    f"  {json.dumps(axis.render())}," for axis in step.search.axes
+                )
+                lines.append("]")
+            elif isinstance(step.search, DeSearch):
+                lines.extend(
+                    (
+                        "",
+                        f"[{_toml_key(step.name)}.SEARCH.DE]",
+                        f"SEED = {step.search.seed}",
+                        "COORDINATES = [",
+                    )
+                )
+                lines.extend(
+                    f"  {json.dumps(coordinate.render())},"
+                    for coordinate in step.search.coordinates
+                )
+                lines.append("]")
+            lines.extend(_render_statistics(step.name, step.statistics))
+        return "\n".join(lines) + "\n"
+
+    def validate(self, parameter_model: SealedParameterModel) -> None:
+        from chemex.configuration.method_validation import validate_method_plan
+
+        validate_method_plan(self, parameter_model)
+
+
+_BARE_TOML_KEY = re.compile(r"[A-Za-z0-9_-]+\Z")
+
+
+def _toml_key(value: str) -> str:
+    return value if _BARE_TOML_KEY.fullmatch(value) else json.dumps(value)
+
+
+def _render_profile_set(value: tuple[str, ...] | Literal["*"]) -> str:
+    if value == "*":
+        return json.dumps("ALL")
+    return f"[{', '.join(json.dumps(item) for item in value)}]"
+
+
+def _render_selection(selection: ProfileSelection) -> list[str]:
+    lines: list[str] = []
+    if selection.include is not None:
+        lines.append(f"INCLUDE = {_render_profile_set(selection.include)}")
+    if selection.exclude is not None:
+        lines.append(f"EXCLUDE = {_render_profile_set(selection.exclude)}")
+    return lines
+
+
+def _render_statistics(name: str, statistics: StatisticsPlan | None) -> list[str]:
+    if statistics is None:
+        return []
+
+    key = _toml_key(name)
+    lines: list[str] = []
+    for request_name, request in (
+        ("MC", statistics.mc),
+        ("BS", statistics.bs),
+        ("BSN", statistics.bsn),
+    ):
+        if request is None:
+            continue
+        lines.extend(_render_resampling(key, request_name, request))
+    if statistics.mcmc is not None:
+        lines.extend(_render_mcmc(key, statistics.mcmc))
+    return lines
+
+
+def _render_resampling(
+    step_key: str,
+    request_name: str,
+    request: ResamplingRequest,
+) -> list[str]:
+    lines = [
+        "",
+        f"[{step_key}.STATISTICS.{request_name}]",
+        f"REPLICATES = {request.replicates}",
+    ]
+    if request.seed is not None:
+        lines.append(f"SEED = {request.seed}")
+    return lines
+
+
+def _render_mcmc(step_key: str, request: McmcRequest) -> list[str]:
+    lines = [
+        "",
+        f"[{step_key}.STATISTICS.MCMC]",
+        f"STEPS = {request.steps}",
+    ]
+    if request.burn is not None:
+        lines.append(f"BURN = {request.burn}")
+    if request.seed is not None:
+        lines.append(f"SEED = {request.seed}")
+    if request.thin != 1:
+        lines.append(f"# V1_ONLY_THIN = {request.thin}")
+    if request.walkers is not None:
+        lines.append(f"# V1_ONLY_WALKERS = {request.walkers}")
+    if request.workers is not None:
+        lines.append(f"# V1_ONLY_WORKERS = {request.workers}")
+    return lines

--- a/src/chemex/configuration/method_plan.py
+++ b/src/chemex/configuration/method_plan.py
@@ -18,10 +18,6 @@ class FormatOrigin(StrEnum):
     V2 = "v2"
 
 
-class LocalFit(StrEnum):
-    TRF = "trf"
-
-
 @dataclass(frozen=True, slots=True)
 class SourceRef:
     filename: Path
@@ -311,7 +307,6 @@ class StepPlan:
     role_actions: tuple[RoleAction, ...] = ()
     search: GridSearch | DeSearch | None = None
     statistics: StatisticsPlan | None = None
-    local_fit: LocalFit = LocalFit.TRF
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/chemex/configuration/method_v1.py
+++ b/src/chemex/configuration/method_v1.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from chemex.configuration.method_expressions import (
+    parse_constraint,
+    parse_legacy_grid_axis,
+    parse_legacy_selector,
+)
+from chemex.configuration.method_plan import (
+    ConstrainAction,
+    Constraint,
+    FitAction,
+    FixAction,
+    FormatOrigin,
+    GridSearch,
+    McmcRequest,
+    MethodPlan,
+    ParameterSelector,
+    ProfileSelection,
+    ResamplingRequest,
+    SourceRef,
+    StatisticsPlan,
+    StepPlan,
+    profile_selection,
+)
+
+
+def _selector(text: str, source: SourceRef) -> ParameterSelector:
+    return parse_legacy_selector(text, source)
+
+
+def _constraint(text: str, source: SourceRef) -> Constraint:
+    return parse_constraint(text, source, _selector)
+
+
+def _statistics(value: object) -> StatisticsPlan | None:
+    if not isinstance(value, dict):
+        return None
+    settings = {str(key).lower(): item for key, item in value.items()}
+
+    def resampling(name: str) -> ResamplingRequest | None:
+        request = settings.get(name)
+        return ResamplingRequest(request) if isinstance(request, int) else None
+
+    mcmc_value = settings.get("mcmc")
+    mcmc = None
+    if isinstance(mcmc_value, int):
+        mcmc = McmcRequest(mcmc_value)
+    elif isinstance(mcmc_value, dict):
+        expanded = {str(key).lower(): item for key, item in mcmc_value.items()}
+
+        def integer(name: str, default: int | None = None) -> int | None:
+            item = expanded.get(name, default)
+            return (
+                item
+                if isinstance(item, int) and not isinstance(item, bool)
+                else default
+            )
+
+        burn_value = expanded.get("burn")
+        burn = burn_value if isinstance(burn_value, int) else None
+        steps = integer("steps")
+        if steps is None:
+            return None
+        mcmc = McmcRequest(
+            steps,
+            burn,
+            integer("seed"),
+            integer("thin", 1) or 1,
+            integer("walkers"),
+            integer("workers"),
+        )
+    return StatisticsPlan(resampling("mc"), resampling("bs"), resampling("bsn"), mcmc)
+
+
+def adapt_v1(raw_steps: list[tuple[Path, str, dict[str, Any]]]) -> MethodPlan:
+    steps: list[StepPlan] = []
+    previous: str | None = None
+    previous_selection = ProfileSelection()
+    for filename, name, settings in raw_steps:
+        normalized = {str(key).lower(): value for key, value in settings.items()}
+        selection = (
+            profile_selection(
+                normalized.get("include"),
+                normalized.get("exclude"),
+            )
+            if "include" in normalized or "exclude" in normalized
+            else previous_selection
+        )
+        actions = []
+        constraints = tuple(
+            _constraint(
+                text,
+                SourceRef(filename, name, "CONSTRAINTS", index),
+            )
+            for index, text in enumerate(normalized.get("constraints", []))
+        )
+        if constraints:
+            actions.append(
+                ConstrainAction(
+                    constraints,
+                    SourceRef(filename, name, "CONSTRAINTS"),
+                )
+            )
+        for key, action_type in (("fix", FixAction), ("fit", FitAction)):
+            texts = normalized.get(key, [])
+            if texts:
+                actions.append(
+                    action_type(
+                        tuple(
+                            _selector(
+                                text,
+                                SourceRef(filename, name, key.upper(), index),
+                            )
+                            for index, text in enumerate(texts)
+                        ),
+                        SourceRef(filename, name, key.upper()),
+                    )
+                )
+        steps.append(
+            StepPlan(
+                name=name,
+                selection=selection,
+                roles_from=previous,
+                role_actions=tuple(actions),
+                search=(
+                    GridSearch(
+                        tuple(
+                            parse_legacy_grid_axis(
+                                text,
+                                SourceRef(filename, name, "GRID", index),
+                            )
+                            for index, text in enumerate(normalized.get("grid", []))
+                        )
+                    )
+                    if normalized.get("grid")
+                    else None
+                ),
+                statistics=_statistics(normalized.get("statistics")),
+            )
+        )
+        previous = name
+        previous_selection = selection
+    return MethodPlan(FormatOrigin.V1, tuple(steps))

--- a/src/chemex/configuration/method_v2.py
+++ b/src/chemex/configuration/method_v2.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from chemex.configuration.method_expressions import (
+    parse_constraint,
+    parse_strict_de_coordinate,
+    parse_strict_grid_axis,
+    parse_strict_selector,
+)
+from chemex.configuration.method_plan import (
+    ConstrainAction,
+    Constraint,
+    DeSearch,
+    FitAction,
+    FixAction,
+    FormatOrigin,
+    GridSearch,
+    McmcRequest,
+    MethodFormatError,
+    MethodPlan,
+    ParameterSelector,
+    ProfileSelection,
+    ResamplingRequest,
+    RoleAction,
+    SourceRef,
+    StatisticsPlan,
+    StepPlan,
+    profile_selection,
+)
+
+
+def _selector(text: str, source: SourceRef) -> ParameterSelector:
+    return parse_strict_selector(text, source)
+
+
+def _constraint(text: str, source: SourceRef) -> Constraint:
+    return parse_constraint(text, source, _selector)
+
+
+def _seed(value: object, source: SourceRef) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value < 1 << 64
+    ):
+        raise MethodFormatError("SEED must be an unsigned 64-bit integer", source)
+    return value
+
+
+def _positive_int(value: object, name: str, source: SourceRef) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise MethodFormatError(f"{name} must be a positive integer", source)
+    return value
+
+
+def _string_list(value: object, source: SourceRef) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise MethodFormatError(f"{source.field} must be a list of strings", source)
+    return [item for item in value if isinstance(item, str)]
+
+
+def _selection(
+    include: object,
+    exclude: object,
+    filename: Path,
+    name: str,
+) -> ProfileSelection:
+    for field, value in (("INCLUDE", include), ("EXCLUDE", exclude)):
+        valid_all = isinstance(value, str) and value.lower() in {"*", "all"}
+        valid_list = isinstance(value, list) and all(
+            isinstance(item, (int, str)) and not isinstance(item, bool)
+            for item in value
+        )
+        if value is not None and not valid_all and not valid_list:
+            raise MethodFormatError(
+                f"{field} must be ALL or a list of profile names/residue numbers",
+                SourceRef(filename, name, field),
+            )
+    return profile_selection(include, exclude)
+
+
+def _mapping(
+    value: object,
+    allowed: set[str],
+    source: SourceRef,
+) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise MethodFormatError(f"{source.field} must be a TOML table", source)
+    normalized: dict[str, object] = {}
+    for raw_key, item in value.items():
+        key = str(raw_key).lower()
+        if key in normalized:
+            raise MethodFormatError(f"Duplicate key {raw_key}", source)
+        if key not in allowed:
+            raise MethodFormatError(f"Unsupported v2 field {raw_key}", source)
+        normalized[key] = item
+    return normalized
+
+
+def _resampling(
+    settings: dict[str, object], name: str, source: SourceRef
+) -> ResamplingRequest | None:
+    request = settings.get(name)
+    if request is None:
+        return None
+    request_source = SourceRef(
+        source.filename, source.step, f"STATISTICS.{name.upper()}"
+    )
+    if isinstance(request, int) and not isinstance(request, bool):
+        return ResamplingRequest(_positive_int(request, "REPLICATES", request_source))
+    expanded = _mapping(request, {"replicates", "seed"}, request_source)
+    if "replicates" not in expanded:
+        raise MethodFormatError("Expanded request requires REPLICATES", request_source)
+    seed = expanded.get("seed")
+    return ResamplingRequest(
+        _positive_int(expanded["replicates"], "REPLICATES", request_source),
+        _seed(seed, request_source) if seed is not None else None,
+    )
+
+
+def _burn(value: object, steps: int, source: SourceRef) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise MethodFormatError("BURN must be a nonnegative integer", source)
+    if value >= steps:
+        raise MethodFormatError("BURN must be smaller than STEPS", source)
+    return value
+
+
+def _mcmc(value: object, source: SourceRef) -> McmcRequest | None:
+    if value is None:
+        return None
+    mcmc_source = SourceRef(source.filename, source.step, "STATISTICS.MCMC")
+    if isinstance(value, int) and not isinstance(value, bool):
+        return McmcRequest(_positive_int(value, "STEPS", mcmc_source))
+    expanded = _mapping(value, {"steps", "burn", "seed"}, mcmc_source)
+    if "steps" not in expanded:
+        raise MethodFormatError("Expanded MCMC requires STEPS", mcmc_source)
+    steps = _positive_int(expanded["steps"], "STEPS", mcmc_source)
+    seed = expanded.get("seed")
+    return McmcRequest(
+        steps,
+        _burn(expanded.get("burn"), steps, mcmc_source),
+        _seed(seed, mcmc_source) if seed is not None else None,
+    )
+
+
+def _statistics(value: object, source: SourceRef) -> StatisticsPlan:
+    settings = _mapping(value, {"mc", "bs", "bsn", "mcmc"}, source)
+    return StatisticsPlan(
+        _resampling(settings, "mc", source),
+        _resampling(settings, "bs", source),
+        _resampling(settings, "bsn", source),
+        _mcmc(settings.get("mcmc"), source),
+    )
+
+
+def _grid_search(value: object, filename: Path, name: str) -> GridSearch:
+    source = SourceRef(filename, name, "SEARCH.GRID")
+    settings = _mapping(value, {"axes"}, source)
+    if "axes" not in settings:
+        raise MethodFormatError("SEARCH.GRID requires AXES", source)
+    axes = _string_list(settings["axes"], SourceRef(filename, name, "SEARCH.GRID.AXES"))
+    if not axes:
+        raise MethodFormatError(
+            "SEARCH.GRID.AXES must contain at least one entry",
+            SourceRef(filename, name, "SEARCH.GRID.AXES"),
+        )
+    return GridSearch(
+        tuple(
+            parse_strict_grid_axis(
+                text, SourceRef(filename, name, "SEARCH.GRID.AXES", index)
+            )
+            for index, text in enumerate(axes)
+        )
+    )
+
+
+def _de_search(value: object, filename: Path, name: str) -> DeSearch:
+    source = SourceRef(filename, name, "SEARCH.DE")
+    settings = _mapping(value, {"seed", "coordinates"}, source)
+    if "seed" not in settings or "coordinates" not in settings:
+        raise MethodFormatError("SEARCH.DE requires SEED and COORDINATES", source)
+    coordinates = _string_list(
+        settings["coordinates"], SourceRef(filename, name, "SEARCH.DE.COORDINATES")
+    )
+    if not coordinates:
+        raise MethodFormatError(
+            "SEARCH.DE.COORDINATES must contain at least one entry",
+            SourceRef(filename, name, "SEARCH.DE.COORDINATES"),
+        )
+    return DeSearch(
+        _seed(settings["seed"], SourceRef(filename, name, "SEARCH.DE.SEED")),
+        tuple(
+            parse_strict_de_coordinate(
+                text, SourceRef(filename, name, "SEARCH.DE.COORDINATES", index)
+            )
+            for index, text in enumerate(coordinates)
+        ),
+    )
+
+
+def _search(value: object, filename: Path, name: str) -> GridSearch | DeSearch:
+    source = SourceRef(filename, name, "SEARCH")
+    settings = _mapping(value, {"grid", "de"}, source)
+    if len(settings) != 1:
+        raise MethodFormatError("SEARCH must contain exactly one of GRID or DE", source)
+    if "grid" in settings:
+        return _grid_search(settings["grid"], filename, name)
+    return _de_search(settings["de"], filename, name)
+
+
+def _role_action(
+    value: object, filename: Path, name: str, action_index: int
+) -> RoleAction:
+    action_source = SourceRef(filename, name, "ROLES", action_index)
+    settings = _mapping(value, {"fix", "fit", "constrain"}, action_source)
+    if len(settings) != 1:
+        keys = ", ".join(str(key).upper() for key in settings)
+        raise MethodFormatError(
+            f"Each ROLES action must contain exactly one key; found {keys}",
+            action_source,
+        )
+    key, value = next(iter(settings.items()))
+    texts = _string_list(value, action_source)
+    if not texts:
+        raise MethodFormatError("ROLES actions cannot be empty", action_source)
+    source = SourceRef(filename, name, f"ROLES.{key}", action_index)
+    if key == "constrain":
+        return ConstrainAction(
+            tuple(
+                _constraint(
+                    text,
+                    SourceRef(
+                        filename, name, f"ROLES[{action_index}].CONSTRAIN[{index}]"
+                    ),
+                )
+                for index, text in enumerate(texts)
+            ),
+            source,
+        )
+    selectors = tuple(
+        _selector(
+            text,
+            SourceRef(filename, name, f"ROLES[{action_index}].{key.upper()}[{index}]"),
+        )
+        for index, text in enumerate(texts)
+    )
+    return (
+        FixAction(selectors, source) if key == "fix" else FitAction(selectors, source)
+    )
+
+
+def _role_actions(value: object, filename: Path, name: str) -> tuple[RoleAction, ...]:
+    if not isinstance(value, list):
+        raise MethodFormatError(
+            "ROLES must be an ordered array of single-key actions",
+            SourceRef(filename, name, "ROLES"),
+        )
+    if not value:
+        raise MethodFormatError(
+            "ROLES must contain at least one action",
+            SourceRef(filename, name, "ROLES"),
+        )
+    return tuple(
+        _role_action(action, filename, name, index)
+        for index, action in enumerate(value)
+    )
+
+
+def _roles_from(
+    value: object, filename: Path, name: str, earlier: set[str]
+) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or value not in earlier:
+        raise MethodFormatError(
+            "ROLES_FROM must name one unique earlier step",
+            SourceRef(filename, name, "ROLES_FROM"),
+        )
+    return value
+
+
+def _step(
+    filename: Path,
+    name: str,
+    settings: dict[str, Any],
+    earlier: set[str],
+) -> StepPlan:
+    normalized = _mapping(
+        settings,
+        {"include", "exclude", "roles", "roles_from", "search", "statistics"},
+        SourceRef(filename, name, "<step>"),
+    )
+    return StepPlan(
+        name=name,
+        selection=_selection(
+            normalized.get("include"), normalized.get("exclude"), filename, name
+        ),
+        roles_from=_roles_from(normalized.get("roles_from"), filename, name, earlier),
+        role_actions=(
+            _role_actions(normalized["roles"], filename, name)
+            if "roles" in normalized
+            else ()
+        ),
+        search=(
+            _search(normalized["search"], filename, name)
+            if "search" in normalized
+            else None
+        ),
+        statistics=(
+            _statistics(
+                normalized["statistics"], SourceRef(filename, name, "STATISTICS")
+            )
+            if "statistics" in normalized
+            else None
+        ),
+    )
+
+
+def adapt_v2(raw_steps: list[tuple[Path, str, dict[str, Any]]]) -> MethodPlan:
+    steps: list[StepPlan] = []
+    earlier: set[str] = set()
+    for filename, name, settings in raw_steps:
+        steps.append(_step(filename, name, settings, earlier))
+        earlier.add(name)
+    return MethodPlan(FormatOrigin.V2, tuple(steps))

--- a/src/chemex/configuration/method_validation.py
+++ b/src/chemex/configuration/method_validation.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from chemex.configuration.conditions import Conditions
+from chemex.configuration.method_plan import (
+    BinaryExpression,
+    ConstrainAction,
+    Constraint,
+    ConstraintExpression,
+    DeSearch,
+    FitAction,
+    FixAction,
+    GridAxis,
+    GridSearch,
+    GridValues,
+    MethodFormatError,
+    MethodPlan,
+    ParameterSelector,
+    SelectorExpression,
+    SourceRef,
+    UnaryExpression,
+)
+from chemex.parameters.name import ParamName, matches_parameter_index_selector
+from chemex.parameters.parameterization import (
+    ParameterRole,
+    SealedParameterModel,
+    compatible_reference_context,
+)
+from chemex.parameters.sealed import ParamDefinition
+from chemex.parameters.spin_system import SpinSystem
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedConstraint:
+    declaration: Constraint
+    dependencies: tuple[str, ...]
+
+
+def _param_name(definition: ParamDefinition) -> ParamName:
+    return ParamName(
+        definition.name,
+        SpinSystem.from_name(definition.spin_system_name),
+        Conditions.model_construct(None, **dict(definition.condition_entries)),
+    )
+
+
+def _selector_name(selector: ParameterSelector) -> ParamName:
+    return ParamName(
+        selector.name,
+        SpinSystem.from_name(selector.spin_system or ""),
+        Conditions.model_construct(
+            None,
+            temperature=selector.temperature,
+            h_larmor_frq=selector.h_larmor_frq,
+            p_total=selector.p_total,
+            l_total=selector.l_total,
+            d2o=selector.d2o,
+        ),
+    )
+
+
+def _source(selector: ParameterSelector, fallback: SourceRef) -> SourceRef:
+    return selector.source if selector.source is not None else fallback
+
+
+def _matches(
+    selector: ParameterSelector,
+    model: SealedParameterModel,
+    fallback: SourceRef,
+) -> tuple[str, ...]:
+    parsed = _selector_name(selector)
+    matches = tuple(
+        definition.param_id
+        for definition in model.definitions
+        if matches_parameter_index_selector(parsed, _param_name(definition))
+    )
+    if not matches:
+        raise MethodFormatError(
+            f"No parameter matches selector [{selector.render()}]",
+            _source(selector, fallback),
+        )
+    return matches
+
+
+def _resolve_constraint_reference(
+    selector: ParameterSelector,
+    target_id: str,
+    model: SealedParameterModel,
+    source: SourceRef,
+) -> str:
+    parsed = _selector_name(selector)
+    candidates = tuple(
+        definition
+        for definition in model.definitions
+        if matches_parameter_index_selector(parsed, _param_name(definition))
+    )
+    if not candidates:
+        raise MethodFormatError(
+            f"No parameter matches constraint reference [{selector.render()}]", source
+        )
+    non_self = tuple(item for item in candidates if item.param_id != target_id)
+    if not non_self:
+        raise MethodFormatError(
+            f"Constraint reference [{selector.render()}] resolves only to its target",
+            source,
+        )
+    target = model.definitions[target_id]
+    ranked = tuple(
+        (candidate, context)
+        for candidate in non_self
+        if (context := compatible_reference_context(candidate, target, parsed))
+        is not None
+    )
+    if not ranked:
+        raise MethodFormatError(
+            f"No context-compatible parameter matches [{selector.render()}]", source
+        )
+    minimum_extras = min(context[1] for _candidate, context in ranked)
+    eligible = tuple(
+        (candidate, context[0])
+        for candidate, context in ranked
+        if context[1] == minimum_extras
+    )
+    maximal = tuple(
+        candidate
+        for candidate, fields in eligible
+        if not any(fields < other_fields for _other, other_fields in eligible)
+    )
+    if len(maximal) != 1:
+        candidate_ids = tuple(item.param_id for item in maximal)
+        raise MethodFormatError(
+            f"Constraint reference [{selector.render()}] is ambiguous among "
+            f"{candidate_ids}",
+            source,
+        )
+    return maximal[0].param_id
+
+
+def _references(expression: ConstraintExpression) -> Iterator[ParameterSelector]:
+    if isinstance(expression, SelectorExpression):
+        yield expression.selector
+    elif isinstance(expression, UnaryExpression):
+        yield from _references(expression.operand)
+    elif isinstance(expression, BinaryExpression):
+        yield from _references(expression.left)
+        yield from _references(expression.right)
+
+
+def _check_bounds(
+    param_id: str,
+    values: tuple[float, ...],
+    model: SealedParameterModel,
+    source: SourceRef,
+) -> None:
+    configuration = model.configuration[param_id]
+    if any(
+        value < configuration.lower_bound or value > configuration.upper_bound
+        for value in values
+    ):
+        raise MethodFormatError(
+            f"Search range for {param_id} lies outside physical bounds "
+            f"[{configuration.lower_bound}, {configuration.upper_bound}]",
+            source,
+        )
+
+
+def _reject_protected(
+    matches: tuple[str, ...],
+    model: SealedParameterModel,
+    source: SourceRef,
+    operation: str,
+) -> None:
+    protected = tuple(
+        param_id for param_id in matches if model.declarations[param_id].model_owned
+    )
+    if protected:
+        raise MethodFormatError(
+            f"{operation} cannot override model-owned parameters {protected}", source
+        )
+
+
+def _reject_unestimable(
+    matches: tuple[str, ...],
+    model: SealedParameterModel,
+    source: SourceRef,
+) -> None:
+    unestimable = tuple(
+        param_id
+        for param_id in matches
+        if model.declarations[param_id].model_expression
+        and not model.declarations[param_id].supports_estimation
+    )
+    if unestimable:
+        raise MethodFormatError(
+            f"FIT cannot override parameters that do not support estimation "
+            f"{unestimable}",
+            source,
+        )
+
+
+def _apply_actions(
+    roles: dict[str, ParameterRole],
+    constraints: dict[str, _ResolvedConstraint],
+    actions: tuple[FitAction | FixAction | ConstrainAction, ...],
+    model: SealedParameterModel,
+) -> None:
+    for action in actions:
+        if isinstance(action, (FitAction, FixAction)):
+            role = (
+                ParameterRole.FIT
+                if isinstance(action, FitAction)
+                else ParameterRole.FIX
+            )
+            for selector in action.selectors:
+                matches = _matches(selector, model, action.source)
+                _reject_protected(
+                    matches, model, _source(selector, action.source), "Method role"
+                )
+                if isinstance(action, FitAction):
+                    _reject_unestimable(
+                        matches, model, _source(selector, action.source)
+                    )
+                roles.update(dict.fromkeys(matches, role))
+                for param_id in matches:
+                    constraints.pop(param_id, None)
+            continue
+        for constraint in action.constraints:
+            matches = _matches(constraint.target, model, constraint.source)
+            _reject_protected(matches, model, constraint.source, "Constraint")
+            for param_id in matches:
+                dependencies = tuple(
+                    dict.fromkeys(
+                        _resolve_constraint_reference(
+                            reference,
+                            param_id,
+                            model,
+                            _source(reference, constraint.source),
+                        )
+                        for reference in _references(constraint.expression)
+                    )
+                )
+                roles[param_id] = ParameterRole.DERIVED
+                constraints[param_id] = _ResolvedConstraint(constraint, dependencies)
+
+
+def _find_cycle(
+    constraints: dict[str, _ResolvedConstraint], order: tuple[str, ...]
+) -> tuple[str, ...] | None:
+    state = dict.fromkeys(constraints, 0)
+    stack: list[str] = []
+    positions: dict[str, int] = {}
+
+    def visit(param_id: str) -> tuple[str, ...] | None:
+        state[param_id] = 1
+        positions[param_id] = len(stack)
+        stack.append(param_id)
+        for dependency in constraints[param_id].dependencies:
+            if dependency not in constraints:
+                continue
+            if state[dependency] == 0 and (cycle := visit(dependency)):
+                return cycle
+            if state[dependency] == 1:
+                return tuple(stack[positions[dependency] :])
+        stack.pop()
+        positions.pop(param_id)
+        state[param_id] = 2
+        return None
+
+    for param_id in order:
+        if (
+            param_id in constraints
+            and state[param_id] == 0
+            and (cycle := visit(param_id))
+        ):
+            return cycle
+    return None
+
+
+def _validate_constraint_graph(
+    constraints: dict[str, _ResolvedConstraint], model: SealedParameterModel
+) -> None:
+    order = tuple(definition.param_id for definition in model.definitions)
+    cycle = _find_cycle(constraints, order)
+    if cycle is not None:
+        source = constraints[cycle[0]].declaration.source
+        raise MethodFormatError(
+            f"Constraint dependency cycle contains {', '.join(cycle)}", source
+        )
+
+
+def _validate_grid(
+    search: GridSearch,
+    roles: dict[str, ParameterRole],
+    model: SealedParameterModel,
+) -> None:
+    concrete: dict[str, GridAxis] = {}
+    for axis in search.axes:
+        matches = _matches(axis.selector, model, axis.source)
+        for param_id in matches:
+            if roles[param_id] is not ParameterRole.FIT:
+                raise MethodFormatError(
+                    f"GRID target {param_id} is not a final independent FIT coordinate",
+                    axis.source,
+                )
+            concrete[param_id] = axis
+    for param_id, axis in concrete.items():
+        values = (
+            axis.spacing.values
+            if isinstance(axis.spacing, GridValues)
+            else (axis.spacing.low, axis.spacing.high)
+        )
+        _check_bounds(param_id, values, model, axis.source)
+
+
+def _validate_de(
+    search: DeSearch,
+    roles: dict[str, ParameterRole],
+    model: SealedParameterModel,
+) -> None:
+    seen: set[str] = set()
+    for coordinate in search.coordinates:
+        matches = _matches(coordinate.selector, model, coordinate.source)
+        if len(matches) != 1:
+            raise MethodFormatError(
+                "Each DE entry must resolve to exactly one final independent "
+                f"FIT coordinate; matched {len(matches)}",
+                coordinate.source,
+            )
+        param_id = matches[0]
+        if roles[param_id] is not ParameterRole.FIT:
+            raise MethodFormatError(
+                f"DE target {param_id} is not a final independent FIT coordinate",
+                coordinate.source,
+            )
+        if param_id in seen:
+            raise MethodFormatError(
+                f"Duplicate DE coordinate {param_id}", coordinate.source
+            )
+        seen.add(param_id)
+        _check_bounds(
+            param_id,
+            (coordinate.range.low, coordinate.range.high),
+            model,
+            coordinate.source,
+        )
+
+
+def validate_method_plan(plan: MethodPlan, model: SealedParameterModel) -> None:
+    baseline = {
+        param_id: ParameterRole.DERIVED
+        if declaration.model_expression
+        else ParameterRole.FIT
+        if declaration.supports_estimation
+        else ParameterRole.FIX
+        for param_id, declaration in model.declarations.items()
+    }
+    effective_by_step: dict[str, dict[str, ParameterRole]] = {}
+    constraints_by_step: dict[str, dict[str, _ResolvedConstraint]] = {}
+    for step in plan.steps:
+        roles = dict(
+            baseline if step.roles_from is None else effective_by_step[step.roles_from]
+        )
+        constraints = dict(
+            {} if step.roles_from is None else constraints_by_step[step.roles_from]
+        )
+        _apply_actions(roles, constraints, step.role_actions, model)
+        _validate_constraint_graph(constraints, model)
+        effective_by_step[step.name] = roles
+        constraints_by_step[step.name] = constraints
+        if isinstance(step.search, GridSearch):
+            _validate_grid(step.search, roles, model)
+        elif isinstance(step.search, DeSearch):
+            _validate_de(step.search, roles, model)

--- a/src/chemex/configuration/methods.py
+++ b/src/chemex/configuration/methods.py
@@ -18,6 +18,9 @@ from pydantic import (
 )
 from pydantic.types import NonNegativeInt, PositiveInt
 
+from chemex.configuration.method_plan import MethodFormatError, MethodPlan, SourceRef
+from chemex.configuration.method_v1 import adapt_v1
+from chemex.configuration.method_v2 import adapt_v2
 from chemex.configuration.utils import key_to_lower
 from chemex.messages import print_method_error
 from chemex.parameters.spin_system import SpinSystem
@@ -138,6 +141,104 @@ class Method(BaseModel):
 
 
 Methods = dict[str, Method]
+type _MethodSource = tuple[Path, dict[str, object]]
+type _RawStep = tuple[Path, str, dict[str, object]]
+
+
+def _method_format(sources: list[_MethodSource]) -> bool:
+    formats: set[int] = set()
+    for filename, data in sources:
+        version_items = [
+            value for key, value in data.items() if str(key).lower() == "format_version"
+        ]
+        if len(version_items) > 1:
+            raise MethodFormatError(
+                "Duplicate FORMAT_VERSION declaration",
+                SourceRef(filename, "<file>", "FORMAT_VERSION"),
+            )
+        if not version_items:
+            formats.add(1)
+        elif (
+            isinstance(version_items[0], int)
+            and not isinstance(version_items[0], bool)
+            and version_items[0] == 2
+        ):
+            formats.add(2)
+        else:
+            raise MethodFormatError(
+                "FORMAT_VERSION supports only version 2; omit it for legacy v1",
+                SourceRef(filename, "<file>", "FORMAT_VERSION"),
+            )
+    if len(formats) > 1:
+        filename = sources[-1][0]
+        raise MethodFormatError(
+            "A mixed v1/v2 method invocation is not supported",
+            SourceRef(filename, "<file>", "FORMAT_VERSION"),
+        )
+    return formats == {2}
+
+
+def _explicit_model_values(model: BaseModel) -> dict[str, object]:
+    return {
+        field: _explicit_model_values(value) if isinstance(value, BaseModel) else value
+        for field in model.model_fields_set
+        if (value := getattr(model, field)) is not None
+    }
+
+
+def _validate_v1_step(
+    filename: Path, name: str, settings: dict[str, object]
+) -> dict[str, object]:
+    try:
+        return _explicit_model_values(Method.model_validate(settings))
+    except ValidationError as error:
+        first = error.errors()[0]
+        field = ".".join(str(item).upper() for item in first["loc"])
+        raise MethodFormatError(
+            str(first["msg"]),
+            SourceRef(filename, name, field or "<step>"),
+        ) from error
+
+
+def _raw_steps(sources: list[_MethodSource], *, is_v2: bool) -> list[_RawStep]:
+    raw_steps: list[_RawStep] = []
+    step_positions: dict[str, int] = {}
+    for filename, data in sources:
+        for name, settings in data.items():
+            if str(name).lower() == "format_version":
+                continue
+            if not isinstance(settings, dict):
+                raise MethodFormatError(
+                    "Method steps must be TOML tables",
+                    SourceRef(filename, str(name), "<step>"),
+                )
+            normalized_settings = {str(key): value for key, value in settings.items()}
+            if not is_v2:
+                normalized_settings = _validate_v1_step(
+                    filename, name, normalized_settings
+                )
+            if name in step_positions:
+                if is_v2:
+                    raise MethodFormatError(
+                        f"Duplicate v2 step {name!r}",
+                        SourceRef(filename, str(name), "<step>"),
+                    )
+                raw_steps[step_positions[name]] = (filename, name, normalized_settings)
+            else:
+                step_positions[name] = len(raw_steps)
+                raw_steps.append((filename, name, normalized_settings))
+    return raw_steps
+
+
+def read_method_plan(filenames: Iterable[Path]) -> MethodPlan:
+    sources: list[_MethodSource] = [
+        (filename, read_toml(filename)) for filename in filenames
+    ]
+    is_v2 = _method_format(sources)
+    raw_steps = _raw_steps(sources, is_v2=is_v2)
+    if is_v2:
+        return adapt_v2(raw_steps)
+    return adapt_v1(raw_steps)
 
 
 def read_methods(filenames: Iterable[Path]) -> Methods:

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -1126,7 +1126,7 @@ def _replace_selectors(right: str) -> tuple[str, Mapping[str, str]]:
     return "".join(parts), MappingProxyType(replacements)
 
 
-def _compatible_context(
+def compatible_reference_context(
     candidate: ParamDefinition,
     target: ParamDefinition,
     selector: ParamName,
@@ -1190,7 +1190,8 @@ def _resolve_reference(
     ranked = tuple(
         (candidate, context)
         for candidate in non_self
-        if (context := _compatible_context(candidate, target, selector)) is not None
+        if (context := compatible_reference_context(candidate, target, selector))
+        is not None
     )
     if not ranked:
         raise NoParameterMatchError(

--- a/src/chemex/parameters/spin_system/spin_system.py
+++ b/src/chemex/parameters/spin_system/spin_system.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, Self
 from pydantic import BaseModel, Field, InstanceOf, computed_field, model_validator
 
 from chemex.parameters.spin_system.atom import Atom
+from chemex.parameters.spin_system.constants import STANDARD_ATOM_NAMES
 from chemex.parameters.spin_system.group import Group
 from chemex.parameters.spin_system.nucleus import Nucleus
 from chemex.parameters.spin_system.spin import Spin
@@ -16,6 +17,13 @@ if TYPE_CHECKING:
     from chemex.nmr.basis import Basis
 
 SPIN_ALIASES = "isx"
+
+
+def _is_strict_group_name(group: Group) -> bool:
+    return all(
+        character.isascii() and (character.isalnum() or character == "_")
+        for character in group.name
+    )
 
 
 @cache
@@ -62,6 +70,40 @@ class SpinSystem(BaseModel):
         if isinstance(name, int):
             name = str(name)
         return cls(name=name)
+
+    @classmethod
+    def from_name_strict(cls, name: str) -> Self:
+        """Parse one fully consumed public spin-system name.
+
+        The established parser owns group completion, atom aliases, and canonical
+        rendering. This strict entry point additionally rejects components the
+        domain parser would otherwise truncate or preserve as unknown text.
+        """
+        normalized = name.strip().upper()
+        components = normalized.split("-")
+        if (
+            not normalized
+            or len(components) > len(SPIN_ALIASES)
+            or any(
+                not component or component != component.strip()
+                for component in components
+            )
+        ):
+            msg = f"Invalid spin-system name: {name!r}"
+            raise ValueError(msg)
+
+        spin_system = cls.from_name(normalized)
+        if len(spin_system.spins) != len(components):
+            msg = f"Invalid spin-system name: {name!r}"
+            raise ValueError(msg)
+
+        for spin in spin_system.spins.values():
+            valid_group = not spin.group or _is_strict_group_name(spin.group)
+            valid_atom = not spin.atom or spin.atom.name in STANDARD_ATOM_NAMES
+            if not spin or not valid_group or not valid_atom:
+                msg = f"Invalid spin-system name: {name!r}"
+                raise ValueError(msg)
+        return spin_system
 
     @computed_field
     @cached_property

--- a/tests/configuration/test_method_plan.py
+++ b/tests/configuration/test_method_plan.py
@@ -663,6 +663,31 @@ def test_v2_selector_diagnostics_reject_the_complete_invalid_input(
         read_method_plan([method])
 
 
+@pytest.mark.parametrize(
+    "spin_system",
+    ("G23C1'", "G23H1'", "G23H5'1", "G23C1'-H1'"),
+)
+def test_v2_nuc_selector_accepts_and_round_trips_prime_atom_names(
+    tmp_path: Path,
+    spin_system: str,
+) -> None:
+    method = _write(
+        tmp_path / "prime-nucleus.toml",
+        f"""FORMAT_VERSION = 2
+[STEP]
+ROLES = [{{ FIT = ["DW_AB, NUC->{spin_system}"] }}]
+""",
+    )
+
+    plan = read_method_plan([method])
+    selector = plan.steps[0].role_actions[0].selectors[0]
+    normalized = _write(tmp_path / "prime-nucleus-normalized.toml", plan.render())
+    round_tripped = read_method_plan([normalized]).steps[0].role_actions[0].selectors[0]
+
+    assert selector.render() == f"DW_AB, NUC->{spin_system}"
+    assert round_tripped == selector
+
+
 def test_selector_rendering_preserves_round_trip_condition_values(
     tmp_path: Path,
 ) -> None:

--- a/tests/configuration/test_method_plan.py
+++ b/tests/configuration/test_method_plan.py
@@ -1,0 +1,821 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from chemex.configuration.method_plan import (
+    ConstrainAction,
+    DeSearch,
+    FitAction,
+    FixAction,
+    MethodFormatError,
+    ProfileSelection,
+)
+from chemex.configuration.methods import read_method_plan
+from chemex.parameters.parameterization import (
+    ParameterDeclaration,
+    SealedParameterDeclarations,
+    SealedParameterModel,
+)
+from chemex.parameters.sealed import (
+    ParamConfig,
+    ParamDefinition,
+    SealedConfiguration,
+    SealedDefinitions,
+)
+
+ROOT = Path(__file__).parents[2]
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _parameter_model(
+    *definitions: ParamDefinition,
+    supports_estimation: bool = True,
+    model_expression: str = "",
+) -> SealedParameterModel:
+    sealed_definitions = SealedDefinitions(tuple(definitions), {})
+    configuration = SealedConfiguration(
+        tuple(
+            ParamConfig(
+                definition.param_id,
+                definition.default_value,
+                definition.lower_bound,
+                definition.upper_bound,
+            )
+            for definition in definitions
+        ),
+        {},
+        sealed_definitions.identity,
+    )
+    declarations = SealedParameterDeclarations(
+        tuple(
+            ParameterDeclaration(
+                definition.param_id,
+                supports_estimation,
+                model_expression,
+            )
+            for definition in definitions
+        )
+    )
+    return SealedParameterModel(
+        "2st",
+        "model",
+        sealed_definitions,
+        configuration,
+        declarations,
+    )
+
+
+def test_v1_and_v2_normalize_to_the_same_ordered_role_semantics(
+    tmp_path: Path,
+) -> None:
+    v1 = _write(
+        tmp_path / "v1.toml",
+        """
+[STEP]
+CONSTRAINTS = ["[R2_B] = [R2_A]"]
+FIX = ["PB"]
+FIT = ["KEX_AB"]
+""",
+    )
+    v2 = _write(
+        tmp_path / "v2.toml",
+        """
+FORMAT_VERSION = 2
+
+[STEP]
+ROLES = [
+  { CONSTRAIN = ["[R2_B] = [R2_A]"] },
+  { FIX = ["PB"] },
+  { FIT = ["KEX_AB"] },
+]
+""",
+    )
+
+    v1_plan = read_method_plan([v1])
+    v2_plan = read_method_plan([v2])
+
+    assert v1_plan.steps == v2_plan.steps
+
+
+def test_v2_preserves_broad_to_specific_order_and_step_local_selection(
+    tmp_path: Path,
+) -> None:
+    method = _write(
+        tmp_path / "method.toml",
+        """
+FORMAT_VERSION = 2
+
+[FIRST]
+INCLUDE = [24]
+ROLES = [
+  { FIX = ["DW_AB"] },
+  { FIT = ["DW_AB, NUC->G24N-H"] },
+  { CONSTRAIN = ["[DW_AB, NUC->G31N-H] = [DW_AB, NUC->G24N-H]"] },
+]
+
+[SECOND]
+ROLES_FROM = "FIRST"
+""",
+    )
+
+    plan = read_method_plan([method])
+    first, second = plan.steps
+
+    assert tuple(type(action) for action in first.role_actions) == (
+        FixAction,
+        FitAction,
+        ConstrainAction,
+    )
+    assert first.selection == ProfileSelection(include=("24",), exclude=None)
+    assert second.roles_from == "FIRST"
+    assert second.selection == ProfileSelection()
+
+
+def test_v2_selector_is_strict_while_v1_preserves_partial_legacy_parsing(
+    tmp_path: Path,
+) -> None:
+    v1 = _write(
+        tmp_path / "legacy.toml",
+        '[STEP]\nFIT = ["PB, TYPO->ignored"]\n',
+    )
+    v2 = _write(
+        tmp_path / "strict.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+ROLES = [{ FIT = ["PB, TYPO->ignored"] }]
+""",
+    )
+
+    legacy_selector = read_method_plan([v1]).steps[0].role_actions[0].selectors[0]
+    assert legacy_selector.render() == "PB"
+
+    with pytest.raises(MethodFormatError) as error:
+        read_method_plan([v2])
+
+    diagnostic = str(error.value)
+    assert str(v2) in diagnostic
+    assert "[STEP]" in diagnostic
+    assert "ROLES[0].FIT[0]" in diagnostic
+    assert "TYPO->ignored" in diagnostic
+
+
+def test_constraint_equations_compile_to_typed_ast_and_render_canonically(
+    tmp_path: Path,
+) -> None:
+    method = _write(
+        tmp_path / "constraint.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+ROLES = [
+  { CONSTRAIN = [
+    "[r2_b, b0->800.03mhz] = -[r1_a] + 2 * ([r2_a] - 1) / 3"
+  ] },
+]
+""",
+    )
+
+    action = read_method_plan([method]).steps[0].role_actions[0]
+    constraint = action.constraints[0]
+
+    assert (
+        constraint.render()
+        == "[R2_B, B0->800.0MHz] = -[R1_A] + 2.0 * ([R2_A] - 1.0) / 3.0"
+    )
+
+
+def test_v1_grid_tuple_and_v2_values_normalize_to_the_same_search(
+    tmp_path: Path,
+) -> None:
+    v1 = _write(
+        tmp_path / "grid-v1.toml",
+        '[STEP]\nGRID = ["[PB] = (0.01, 0.02, 0.05)"]\n',
+    )
+    v2 = _write(
+        tmp_path / "grid-v2.toml",
+        """
+FORMAT_VERSION = 2
+[STEP.SEARCH.GRID]
+AXES = ["[PB] = values(0.01, 0.02, 0.05)"]
+""",
+    )
+
+    assert (
+        read_method_plan([v1]).steps[0].search == read_method_plan([v2]).steps[0].search
+    )
+    assert (
+        read_method_plan([v2]).steps[0].search.axes[0].render()
+        == "[PB] = values(0.01, 0.02, 0.05)"
+    )
+
+
+def test_v2_de_parses_only_seeded_two_argument_coordinate_ranges(
+    tmp_path: Path,
+) -> None:
+    method = _write(
+        tmp_path / "de.toml",
+        """
+FORMAT_VERSION = 2
+[STEP.SEARCH.DE]
+SEED = 597
+COORDINATES = [
+  "[PB] = log(0.01, 0.20)",
+  "[KEX_AB] = lin(100, 5000)",
+]
+""",
+    )
+
+    search = read_method_plan([method]).steps[0].search
+
+    assert isinstance(search, DeSearch)
+    assert search.seed == 597
+    assert tuple(coordinate.render() for coordinate in search.coordinates) == (
+        "[PB] = log(0.01, 0.2)",
+        "[KEX_AB] = lin(100.0, 5000.0)",
+    )
+
+    invalid = _write(
+        tmp_path / "invalid-de.toml",
+        """
+FORMAT_VERSION = 2
+[STEP.SEARCH.DE]
+SEED = 1
+COORDINATES = ["[PB] = values(0.01, 0.20)"]
+""",
+    )
+    with pytest.raises(MethodFormatError, match="DE accepts only lin"):
+        read_method_plan([invalid])
+
+
+def test_v2_compact_and_expanded_statistics_normalize_to_typed_requests(
+    tmp_path: Path,
+) -> None:
+    compact = _write(
+        tmp_path / "compact.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+STATISTICS = { MC = 100, MCMC = 5000 }
+""",
+    )
+    expanded = _write(
+        tmp_path / "expanded.toml",
+        """
+FORMAT_VERSION = 2
+[STEP.STATISTICS.MC]
+REPLICATES = 100
+
+[STEP.STATISTICS.MCMC]
+STEPS = 5000
+""",
+    )
+
+    assert (
+        read_method_plan([compact]).steps[0].statistics
+        == read_method_plan([expanded]).steps[0].statistics
+    )
+
+    seeded = _write(
+        tmp_path / "seeded.toml",
+        """
+FORMAT_VERSION = 2
+[STEP.STATISTICS.BS]
+REPLICATES = 20
+SEED = 7
+
+[STEP.STATISTICS.BSN]
+REPLICATES = 30
+
+[STEP.STATISTICS.MCMC]
+STEPS = 5000
+BURN = 1000
+SEED = 9
+""",
+    )
+    statistics = read_method_plan([seeded]).steps[0].statistics
+    assert statistics is not None
+    assert statistics.bs is not None
+    assert (statistics.bs.replicates, statistics.bs.seed) == (20, 7)
+    assert statistics.bsn is not None
+    assert (statistics.bsn.replicates, statistics.bsn.seed) == (30, None)
+    assert statistics.mcmc is not None
+    assert (
+        statistics.mcmc.steps,
+        statistics.mcmc.burn,
+        statistics.mcmc.seed,
+    ) == (5000, 1000, 9)
+
+    invalid = _write(
+        tmp_path / "invalid-mcmc.toml",
+        """
+FORMAT_VERSION = 2
+[STEP.STATISTICS.MCMC]
+STEPS = 5000
+THIN = 2
+""",
+    )
+    with pytest.raises(MethodFormatError, match="THIN"):
+        read_method_plan([invalid])
+
+
+def test_multifile_loading_rejects_mixed_formats_and_duplicate_v2_steps(
+    tmp_path: Path,
+) -> None:
+    v1 = _write(tmp_path / "v1.toml", "[ONE]\n")
+    v2 = _write(tmp_path / "v2.toml", "FORMAT_VERSION = 2\n[TWO]\n")
+
+    with pytest.raises(MethodFormatError, match="mixed v1/v2"):
+        read_method_plan([v1, v2])
+
+    duplicate = _write(
+        tmp_path / "duplicate.toml",
+        'FORMAT_VERSION = 2\n[TWO]\nROLES = [{ FIX = ["PB"] }]\n',
+    )
+    with pytest.raises(MethodFormatError, match="Duplicate v2 step.*TWO"):
+        read_method_plan([v2, duplicate])
+
+    non_integer_version = _write(
+        tmp_path / "float-version.toml", "FORMAT_VERSION = 2.0\n[STEP]\n"
+    )
+    with pytest.raises(MethodFormatError, match="supports only version 2"):
+        read_method_plan([non_integer_version])
+
+
+def test_v2_rejects_invalid_role_actions_and_future_inheritance(
+    tmp_path: Path,
+) -> None:
+    invalid_action = _write(
+        tmp_path / "invalid-action.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+ROLES = [{ FIX = ["PB"], FIT = ["KEX_AB"] }]
+""",
+    )
+    with pytest.raises(MethodFormatError, match="exactly one.*FIX.*FIT"):
+        read_method_plan([invalid_action])
+
+    empty_roles = _write(
+        tmp_path / "empty-roles.toml",
+        "FORMAT_VERSION = 2\n[STEP]\nROLES = []\n",
+    )
+    with pytest.raises(MethodFormatError, match="at least one action"):
+        read_method_plan([empty_roles])
+
+    future = _write(
+        tmp_path / "future.toml",
+        """
+FORMAT_VERSION = 2
+[FIRST]
+ROLES_FROM = "SECOND"
+[SECOND]
+""",
+    )
+    with pytest.raises(MethodFormatError, match="earlier step"):
+        read_method_plan([future])
+
+    fitmethod = _write(
+        tmp_path / "fitmethod.toml",
+        'FORMAT_VERSION = 2\n[STEP]\nFITMETHOD = "trf"\n',
+    )
+    with pytest.raises(MethodFormatError, match="Unsupported v2 field FITMETHOD"):
+        read_method_plan([fitmethod])
+
+
+def test_v1_synthesizes_role_and_selection_carry_forward_and_keeps_mcmc_controls(
+    tmp_path: Path,
+) -> None:
+    method = _write(
+        tmp_path / "legacy-multistep.toml",
+        """
+[FIRST]
+INCLUDE = [24]
+FITMETHOD = "least_squares"
+FIX = ["PB"]
+[FIRST.STATISTICS.MCMC]
+STEPS = 5000
+BURN = "AUTO"
+THIN = 5
+WALKERS = 32
+SEED = 9
+WORKERS = 2
+
+[SECOND]
+FIT = ["PB"]
+""",
+    )
+
+    first, second = read_method_plan([method]).steps
+
+    assert second.roles_from == "FIRST"
+    assert second.selection == first.selection
+    assert first.statistics is not None
+    assert first.statistics.mcmc is not None
+    assert first.statistics.mcmc.burn is None
+    assert first.statistics.mcmc.thin == 5
+    assert first.statistics.mcmc.walkers == 32
+    assert first.statistics.mcmc.seed == 9
+    assert first.statistics.mcmc.workers == 2
+    assert "# V1_ONLY_THIN = 5" in read_method_plan([method]).render()
+
+
+def test_v1_adapter_preserves_values_coerced_by_the_legacy_schema(
+    tmp_path: Path,
+) -> None:
+    method = _write(
+        tmp_path / "legacy-coercions.toml",
+        """
+[STEP]
+INCLUDE = [24]
+STATISTICS = { MC = "10", MCMC = { STEPS = "5000", THIN = "5" } }
+""",
+    )
+
+    step = read_method_plan([method]).steps[0]
+
+    assert step.selection == ProfileSelection(include=("24",), exclude=None)
+    assert step.statistics is not None
+    assert step.statistics.mc is not None
+    assert step.statistics.mc.replicates == 10
+    assert step.statistics.mcmc is not None
+    assert (step.statistics.mcmc.steps, step.statistics.mcmc.thin) == (5000, 5)
+
+
+def test_canonical_rendering_is_deterministic_valid_v2_toml(
+    tmp_path: Path,
+) -> None:
+    source = _write(
+        tmp_path / "render-source.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+INCLUDE = [24]
+ROLES = [{ FIT = ["pb", "kex_ab"] }]
+STATISTICS = { MC = 10 }
+[STEP.SEARCH.GRID]
+AXES = ["[PB] = LOG(0.01, 0.2, 3)"]
+""",
+    )
+    plan = read_method_plan([source])
+
+    rendered = plan.render()
+    normalized = _write(tmp_path / "normalized.toml", rendered)
+
+    assert rendered == plan.render()
+    assert read_method_plan([normalized]).steps == plan.steps
+    assert "FORMAT_VERSION = 2" in rendered
+    assert '{ FIT = ["PB", "KEX_AB"] }' in rendered
+    assert '"[PB] = log(0.01, 0.2, 3)"' in rendered
+    assert "[STEP.STATISTICS.MC]\nREPLICATES = 10" in rendered
+
+
+def test_de_validation_requires_one_final_independent_fit_coordinate(
+    tmp_path: Path,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition("pb-600", "PB", "", (("h_larmor_frq", 600.0),), 0.1, 0.0, 1.0),
+        ParamDefinition("pb-800", "PB", "", (("h_larmor_frq", 800.0),), 0.1, 0.0, 1.0),
+    )
+    broad = _write(
+        tmp_path / "broad-de.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+ROLES = [{ FIT = ["PB"] }]
+[STEP.SEARCH.DE]
+SEED = 1
+COORDINATES = ["[PB] = lin(0.01, 0.2)"]
+""",
+    )
+    with pytest.raises(MethodFormatError, match="exactly one.*matched 2"):
+        read_method_plan([broad]).validate(model)
+
+    exact = _write(
+        tmp_path / "exact-de.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+ROLES = [{ FIT = ["PB"] }]
+[STEP.SEARCH.DE]
+SEED = 1
+COORDINATES = ["[PB, B0->600MHz] = lin(0.01, 0.2)"]
+""",
+    )
+    read_method_plan([exact]).validate(model)
+
+
+def test_representative_multistep_v1_and_v2_workflows_are_structurally_equivalent(
+    tmp_path: Path,
+) -> None:
+    v1 = _write(
+        tmp_path / "workflow-v1.toml",
+        """
+[FIRST]
+INCLUDE = [24]
+CONSTRAINTS = ["[R2_B] = [R2_A]"]
+FIX = ["PB"]
+GRID = ["[KEX_AB] = (100, 500)"]
+
+[SECOND]
+FIT = ["PB", "KEX_AB"]
+STATISTICS = { MC = 10, BS = 20, BSN = 30, MCMC = 5000 }
+""",
+    )
+    v2 = _write(
+        tmp_path / "workflow-v2.toml",
+        """
+FORMAT_VERSION = 2
+[FIRST]
+INCLUDE = [24]
+ROLES = [
+  { CONSTRAIN = ["[R2_B] = [R2_A]"] },
+  { FIX = ["PB"] },
+]
+[FIRST.SEARCH.GRID]
+AXES = ["[KEX_AB] = values(100, 500)"]
+
+[SECOND]
+INCLUDE = [24]
+ROLES_FROM = "FIRST"
+ROLES = [{ FIT = ["PB", "KEX_AB"] }]
+STATISTICS = { MC = 10, BS = 20, BSN = 30, MCMC = 5000 }
+""",
+    )
+
+    assert read_method_plan([v1]).steps == read_method_plan([v2]).steps
+
+
+def test_all_shipped_v1_methods_normalize_without_compatibility_regressions() -> None:
+    methods = sorted((ROOT / "examples").glob("**/Methods/*.toml"))
+
+    assert len(methods) == 29
+    for method in methods:
+        read_method_plan([method])
+
+
+def test_method_plan_is_deeply_immutable(tmp_path: Path) -> None:
+    method = _write(
+        tmp_path / "immutable.toml",
+        'FORMAT_VERSION = 2\n[STEP]\nROLES = [{ FIT = ["PB"] }]\n',
+    )
+    plan = read_method_plan([method])
+
+    with pytest.raises(FrozenInstanceError):
+        plan.steps[0].name = "CHANGED"  # type: ignore[misc]
+
+
+def test_constraint_validation_rejects_final_dependency_cycles(tmp_path: Path) -> None:
+    model = _parameter_model(
+        ParamDefinition("pb", "PB", "", (), 0.1, 0.0, 1.0),
+        ParamDefinition("kex", "KEX_AB", "", (), 500.0, 0.0, 5000.0),
+    )
+    method = _write(
+        tmp_path / "cycle.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+ROLES = [{ CONSTRAIN = [
+  "[PB] = [KEX_AB]",
+  "[KEX_AB] = [PB]",
+] }]
+""",
+    )
+
+    with pytest.raises(MethodFormatError, match="cycle.*pb.*kex"):
+        read_method_plan([method]).validate(model)
+
+    overridden = _write(
+        tmp_path / "cycle-overridden.toml",
+        method.read_text(encoding="utf-8").replace(
+            "] }]",
+            '] }, { FIT = ["PB", "KEX_AB"] }]',
+        ),
+    )
+    read_method_plan([overridden]).validate(model)
+
+
+def test_constraint_resolution_errors_point_to_the_reference_span(
+    tmp_path: Path,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition("pb", "PB", "", (), 0.1, 0.0, 1.0),
+    )
+    equation = "[PB] = [MISSING]"
+    method = _write(
+        tmp_path / "missing-reference.toml",
+        f'FORMAT_VERSION = 2\n[STEP]\nROLES = [{{ CONSTRAIN = ["{equation}"] }}]\n',
+    )
+
+    with pytest.raises(MethodFormatError) as error:
+        read_method_plan([method]).validate(model)
+
+    assert error.value.source.start == equation.index("MISSING")
+    assert error.value.source.end == equation.index("MISSING") + len("MISSING")
+
+
+def test_fit_cannot_override_a_structurally_unestimable_parameter(
+    tmp_path: Path,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition("pb", "PB", "", (), 0.1, 0.0, 1.0),
+        supports_estimation=False,
+        model_expression="1.0",
+    )
+    method = _write(
+        tmp_path / "unestimable.toml",
+        'FORMAT_VERSION = 2\n[STEP]\nROLES = [{ FIT = ["PB"] }]\n',
+    )
+
+    with pytest.raises(MethodFormatError, match="do not support estimation"):
+        read_method_plan([method]).validate(model)
+
+
+@pytest.mark.parametrize(
+    "selector, message",
+    (
+        ("PB, B0->600MHz, B0->800MHz", "Duplicate selector qualifier B0"),
+        ("PB, [P]->1.0MHz", "Invalid value or unit"),
+        ("PB trailing", "Invalid parameter-name token"),
+        ("PB, D2O->1.0", "between 0 and 1"),
+        ("PB, NUC->G24N-H-C-X", "Invalid NUC spin-system selector"),
+        ("PB, NUC->G24N/H", "Invalid NUC spin-system selector"),
+    ),
+)
+def test_v2_selector_diagnostics_reject_the_complete_invalid_input(
+    tmp_path: Path,
+    selector: str,
+    message: str,
+) -> None:
+    method = _write(
+        tmp_path / "invalid-selector.toml",
+        f'FORMAT_VERSION = 2\n[STEP]\nROLES = [{{ FIT = ["{selector}"] }}]\n',
+    )
+
+    with pytest.raises(MethodFormatError, match=message):
+        read_method_plan([method])
+
+
+def test_selector_rendering_preserves_round_trip_condition_values(
+    tmp_path: Path,
+) -> None:
+    method = _write(
+        tmp_path / "selector-rendering.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+ROLES = [{ FIT = ["PB, [P]->0.00123456789M, [L]->2.3456789e-6M, D2O->0.123456789"] }]
+""",
+    )
+
+    selector = read_method_plan([method]).steps[0].role_actions[0].selectors[0]
+
+    assert selector.render() == (
+        "PB, [P]->0.00123456789M, [L]->2.3456789e-06M, D2O->0.123456789"
+    )
+
+
+def test_oversized_v2_numeric_literals_report_method_errors(tmp_path: Path) -> None:
+    count = "9" * 5000
+    method = _write(
+        tmp_path / "oversized-count.toml",
+        f'FORMAT_VERSION = 2\n[STEP.SEARCH.GRID]\nAXES = ["[PB] = lin(0, 1, {count})"]\n',
+    )
+
+    with pytest.raises(MethodFormatError, match="Search arguments must be finite"):
+        read_method_plan([method])
+
+
+def test_constraint_and_search_errors_retain_expression_spans(tmp_path: Path) -> None:
+    constraint = "[PB] = 2 ** [KEX_AB]"
+    constraint_method = _write(
+        tmp_path / "constraint-span.toml",
+        f'FORMAT_VERSION = 2\n[STEP]\nROLES = [{{ CONSTRAIN = ["{constraint}"] }}]\n',
+    )
+    with pytest.raises(MethodFormatError) as constraint_error:
+        read_method_plan([constraint_method])
+    assert constraint_error.value.source.start == constraint.index("2")
+    assert constraint_error.value.source.end == len(constraint)
+
+    search = "  [PB] = spline(0, 1, 3)  "
+    search_method = _write(
+        tmp_path / "search-span.toml",
+        f'FORMAT_VERSION = 2\n[STEP.SEARCH.GRID]\nAXES = ["{search}"]\n',
+    )
+    with pytest.raises(MethodFormatError) as search_error:
+        read_method_plan([search_method])
+    assert search_error.value.source.start == len(search) - len(search.lstrip())
+    assert search_error.value.source.end == len(search.rstrip())
+
+
+def test_grid_keeps_lin_log_values_and_broad_to_specific_declaration_order(
+    tmp_path: Path,
+) -> None:
+    method = _write(
+        tmp_path / "all-grid-forms.toml",
+        """
+FORMAT_VERSION = 2
+[STEP.SEARCH.GRID]
+AXES = [
+  "[DW_AB] = lin(0, 10, 3)",
+  "[KEX_AB] = log(100, 5000, 4)",
+  "[DW_AB, NUC->G24N-H] = values(1, 2.5)",
+]
+""",
+    )
+
+    search = read_method_plan([method]).steps[0].search
+
+    assert tuple(axis.render() for axis in search.axes) == (
+        "[DW_AB] = lin(0.0, 10.0, 3)",
+        "[KEX_AB] = log(100.0, 5000.0, 4)",
+        "[DW_AB, NUC->G24N-H] = values(1.0, 2.5)",
+    )
+
+
+def test_v1_duplicate_steps_keep_first_position_and_replace_the_complete_step(
+    tmp_path: Path,
+) -> None:
+    first = _write(
+        tmp_path / "first.toml",
+        '[A]\nFIT = ["PB"]\n[B]\nFIT = ["KEX_AB"]\n',
+    )
+    replacement = _write(
+        tmp_path / "replacement.toml",
+        '[A]\nFIX = ["PB"]\n',
+    )
+
+    plan = read_method_plan([first, replacement])
+
+    assert tuple(step.name for step in plan.steps) == ("A", "B")
+    assert isinstance(plan.steps[0].role_actions[0], FixAction)
+    assert plan.steps[1].roles_from == "A"
+
+
+def test_grid_validation_applies_broad_to_specific_overrides_before_bounds(
+    tmp_path: Path,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition(
+            "dw-600", "DW_AB", "", (("h_larmor_frq", 600.0),), 1.0, 0.0, 10.0
+        ),
+        ParamDefinition(
+            "dw-800", "DW_AB", "", (("h_larmor_frq", 800.0),), 1.0, 0.0, 2.0
+        ),
+    )
+    method = _write(
+        tmp_path / "grid-overrides.toml",
+        """
+FORMAT_VERSION = 2
+[STEP.SEARCH.GRID]
+AXES = [
+  "[DW_AB] = lin(0, 10, 3)",
+  "[DW_AB, B0->800MHz] = lin(0, 2, 3)",
+]
+""",
+    )
+
+    read_method_plan([method]).validate(model)
+
+
+def test_ordered_complete_roles_validate_fix_fit_constrain_exceptions(
+    tmp_path: Path,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition("dw-g24", "DW_AB", "G24N-H", (), 1.0, -10.0, 10.0),
+        ParamDefinition("dw-g31", "DW_AB", "G31N-H", (), 1.0, -10.0, 10.0),
+        ParamDefinition("dw-g40", "DW_AB", "G40N-H", (), 1.0, -10.0, 10.0),
+    )
+    method = _write(
+        tmp_path / "ordered-roles.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+ROLES = [
+  { FIX = ["DW_AB"] },
+  { FIT = ["DW_AB, NUC->G24N-H"] },
+  { CONSTRAIN = ["[DW_AB, NUC->G31N-H] = [DW_AB, NUC->G24N-H]"] },
+]
+[STEP.SEARCH.GRID]
+AXES = ["[DW_AB, NUC->G24N-H] = values(1)"]
+""",
+    )
+
+    read_method_plan([method]).validate(model)
+
+    constrained_search = _write(
+        tmp_path / "constrained-search.toml",
+        method.read_text(encoding="utf-8").replace(
+            'AXES = ["[DW_AB, NUC->G24N-H] = values(1)"]',
+            'AXES = ["[DW_AB, NUC->G31N-H] = values(1)"]',
+        ),
+    )
+    with pytest.raises(MethodFormatError, match="not a final independent FIT"):
+        read_method_plan([constrained_search]).validate(model)

--- a/tests/test_spin_system.py
+++ b/tests/test_spin_system.py
@@ -4,6 +4,7 @@ import pickle
 
 from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.spin_system.atom import Atom
+from chemex.parameters.spin_system.constants import STANDARD_ATOM_NAMES
 from chemex.parameters.spin_system.group import Group
 
 
@@ -44,3 +45,10 @@ def test_spin_system_pickle_rebuilds_nested_search_keys() -> None:
 
     assert restored == spin_system
     assert restored.search_keys == spin_system.search_keys
+
+
+def test_strict_spin_system_parser_accepts_every_registered_atom_name() -> None:
+    for atom_name in STANDARD_ATOM_NAMES:
+        spin_system = SpinSystem.from_name_strict(f"G23{atom_name}")
+
+        assert spin_system.atoms["i"].name == atom_name


### PR DESCRIPTION
Closes #681.

## Summary
- add one immutable canonical MethodPlan with deterministic v2 rendering
- add separate behavior-compatible v1 and strict v2 adapters that normalize immediately to the same step semantics
- add typed selector, constraint, GRID, DE, role, selection, and statistics models with preflight validation against the sealed parameter model
- preserve v1 role/profile carry-forward, GRID tuples, least_squares policy, coercions, and v1-only MCMC controls
- enforce v2 ordered complete-role replacement, explicit ROLES_FROM, step-local selection, strict multi-file rules, and exact source diagnostics
- delegate strict NUC validation to the SpinSystem domain grammar so registered DNA/RNA prime atom names remain valid and round-trip canonically
- keep TRF as implicit execution policy without an unused MethodPlan solver field

## Scope
This PR intentionally does not wire MethodPlan into fitting or ParameterStore mutation. DE is parsed and validated but not executed. No fitting, uncertainty, statistics execution, publication, provenance, or run_info flow is refactored.

## Validation
- 1109 tests passed
- uv run ty check
- uv run ruff check .
- uv run ruff format --check .
- git diff --check
- uv build
- graphify update .

## Review
Independent standards and frozen-spec reviews completed with no remaining actionable findings. The follow-up NUC compatibility audit covers every registered SpinSystem atom name and retains malformed-input and maximum-spin rejection. A final YAGNI audit confirmed LocalFit and StepPlan.local_fit had no consumer or downstream interface requirement, so both were removed without replacement.

Documentation and examples are unchanged because this ticket adds the parser and canonical model seam only; user-facing execution wiring belongs to later tickets.