### PR TITLE
Remove mutable method role inheritance

### DIFF
--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -6,11 +6,18 @@ from argparse import Namespace
 from collections.abc import Sequence
 
 from chemex.cli import build_parser
-from chemex.configuration.methods import Method, Methods, Selection, read_methods
+from chemex.configuration.method_plan import (
+    FormatOrigin,
+    MethodFormatError,
+    MethodPlan,
+    StepPlan,
+)
+from chemex.configuration.methods import Methods, Selection, read_method_plan
 from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
 from chemex.experiments.builder import build_experiments
 from chemex.messages import (
+    console,
     print_logo,
     print_no_data,
     print_reading_defaults,
@@ -34,7 +41,7 @@ def run_fit(
     session: AnalysisSession,
     *,
     argv: Sequence[str] | None = None,
-    methods: Methods | None = None,
+    methods: Methods | MethodPlan | None = None,
 ) -> None:
     if methods is None:
         methods = _read_fit_methods(args)
@@ -87,11 +94,15 @@ def run_sim(
     )
 
 
-def _read_fit_methods(args: Namespace) -> Methods:
+def _read_fit_methods(args: Namespace) -> MethodPlan:
     if args.method is None:
-        return {"": Method()}
+        return MethodPlan(FormatOrigin.V1, (StepPlan(""),))
     print_reading_methods()
-    return read_methods(args.method)
+    try:
+        return read_method_plan(args.method)
+    except MethodFormatError as error:
+        console.print(f"[red] -- ERROR: {error}")
+        sys.exit(1)
 
 
 def run(
@@ -141,6 +152,9 @@ def run(
         if construction_error is None:
             raise RuntimeError(msg)
         raise RuntimeError(f"{msg}: {construction_error}") from construction_error
+
+    if isinstance(methods, MethodPlan):
+        session.validate_method_plan(methods)
 
     if args.commands == "simulate":
         run_sim(args, experiments, session)

--- a/src/chemex/configuration/method_execution.py
+++ b/src/chemex/configuration/method_execution.py
@@ -1,0 +1,114 @@
+"""Operational adapters for canonical and legacy method configuration."""
+
+from pathlib import Path
+
+from chemex.configuration.method_plan import (
+    DeSearch,
+    GridRange,
+    GridSearch,
+    GridValues,
+    McmcRequest,
+    MethodPlan,
+    StepPlan,
+)
+from chemex.configuration.method_v1 import adapt_v1
+from chemex.configuration.methods import McmcSettings, Method, Methods, Statistics
+
+
+def step_names(methods: Methods | MethodPlan) -> tuple[str, ...]:
+    """Return method step names in execution order."""
+    if isinstance(methods, MethodPlan):
+        return tuple(step.name for step in methods.steps)
+    return tuple(methods)
+
+
+def mcmc_settings(request: McmcRequest | None) -> McmcSettings | None:
+    """Adapt canonical MCMC settings to the operational v1-shaped model."""
+    if request is None:
+        return None
+    return McmcSettings(
+        steps=request.steps,
+        burn="auto" if request.burn is None else request.burn,
+        thin=request.thin,
+        walkers=request.walkers,
+        seed=request.seed,
+        workers=request.workers,
+    )
+
+
+def _selection_value(value: tuple[str, ...] | str | None) -> list[str] | str | None:
+    return list(value) if isinstance(value, tuple) else value
+
+
+def _grid_entries(step: StepPlan, search: GridSearch) -> list[str]:
+    entries: list[str] = []
+    for axis in search.axes:
+        if isinstance(axis.spacing, GridRange):
+            spacing = axis.spacing.render()
+        elif isinstance(axis.spacing, GridValues):
+            spacing = f"({', '.join(str(value) for value in axis.spacing.values)})"
+        else:  # pragma: no cover - closed canonical union
+            raise TypeError(f"Unsupported grid spacing in step {step.name!r}")
+        entries.append(f"[{axis.selector.render()}] = {spacing}")
+    return entries
+
+
+def operational_method_from_step(step: StepPlan) -> Method:
+    """Adapt one canonical step without adding cross-step inheritance."""
+    if isinstance(step.search, DeSearch):
+        raise NotImplementedError("V2 DE execution is tracked separately by issue #682")
+    statistics = step.statistics
+    settings: dict[str, object] = {
+        # Canonical selection is step-local. An omitted INCLUDE therefore
+        # restores all profiles that an earlier step may have filtered.
+        "include": (
+            "*"
+            if step.selection.include is None
+            else _selection_value(step.selection.include)
+        ),
+        "grid": (
+            _grid_entries(step, step.search)
+            if isinstance(step.search, GridSearch)
+            else []
+        ),
+        "statistics": (
+            None
+            if statistics is None
+            else Statistics(
+                mc=None if statistics.mc is None else statistics.mc.replicates,
+                bs=None if statistics.bs is None else statistics.bs.replicates,
+                bsn=None if statistics.bsn is None else statistics.bsn.replicates,
+                mcmc=mcmc_settings(statistics.mcmc),
+            )
+        ),
+    }
+    if step.selection.exclude is not None:
+        settings["exclude"] = _selection_value(step.selection.exclude)
+    return Method.model_validate(settings)
+
+
+def normalize_methods_for_execution(
+    methods: Methods | MethodPlan,
+) -> tuple[MethodPlan, Methods]:
+    """Return canonical semantics plus the existing operational method shape."""
+    if isinstance(methods, MethodPlan):
+        plan = methods
+    else:
+        raw_steps = []
+        for name, method in methods.items():
+            settings: dict[str, object] = {
+                "constraints": method.constraints,
+                "fix": method.fix,
+                "fit": method.fit,
+                "grid": method.grid,
+            }
+            if method.statistics is not None:
+                settings["statistics"] = method.statistics.model_dump(exclude_none=True)
+            if "include" in method.model_fields_set:
+                settings["include"] = method.include
+            if "exclude" in method.model_fields_set:
+                settings["exclude"] = method.exclude
+            raw_steps.append((Path("<runtime-v1-method>"), name, settings))
+        plan = adapt_v1(raw_steps)
+    operational = {step.name: operational_method_from_step(step) for step in plan.steps}
+    return plan, operational

--- a/src/chemex/configuration/method_plan.py
+++ b/src/chemex/configuration/method_plan.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal
 
 from chemex.parameters.spin_system import SpinSystem
@@ -313,6 +315,14 @@ class StepPlan:
 class MethodPlan:
     format_origin: FormatOrigin
     steps: tuple[StepPlan, ...]
+
+    def effective_role_actions(self) -> Mapping[str, tuple[RoleAction, ...]]:
+        """Resolve each step's immutable baseline or inherited action chain."""
+        effective: dict[str, tuple[RoleAction, ...]] = {}
+        for step in self.steps:
+            inherited = () if step.roles_from is None else effective[step.roles_from]
+            effective[step.name] = (*inherited, *step.role_actions)
+        return MappingProxyType(effective)
 
     def render(self) -> str:
         lines = ["FORMAT_VERSION = 2"]

--- a/src/chemex/configuration/method_v1.py
+++ b/src/chemex/configuration/method_v1.py
@@ -42,7 +42,7 @@ def _statistics(value: object) -> StatisticsPlan | None:
 
     def resampling(name: str) -> ResamplingRequest | None:
         request = settings.get(name)
-        return ResamplingRequest(request) if isinstance(request, int) else None
+        return ResamplingRequest(request, seed=0) if isinstance(request, int) else None
 
     mcmc_value = settings.get("mcmc")
     mcmc = None

--- a/src/chemex/configuration/method_validation.py
+++ b/src/chemex/configuration/method_validation.py
@@ -26,6 +26,7 @@ from chemex.parameters.name import ParamName, matches_parameter_index_selector
 from chemex.parameters.parameterization import (
     ParameterRole,
     SealedParameterModel,
+    baseline_parameter_role,
     compatible_reference_context,
 )
 from chemex.parameters.sealed import ParamDefinition
@@ -349,11 +350,7 @@ def _validate_de(
 
 def validate_method_plan(plan: MethodPlan, model: SealedParameterModel) -> None:
     baseline = {
-        param_id: ParameterRole.DERIVED
-        if declaration.model_expression
-        else ParameterRole.FIT
-        if declaration.supports_estimation
-        else ParameterRole.FIX
+        param_id: baseline_parameter_role(declaration)
         for param_id, declaration in model.declarations.items()
     }
     effective_by_step: dict[str, dict[str, ParameterRole]] = {}

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -14,7 +14,6 @@ Typical usage example:
   print_loading_experiments()
 """
 
-from collections import Counter
 from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import replace
@@ -558,43 +557,6 @@ def print_fitmethod(fit_method: str) -> None:
     console.print(Text.assemble("  • Fit method -> ", (f"{fit_method}", "blue")))
 
 
-def print_status_changes(
-    vary: Counter[str],
-    fixed: Counter[str],
-    constrained: Counter[str],
-) -> None:
-    """Print changes in parameter status like varied, fixed, or constrained.
-
-    Args:
-        vary (Counter[str]): Parameters varied during fitting.
-        fixed (Counter[str]): Parameters fixed during fitting.
-        constrained (Counter[str]): Parameters constrained during fitting.
-
-    """
-    if not any([vary, fixed, constrained]):
-        return
-
-    console.print(Text("  • Setting parameter status..."))
-
-    table = Table()
-    table.add_column("Name")
-    table.add_column("Status")
-    table.add_column("Updated", justify="right")
-
-    for name, nb in vary.items():
-        table.add_row(name, "fitted", str(nb))
-
-    for name, nb in fixed.items():
-        table.add_row(name, "fixed", str(nb))
-
-    for name, nb in constrained.items():
-        table.add_row(name, "constrained", str(nb))
-
-    table.box = box.SIMPLE_HEAD
-
-    console.print(Padding.indent(table, 3))
-
-
 def print_minimizing() -> None:
     """Display a message indicating that the minimization process is running."""
     console.print(Text("  • Running the minimization..."))
@@ -873,16 +835,6 @@ def print_error_constraints(expression: str, detail: str | None = None) -> None:
     console.print(f'[red] -- ERROR: Error reading constraints -> "{expression}" --')
     if detail is not None:
         console.print(Text(f"    {detail}", style="red"))
-    console.print()
-
-
-def print_grid_statistic_warning() -> None:
-    """Warn that 'GRID' and 'STATISTICS' options are mutually exclusive."""
-    console.print()
-    console.print(
-        "[yellow] -- WARNING: The 'GRID' and 'STATISTICS' options are mutually "
-        "exclusive. Only the 'GRID' calculation will be run.",
-    )
     console.print()
 
 

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -1,13 +1,22 @@
 """The fitting module contains the code for fitting the experimental data."""
 
+import secrets
 import shutil
 from pathlib import Path
 
-from chemex.configuration.methods import Method, Methods, Statistics
+from chemex.configuration.method_execution import (
+    mcmc_settings,
+    normalize_methods_for_execution,
+    step_names,
+)
+from chemex.configuration.method_plan import MethodPlan, StatisticsPlan
+from chemex.configuration.methods import (
+    Methods,
+    Statistics,
+)
 from chemex.containers.experiments import Experiments
 from chemex.messages import (
     print_fitmethod,
-    print_grid_statistic_warning,
     print_mcmc_no_vary_warning,
     print_no_data,
     print_running_statistics,
@@ -34,11 +43,12 @@ _CHEMEX_RESULT_PATHS = (
 )
 
 
-def invalidate_planned_outputs(methods: Methods, path: Path) -> None:
+def invalidate_planned_outputs(methods: Methods | MethodPlan, path: Path) -> None:
     """Remove only ChemEx-owned results for every method step planned now."""
-    if len(methods) > 1:
+    names = step_names(methods)
+    if len(names) > 1:
         output_root = path.resolve()
-        step_roots = tuple(path / section for section in methods)
+        step_roots = tuple(path / section for section in names)
         if any(
             not step_root.resolve().is_relative_to(output_root)
             for step_root in step_roots
@@ -59,26 +69,37 @@ def invalidate_planned_outputs(methods: Methods, path: Path) -> None:
 def _run_native_statistics(
     experiments: Experiments,
     path: Path,
-    statistics: Statistics,
+    statistics: StatisticsPlan,
     fit: NativeDeterministicFit,
     *,
     session: AnalysisSession,
 ) -> None:
     committed = session.analysis_values.snapshot()
     try:
-        run_native_resampling_statistics(
-            experiments,
-            path,
-            statistics,
-            fit,
-            execution=session.execution,
-        )
-        if statistics.mcmc is not None:
+        for name, request in (
+            ("mc", statistics.mc),
+            ("bs", statistics.bs),
+            ("bsn", statistics.bsn),
+        ):
+            if request is None:
+                continue
+            run_native_resampling_statistics(
+                experiments,
+                path,
+                Statistics(**{name: request.replicates}),
+                fit,
+                execution=session.execution,
+                root_seed=(
+                    secrets.randbits(64) if request.seed is None else request.seed
+                ),
+            )
+        mcmc = mcmc_settings(statistics.mcmc)
+        if mcmc is not None:
             print_running_statistics("MCMC")
             run_native_mcmc(
                 experiments,
                 fit,
-                statistics.mcmc,
+                mcmc,
                 path,
                 execution=session.execution,
             )
@@ -87,7 +108,7 @@ def _run_native_statistics(
             raise RuntimeError("Native statistics mutated the committed central fit")
 
 
-def _requests_only_mcmc(statistics: Statistics) -> bool:
+def _requests_only_mcmc(statistics: StatisticsPlan) -> bool:
     return (
         statistics.mcmc is not None
         and statistics.mc is None
@@ -99,7 +120,7 @@ def _requests_only_mcmc(statistics: Statistics) -> bool:
 def _run_requested_native_statistics(
     experiments: Experiments,
     path: Path,
-    statistics: Statistics | None,
+    statistics: StatisticsPlan | None,
     fit: NativeDeterministicFit | None,
     *,
     session: AnalysisSession,
@@ -122,15 +143,19 @@ def _run_requested_native_statistics(
 
 def run_methods(
     experiments: Experiments,
-    methods: Methods,
+    methods: Methods | MethodPlan,
     path: Path,
     plot_level: str,
     *,
     session: AnalysisSession,
 ) -> None:
-    for index, (section, method) in enumerate(methods.items(), start=1):
+    plan, operational = normalize_methods_for_execution(methods)
+    effective_actions = plan.effective_role_actions()
+    for index, step in enumerate(plan.steps, start=1):
+        section = step.name
+        method = operational[section]
         if section:
-            print_step_name(section, index, len(methods))
+            print_step_name(section, index, len(plan.steps))
 
         # Select a subset of profiles based on "INCLUDE" and "EXCLUDE"
         experiments.select(method.selection)
@@ -139,32 +164,27 @@ def run_methods(
             print_no_data()
             continue
 
-        effective_method: Method = method
-        if method.grid and method.statistics:
-            print_grid_statistic_warning()
-            effective_method = method.model_copy(update={"statistics": None})
+        print_fitmethod(method.fitmethod)
 
-        print_fitmethod(effective_method.fitmethod)
-
-        # Update the parameter "vary" and "expr" status
-        session.apply_current_parameter_roles(
-            effective_method,
+        parameterization = session.compile_parameterization_from_actions(
+            effective_actions[section],
             experiments.param_ids,
         )
 
-        path_sect = path / section if len(methods) > 1 else path
+        path_sect = path / section if len(plan.steps) > 1 else path
 
         fit = run_native_deterministic(
             experiments,
-            effective_method,
+            method,
             path_sect,
             plot_level,
             session=session,
+            parameterization=parameterization,
         )
         _run_requested_native_statistics(
             experiments,
             path_sect,
-            effective_method.statistics,
+            step.statistics,
             fit,
             session=session,
         )

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -17,6 +17,7 @@ from chemex.optimize.uncertainty import (
     UncertaintyEvidence,
 )
 from chemex.parameters.database import ParameterStore
+from chemex.parameters.parameterization import ActiveParameterization
 from chemex.printers.native_reporting import (
     write_block_uncertainty,
     write_json,
@@ -84,6 +85,7 @@ def _write_files(
     uncertainty_evidence: UncertaintyEvidence | None = None,
     uncertainty_status: tuple[str, str] | None = None,
     block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None,
+    parameterization: ActiveParameterization | None = None,
 ) -> None:
     """Write the results of the fit to output files."""
     print_writing_results(path)
@@ -93,6 +95,7 @@ def _write_files(
         path,
         parameter_store=experiments.parameter_store,
         uncertainty=uncertainty,
+        parameterization=parameterization,
     )
     experiments.write(path)
     _write_statistics(
@@ -169,6 +172,7 @@ def execute_post_fit(
     uncertainty_evidence: UncertaintyEvidence | None = None,
     uncertainty_status: tuple[str, str] | None = None,
     block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None,
+    parameterization: ActiveParameterization | None = None,
 ) -> None:
     _write_files(
         experiments,
@@ -179,6 +183,7 @@ def execute_post_fit(
         uncertainty_evidence=uncertainty_evidence,
         uncertainty_status=uncertainty_status,
         block_uncertainty=block_uncertainty,
+        parameterization=parameterization,
     )
     if plot:
         _write_plots(experiments, path)

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -529,6 +529,7 @@ def run_native_deterministic(
     plot: str,
     *,
     session: AnalysisSession,
+    parameterization: ActiveParameterization | None = None,
 ) -> NativeDeterministicFit | None:
     """Execute one complete deterministic method occurrence natively."""
     parameter_model = session.parameter_factory.sealed_parameter_model
@@ -537,7 +538,11 @@ def run_native_deterministic(
         raise RuntimeError("Native parameter configuration is unavailable")
 
     normalized_method = method.model_copy(update={"fitmethod": "trf"})
-    parameterization = session.compile_current_parameterization(experiments.param_ids)
+    if parameterization is None:
+        parameterization = session.compile_parameterization(
+            method,
+            experiments.param_ids,
+        )
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
     starting_snapshot = session.analysis_values.snapshot()
     if not _has_controlled_parameters(parameterization):
@@ -567,6 +572,7 @@ def run_native_deterministic(
             plot=plot != "nothing",
             residuals=result.residuals,
             nvarys=0,
+            parameterization=parameterization,
         )
         return None
 
@@ -750,6 +756,7 @@ def run_native_deterministic(
             uncertainty_evidence=uncertainty_evidence,
             uncertainty_status=uncertainty_status,
             block_uncertainty=block_uncertainty,
+            parameterization=parameterization,
         )
         return fit
 
@@ -763,5 +770,6 @@ def run_native_deterministic(
         uncertainty_evidence=uncertainty_evidence,
         uncertainty_status=uncertainty_status,
         block_uncertainty=block_uncertainty,
+        parameterization=parameterization,
     )
     return fit

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -9,12 +9,10 @@ from typing import Protocol
 
 import numpy as np
 
-from chemex.configuration.methods import Method
 from chemex.configuration.parameters import DefaultListType
 from chemex.messages import (
     print_error_constraints,
     print_error_grid_settings,
-    print_status_changes,
     print_warning_negative_jch,
     print_warning_positive_jnh,
 )
@@ -445,7 +443,6 @@ class ParameterCatalog:
                 grid_values.update(dict.fromkeys(ids_changed, values))
                 ids_pool -= ids_changed
 
-                self.set_vary([name], vary=False)
         except GridExpressionError as error:
             print_error_grid_settings(error.entry, error.detail)
             sys.exit(1)
@@ -652,13 +649,6 @@ class ParameterStore:
 
         """
         return self.database.set_expressions(expression_list)
-
-    def set_parameter_status(self, method: Method) -> None:
-        matches_con = self.set_expressions(method.constraints)
-        matches_fix = self.set_vary(method.fix, vary=False)
-        matches_fit = self.set_vary(method.fit, vary=True)
-
-        print_status_changes(matches_fit, matches_fix, matches_con)
 
     def parse_grid(self, grid_entries: list[str]) -> dict[str, Array]:
         """Parse grid definitions and sets up parameters in the active catalog.

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -28,6 +28,21 @@ from uuid import uuid4
 import numpy as np
 
 from chemex.configuration.conditions import Conditions
+from chemex.configuration.method_plan import (
+    ConstrainAction as MethodConstrainAction,
+)
+from chemex.configuration.method_plan import (
+    FitAction as MethodFitAction,
+)
+from chemex.configuration.method_plan import (
+    FixAction as MethodFixAction,
+)
+from chemex.configuration.method_plan import (
+    RoleAction as MethodRoleAction,
+)
+from chemex.configuration.method_plan import (
+    render_expression as render_method_expression,
+)
 from chemex.configuration.methods import Method
 from chemex.nmr.rates import rate_functions
 from chemex.parameters.name import ParamName, matches_parameter_index_selector
@@ -134,6 +149,17 @@ class ParameterDeclaration:
     supports_estimation: bool
     model_expression: str = ""
     model_owned: bool = False
+
+
+def baseline_parameter_role(declaration: ParameterDeclaration) -> ParameterRole:
+    """Return the authoritative method-local role for one sealed declaration."""
+    if declaration.model_expression and (
+        declaration.model_owned or not declaration.supports_estimation
+    ):
+        return ParameterRole.DERIVED
+    if declaration.supports_estimation:
+        return ParameterRole.FIT
+    return ParameterRole.FIX
 
 
 def _fingerprint(kind: str, records: object) -> str:
@@ -1042,17 +1068,73 @@ def _build_rules(
     return tuple(rules)
 
 
+def _build_action_rules(
+    actions: Sequence[MethodRoleAction],
+    definitions: SealedDefinitions,
+) -> tuple[_RoleRule, ...]:
+    """Compile canonical ordered complete-role actions without legacy buckets."""
+    rules: list[_RoleRule] = []
+    ordinal = 0
+    for action in actions:
+        if isinstance(action, (MethodFitAction, MethodFixAction)):
+            role = (
+                ParameterRole.FIT
+                if isinstance(action, MethodFitAction)
+                else ParameterRole.FIX
+            )
+            for selector in action.selectors:
+                selector_text = selector.render()
+                rules.append(
+                    _RoleRule(
+                        role,
+                        selector_text,
+                        "",
+                        _match_selector(
+                            selector_text,
+                            definitions,
+                            role=role,
+                            ordinal=ordinal,
+                        ),
+                        ordinal,
+                    )
+                )
+                ordinal += 1
+            continue
+        if not isinstance(action, MethodConstrainAction):
+            raise TypeError(f"Unsupported canonical role action {type(action)!r}")
+        for constraint in action.constraints:
+            selector_text = constraint.target.render()
+            expression_text = render_method_expression(constraint.expression)
+            _validate_public_expression_syntax(expression_text)
+            rules.append(
+                _RoleRule(
+                    ParameterRole.DERIVED,
+                    selector_text,
+                    expression_text,
+                    _match_selector(
+                        selector_text,
+                        definitions,
+                        role=ParameterRole.DERIVED,
+                        ordinal=ordinal,
+                    ),
+                    ordinal,
+                )
+            )
+            ordinal += 1
+    return tuple(rules)
+
+
 def _role_for(
     param_id: str,
     declaration: ParameterDeclaration,
     rules: Sequence[_RoleRule],
+    *,
+    initialize_missing: bool = False,
 ) -> tuple[ParameterRole, str, str]:
     role = (
         ParameterRole.DERIVED
-        if declaration.model_expression
-        else ParameterRole.FIT
-        if declaration.supports_estimation
-        else ParameterRole.FIX
+        if initialize_missing and declaration.model_expression
+        else baseline_parameter_role(declaration)
     )
     expression = declaration.model_expression
     source = "model" if declaration.model_owned else "baseline"
@@ -1603,6 +1685,8 @@ def _compile_active_scope(
     rules: Sequence[_RoleRule],
     binder: ScientificFunctionBinder,
     required: set[str],
+    *,
+    initialize_missing: bool = False,
 ) -> tuple[
     set[str],
     dict[str, tuple[ParameterRole, str, str]],
@@ -1620,7 +1704,12 @@ def _compile_active_scope(
             if param_id not in active or param_id in role_data:
                 continue
             declaration = parameter_model.declarations[param_id]
-            role, expression_text, source = _role_for(param_id, declaration, rules)
+            role, expression_text, source = _role_for(
+                param_id,
+                declaration,
+                rules,
+                initialize_missing=initialize_missing,
+            )
             role_data[param_id] = (role, expression_text, source)
             if role is not ParameterRole.DERIVED:
                 continue
@@ -1668,13 +1757,15 @@ def _validate_rules_in_active_scope(
     )
 
 
-def compile_active_parameterization(
+def _compile_active_parameterization_from_rules(
     parameter_model: SealedParameterModel,
     snapshot: AnalysisValuesSnapshot,
-    method: Method,
+    rules: Sequence[_RoleRule],
     required_ids: Sequence[str] | set[str],
+    *,
+    initialize_missing: bool = False,
+    require_active_rule_matches: bool = True,
 ) -> ActiveParameterization:
-    """Compile one fresh method-scoped role and constraint program."""
     required = _validate_parameterization_inputs(
         parameter_model,
         snapshot,
@@ -1682,7 +1773,6 @@ def compile_active_parameterization(
     )
 
     definitions = parameter_model.definitions
-    rules = _build_rules(method, definitions)
     _validate_model_derivation_authority(rules, parameter_model.declarations)
     binder = ScientificFunctionBinder.for_model(parameter_model.model_name)
     definition_order = {
@@ -1693,9 +1783,11 @@ def compile_active_parameterization(
         rules,
         binder,
         required,
+        initialize_missing=initialize_missing,
     )
     _validate_estimation_authority(rules, parameter_model.declarations, active)
-    _validate_rules_in_active_scope(rules, active)
+    if require_active_rule_matches:
+        _validate_rules_in_active_scope(rules, active)
 
     scope_ids = tuple(
         definition.param_id
@@ -1738,6 +1830,39 @@ def compile_active_parameterization(
     )
 
 
+def compile_active_parameterization(
+    parameter_model: SealedParameterModel,
+    snapshot: AnalysisValuesSnapshot,
+    method: Method,
+    required_ids: Sequence[str] | set[str],
+) -> ActiveParameterization:
+    """Compile one fresh method-scoped role and constraint program."""
+    rules = _build_rules(method, parameter_model.definitions)
+    return _compile_active_parameterization_from_rules(
+        parameter_model,
+        snapshot,
+        rules,
+        required_ids,
+    )
+
+
+def compile_active_parameterization_from_actions(
+    parameter_model: SealedParameterModel,
+    snapshot: AnalysisValuesSnapshot,
+    actions: Sequence[MethodRoleAction],
+    required_ids: Sequence[str] | set[str],
+) -> ActiveParameterization:
+    """Compile directly from canonical effective method-role semantics."""
+    rules = _build_action_rules(actions, parameter_model.definitions)
+    return _compile_active_parameterization_from_rules(
+        parameter_model,
+        snapshot,
+        rules,
+        required_ids,
+        require_active_rule_matches=False,
+    )
+
+
 def build_initial_analysis_values(
     parameter_model: SealedParameterModel,
 ) -> Mapping[str, float]:
@@ -1764,11 +1889,12 @@ def build_initial_analysis_values(
             if config.effective_value is not None
         ),
     )
-    parameterization = compile_active_parameterization(
+    parameterization = _compile_active_parameterization_from_rules(
         parameter_model,
         bootstrap_snapshot,
-        Method(),
+        (),
         set(parameter_model.declarations),
+        initialize_missing=True,
     )
     resolved = parameterization.resolve(
         parameterization.frame_from_snapshot(bootstrap_snapshot)

--- a/src/chemex/printers/parameters.py
+++ b/src/chemex/printers/parameters.py
@@ -12,6 +12,7 @@ from chemex.optimize.uncertainty import (
 )
 from chemex.parameters.database import ParameterStore
 from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
 from chemex.parameters.setting import ParamSetting
 
 Parameters = dict[ParamName, ParamSetting]
@@ -234,6 +235,7 @@ def _format_constrained(
     param: ParamSetting,
     parameter_store: ParameterStore,
     uncertainty: ParameterUncertaintyView | None,
+    constraint_expression: str | None = None,
 ) -> str:
     if param.value is None:
         return ""
@@ -250,10 +252,11 @@ def _format_constrained(
         if reason is not None
         else ""
     )
-    constraint = param.expr
-    parameters = parameter_store.get_parameters(param.dependencies)
-    for param_id, parameter in parameters.items():
-        constraint = constraint.replace(param_id, str(parameter.param_name))
+    constraint = param.expr if constraint_expression is None else constraint_expression
+    if constraint_expression is None:
+        parameters = parameter_store.get_parameters(param.dependencies)
+        for param_id, parameter in parameters.items():
+            constraint = constraint.replace(param_id, str(parameter.param_name))
     return f"{param.value: .5e} # {error}({constraint})"
 
 
@@ -267,6 +270,7 @@ def _params_to_strings(
     parameter_store: ParameterStore,
     parameter_ids: dict[ParamName, str],
     uncertainty: ParameterUncertaintyView | None,
+    constraint_expressions: dict[str, str] | None,
 ) -> dict[str, dict[str, str]]:
     result: defaultdict[str, dict[str, str]] = defaultdict(dict)
 
@@ -277,6 +281,9 @@ def _params_to_strings(
             status,
             parameter_store,
             uncertainty,
+            None
+            if constraint_expressions is None
+            else constraint_expressions.get(parameter_ids[pname]),
         )
 
     for pname, param in parameters.local.items():
@@ -286,6 +293,9 @@ def _params_to_strings(
             status,
             parameter_store,
             uncertainty,
+            None
+            if constraint_expressions is None
+            else constraint_expressions.get(parameter_ids[pname]),
         )
 
     return result
@@ -297,13 +307,20 @@ def _format_parameter(
     status: str,
     parameter_store: ParameterStore,
     uncertainty: ParameterUncertaintyView | None,
+    constraint_expression: str | None = None,
 ) -> str:
     if status == "fitted":
         return _format_fitted(param_id, param, uncertainty)
     if status == "fixed":
         return _format_fixed(param)
     if status == "constrained":
-        return _format_constrained(param_id, param, parameter_store, uncertainty)
+        return _format_constrained(
+            param_id,
+            param,
+            parameter_store,
+            uncertainty,
+            constraint_expression,
+        )
     msg = (
         f"Unknown parameter status: {status!r}. Expected 'fitted', 'fixed', "
         "or 'constrained'."
@@ -336,6 +353,7 @@ def write_file(
     parameter_store: ParameterStore,
     parameter_ids: dict[ParamName, str] | None = None,
     uncertainty: ParameterUncertaintyView | None = None,
+    constraint_expressions: dict[str, str] | None = None,
 ) -> None:
     if not parameters:
         return
@@ -352,6 +370,7 @@ def write_file(
         parameter_store,
         ids,
         uncertainty,
+        constraint_expressions,
     )
     formatted_strings = _format_strings(par_strings)
     filename = path / f"{status}.toml"
@@ -374,6 +393,7 @@ def classify_global(parameters: Parameters) -> GlobalLocalParameters:
 def classify_parameters(
     experiments: Experiments,
     parameter_store: ParameterStore,
+    parameterization: ActiveParameterization | None = None,
 ) -> ClassifiedParameters:
     param_ids = experiments.param_ids
     parameters = {
@@ -381,12 +401,26 @@ def classify_parameters(
         for param in parameter_store.get_parameters(param_ids).values()
     }
 
-    constrained = {pname: param for pname, param in parameters.items() if param.expr}
-    fitted = {
-        pname: param
-        for pname, param in parameters.items()
-        if param.vary and pname not in constrained
-    }
+    if parameterization is None:
+        constrained = {
+            pname: param for pname, param in parameters.items() if param.expr
+        }
+        fitted = {
+            pname: param
+            for pname, param in parameters.items()
+            if param.vary and pname not in constrained
+        }
+    else:
+        constrained = {
+            pname: param
+            for pname, param in parameters.items()
+            if parameterization.role(param.id_) is ParameterRole.DERIVED
+        }
+        fitted = {
+            pname: param
+            for pname, param in parameters.items()
+            if parameterization.role(param.id_) is ParameterRole.FIT
+        }
 
     fixed_ids = set(parameters) - set(fitted) - set(constrained)
     fixed = {
@@ -407,11 +441,25 @@ def write_parameters(
     path: Path,
     parameter_store: ParameterStore,
     uncertainty: ParameterUncertaintyView | None = None,
+    parameterization: ActiveParameterization | None = None,
 ) -> None:
     """Write the model parameter values and their uncertainties to a file."""
     path_par = path / "Parameters"
     path_par.mkdir(parents=True, exist_ok=True)
-    classified_parameters = classify_parameters(experiments, parameter_store)
+    classified_parameters = classify_parameters(
+        experiments,
+        parameter_store,
+        parameterization,
+    )
+    constraint_expressions = (
+        None
+        if parameterization is None
+        else {
+            item.target_id: item.expression_text
+            for item in parameterization.program.constraints
+            if item.source.startswith("method-rule:")
+        }
+    )
     parameter_ids = {
         parameter.param_name: param_id
         for param_id, parameter in parameter_store.get_parameters(
@@ -441,4 +489,5 @@ def write_parameters(
         parameter_store,
         parameter_ids,
         uncertainty,
+        constraint_expressions,
     )

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Protocol
 
+from chemex.configuration.method_plan import MethodPlan, RoleAction
 from chemex.configuration.methods import Method
 from chemex.experiments.loader import register_experiments
 from chemex.models.loader import register_kinetic_settings
@@ -15,9 +16,9 @@ from chemex.parameters.database import (
 from chemex.parameters.factory import ParameterFactory
 from chemex.parameters.parameterization import (
     ActiveParameterization,
-    ModelDerivationOverrideError,
     build_initial_analysis_values,
     compile_active_parameterization,
+    compile_active_parameterization_from_actions,
 )
 from chemex.parameters.values import AnalysisValues
 from chemex.runtime.execution import ExecutionSettings
@@ -163,90 +164,36 @@ class AnalysisSession:
             required_ids,
         )
 
-    def compile_current_parameterization(
+    def compile_parameterization_from_actions(
         self,
+        actions: tuple[RoleAction, ...],
         required_ids: set[str],
     ) -> ActiveParameterization:
-        """Compile the effective inherited v1 roles in the active catalog."""
+        """Compile one canonical effective method step without mutable role state."""
         parameter_model = self.parameter_factory.sealed_parameter_model
         if parameter_model is None:
             msg = "The sealed native parameter model is unavailable"
             raise RuntimeError(msg)
-        parameters = self.parameters.get_parameters(required_ids)
-        fit: list[str] = []
-        fix: list[str] = []
-        constraints: list[str] = []
-        for param_id, parameter in parameters.items():
-            declaration = parameter_model.declarations[param_id]
-            if declaration.model_owned:
-                if parameter.vary or parameter.expr != declaration.model_expression:
-                    raise ModelDerivationOverrideError(
-                        "Current parameter role cannot override a model-owned "
-                        "derivation",
-                        param_ids=(param_id,),
-                    )
-                continue
-            selector = str(parameter.param_name)
-            if parameter.expr:
-                if parameter.expr == declaration.model_expression:
-                    continue
-                expression = parameter.expr
-                for dependency in sorted(
-                    parameter.dependencies,
-                    key=len,
-                    reverse=True,
-                ):
-                    dependency_name = parameters[dependency].param_name
-                    expression = expression.replace(
-                        dependency,
-                        str(dependency_name),
-                    )
-                constraints.append(f"[{selector}] = {expression}")
-            elif parameter.vary:
-                fit.append(selector)
-            else:
-                fix.append(selector)
-        effective_method = Method(
-            fit=fit,
-            fix=fix,
-            constraints=constraints,
-        )
-        return compile_active_parameterization(
+        return compile_active_parameterization_from_actions(
             parameter_model,
             self.analysis_values.snapshot(),
-            effective_method,
+            actions,
             required_ids,
         )
 
-    def apply_current_parameter_roles(
-        self,
-        method: Method,
-        required_ids: set[str],
-    ) -> None:
-        """Validate explicit method intent, then update inherited v1 roles."""
-        self.compile_parameterization(method, required_ids)
-        self.parameters.set_parameter_status(method)
-
-    def try_compile_parameterization(
-        self,
-        method: Method,
-        required_ids: set[str],
-    ) -> ActiveParameterization | None:
-        """Best-effort native parameterization preview."""
-        try:
-            candidate = self.compile_parameterization(method, required_ids)
-            frame = candidate.frame_from_snapshot(self.analysis_values.snapshot())
-            candidate.resolve(frame)
-        except Exception:  # noqa: BLE001 - checkpoint-1 isolation boundary
-            return None
-        return candidate
+    def validate_method_plan(self, plan: MethodPlan) -> None:
+        """Validate canonical method semantics against the sealed model."""
+        parameter_model = self.parameter_factory.sealed_parameter_model
+        if parameter_model is None:
+            raise RuntimeError("Native parameter model is unavailable")
+        plan.validate(parameter_model)
 
     def resolve_current_values(
         self,
         required_ids: set[str],
     ) -> Mapping[str, float]:
         """Resolve current stable values through native parameterization."""
-        parameterization = self.compile_current_parameterization(required_ids)
+        parameterization = self.compile_parameterization(Method(), required_ids)
         frame = parameterization.frame_from_snapshot(self.analysis_values.snapshot())
         return parameterization.resolve(frame)
 

--- a/tests/configuration/test_method_plan.py
+++ b/tests/configuration/test_method_plan.py
@@ -104,6 +104,38 @@ ROLES = [
     assert v1_plan.steps == v2_plan.steps
 
 
+def test_v1_and_v2_grid_statistics_normalize_to_the_same_step_semantics(
+    tmp_path: Path,
+) -> None:
+    v1 = _write(
+        tmp_path / "v1.toml",
+        """
+[STEP]
+GRID = ["[PB] = (0.1, 0.2)"]
+STATISTICS = { MC = 2 }
+""",
+    )
+    v2 = _write(
+        tmp_path / "v2.toml",
+        """
+FORMAT_VERSION = 2
+[STEP]
+
+[STEP.SEARCH.GRID]
+AXES = ["[PB] = values(0.1, 0.2)"]
+
+[STEP.STATISTICS.MC]
+REPLICATES = 2
+SEED = 0
+""",
+    )
+
+    v1_step = read_method_plan([v1]).steps[0]
+    v2_step = read_method_plan([v2]).steps[0]
+
+    assert v1_step == v2_step
+
+
 def test_v2_preserves_broad_to_specific_order_and_step_local_selection(
     tmp_path: Path,
 ) -> None:
@@ -427,6 +459,26 @@ FIT = ["PB"]
     assert "# V1_ONLY_THIN = 5" in read_method_plan([method]).render()
 
 
+def test_v1_adapter_resolves_resampling_seed_zero_but_not_mcmc_seed(
+    tmp_path: Path,
+) -> None:
+    method = _write(
+        tmp_path / "legacy-statistics.toml",
+        """
+[STEP]
+STATISTICS = { MC = 2, BS = 3, BSN = 4, MCMC = 5 }
+""",
+    )
+
+    statistics = read_method_plan([method]).steps[0].statistics
+
+    assert statistics is not None
+    assert statistics.mc is not None and statistics.mc.seed == 0
+    assert statistics.bs is not None and statistics.bs.seed == 0
+    assert statistics.bsn is not None and statistics.bsn.seed == 0
+    assert statistics.mcmc is not None and statistics.mcmc.seed is None
+
+
 def test_v1_adapter_preserves_values_coerced_by_the_legacy_schema(
     tmp_path: Path,
 ) -> None:
@@ -546,7 +598,21 @@ AXES = ["[KEX_AB] = values(100, 500)"]
 INCLUDE = [24]
 ROLES_FROM = "FIRST"
 ROLES = [{ FIT = ["PB", "KEX_AB"] }]
-STATISTICS = { MC = 10, BS = 20, BSN = 30, MCMC = 5000 }
+
+[SECOND.STATISTICS.MC]
+REPLICATES = 10
+SEED = 0
+
+[SECOND.STATISTICS.BS]
+REPLICATES = 20
+SEED = 0
+
+[SECOND.STATISTICS.BSN]
+REPLICATES = 30
+SEED = 0
+
+[SECOND.STATISTICS.MCMC]
+STEPS = 5000
 """,
     )
 

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -8,7 +8,24 @@ import numpy as np
 import pytest
 
 from chemex import chemex as chemex_module
-from chemex.configuration.methods import Method, Selection
+from chemex.configuration.method_execution import normalize_methods_for_execution
+from chemex.configuration.method_plan import (
+    FitAction,
+    FixAction,
+    FormatOrigin,
+    GridAxis,
+    GridSearch,
+    GridValues,
+    McmcRequest,
+    MethodPlan,
+    ParameterSelector,
+    ProfileSelection,
+    ResamplingRequest,
+    SourceRef,
+    StatisticsPlan,
+    StepPlan,
+)
+from chemex.configuration.methods import McmcSettings, Method, Selection, Statistics
 from chemex.experiments import builder as builder_module
 from chemex.nmr.basis import Basis
 from chemex.optimize import fitting as fitting_module
@@ -16,6 +33,7 @@ from chemex.optimize import helper as helper_module
 from chemex.optimize import resampling as resampling_module
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
+from chemex.parameters.spin_system import SpinSystem
 from chemex.printers import parameters as parameter_printer_module
 from chemex.runtime import AnalysisSession, ExecutionSettings
 from chemex.runtime import session as session_module
@@ -39,7 +57,6 @@ class StubParameters:
         self.defaults_calls: list[object] = []
         self.fix_all_calls = 0
         self.sort_calls = 0
-        self.status_calls: list[Method] = []
 
     def reset(self) -> None:
         self.reset_calls += 1
@@ -52,9 +69,6 @@ class StubParameters:
 
     def sort(self) -> None:
         self.sort_calls += 1
-
-    def set_parameter_status(self, method: Method) -> None:
-        self.status_calls.append(method)
 
 
 class StubParameterFactory:
@@ -95,15 +109,11 @@ class StubSession:
         self.build_analysis_values_calls += 1
         return self.parameter_factory.try_seal_configuration()
 
-    def try_compile_parameterization(
-        self,
-        _method: object,
-        _required_ids: set[str],
-    ) -> None:
-        return None
-
     def resolve_current_values(self, _required_ids: set[str]) -> dict[str, float]:
         return {}
+
+    def validate_method_plan(self, _plan: MethodPlan) -> None:
+        return None
 
 
 class WriterParameterStore:
@@ -352,7 +362,7 @@ def test_run_uses_explicit_session_for_fit_flow(
 
     def fake_run_methods(
         experiments_arg: FakeExperiments,
-        methods: dict[str, Method],
+        methods: MethodPlan,
         path: Path,
         plot_level: str,
         *,
@@ -597,7 +607,275 @@ def test_run_methods_skips_fit_when_selection_removes_all_profiles(
 
     np.testing.assert_equal(calls, ["no_data"])
     np.testing.assert_equal(len(experiments.selections), 1)
-    np.testing.assert_equal(session.parameters.status_calls, [])
+
+
+def test_legacy_methods_compatibility_keeps_implicit_selection_inheritance() -> None:
+    plan, _operational = normalize_methods_for_execution(
+        {
+            "FIRST": Method(include=["1H"]),
+            "SECOND": Method(),
+        }
+    )
+
+    assert plan.steps[1].selection == plan.steps[0].selection
+
+
+def test_programmatic_v1_methods_normalize_grid_and_statistics_canonically() -> None:
+    plan, _operational = normalize_methods_for_execution(
+        {
+            "STEP": Method(
+                fix=["PB"],
+                grid=["[PB] = (0.1, 0.2)"],
+                statistics=Statistics(
+                    mc=2,
+                    mcmc=McmcSettings(
+                        steps=10,
+                        burn=2,
+                        thin=2,
+                        walkers=4,
+                        seed=9,
+                        workers=2,
+                    ),
+                ),
+            )
+        }
+    )
+
+    step = plan.steps[0]
+    assert isinstance(step.search, GridSearch)
+    assert step.statistics is not None
+    assert step.statistics.mc == ResamplingRequest(2, seed=0)
+    assert step.statistics.mcmc == McmcRequest(
+        steps=10,
+        burn=2,
+        thin=2,
+        walkers=4,
+        seed=9,
+        workers=2,
+    )
+    _same_plan, canonical_operational = normalize_methods_for_execution(plan)
+    assert _operational == canonical_operational
+
+
+def test_v2_omitted_selection_restores_the_step_local_all_profiles_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = StubSession()
+    experiments = FakeExperiments(parameter_store=session.parameters)
+    plan = MethodPlan(
+        FormatOrigin.V2,
+        (
+            StepPlan("FIRST", selection=ProfileSelection(("1H",), None)),
+            StepPlan("SECOND"),
+        ),
+    )
+    session.compile_parameterization_from_actions = lambda *_args: object()  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        fitting_module, "run_native_deterministic", lambda *_args, **_kwargs: None
+    )
+
+    fitting_module.run_methods(
+        experiments,
+        plan,
+        Path("Output"),
+        "normal",
+        session=session,
+    )
+
+    assert experiments.selections[0].include == [SpinSystem.from_name("1H")]
+    assert experiments.selections[1] == Selection(include="*", exclude=None)
+
+
+@pytest.mark.parametrize("origin", tuple(FormatOrigin))
+def test_canonical_grid_runs_requested_statistics_independently_of_origin(
+    monkeypatch: pytest.MonkeyPatch,
+    origin: FormatOrigin,
+) -> None:
+    session = StubSession()
+    experiments = FakeExperiments(parameter_store=session.parameters)
+    source = SourceRef(Path("method.toml"), "STEP", "SEARCH.GRID.AXES", 0)
+    selector = ParameterSelector("PB", source=source)
+    plan = MethodPlan(
+        origin,
+        (
+            StepPlan(
+                "STEP",
+                search=GridSearch(
+                    (GridAxis(selector, GridValues((0.1, 0.2)), source),)
+                ),
+                statistics=StatisticsPlan(mc=ResamplingRequest(1, seed=7)),
+            ),
+        ),
+    )
+    accepted_fit = object()
+    statistics_calls: list[tuple[object, object]] = []
+    session.compile_parameterization_from_actions = lambda *_args: object()  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        fitting_module,
+        "run_native_deterministic",
+        lambda *_args, **_kwargs: accepted_fit,
+    )
+    monkeypatch.setattr(
+        fitting_module,
+        "_run_requested_native_statistics",
+        lambda _experiments, _path, statistics, fit, **_kwargs: statistics_calls.append(
+            (statistics, fit)
+        ),
+    )
+
+    fitting_module.run_methods(
+        experiments,
+        plan,
+        Path("Output"),
+        "normal",
+        session=session,
+    )
+
+    assert statistics_calls == [(plan.steps[0].statistics, accepted_fit)]
+
+
+def test_v2_omitted_resampling_seed_is_resolved_once_for_the_occurrence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved_seed = 0x1234_5678_90AB_CDEF
+    calls: list[int] = []
+    monkeypatch.setattr(fitting_module.secrets, "randbits", lambda _bits: resolved_seed)
+    monkeypatch.setattr(
+        fitting_module,
+        "run_native_resampling_statistics",
+        lambda *_args, root_seed, **_kwargs: calls.append(root_seed),
+    )
+    session = StubSession()
+    snapshot = object()
+    session.analysis_values = SimpleNamespace(snapshot=lambda: snapshot)  # type: ignore[attr-defined]
+
+    fitting_module._run_native_statistics(
+        FakeExperiments(),
+        Path("Output"),
+        StatisticsPlan(mc=ResamplingRequest(1)),
+        object(),  # type: ignore[arg-type]
+        session=session,  # type: ignore[arg-type]
+    )
+
+    assert calls == [resolved_seed]
+
+
+def test_failed_step_cannot_change_effective_roles_seen_by_a_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = StubSession()
+    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments.param_ids = {"__PB"}
+    source = SourceRef(Path("method.toml"), "STEP", "ROLES")
+    fixed = FixAction((ParameterSelector("PB"),), source)
+    fitted = FitAction((ParameterSelector("PB"),), source)
+    plan = MethodPlan(
+        FormatOrigin.V2,
+        (
+            StepPlan("FIRST", role_actions=(fixed,)),
+            StepPlan("SECOND", roles_from="FIRST", role_actions=(fitted,)),
+            StepPlan("THIRD", role_actions=(fixed,)),
+        ),
+    )
+    compiled: list[tuple[object, ...]] = []
+    execution_count = 0
+
+    def compile_actions(actions: tuple[object, ...], _required: set[str]) -> object:
+        compiled.append(actions)
+        return actions
+
+    def fail_once(*_args: object, **_kwargs: object) -> None:
+        nonlocal execution_count
+        execution_count += 1
+        if execution_count == 2:
+            raise RuntimeError("injected second-step failure")
+
+    session.compile_parameterization_from_actions = compile_actions  # type: ignore[attr-defined]
+    monkeypatch.setattr(fitting_module, "run_native_deterministic", fail_once)
+
+    with pytest.raises(RuntimeError, match="second-step failure"):
+        fitting_module.run_methods(
+            experiments, plan, Path("Output"), "normal", session=session
+        )
+    fitting_module.run_methods(
+        experiments, plan, Path("Output"), "normal", session=session
+    )
+
+    assert compiled == [
+        (fixed,),
+        (fixed, fitted),
+        (fixed,),
+        (fixed, fitted),
+        (fixed,),
+    ]
+
+
+@pytest.mark.parametrize("origin", tuple(FormatOrigin))
+def test_run_methods_compiles_each_canonical_step_without_origin_or_store_state(
+    monkeypatch: pytest.MonkeyPatch,
+    origin: FormatOrigin,
+) -> None:
+    session = StubSession()
+    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments.param_ids = {"__PB"}
+    source = SourceRef(Path("method.toml"), "STEP", "ROLES")
+    selector = ParameterSelector("PB")
+    fixed = FixAction((selector,), source)
+    fitted = FitAction((selector,), source)
+    plan = MethodPlan(
+        origin,
+        (
+            StepPlan("FIRST", role_actions=(fixed,)),
+            StepPlan("SECOND", roles_from="FIRST", role_actions=(fitted,)),
+            StepPlan("THIRD", role_actions=(fitted,)),
+        ),
+    )
+    compiled: list[tuple[object, ...]] = []
+    executed: list[tuple[str, object]] = []
+
+    def compile_actions(
+        actions: tuple[object, ...],
+        required_ids: set[str],
+    ) -> object:
+        compiled.append(actions)
+        assert required_ids == {"__PB"}
+        return actions
+
+    session.compile_parameterization_from_actions = compile_actions  # type: ignore[attr-defined]
+
+    def run_deterministic(
+        _experiments: object,
+        _method: Method,
+        path: Path,
+        _plot: str,
+        *,
+        session: object,
+        parameterization: object,
+    ) -> None:
+        assert session is not None
+        executed.append((path.name, parameterization))
+
+    monkeypatch.setattr(
+        fitting_module,
+        "run_native_deterministic",
+        run_deterministic,
+    )
+
+    fitting_module.run_methods(
+        experiments,
+        plan,
+        Path("Output"),
+        "normal",
+        session=session,
+    )
+
+    assert compiled == [(fixed,), (fixed, fitted), (fitted,)]
+    assert executed == [
+        ("FIRST", (fixed,)),
+        ("SECOND", (fixed, fitted)),
+        ("THIRD", (fitted,)),
+    ]
+    assert session.parameters.fix_all_calls == 0
 
 
 def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None:

--- a/tests/test_analysis_values.py
+++ b/tests/test_analysis_values.py
@@ -80,10 +80,13 @@ def test_revision_zero_model_values_and_constraints_resolve_without_lmfit() -> N
     assert session.try_build_analysis_values()
     initial = session.resolve_current_values(experiments.param_ids)
 
-    session.parameters.set_parameter_status(
-        Method(constraints=["[PB] = [KEX_AB] / 10000.0"])
+    parameterization = session.compile_parameterization(
+        Method(constraints=["[PB] = [KEX_AB] / 10000.0"]),
+        experiments.param_ids,
     )
-    constrained = session.resolve_current_values(experiments.param_ids)
+    constrained = parameterization.resolve(
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot())
+    )
 
     assert initial["__PB"] == pytest.approx(0.07)
     assert initial["__PA"] == pytest.approx(0.93)

--- a/tests/test_grid_entries.py
+++ b/tests/test_grid_entries.py
@@ -24,7 +24,7 @@ def get_setting(catalog: ParameterCatalog, param_id: str) -> ParamSetting:
     return catalog.get_parameters([param_id])[param_id]
 
 
-def test_parse_grid_preserves_specific_entry_precedence() -> None:
+def test_parse_grid_preserves_precedence_without_mutating_parameter_roles() -> None:
     global_pb = make_param("PB")
     local_pb = make_param("PB", "10N-H")
     catalog = make_catalog(global_pb, local_pb)
@@ -35,8 +35,8 @@ def test_parse_grid_preserves_specific_entry_precedence() -> None:
 
     assert grid[global_pb.id_].tolist() == [1.0, 2.0]
     assert grid[local_pb.id_].tolist() == [3.0, 4.0]
-    assert get_setting(catalog, global_pb.id_).vary is False
-    assert get_setting(catalog, local_pb.id_).vary is False
+    assert get_setting(catalog, global_pb.id_).vary is True
+    assert get_setting(catalog, local_pb.id_).vary is True
 
 
 def test_parse_grid_last_matching_entry_wins() -> None:

--- a/tests/test_native_evaluation.py
+++ b/tests/test_native_evaluation.py
@@ -113,8 +113,9 @@ def test_cest_infinite_sweep_width_sentinel_has_a_stable_native_plan() -> None:
         )
         session.parameters.set_defaults(read_defaults([CEST_PARAMETERS]))
         assert session.try_build_analysis_values()
-        parameterization = session.compile_current_parameterization(
-            experiments.param_ids
+        parameterization = session.compile_parameterization(
+            Method(),
+            experiments.param_ids,
         )
         engine = EvaluationEngine.from_experiments(
             experiments,

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -243,6 +243,44 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
 
 
+def test_v2_role_change_keeps_the_prior_committed_value_without_store_roles(
+    tmp_path: Path,
+) -> None:
+    method = tmp_path / "method-v2.toml"
+    method.write_text(
+        """
+FORMAT_VERSION = 2
+[FIRST]
+ROLES = [{ FIX = ["PB", "KEX_AB"] }]
+
+[SECOND]
+ROLES_FROM = "FIRST"
+ROLES = [{ FIX = ["R1A_A"] }]
+""",
+        encoding="utf-8",
+    )
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+
+    run(_fit_arguments(output, method), session=session)
+
+    first_fitted = (output / "FIRST/Parameters/fitted.toml").read_text(encoding="utf-8")
+    second_fixed = (output / "SECOND/Parameters/fixed.toml").read_text(encoding="utf-8")
+    first_value = float(
+        next(line for line in first_fitted.splitlines() if "G2N-H" in line)
+        .split("=", 1)[1]
+        .split()[0]
+    )
+    second_value = float(
+        next(line for line in second_fixed.splitlines() if "G2N-H" in line)
+        .split("=", 1)[1]
+        .split()[0]
+    )
+
+    assert session.analysis_values.snapshot().revision == 1
+    assert second_value == pytest.approx(first_value, rel=1.0e-12)
+
+
 def test_relaxation_product_covariance_matches_absolute_sigma_reference(
     tmp_path: Path,
 ) -> None:
@@ -1046,11 +1084,15 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     parameters = _bounded_parameters(tmp_path / "parameters.toml")
     session = AnalysisSession.create()
 
-    with patch.object(
-        mcmc_module,
-        "execute_mcmc_evidence",
-        wraps=mcmc_module.execute_mcmc_evidence,
-    ) as native_sampler:
+    generated_seed = 0x1234_5678_90AB_CDEF
+    with (
+        patch.object(mcmc_module.secrets, "randbits", return_value=generated_seed),
+        patch.object(
+            mcmc_module,
+            "execute_mcmc_evidence",
+            wraps=mcmc_module.execute_mcmc_evidence,
+        ) as native_sampler,
+    ):
         run(
             _fit_arguments(output, method, parameters=parameters),
             session=session,
@@ -1069,6 +1111,7 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     assert diagnostics["engine"] == "native MCMC"
     assert diagnostics["steps"] == 2
     assert diagnostics["walkers"] == 32
+    assert diagnostics["root_seed"] == generated_seed
     assert "lmfit_version" not in diagnostics
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
     assert "# ±" in fitted
@@ -1456,6 +1499,10 @@ def test_real_bs_fit_uses_native_refits_and_writes_bootstrap_products(
     assert (statistics / "diagnostics.toml").is_file()
     assert (statistics / "plots.pdf").stat().st_size > 0
     _assert_truthful_resampling_summary(statistics / "summary.toml")
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["root_seed"] == 0
 
 
 def test_real_bsn_fit_uses_native_nucleus_resampling_products(tmp_path: Path) -> None:
@@ -1475,6 +1522,10 @@ def test_real_bsn_fit_uses_native_nucleus_resampling_products(tmp_path: Path) ->
     assert (statistics / "diagnostics.toml").is_file()
     assert (statistics / "plots.pdf").stat().st_size > 0
     _assert_truthful_resampling_summary(statistics / "summary.toml")
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["root_seed"] == 0
 
 
 def test_seeded_native_mc_products_are_ordered_across_worker_counts(
@@ -2039,9 +2090,8 @@ STATISTICS = { "MC" = 1 }
     assert (output / "Statistics" / "MonteCarlo" / "samples.tsv").is_file()
 
 
-def test_grid_with_statistics_warns_and_runs_native_grid_only(
+def test_v1_grid_runs_mc_from_the_accepted_aggregate_grid_fit(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     output = tmp_path / "Output"
     method = tmp_path / "method.toml"
@@ -2054,15 +2104,72 @@ STATISTICS = { "MC" = 1 }
     )
     session = AnalysisSession.create()
 
-    with patch(
-        "chemex.optimize.fitting.run_native_resampling_statistics",
-        side_effect=AssertionError("statistics after GRID were entered"),
-    ):
-        run(_fit_arguments(output, method), session=session)
+    run(_fit_arguments(output, method), session=session)
 
-    captured = capsys.readouterr()
-    assert "GRID" in captured.out
-    assert "STATISTICS" in captured.out
     assert (output / "Grid").is_dir()
     assert (output / "Statistics" / "Covariance" / "evidence.json").is_file()
-    assert not (output / "Statistics" / "MonteCarlo").exists()
+    diagnostics = tomllib.loads(
+        (output / "Statistics" / "MonteCarlo" / "diagnostics.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert diagnostics["status"] == "complete"
+    assert diagnostics["root_seed"] == 0
+
+
+def test_v2_grid_runs_requested_statistics_from_the_accepted_grid_fit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method-v2.toml"
+    method.write_text(
+        """FORMAT_VERSION = 2
+[DEFAULT]
+
+[DEFAULT.SEARCH.GRID]
+AXES = ["[R1A_A] = values(1.0, 3.0)"]
+
+[DEFAULT.STATISTICS.MC]
+REPLICATES = 1
+SEED = 7
+""",
+        encoding="utf-8",
+    )
+
+    run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    assert (output / "Grid").is_dir()
+    assert (output / "Statistics" / "MonteCarlo" / "samples.tsv").is_file()
+    diagnostics = tomllib.loads(
+        (output / "Statistics" / "MonteCarlo" / "diagnostics.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert diagnostics["root_seed"] == 7
+
+
+def test_v2_omitted_resampling_seed_is_generated_once_and_recorded(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method-v2.toml"
+    method.write_text(
+        """FORMAT_VERSION = 2
+[DEFAULT]
+
+[DEFAULT.STATISTICS.MC]
+REPLICATES = 1
+""",
+        encoding="utf-8",
+    )
+    generated_seed = 0xFEDC_BA09_8765_4321
+
+    with patch("chemex.optimize.fitting.secrets.randbits", return_value=generated_seed):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    diagnostics = tomllib.loads(
+        (output / "Statistics" / "MonteCarlo" / "diagnostics.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert diagnostics["root_seed"] == generated_seed

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -14,7 +14,29 @@ import pytest
 
 from chemex import chemex as chemex_module
 from chemex.configuration.conditions import Conditions
-from chemex.configuration.methods import Method, Selection, read_methods
+from chemex.configuration.method_plan import (
+    ConstrainAction,
+    Constraint,
+    FitAction,
+    FixAction,
+    FormatOrigin,
+    MethodPlan,
+    ParameterSelector,
+    SourceRef,
+    StepPlan,
+)
+from chemex.configuration.method_plan import (
+    LiteralExpression as MethodLiteralExpression,
+)
+from chemex.configuration.method_plan import (
+    SelectorExpression as MethodSelectorExpression,
+)
+from chemex.configuration.methods import (
+    Method,
+    Selection,
+    read_method_plan,
+    read_methods,
+)
 from chemex.configuration.parameters import read_defaults
 from chemex.experiments.builder import build_experiments
 from chemex.models.factory import model_factory
@@ -40,6 +62,7 @@ from chemex.parameters.parameterization import (
     SealedParameterModel,
     UnsupportedConstraintExpressionError,
     compile_active_parameterization,
+    compile_active_parameterization_from_actions,
     seal_parameter_declarations,
 )
 from chemex.parameters.sealed import (
@@ -71,6 +94,7 @@ BINDING_ROOT = ROOT / "examples/Combinations/2stBinding"
 BINDING_EXPERIMENTS = tuple(sorted((BINDING_ROOT / "Experiments").glob("*.toml")))
 BINDING_PARAMETERS = BINDING_ROOT / "Parameters/params.toml"
 BINDING_METHOD = BINDING_ROOT / "Methods/method.toml"
+_METHOD_SOURCE = SourceRef(Path("method.toml"), "STEP", "ROLES")
 
 _BINDING_STEP1_R2_B_IDS = {
     "__R2_B_486N_800_0MHZ",
@@ -217,57 +241,6 @@ def _build_fit_session() -> tuple[AnalysisSession, set[str]]:
     return session, experiments.param_ids
 
 
-def _presentation_roles_and_values(
-    session: AnalysisSession,
-    method: Method,
-    required_ids: set[str],
-) -> tuple[dict[str, ParameterRole], dict[str, float]]:
-    session.parameters.set_parameter_status(method)
-    parameters = session.parameters.get_parameters(required_ids)
-    roles = {
-        param_id: (
-            ParameterRole.DERIVED
-            if parameter.expr
-            else ParameterRole.FIT
-            if parameter.vary
-            else ParameterRole.FIX
-        )
-        for param_id, parameter in parameters.items()
-    }
-    return roles, dict(session.resolve_current_values(required_ids))
-
-
-def _assert_complete_shipped_parity(
-    native_session: AnalysisSession,
-    presentation_session: AnalysisSession,
-    method: Method,
-    required_ids: set[str],
-) -> None:
-    snapshot = native_session.analysis_values.snapshot()
-    parameterization = native_session.compile_parameterization(
-        method,
-        required_ids,
-    )
-    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
-    presentation_roles, presentation_values = _presentation_roles_and_values(
-        presentation_session,
-        method,
-        required_ids,
-    )
-
-    assert parameterization.scope_ids == tuple(presentation_roles)
-    assert {
-        param_id: parameterization.role(param_id)
-        for param_id in parameterization.scope_ids
-    } == presentation_roles
-    assert dict(resolved) == pytest.approx(
-        presentation_values,
-        rel=1e-13,
-        abs=1e-13,
-    )
-    assert native_session.analysis_values.snapshot() == snapshot
-
-
 def _native_fixture(
     declarations: tuple[ParameterDeclaration, ...],
     *,
@@ -322,6 +295,146 @@ def _native_fixture(
     return parameter_model, snapshot
 
 
+def test_canonical_ordered_actions_compile_complete_replacement_roles() -> None:
+    declarations = (
+        ParameterDeclaration("__DW_AB_24N", True),
+        ParameterDeclaration("__DW_AB_31N", True),
+        ParameterDeclaration("__DW_AB_40N", True),
+    )
+    definitions = tuple(
+        ParamDefinition(
+            declaration.param_id,
+            "DW_AB",
+            spin_system,
+            (),
+            1.0,
+            -float("inf"),
+            float("inf"),
+        )
+        for declaration, spin_system in zip(
+            declarations,
+            ("24N", "31N", "40N"),
+            strict=True,
+        )
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        definitions=definitions,
+    )
+    broad = ParameterSelector("DW_AB")
+    subset_a = ParameterSelector("DW_AB", spin_system="24N")
+    subset_b = ParameterSelector("DW_AB", spin_system="31N")
+    actions = (
+        FixAction((broad,), _METHOD_SOURCE),
+        FitAction((subset_a,), _METHOD_SOURCE),
+        ConstrainAction(
+            (
+                Constraint(
+                    subset_b,
+                    MethodSelectorExpression(subset_a),
+                    _METHOD_SOURCE,
+                ),
+            ),
+            _METHOD_SOURCE,
+        ),
+    )
+
+    parameterization = compile_active_parameterization_from_actions(
+        parameter_model,
+        snapshot,
+        actions,
+        set(parameter_model.declarations),
+    )
+
+    assert parameterization.role("__DW_AB_24N") is ParameterRole.FIT
+    assert parameterization.role("__DW_AB_31N") is ParameterRole.DERIVED
+    assert parameterization.role("__DW_AB_40N") is ParameterRole.FIX
+
+
+@pytest.mark.parametrize("replacement", (FitAction, FixAction))
+def test_canonical_fit_or_fix_removes_an_earlier_constraint(
+    replacement: type[FitAction] | type[FixAction],
+) -> None:
+    declarations = (ParameterDeclaration("__PB", True),)
+    parameter_model, snapshot = _native_fixture(declarations)
+    selector = ParameterSelector("PB")
+    actions = (
+        ConstrainAction(
+            (
+                Constraint(
+                    selector,
+                    MethodLiteralExpression(0.25),
+                    _METHOD_SOURCE,
+                ),
+            ),
+            _METHOD_SOURCE,
+        ),
+        replacement((selector,), _METHOD_SOURCE),
+    )
+
+    parameterization = compile_active_parameterization_from_actions(
+        parameter_model,
+        snapshot,
+        actions,
+        {"__PB"},
+    )
+
+    expected = ParameterRole.FIT if replacement is FitAction else ParameterRole.FIX
+    assert parameterization.role("__PB") is expected
+    assert parameterization.program.constraints == ()
+
+
+def test_method_plan_resolves_explicit_and_baseline_role_actions_immutably() -> None:
+    selector = ParameterSelector("PB")
+    fixed = FixAction((selector,), _METHOD_SOURCE)
+    fitted = FitAction((selector,), _METHOD_SOURCE)
+    plan = MethodPlan(
+        FormatOrigin.V2,
+        (
+            StepPlan("FIRST", role_actions=(fixed,)),
+            StepPlan("INHERITED", roles_from="FIRST", role_actions=(fitted,)),
+            StepPlan("BASELINE", role_actions=(fitted,)),
+        ),
+    )
+
+    effective = plan.effective_role_actions()
+
+    assert effective == {
+        "FIRST": (fixed,),
+        "INHERITED": (fixed, fitted),
+        "BASELINE": (fitted,),
+    }
+
+
+def test_inherited_canonical_action_outside_selected_scope_is_inert() -> None:
+    declarations = (
+        ParameterDeclaration("__DW_AB_24N", True),
+        ParameterDeclaration("__DW_AB_31N", True),
+    )
+    definitions = (
+        ParamDefinition("__DW_AB_24N", "DW_AB", "24N", (), 1.0, -10.0, 10.0),
+        ParamDefinition("__DW_AB_31N", "DW_AB", "31N", (), 1.0, -10.0, 10.0),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        definitions=definitions,
+    )
+    inherited = FixAction(
+        (ParameterSelector("DW_AB", spin_system="31N"),),
+        _METHOD_SOURCE,
+    )
+
+    parameterization = compile_active_parameterization_from_actions(
+        parameter_model,
+        snapshot,
+        (inherited,),
+        {"__DW_AB_24N"},
+    )
+
+    assert parameterization.scope_ids == ("__DW_AB_24N",)
+    assert parameterization.role("__DW_AB_24N") is ParameterRole.FIT
+
+
 def test_shipped_method_compiles_roles_and_resolves_without_mutation() -> None:
     session, required_ids = _build_dcest_session()
     methods = read_methods([DCEST_METHOD])
@@ -332,8 +445,7 @@ def test_shipped_method_compiles_roles_and_resolves_without_mutation() -> None:
         for param_id, parameter in session.parameters.database._parameters.items()
     }
 
-    parameterization = session.try_compile_parameterization(method, required_ids)
-    assert parameterization is not None
+    parameterization = session.compile_parameterization(method, required_ids)
     resolved = parameterization.resolve(parameterization.frame_from_snapshot(before))
 
     definitions = session.parameter_factory.sealed_definitions
@@ -358,38 +470,9 @@ def test_shipped_method_compiles_roles_and_resolves_without_mutation() -> None:
         session.parameters.database._parameters[r1_b].expr == legacy_expressions[r1_b]
     )
 
-    step2 = session.try_compile_parameterization(methods["STEP2"], required_ids)
-    assert step2 is not None
+    step2 = session.compile_parameterization(methods["STEP2"], required_ids)
     assert step2.role(d2o) is ParameterRole.FIX
     assert session.analysis_values.snapshot() == before
-
-
-def test_shipped_dcest_constraint_roles_and_values_match_legacy_completely() -> None:
-    native_session, required_ids = _build_dcest_session()
-    presentation_session, presentation_required_ids = _build_dcest_session()
-    assert presentation_required_ids == required_ids
-    method = read_methods([DCEST_METHOD])["STEP1"]
-
-    _assert_complete_shipped_parity(
-        native_session,
-        presentation_session,
-        method,
-        required_ids,
-    )
-
-
-def test_shipped_fix_roles_and_values_match_legacy_completely() -> None:
-    native_session, required_ids = _build_fit_session()
-    presentation_session, presentation_required_ids = _build_fit_session()
-    assert presentation_required_ids == required_ids
-    method = read_methods([FIT_METHOD])["DEFAULT"]
-
-    _assert_complete_shipped_parity(
-        native_session,
-        presentation_session,
-        method,
-        required_ids,
-    )
 
 
 @pytest.mark.parametrize(
@@ -526,7 +609,7 @@ def test_product_role_application_rejects_model_owned_override(method: Method) -
     session, required_ids = _build_dcest_session()
 
     with pytest.raises(ModelDerivationOverrideError):
-        session.apply_current_parameter_roles(method, required_ids)
+        session.compile_parameterization(method, required_ids)
 
 
 def test_non_estimable_declaration_cannot_compile_as_fit() -> None:
@@ -560,10 +643,14 @@ def test_binding_current_roles_compile_all_estimable_r2_b_coordinates() -> None:
         session.parameter_factory.native_construction_error
     )
     methods = read_methods([BINDING_METHOD])
+    plan = read_method_plan([BINDING_METHOD])
+    effective_actions = plan.effective_role_actions()
 
     experiments.select(methods["STEP1"].selection)
-    session.apply_current_parameter_roles(methods["STEP1"], experiments.param_ids)
-    step1 = session.compile_current_parameterization(experiments.param_ids)
+    step1 = session.compile_parameterization_from_actions(
+        effective_actions["STEP1"],
+        experiments.param_ids,
+    )
     step1_fit_ids = {
         param_id
         for param_id in step1.independent_ids
@@ -584,8 +671,10 @@ def test_binding_current_roles_compile_all_estimable_r2_b_coordinates() -> None:
         assert not declaration.model_owned
 
     experiments.select(methods["STEP2"].selection)
-    session.apply_current_parameter_roles(methods["STEP2"], experiments.param_ids)
-    step2 = session.compile_current_parameterization(experiments.param_ids)
+    step2 = session.compile_parameterization_from_actions(
+        effective_actions["STEP2"],
+        experiments.param_ids,
+    )
     step2_fit_ids = {
         param_id
         for param_id in step2.independent_ids
@@ -709,8 +798,6 @@ def test_shadowed_constraint_still_receives_public_syntax_validation() -> None:
 
 def test_real_model_free_scientific_expression_matches_legacy_resolution() -> None:
     native_session, required_ids = _build_mf_session()
-    presentation_session, presentation_required_ids = _build_mf_session()
-    assert presentation_required_ids == required_ids
     snapshot = native_session.analysis_values.snapshot()
     configuration = native_session.parameter_factory.sealed_configuration
     assert configuration is not None
@@ -734,12 +821,6 @@ def test_real_model_free_scientific_expression_matches_legacy_resolution() -> No
     assert any(
         item.param_id in parameterization.derived_ids and item.name.startswith("R2")
         for item in definitions
-    )
-    _assert_complete_shipped_parity(
-        native_session,
-        presentation_session,
-        method,
-        required_ids,
     )
 
 
@@ -1348,7 +1429,7 @@ def test_native_compilation_failure_cannot_fall_back_to_legacy_fit(
         msg = "native compilation failed"
         raise RuntimeError(msg)
 
-    monkeypatch.setattr(session, "compile_current_parameterization", fail_preview)
+    monkeypatch.setattr(session, "compile_parameterization_from_actions", fail_preview)
     args = Namespace(
         commands="fit",
         model="2st",

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -21,10 +21,16 @@ accepted temporarily as an alias and is canonicalized to `"trf"`; historical
 optimizer names fail during method-file validation, before fit outputs are
 invalidated. ChemEx no longer forwards arbitrary optimizer names or depends on
 lmfit at runtime; fitting and statistics use the native ChemEx parameter and
-evaluation stack. When `GRID` and `STATISTICS` occur in the same step, ChemEx prints
-the compatibility warning, executes the native grid, and ignores statistics.
+evaluation stack. When `GRID` and `STATISTICS` occur in the same step, ChemEx
+first commits the accepted aggregate grid fit and then runs the requested
+statistics from that fit. This canonical workflow applies to both legacy and
+version 2 method files.
 
-Method files are structured in sections, each representing a fitting step. Fitting steps are executed in the order they appear, and parameter settings inherit from previous steps if not redefined.
+Method files are structured in sections, each representing a fitting step.
+Steps execute in the order they appear. Files without `FORMAT_VERSION` use the
+legacy version 1 behavior: profile selection and parameter roles implicitly
+carry forward when omitted. Version 2 makes role inheritance explicit and
+treats profile selection as local to each step.
 
 :::tip
 When performing multi-step fitting, start with a subset of residues with high-quality data (e.g., large CPMG dispersion or clear CEST dips) to estimate global parameters, then fix these parameters in subsequent steps to fit residue-specific parameters. For example, see the method file for `CPMG_CH3_1H_SQ/` in `Examples/Experiments/`.
@@ -64,6 +70,51 @@ This method file performs the following steps:
 4. `"DW_AB"` is varied.
 
 Results are saved in directories named according to each step.
+
+## Explicit Step Semantics (Version 2)
+
+Set `FORMAT_VERSION = 2` at the top of a method file to use canonical,
+step-local semantics. Each step starts from the sealed parameter model's roles
+unless `ROLES_FROM` names an earlier step. Starting parameter values always come
+from the latest accepted fit; inheriting roles is not required to carry fitted
+values into a later step.
+
+`ROLES` is an ordered list. Each entry contains exactly one of `FIT`, `FIX`, or
+`CONSTRAIN`. A later matching action replaces the parameter's complete earlier
+role, including removal of an earlier constraint.
+
+```toml title="method-v2.toml"
+FORMAT_VERSION = 2
+
+[FIRST]
+INCLUDE = [15, 31, 33, 34, 37]
+ROLES = [
+    { FIX = ["PB", "KEX_AB"] },
+    { FIT = ["DW_AB"] },
+]
+
+[FIRST.SEARCH.GRID]
+AXES = ["[DW_AB] = lin(0.0, 10.0, 20)"]
+
+[SECOND]
+INCLUDE = "ALL"
+ROLES_FROM = "FIRST"
+ROLES = [
+    { FIT = ["PB", "KEX_AB"] },
+    { CONSTRAIN = ["[R2_B, NUC->N] = [R2_A, NUC->N]"] },
+]
+
+[SECOND.STATISTICS.MC]
+REPLICATES = 100
+SEED = 1234
+```
+
+Omitting `ROLES_FROM` means no role inheritance, even when the preceding step
+changed roles. Omitting `INCLUDE` and `EXCLUDE` selects all profiles for that
+step; selection never inherits in version 2. `SEARCH.GRID.AXES` accepts strict
+`lin(...)`, `log(...)`, and `values(...)` expressions; the legacy bare tuple
+form is not accepted. Differential-evolution product execution is not yet
+available through version 2 method files.
 
 ## Setting Parameter Behavior
 


### PR DESCRIPTION
Closes #683.

## Summary

- Make the canonical `MethodPlan` and its effective method semantics the authority for per-step parameter roles.
- Compile active parameterization directly from the sealed parameter model, canonical role actions, the current committed `AnalysisValues` snapshot, and the selected experiment/profile scope.
- Remove mutable `ParameterStore` `vary`/`expr` inheritance and the old session/store role-synchronization bridge from method execution.
- Keep `AnalysisValues` as the numerical continuity source across accepted steps and role changes.
- Preserve v1 behavior through canonical translation, including implicit role and selection carry-forward, deterministic MC/BS/BSN seed 0, and v1-only MCMC controls.
- Activate v2 ordered role replacement, explicit `ROLES_FROM`, and step-local profile selection.
- Make canonical `StepPlan.statistics` authoritative for both formats; downstream fitting, parameterization, GRID, and statistics dispatch do not branch on `FormatOrigin`.
- Run requested statistics from the accepted aggregate GRID result for both v1 and v2. V2 explicit seeds remain exact, while omitted v2 evidence seeds are resolved once and recorded.

The duplicate `ParameterStore` value authority remains intentionally in place; #684 owns its removal. Differential-evolution product execution remains intentionally unconnected; #682 owns that work.

## Compatibility and scientific impact

- Existing v1 method files retain their established inheritance, deterministic resampling seed 0, optional MCMC seed behavior, v1-only MCMC controls, CLI, TOML, parameter-ID, and output-path behavior.
- V2 starting values always come from the latest accepted `AnalysisValues`, independently of role inheritance.
- Failed or interrupted steps cannot leave mutable role state for later steps or retries.
- Optimizer mathematics, calculated intensities, residual conventions, parameter IDs, and scientific reference values are unchanged.
- A product regression verifies committed-value continuity through a role change at `1e-12` relative tolerance.

## Validation

- Full suite: `1126 passed in 162.97s`
- Focused canonical method/GRID/statistics/resampling/MCMC suite: `314 passed in 32.58s`
- Ruff lint: passed
- Ruff formatting: `391 files already formatted`
- `ty check`: passed
- `git diff --check`: passed
- `uv build`: source distribution and wheel passed
- Graphify knowledge graph refreshed
- Docusaurus production build: passed

`npm ci` reported 29 dependency audit findings (9 moderate, 20 high). These are pre-existing and non-blocking for this PR; no website dependency or lock file was changed.

## Documentation

The method-file guide now documents v1 versus v2 inheritance, ordered v2 roles, `ROLES_FROM`, step-local selection, strict v2 GRID expressions, and the canonical GRID-plus-statistics workflow for both formats. Shipped examples remain v1 intentionally.
