### PR TITLE
Make AnalysisValues the runtime value authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,14 +102,14 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   `set_param_values`, `set_param_defaults`, `fix_all_parameters`,
   `reset_parameters`) left over from the `AnalysisSession` migration. Internal
   callers now use the canonical short method names
-  (`add_multiple`/`add_multiple_mf`, `sort`, `set_values`, `set_defaults`,
-  `fix_all`, `reset`); parameter semantics and fit/simulate behavior are
-  unchanged.
+  (`add_multiple`/`add_multiple_mf`, `sort`, `set_defaults`, `fix_all`,
+  `reset`); parameter semantics and fit/simulate behavior are unchanged.
 - Kept `AnalysisSession` at the `run_methods` orchestration boundary so native
   deterministic steps can use revisioned analysis values and stale-safe commit;
-  lower-level output helpers still access parameters through
-  `Experiments.parameter_store`, and statistics execution still receives the
-  session's explicit `ExecutionSettings`.
+  experiments now own profiles and their direct required IDs, while runtime and
+  output consumers receive sealed metadata plus committed or resolved values
+  explicitly. Statistics execution still receives the session's explicit
+  `ExecutionSettings`.
 
 ## [2026.06.1] - 2026-06-26
 

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -3,7 +3,7 @@
 import os
 import sys
 from argparse import Namespace
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from chemex.cli import build_parser
 from chemex.configuration.method_plan import (
@@ -12,7 +12,7 @@ from chemex.configuration.method_plan import (
     MethodPlan,
     StepPlan,
 )
-from chemex.configuration.methods import Methods, Selection, read_method_plan
+from chemex.configuration.methods import Method, Methods, Selection, read_method_plan
 from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
 from chemex.experiments.builder import build_experiments
@@ -42,11 +42,27 @@ def run_fit(
     *,
     argv: Sequence[str] | None = None,
     methods: Methods | MethodPlan | None = None,
+    brute_steps: Mapping[str, float],
 ) -> None:
     if methods is None:
         methods = _read_fit_methods(args)
 
-    write_run_info(args, experiments, argv=argv)
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    if parameter_model is None:
+        raise RuntimeError("Native parameter model is unavailable")
+    starting_values = session.analysis_values.snapshot()
+    starting_parameterization = session.compile_parameterization(
+        Method(),
+        experiments.param_ids,
+    )
+    write_run_info(
+        args,
+        parameter_model=parameter_model,
+        parameterization=starting_parameterization,
+        starting_values=starting_values,
+        brute_steps=brute_steps,
+        argv=argv,
+    )
 
     try:
         invalidate_planned_outputs(methods, args.output)
@@ -83,13 +99,21 @@ def run_sim(
     path = args.output
     plot = args.plot == "normal"
 
-    session.parameters.fix_all()
-    resolved_values = session.resolve_current_values(experiments.param_ids)
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    if parameter_model is None:
+        raise RuntimeError("Native parameter model is unavailable")
+    snapshot = session.analysis_values.snapshot()
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    resolved_values = parameterization.resolve(
+        parameterization.frame_from_snapshot(snapshot)
+    )
 
     execute_simulation(
         experiments,
         path,
         parameter_values=resolved_values,
+        parameter_model=parameter_model,
+        parameterization=parameterization,
         plot=plot,
     )
 
@@ -132,16 +156,18 @@ def run(
         print_no_data()
         sys.exit()
 
-    if experiments.parameter_store is not session.parameters:
-        msg = "Experiments parameter store does not match the active session"
-        raise ValueError(msg)
-
     methods = _read_fit_methods(args) if args.commands == "fit" else None
 
     # Read initial values of fitting/fixed parameters
     print_reading_defaults()
     defaults = read_defaults(args.parameters)
     session.parameters.set_defaults(defaults)
+    configured_parameters = session.parameters.get_parameters(experiments.param_ids)
+    brute_steps = {
+        param_id: parameter.brute_step
+        for param_id, parameter in configured_parameters.items()
+        if parameter.brute_step is not None
+    }
     if not session.try_build_analysis_values():
         construction_error = getattr(
             session.parameter_factory,
@@ -159,7 +185,14 @@ def run(
     if args.commands == "simulate":
         run_sim(args, experiments, session)
     else:
-        run_fit(args, experiments, session, argv=argv, methods=methods)
+        run_fit(
+            args,
+            experiments,
+            session,
+            argv=argv,
+            methods=methods,
+            brute_steps=brute_steps,
+        )
 
 
 def main() -> None:

--- a/src/chemex/containers/experiment.py
+++ b/src/chemex/containers/experiment.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from chemex.configuration.methods import Selection
 from chemex.containers.profile import Profile
-from chemex.parameters.database import ParameterStore
 from chemex.parameters.spin_system import Group
 from chemex.plotters.plotter import Plotter
 from chemex.printers.data import Printer
@@ -43,7 +42,6 @@ class Experiment:
     filtered_profiles: list[Profile] = field(init=False, default_factory=list)
     printer: Printer
     plotter: Plotter
-    parameter_store: ParameterStore = field(compare=False)
     _noise_notices: tuple[NoiseEstimateNotice, ...] = field(
         init=False,
         repr=False,
@@ -146,7 +144,6 @@ class Experiment:
             profiles,
             self.printer,
             self.plotter,
-            self.parameter_store,
         )
 
     def bootstrap(self) -> Self:
@@ -157,7 +154,6 @@ class Experiment:
             profiles,
             self.printer,
             self.plotter,
-            self.parameter_store,
         )
 
     def bootstrap_ns(self, groups: list[Group]) -> Self:
@@ -174,7 +170,6 @@ class Experiment:
             profiles_bs_ns,
             self.printer,
             self.plotter,
-            self.parameter_store,
         )
 
     @property
@@ -182,27 +177,9 @@ class Experiment:
         return {profile.spin_system.groups["i"] for profile in self.profiles}
 
     @property
-    def param_id_sets(self) -> list[set[str]]:
-        return [
-            set(self.parameter_store.get_parameters(profile.param_ids))
-            for profile in self.profiles
-        ]
-
-    def get_relevant_subset(self, param_ids: set[str]) -> Self:
-        profiles = [
-            profile
-            for profile in self.profiles
-            if set(self.parameter_store.get_parameters(profile.param_ids)) & param_ids
-        ]
-
-        return type(self)(
-            self.filename,
-            self.name,
-            profiles,
-            self.printer,
-            self.plotter,
-            self.parameter_store,
-        )
+    def _required_param_id_sets(self) -> list[set[str]]:
+        """Return direct profile requirements without expanding constraints."""
+        return [set(profile.param_ids) for profile in self.profiles]
 
     def __iter__(self) -> Iterator[Profile]:
         yield from self.profiles

--- a/src/chemex/containers/experiments.py
+++ b/src/chemex/containers/experiments.py
@@ -9,12 +9,11 @@ from hashlib import blake2b
 from itertools import chain
 from pathlib import Path
 from random import choices
-from typing import Literal, Self
+from typing import Literal
 
 from chemex.configuration.methods import Selection
 from chemex.containers.experiment import Experiment
 from chemex.messages import print_selecting_profiles
-from chemex.parameters.database import ParameterStore
 from chemex.parameters.spin_system import Group, SpinSystem
 
 # Type definitions
@@ -114,10 +113,9 @@ class Experiments:
     data, plotting, and more.
     """
 
-    def __init__(self, *, parameter_store: ParameterStore) -> None:
+    def __init__(self) -> None:
         """Initialize an empty Experiments collection."""
         self._experiments: dict[Path, Experiment] = {}
-        self.parameter_store = parameter_store
 
     @property
     def groups(self) -> set[Group]:
@@ -213,48 +211,28 @@ class Experiments:
         print_selecting_profiles(len(self))
 
     @property
-    def param_id_sets(self) -> list[set[str]]:
-        """Get a list of parameter ID sets for all experiments.
-
-        Returns:
-            list[set[str]]: List of sets containing parameter IDs.
-
-        """
+    def _required_param_id_sets(self) -> list[set[str]]:
+        """Return direct profile requirements without expanding constraints."""
         return list(
-            chain.from_iterable(experiment.param_id_sets for experiment in self),
+            chain.from_iterable(
+                experiment._required_param_id_sets for experiment in self
+            ),
         )
 
     @property
     def param_ids(self) -> set[str]:
-        """Get a set of all unique parameter IDs across experiments.
+        """Return direct profile requirements for parameterization compilation.
 
-        Returns:
-            set[str]: Set of unique parameter IDs.
+        Constraint dependency closure is owned by ``ActiveParameterization``.
 
         """
         result: set[str] = set()
-        return result.union(*(self.param_id_sets))
+        return result.union(*(self._required_param_id_sets))
 
     def filter_from_values(self, parameter_values: Mapping[str, float]) -> None:
         """Apply all data filters from resolved native parameter values."""
         for experiment in self:
             experiment.filter_from_values(parameter_values)
-
-    def get_relevant_subset(self, param_ids: set[str]) -> Self:
-        """Get a subset of experiments relevant to specified parameter IDs.
-
-        Args:
-            param_ids (set[str]): Parameter IDs to filter experiments.
-
-        Returns:
-            Self: Subset of Experiments relevant to given parameter IDs.
-
-        """
-        relevant_subset = type(self)(parameter_store=self.parameter_store)
-        for experiment in self:
-            if subset := experiment.get_relevant_subset(param_ids):
-                relevant_subset.add(subset)
-        return relevant_subset
 
     def __iter__(self) -> Iterator[Experiment]:
         """Iterate over the experiments in the collection.
@@ -294,7 +272,7 @@ def generate_monte_carlo_experiments(experiments: Experiments) -> Experiments:
         Experiments: Collection with Monte Carlo simulated data.
 
     """
-    experiments_mc = Experiments(parameter_store=experiments.parameter_store)
+    experiments_mc = Experiments()
     for experiment in experiments:
         experiments_mc.add(experiment.monte_carlo())
     return experiments_mc
@@ -310,7 +288,7 @@ def generate_bootstrap_experiments(experiments: Experiments) -> Experiments:
         Experiments: Collection with Bootstrap simulated data.
 
     """
-    experiments_mc = Experiments(parameter_store=experiments.parameter_store)
+    experiments_mc = Experiments()
     for experiment in experiments:
         experiments_mc.add(experiment.bootstrap())
     return experiments_mc
@@ -328,7 +306,7 @@ def generate_bootstrap_ns_experiments(experiments: Experiments) -> Experiments:
     """
     groups = experiments.groups
     groups_bs = choices(tuple(groups), k=len(groups))
-    experiments_bs = Experiments(parameter_store=experiments.parameter_store)
+    experiments_bs = Experiments()
     for experiment in experiments:
         experiments_bs.add(experiment.bootstrap_ns(groups_bs))
     return experiments_bs

--- a/src/chemex/experiments/builder.py
+++ b/src/chemex/experiments/builder.py
@@ -86,14 +86,12 @@ def build_experiments(
     session: AnalysisSession,
 ) -> Experiments:
     """Build all configured Experiments using one session's parameter state."""
-    parameter_store = session.parameters
-
     if not filenames:
         session.parameter_factory.try_seal_definitions()
-        return Experiments(parameter_store=parameter_store)
+        return Experiments()
 
     print_loading_experiments()
-    experiments = Experiments(parameter_store=parameter_store)
+    experiments = Experiments()
 
     for filename in filenames:
         try:
@@ -128,6 +126,6 @@ def build_experiments(
             _print_notice(notice)
         experiments.add(result.experiment)
 
-    parameter_store.sort()
+    session.parameters.sort()
     session.parameter_factory.try_seal_definitions()
     return experiments

--- a/src/chemex/experiments/experiment_types.py
+++ b/src/chemex/experiments/experiment_types.py
@@ -624,7 +624,6 @@ def _build[ConfigT: GenericConfig](
         profiles,
         printer,
         plotter,
-        parameter_store=parameters.parameter_store,
     )
     experiment.estimate_noise(
         config.data.error,

--- a/src/chemex/optimize/gridding.py
+++ b/src/chemex/optimize/gridding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from itertools import combinations, permutations
 from pathlib import Path
@@ -10,7 +11,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.colors import LogNorm
 from matplotlib.pyplot import get_cmap
 
-from chemex.parameters.database import ParameterStore
+from chemex.parameters.name import ParamName
 from chemex.typing import Array
 
 
@@ -81,11 +82,10 @@ def make_grids_nd(
     grids_combined: list[GridResult],
     ndim: int,
     *,
-    parameter_store: ParameterStore,
+    parameter_names: Mapping[str, ParamName],
 ) -> list[GridResult]:
     grids: list[GridResult] = []
-    parameters = parameter_store.get_parameters(grid)
-    ids = sorted(grid, key=lambda x: parameters[x].param_name)
+    ids = sorted(grid, key=parameter_names.__getitem__)
     for selection in combinations(ids, ndim):
         for grid_result in grids_combined:
             if set(selection) <= set(grid_result.grid):
@@ -100,7 +100,8 @@ def plot_grid_1d(
     grids_1d: list[GridResult],
     path: Path,
     *,
-    parameter_store: ParameterStore,
+    parameter_names: Mapping[str, ParamName],
+    accepted_values: Mapping[str, float],
 ) -> None:
     """Visualize the result of the brute force grid search.
 
@@ -112,14 +113,15 @@ def plot_grid_1d(
 
     with PdfPages(str(path / "grid_1d.pdf")) as pdf:
         for grid_result in grids_1d:
-            parameters = parameter_store.get_parameters(grid_result.grid)
             ((id_, values),) = list(grid_result.grid.items())
             _fig, ax = plt.subplots(1, 1)
             ax.plot(values, grid_result.chisqr, "o", ms=3)
-            best_value = parameters[id_].value
-            if best_value is not None:
-                ax.axvline(best_value, ls="dashed", color=(0.5, 0.5, 0.5))
-            ax.set_xlabel(str(parameters[id_].param_name))
+            ax.axvline(
+                accepted_values[id_],
+                ls="dashed",
+                color=(0.5, 0.5, 0.5),
+            )
+            ax.set_xlabel(str(parameter_names[id_]))
             ax.set_ylabel(r"$\chi^{2}$")
             pdf.savefig()
             plt.close()
@@ -129,7 +131,8 @@ def plot_grid_2d(
     grids_2d: list[GridResult],
     path: Path,
     *,
-    parameter_store: ParameterStore,
+    parameter_names: Mapping[str, ParamName],
+    accepted_values: Mapping[str, float],
 ) -> None:
     """Visualize the result of the brute force grid search.
 
@@ -142,16 +145,21 @@ def plot_grid_2d(
 
     with PdfPages(str(path / "grid_2d.pdf")) as pdf:
         for grid_result in grids_2d:
-            parameters = parameter_store.get_parameters(grid_result.grid)
             (id_x, values_x), (id_y, values_y) = grid_result.grid.items()
             fig, ax = plt.subplots(1, 1)
             grid_x, grid_y = np.meshgrid(values_x, values_y)
-            best_value_x = parameters[id_x].value
-            best_value_y = parameters[id_y].value
-            if best_value_x is not None:
-                ax.axvline(best_value_x, ls="dashed", color=(0.5, 0.5, 0.5), zorder=-1)
-            if best_value_y is not None:
-                ax.axhline(best_value_y, ls="dashed", color=(0.5, 0.5, 0.5), zorder=-1)
+            ax.axvline(
+                accepted_values[id_x],
+                ls="dashed",
+                color=(0.5, 0.5, 0.5),
+                zorder=-1,
+            )
+            ax.axhline(
+                accepted_values[id_y],
+                ls="dashed",
+                color=(0.5, 0.5, 0.5),
+                zorder=-1,
+            )
             cs = ax.scatter(
                 grid_x,
                 grid_y,
@@ -161,7 +169,7 @@ def plot_grid_2d(
             )
             cbar = fig.colorbar(cs)
             cbar.set_label(r"$\chi^{2}$")
-            ax.set_xlabel(str(parameters[id_x].param_name))
-            ax.set_ylabel(str(parameters[id_y].param_name))
+            ax.set_xlabel(str(parameter_names[id_x]))
+            ax.set_ylabel(str(parameter_names[id_y]))
             pdf.savefig()
             plt.close()

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -16,8 +16,10 @@ from chemex.optimize.uncertainty import (
     RootAnchoredBlockCovarianceEvidence,
     UncertaintyEvidence,
 )
-from chemex.parameters.database import ParameterStore
-from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    SealedParameterModel,
+)
 from chemex.printers.native_reporting import (
     write_block_uncertainty,
     write_json,
@@ -85,17 +87,21 @@ def _write_files(
     uncertainty_evidence: UncertaintyEvidence | None = None,
     uncertainty_status: tuple[str, str] | None = None,
     block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None,
-    parameterization: ActiveParameterization | None = None,
+    parameter_model: SealedParameterModel,
+    parameter_values: Mapping[str, float],
+    parameterization: ActiveParameterization,
+    fitted_ids: tuple[str, ...] = (),
 ) -> None:
     """Write the results of the fit to output files."""
     print_writing_results(path)
     path.mkdir(parents=True, exist_ok=True)
     write_parameters(
-        experiments,
         path,
-        parameter_store=experiments.parameter_store,
-        uncertainty=uncertainty,
+        parameter_model=parameter_model,
+        parameter_values=parameter_values,
         parameterization=parameterization,
+        fitted_ids=fitted_ids,
+        uncertainty=uncertainty,
     )
     experiments.write(path)
     _write_statistics(
@@ -128,11 +134,20 @@ def _write_files(
 def _write_simulation_files(
     experiments: Experiments,
     path: Path,
+    *,
+    parameter_model: SealedParameterModel,
+    parameter_values: Mapping[str, float],
+    parameterization: ActiveParameterization,
 ) -> None:
     """Write the results of the simulation to output files."""
     print_writing_results(path)
     path.mkdir(parents=True, exist_ok=True)
-    write_parameters(experiments, path, parameter_store=experiments.parameter_store)
+    write_parameters(
+        path,
+        parameter_model=parameter_model,
+        parameter_values=parameter_values,
+        parameterization=parameterization,
+    )
     experiments.write(path)
 
 
@@ -172,7 +187,10 @@ def execute_post_fit(
     uncertainty_evidence: UncertaintyEvidence | None = None,
     uncertainty_status: tuple[str, str] | None = None,
     block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None,
-    parameterization: ActiveParameterization | None = None,
+    parameter_model: SealedParameterModel,
+    parameter_values: Mapping[str, float],
+    parameterization: ActiveParameterization,
+    fitted_ids: tuple[str, ...] = (),
 ) -> None:
     _write_files(
         experiments,
@@ -183,7 +201,10 @@ def execute_post_fit(
         uncertainty_evidence=uncertainty_evidence,
         uncertainty_status=uncertainty_status,
         block_uncertainty=block_uncertainty,
+        parameter_model=parameter_model,
+        parameter_values=parameter_values,
         parameterization=parameterization,
+        fitted_ids=fitted_ids,
     )
     if plot:
         _write_plots(experiments, path)
@@ -194,10 +215,18 @@ def execute_simulation(
     path: Path,
     *,
     parameter_values: Mapping[str, float],
+    parameter_model: SealedParameterModel,
+    parameterization: ActiveParameterization,
     plot: bool = False,
 ) -> None:
     experiments.prepare_for_simulation(parameter_values)
-    _write_simulation_files(experiments, path)
+    _write_simulation_files(
+        experiments,
+        path,
+        parameter_model=parameter_model,
+        parameter_values=parameter_values,
+        parameterization=parameterization,
+    )
     if plot:
         _write_simulation_plots(experiments, path)
 
@@ -205,10 +234,9 @@ def execute_simulation(
 def print_header(
     grid: Iterable[str],
     *,
-    parameter_store: ParameterStore,
+    parameter_names: Mapping[str, object],
 ) -> str:
-    parameters = parameter_store.get_parameters(grid)
-    header_pnames = " ".join(f"{parameters[param_id].param_name}" for param_id in grid)
+    header_pnames = " ".join(f"{parameter_names[param_id]}" for param_id in grid)
     return f"# {header_pnames} [χ²]\n"
 
 

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -26,7 +26,8 @@ from chemex.optimize.native_mcmc import (
 )
 from chemex.optimize.statistics_plot import write_mcmc_plots
 from chemex.optimize.uncertainty import ParameterUnit
-from chemex.parameters.database import ParameterStore
+from chemex.parameters.parameterization import SealedParameterModel
+from chemex.parameters.sealed import parameter_name_from_definition
 from chemex.runtime import ExecutionSettings
 from chemex.typing import Array
 
@@ -144,10 +145,12 @@ def resolve_mcmc_settings(
 
 def _format_parameter_ids(
     parameter_ids: tuple[str, ...],
-    parameter_store: ParameterStore,
+    parameter_model: SealedParameterModel,
 ) -> tuple[str, ...]:
-    parameters = parameter_store.get_parameters(parameter_ids)
-    return tuple(str(parameters[param_id].param_name) for param_id in parameter_ids)
+    return tuple(
+        str(parameter_name_from_definition(parameter_model.definitions[param_id]))
+        for param_id in parameter_ids
+    )
 
 
 def _summarize_chain(
@@ -436,19 +439,21 @@ def _extend_timing_diagnostics(
 def _write_summary(
     result: McmcResult,
     path: Path,
-    parameter_store: ParameterStore,
+    parameter_model: SealedParameterModel,
 ) -> None:
-    parameters = parameter_store.get_parameters(result.var_names)
     lines: list[str] = []
     for summary in result.summary:
-        parameter = parameters[summary.parameter_id]
-        parameter_name = str(parameter.param_name).strip("[]")
+        param_id = summary.parameter_id
+        parameter_name = str(
+            parameter_name_from_definition(parameter_model.definitions[param_id])
+        ).strip("[]")
+        configuration = parameter_model.configuration[param_id]
         lines.extend(
             [
                 f"[{_quote_toml_string(parameter_name)}]",
                 'prior = "uniform"',
-                f"prior_lower = {_format_toml_float(float(parameter.min))}",
-                f"prior_upper = {_format_toml_float(float(parameter.max))}",
+                f"prior_lower = {_format_toml_float(configuration.lower_bound)}",
+                f"prior_upper = {_format_toml_float(configuration.upper_bound)}",
                 'credible_interval = "95% equal-tailed"',
                 f"mean = {_format_toml_float(summary.mean)}",
                 f"standard_deviation = {_format_toml_float(summary.standard_deviation)}",
@@ -483,9 +488,9 @@ def _write_summary(
 def _write_samples(
     result: McmcResult,
     path: Path,
-    parameter_store: ParameterStore,
+    parameter_model: SealedParameterModel,
 ) -> None:
-    parameter_names = _format_parameter_ids(result.var_names, parameter_store)
+    parameter_names = _format_parameter_ids(result.var_names, parameter_model)
     values = np.column_stack((result.samples, result.log_probabilities))
 
     with (path / "samples.tsv").open("w", encoding="utf-8") as fileout:
@@ -496,9 +501,9 @@ def _write_samples(
 def _write_correlations(
     result: McmcResult,
     path: Path,
-    parameter_store: ParameterStore,
+    parameter_model: SealedParameterModel,
 ) -> None:
-    parameter_names = _format_parameter_ids(result.var_names, parameter_store)
+    parameter_names = _format_parameter_ids(result.var_names, parameter_model)
 
     with (path / "correlations.tsv").open("w", encoding="utf-8") as fileout:
         fileout.write("parameter\t" + "\t".join(parameter_names) + "\n")
@@ -515,7 +520,6 @@ def _write_diagnostics(
     result: McmcResult,
     settings: EffectiveMcmcSettings,
     path: Path,
-    parameter_store: ParameterStore,
     timings: Mapping[str, float],
     *,
     engine: str,
@@ -562,7 +566,7 @@ def write_mcmc_outputs(
     result: McmcResult,
     settings: EffectiveMcmcSettings,
     path: Path,
-    parameter_store: ParameterStore,
+    parameter_model: SealedParameterModel,
     timings: dict[str, float] | None = None,
     *,
     engine: str = "native MCMC",
@@ -574,15 +578,15 @@ def write_mcmc_outputs(
     path_mcmc.mkdir(parents=True, exist_ok=True)
 
     phase_start = perf_counter()
-    _write_summary(result, path_mcmc, parameter_store)
+    _write_summary(result, path_mcmc, parameter_model)
     timings["output_summary_seconds"] = perf_counter() - phase_start
 
     phase_start = perf_counter()
-    _write_samples(result, path_mcmc, parameter_store)
+    _write_samples(result, path_mcmc, parameter_model)
     timings["output_samples_seconds"] = perf_counter() - phase_start
 
     phase_start = perf_counter()
-    _write_correlations(result, path_mcmc, parameter_store)
+    _write_correlations(result, path_mcmc, parameter_model)
     timings["output_correlations_seconds"] = perf_counter() - phase_start
 
     phase_start = perf_counter()
@@ -590,7 +594,7 @@ def write_mcmc_outputs(
         result,
         settings,
         path_mcmc,
-        parameter_names=_format_parameter_ids(result.var_names, parameter_store),
+        parameter_names=_format_parameter_ids(result.var_names, parameter_model),
     )
     timings["output_plots_seconds"] = perf_counter() - phase_start
     timings["output_total_seconds"] = perf_counter() - output_start
@@ -604,7 +608,6 @@ def write_mcmc_outputs(
         result,
         settings,
         path_mcmc,
-        parameter_store,
         timings,
         engine=engine,
         root_seed=root_seed,
@@ -766,7 +769,7 @@ def run_native_mcmc(
                 )
                 if invalid
             ),
-            experiments.parameter_store,
+            fit.parameter_model,
         )
         error = ValueError(
             "Native MCMC requires finite lower and upper bounds with lower < upper "
@@ -836,7 +839,7 @@ def run_native_mcmc(
             result,
             effective,
             path,
-            experiments.parameter_store,
+            fit.parameter_model,
             timings=timings,
             engine="native MCMC",
             root_seed=root_seed,

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -1,5 +1,6 @@
 """Production composition for native deterministic method steps."""
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import reduce
 from itertools import product
@@ -11,7 +12,11 @@ import numpy as np
 
 from chemex.configuration.methods import Method
 from chemex.containers.experiments import Experiments
-from chemex.evaluation.native import EvaluationEngine, EvaluationResult
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationResult,
+    ResolvedEvaluationValues,
+)
 from chemex.messages import (
     MinimizationProgressReporter,
     UncertaintyProgressReporter,
@@ -66,7 +71,14 @@ from chemex.optimize.uncertainty import (
     compile_constraint_linearization_capabilities,
     derive_root_anchored_block_covariance,
 )
-from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
+from chemex.parameters.database import ParameterStore
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    ParameterRole,
+    SealedParameterModel,
+)
+from chemex.parameters.sealed import parameter_name_from_definition
+from chemex.parameters.values import AnalysisValues, AnalysisValuesSnapshot
 from chemex.printers.parameters import (
     BOUNDARY_WARNING_TEXT,
     ParameterUncertaintyView,
@@ -89,6 +101,7 @@ class NativeDeterministicFit:
     problem: OptimizationProblem
     parameterization: ActiveParameterization
     engine: EvaluationEngine
+    parameter_model: SealedParameterModel
     uncertainty: UncertaintyEvidence | None = None
     block_uncertainty: RootAnchoredBlockCovarianceEvidence | None = None
 
@@ -394,13 +407,13 @@ def _build_invocation(
     method: Method,
     problem: OptimizationProblem,
     decomposition: FitDecomposition,
-    experiments: Experiments,
+    parameter_store: ParameterStore,
 ) -> tuple[
     MethodStepStrategy,
     GroupedDirectTrfInvocation | GridDirectTrfInvocation,
 ]:
     if method.grid:
-        grid = experiments.parameter_store.parse_grid(method.grid)
+        grid = parameter_store.parse_grid(method.grid)
         invocation = GridDirectTrfInvocation.for_problem(
             problem,
             axes=tuple(
@@ -430,14 +443,18 @@ def _write_grid_output(
     invocation: GridDirectTrfInvocation,
     path: Path,
     *,
-    experiments: Experiments,
+    parameter_model: SealedParameterModel,
+    accepted_values: Mapping[str, float],
 ) -> None:
     """Render aggregate GRID artifacts from native seed evidence."""
     grid = {
         axis.param_id: np.asarray(axis.values, dtype=np.float64)
         for axis in invocation.axes
     }
-    parameter_store = experiments.parameter_store
+    parameter_names = {
+        definition.param_id: parameter_name_from_definition(definition)
+        for definition in parameter_model.definitions
+    }
     grid_path = path / "Grid"
     grid_path.mkdir(parents=True, exist_ok=True)
     component_results: list[GridResult] = []
@@ -472,7 +489,7 @@ def _write_grid_output(
         component_results.append(GridResult(component_grid, chisqr))
 
     with (grid_path / "grid.out").open("w", encoding="utf-8") as output:
-        output.write(print_header(grid, parameter_store=parameter_store))
+        output.write(print_header(grid, parameter_names=parameter_names))
         for attempt in outcome.attempts:
             coordinates = (
                 float(cast("int | float", value))
@@ -486,31 +503,39 @@ def _write_grid_output(
         grid,
         combined,
         1,
-        parameter_store=parameter_store,
+        parameter_names=parameter_names,
     )
     grids_2d = make_grids_nd(
         grid,
         combined,
         2,
-        parameter_store=parameter_store,
+        parameter_names=parameter_names,
     )
-    plot_grid_1d(grids_1d, grid_path, parameter_store=parameter_store)
-    plot_grid_2d(grids_2d, grid_path, parameter_store=parameter_store)
+    plot_grid_1d(
+        grids_1d,
+        grid_path,
+        parameter_names=parameter_names,
+        accepted_values=accepted_values,
+    )
+    plot_grid_2d(
+        grids_2d,
+        grid_path,
+        parameter_names=parameter_names,
+        accepted_values=accepted_values,
+    )
 
 
 def _fit_component_labels(
     decomposition: FitDecomposition,
-    experiments: Experiments,
+    parameter_model: SealedParameterModel,
 ) -> dict[frozenset[str], str]:
     """Return concise optional labels for transient component presentation."""
     try:
         labels: dict[frozenset[str], str] = {}
         for component in decomposition.components:
-            parameters = experiments.parameter_store.get_parameters(
-                component.controlled_ids
-            )
             param_names = tuple(
-                parameter.param_name for parameter in parameters.values()
+                parameter_name_from_definition(parameter_model.definitions[param_id])
+                for param_id in component.controlled_ids
             )
             if param_names:
                 labels[frozenset(component.controlled_ids)] = reduce(
@@ -520,6 +545,24 @@ def _fit_component_labels(
         return {}
     else:
         return labels
+
+
+def _commit_resolved_continuity_if_changed(
+    analysis_values: AnalysisValues,
+    starting_snapshot: AnalysisValuesSnapshot,
+    resolved_values: ResolvedEvaluationValues,
+) -> None:
+    """Commit a successful derived-only transition when its values changed."""
+    resolved_items = resolved_values.ordered_items()
+    if not any(
+        value != starting_snapshot[param_id] for param_id, value in resolved_items
+    ):
+        return
+    analysis_values.commit(
+        dict(resolved_items),
+        expected=starting_snapshot,
+        scope=tuple(resolved_values),
+    )
 
 
 def run_native_deterministic(
@@ -562,8 +605,10 @@ def run_native_deterministic(
             msg = f"Native deterministic evaluation failed: {outcome.lifecycle.value}"
             raise RuntimeError(msg)
         result = cast("EvaluationResult", outcome.evaluation_result)
-        session.sync_parameter_store_from_analysis_values(
-            dict(result.resolved_values.ordered_items())
+        _commit_resolved_continuity_if_changed(
+            session.analysis_values,
+            starting_snapshot,
+            result.resolved_values,
         )
         _materialize_evaluation(experiments, result)
         execute_post_fit(
@@ -572,6 +617,8 @@ def run_native_deterministic(
             plot=plot != "nothing",
             residuals=result.residuals,
             nvarys=0,
+            parameter_model=parameter_model,
+            parameter_values=result.resolved_values,
             parameterization=parameterization,
         )
         return None
@@ -587,7 +634,7 @@ def run_native_deterministic(
         method,
         problem,
         decomposition,
-        experiments,
+        session.parameters,
     )
     uncertainty_request, unsupported_constrained_ids = _product_uncertainty_request(
         problem,
@@ -605,7 +652,7 @@ def run_native_deterministic(
         invocation=invocation,
         derivations=(uncertainty_request,),
     )
-    component_labels = _fit_component_labels(decomposition, experiments)
+    component_labels = _fit_component_labels(decomposition, parameter_model)
     progress = MinimizationProgressReporter(
         console,
         interactive=console.is_terminal,
@@ -731,11 +778,9 @@ def run_native_deterministic(
         problem,
         parameterization,
         engine,
+        parameter_model,
         uncertainty_evidence,
         block_uncertainty,
-    )
-    session.sync_parameter_store_from_analysis_values(
-        dict(result.resolved_values.ordered_items())
     )
     _materialize_evaluation(experiments, result)
     variable_count = len(problem.controlled_ids)
@@ -744,7 +789,8 @@ def run_native_deterministic(
             cast("GroupedGridDirectTrfOutcome", outcome.primary_execution),
             cast("GridDirectTrfInvocation", invocation),
             path,
-            experiments=experiments,
+            parameter_model=parameter_model,
+            accepted_values=result.resolved_values,
         )
         execute_post_fit(
             experiments,
@@ -756,7 +802,10 @@ def run_native_deterministic(
             uncertainty_evidence=uncertainty_evidence,
             uncertainty_status=uncertainty_status,
             block_uncertainty=block_uncertainty,
+            parameter_model=parameter_model,
+            parameter_values=result.resolved_values,
             parameterization=parameterization,
+            fitted_ids=problem.controlled_ids,
         )
         return fit
 
@@ -770,6 +819,9 @@ def run_native_deterministic(
         uncertainty_evidence=uncertainty_evidence,
         uncertainty_status=uncertainty_status,
         block_uncertainty=block_uncertainty,
+        parameter_model=parameter_model,
+        parameter_values=result.resolved_values,
         parameterization=parameterization,
+        fitted_ids=problem.controlled_ids,
     )
     return fit

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -6,7 +6,6 @@ from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 
@@ -25,6 +24,8 @@ from chemex.optimize.native_resampling import (
     execute_resampling_evidence,
 )
 from chemex.optimize.statistics_plot import write_resampling_plots
+from chemex.parameters.parameterization import SealedParameterModel
+from chemex.parameters.sealed import parameter_name_from_definition
 from chemex.runtime import ExecutionSettings
 
 
@@ -80,13 +81,10 @@ def _format_tsv_float(value: float) -> str:
 
 def _format_parameter_names(
     parameter_ids: list[str],
-    parameter_store: Any,
+    parameter_model: SealedParameterModel,
 ) -> tuple[str, ...]:
-    if not hasattr(parameter_store, "get_parameters"):
-        return tuple(parameter_ids)
-    parameters = parameter_store.get_parameters(parameter_ids)
     return tuple(
-        str(parameters[param_id].param_name) if param_id in parameters else param_id
+        str(parameter_name_from_definition(parameter_model.definitions[param_id]))
         for param_id in parameter_ids
     )
 
@@ -354,9 +352,7 @@ def _run_native_resampling_method(
     statistic_path.mkdir(parents=True, exist_ok=True)
     _clear_native_statistics_artifacts(statistic_path)
     parameter_ids = fit.accepted.controlled_ids
-    parameter_names = _format_parameter_names(
-        list(parameter_ids), experiments.parameter_store
-    )
+    parameter_names = _format_parameter_names(list(parameter_ids), fit.parameter_model)
     worker_count = min(execution.workers, method.iterations)
     _write_native_state_diagnostics(
         statistic_path,

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -204,25 +204,8 @@ class ParameterCatalog:
         """
         return self._index.get_matching_ids(param_name)
 
-    def get_value(self, id_: str) -> float | None:
-        """Retrieve the value of a parameter by its ID.
-
-        Args:
-            id_ (str): The ID of the parameter.
-
-        Returns:
-            float | None: The value of the parameter, or None if not found.
-
-        """
-        return self._parameters[id_].value
-
-    def set_values(self, par_values: dict[str, float]) -> None:
-        """Set the values of specified parameters.
-
-        Args:
-            par_values (dict[str, float]): Dictionary of parameter IDs and values.
-
-        """
+    def _set_values(self, par_values: Mapping[str, float]) -> None:
+        """Apply construction-time auxiliary values before configuration sealing."""
         for id_, value in par_values.items():
             if id_ in self._parameters:
                 self._parameters[id_].value = value
@@ -518,7 +501,7 @@ class ParameterStore:
         return self._defaults_applied
 
     def lock_configuration(self) -> None:
-        """Reject later definition/default mutations while values remain mutable."""
+        """Reject later definition and configuration mutations."""
         self._configuration_locked = True
 
     def _ensure_configuration_open(self) -> None:
@@ -560,30 +543,9 @@ class ParameterStore:
         """
         return self.database.get_parameters(param_ids)
 
-    def get_value(self, param_id: str) -> float | None:
-        """Retrieve the value of a parameter by its ID from the active catalog.
-
-        Args:
-            param_id (str): ID of the parameter.
-
-        Returns:
-            float | None: The value of the parameter or None if not found.
-
-        """
-        return self.database.get_value(param_id)
-
     def sort(self) -> None:
         """Sort parameters in the active catalog."""
         self.database.sort()
-
-    def set_values(self, par_values: dict[str, float]) -> None:
-        """Set the values of specific parameters in the active catalog.
-
-        Args:
-            par_values (dict[str, float]): Parameter values to set.
-
-        """
-        self.database.set_values(par_values)
 
     def set_defaults(self, defaults: DefaultListType) -> None:
         """Set defaults for parameters in both catalogs.
@@ -617,7 +579,7 @@ class ParameterStore:
         if not self._defaults_applied:
             msg = "Parameter defaults must be parsed before model-free initialization"
             raise RuntimeError(msg)
-        self._database.set_values(dict(values))
+        self._database._set_values(values)
         self._database.set_defaults(self._defaults)
         self._database.check_params()
 

--- a/src/chemex/parameters/sealed.py
+++ b/src/chemex/parameters/sealed.py
@@ -1,7 +1,7 @@
 """Canonical immutable parameter definitions and per-analysis configuration.
 
-These ChemEx-native objects are constructed beside the legacy mutable catalog.
-The legacy execution path remains authoritative at this migration checkpoint.
+The mutable catalog supplies construction inputs; sealed metadata and
+``AnalysisValues`` supply post-construction runtime state.
 """
 
 from __future__ import annotations
@@ -275,13 +275,18 @@ def _equal(left: object, right: object) -> bool:
     return left == right
 
 
-def _definition_sort_key(definition: ParamDefinition) -> ParamName:
-    """Reproduce the legacy-authoritative ``ParamName`` ordering exactly."""
+def parameter_name_from_definition(definition: ParamDefinition) -> ParamName:
+    """Reconstruct the canonical presentation name from sealed metadata."""
     return ParamName(
         definition.name,
         SpinSystem.from_name(definition.spin_system_name),
         Conditions.model_construct(None, **dict(definition.condition_entries)),
     )
+
+
+def _definition_sort_key(definition: ParamDefinition) -> ParamName:
+    """Reproduce the established ``ParamName`` ordering exactly."""
+    return parameter_name_from_definition(definition)
 
 
 class InvalidConstructionError(ValueError):

--- a/src/chemex/printers/parameters.py
+++ b/src/chemex/printers/parameters.py
@@ -2,20 +2,21 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from chemex.containers.experiments import Experiments
 from chemex.optimize.uncertainty import (
     UncertaintyEvidence,
     UncertaintyUnavailableKind,
 )
-from chemex.parameters.database import ParameterStore
 from chemex.parameters.name import ParamName
-from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
-from chemex.parameters.setting import ParamSetting
-
-Parameters = dict[ParamName, ParamSetting]
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    ParameterRole,
+    SealedParameterModel,
+)
+from chemex.parameters.sealed import parameter_name_from_definition
 
 RE_GROUPNAME = re.compile(r"^[A-Za-z0-9_-]+$")
 
@@ -194,6 +195,18 @@ def parameter_uncertainty_view(
     )
 
 
+@dataclass(frozen=True, slots=True)
+class ReportParameter:
+    """One disposable presentation row joined from sealed metadata and values."""
+
+    param_id: str
+    param_name: ParamName
+    value: float
+
+
+type Parameters = dict[ParamName, ReportParameter]
+
+
 @dataclass
 class GlobalLocalParameters:
     global_: Parameters
@@ -211,10 +224,10 @@ class ClassifiedParameters:
 
 
 def _format_fitted(
-    param_id: str,
-    param: ParamSetting,
+    param: ReportParameter,
     uncertainty: ParameterUncertaintyView | None,
 ) -> str:
+    param_id = param.param_id
     standard_error = (
         None if uncertainty is None else uncertainty.standard_error(param_id)
     )
@@ -231,15 +244,11 @@ def _format_fitted(
 
 
 def _format_constrained(
-    param_id: str,
-    param: ParamSetting,
-    parameter_store: ParameterStore,
+    param: ReportParameter,
     uncertainty: ParameterUncertaintyView | None,
-    constraint_expression: str | None = None,
+    constraint_expression: str,
 ) -> str:
-    if param.value is None:
-        return ""
-
+    param_id = param.param_id
     standard_error = (
         None if uncertainty is None else uncertainty.standard_error(param_id)
     )
@@ -252,72 +261,53 @@ def _format_constrained(
         if reason is not None
         else ""
     )
-    constraint = param.expr if constraint_expression is None else constraint_expression
-    if constraint_expression is None:
-        parameters = parameter_store.get_parameters(param.dependencies)
-        for param_id, parameter in parameters.items():
-            constraint = constraint.replace(param_id, str(parameter.param_name))
-    return f"{param.value: .5e} # {error}({constraint})"
+    return f"{param.value: .5e} # {error}({constraint_expression})"
 
 
-def _format_fixed(param: ParamSetting) -> str:
+def _format_fixed(param: ReportParameter) -> str:
     return f"{param.value: .5e} # (fixed)"
 
 
 def _params_to_strings(
     parameters: GlobalLocalParameters,
     status: str,
-    parameter_store: ParameterStore,
-    parameter_ids: dict[ParamName, str],
     uncertainty: ParameterUncertaintyView | None,
-    constraint_expressions: dict[str, str] | None,
+    constraint_expressions: Mapping[str, str],
 ) -> dict[str, dict[str, str]]:
     result: defaultdict[str, dict[str, str]] = defaultdict(dict)
 
     for pname, param in parameters.global_.items():
         result["GLOBAL"][pname.section_res] = _format_parameter(
-            parameter_ids[pname],
             param,
             status,
-            parameter_store,
             uncertainty,
-            None
-            if constraint_expressions is None
-            else constraint_expressions.get(parameter_ids[pname]),
+            constraint_expressions.get(param.param_id, ""),
         )
 
     for pname, param in parameters.local.items():
         result[pname.section][str(pname.spin_system)] = _format_parameter(
-            parameter_ids[pname],
             param,
             status,
-            parameter_store,
             uncertainty,
-            None
-            if constraint_expressions is None
-            else constraint_expressions.get(parameter_ids[pname]),
+            constraint_expressions.get(param.param_id, ""),
         )
 
     return result
 
 
 def _format_parameter(
-    param_id: str,
-    param: ParamSetting,
+    param: ReportParameter,
     status: str,
-    parameter_store: ParameterStore,
     uncertainty: ParameterUncertaintyView | None,
-    constraint_expression: str | None = None,
+    constraint_expression: str = "",
 ) -> str:
     if status == "fitted":
-        return _format_fitted(param_id, param, uncertainty)
+        return _format_fitted(param, uncertainty)
     if status == "fixed":
         return _format_fixed(param)
     if status == "constrained":
         return _format_constrained(
-            param_id,
             param,
-            parameter_store,
             uncertainty,
             constraint_expression,
         )
@@ -350,27 +340,17 @@ def write_file(
     parameters: GlobalLocalParameters,
     status: str,
     path: Path,
-    parameter_store: ParameterStore,
-    parameter_ids: dict[ParamName, str] | None = None,
     uncertainty: ParameterUncertaintyView | None = None,
-    constraint_expressions: dict[str, str] | None = None,
+    constraint_expressions: Mapping[str, str] | None = None,
 ) -> None:
     if not parameters:
         return
 
-    ids = (
-        {pname: parameter.id_ for pname, parameter in parameters.global_.items()}
-        | {pname: parameter.id_ for pname, parameter in parameters.local.items()}
-        if parameter_ids is None
-        else parameter_ids
-    )
     par_strings = _params_to_strings(
         parameters,
         status,
-        parameter_store,
-        ids,
         uncertainty,
-        constraint_expressions,
+        {} if constraint_expressions is None else constraint_expressions,
     )
     formatted_strings = _format_strings(par_strings)
     filename = path / f"{status}.toml"
@@ -391,36 +371,31 @@ def classify_global(parameters: Parameters) -> GlobalLocalParameters:
 
 
 def classify_parameters(
-    experiments: Experiments,
-    parameter_store: ParameterStore,
-    parameterization: ActiveParameterization | None = None,
+    parameter_model: SealedParameterModel,
+    parameter_values: Mapping[str, float],
+    parameterization: ActiveParameterization,
+    fitted_ids: tuple[str, ...],
 ) -> ClassifiedParameters:
-    param_ids = experiments.param_ids
     parameters = {
-        param.param_name: param
-        for param in parameter_store.get_parameters(param_ids).values()
+        parameter_name_from_definition(definition): ReportParameter(
+            definition.param_id,
+            parameter_name_from_definition(definition),
+            parameter_values[definition.param_id],
+        )
+        for definition in parameter_model.definitions
+        if definition.param_id in parameterization.scope_ids
     }
-
-    if parameterization is None:
-        constrained = {
-            pname: param for pname, param in parameters.items() if param.expr
-        }
-        fitted = {
-            pname: param
-            for pname, param in parameters.items()
-            if param.vary and pname not in constrained
-        }
-    else:
-        constrained = {
-            pname: param
-            for pname, param in parameters.items()
-            if parameterization.role(param.id_) is ParameterRole.DERIVED
-        }
-        fitted = {
-            pname: param
-            for pname, param in parameters.items()
-            if parameterization.role(param.id_) is ParameterRole.FIT
-        }
+    fitted_id_set = set(fitted_ids)
+    constrained = {
+        pname: param
+        for pname, param in parameters.items()
+        if parameterization.role(param.param_id) is ParameterRole.DERIVED
+    }
+    fitted = {
+        pname: param
+        for pname, param in parameters.items()
+        if param.param_id in fitted_id_set
+    }
 
     fixed_ids = set(parameters) - set(fitted) - set(constrained)
     fixed = {
@@ -437,57 +412,66 @@ def classify_parameters(
 
 
 def write_parameters(
-    experiments: Experiments,
     path: Path,
-    parameter_store: ParameterStore,
+    *,
+    parameter_model: SealedParameterModel,
+    parameter_values: Mapping[str, float],
+    parameterization: ActiveParameterization,
+    fitted_ids: tuple[str, ...] = (),
     uncertainty: ParameterUncertaintyView | None = None,
-    parameterization: ActiveParameterization | None = None,
 ) -> None:
     """Write the model parameter values and their uncertainties to a file."""
     path_par = path / "Parameters"
     path_par.mkdir(parents=True, exist_ok=True)
     classified_parameters = classify_parameters(
-        experiments,
-        parameter_store,
+        parameter_model,
+        parameter_values,
         parameterization,
+        fitted_ids,
     )
-    constraint_expressions = (
-        None
-        if parameterization is None
-        else {
-            item.target_id: item.expression_text
-            for item in parameterization.program.constraints
-            if item.source.startswith("method-rule:")
-        }
-    )
-    parameter_ids = {
-        parameter.param_name: param_id
-        for param_id, parameter in parameter_store.get_parameters(
-            experiments.param_ids
-        ).items()
+    names = {
+        definition.param_id: parameter_name_from_definition(definition)
+        for definition in parameter_model.definitions
+    }
+    constraint_expressions = {
+        item.target_id: _replace_parameter_ids(item.expression_text, names)
+        for item in parameterization.program.constraints
     }
 
     write_file(
         classified_parameters.fitted,
         "fitted",
         path_par,
-        parameter_store,
-        parameter_ids,
         uncertainty,
     )
     write_file(
         classified_parameters.fixed,
         "fixed",
         path_par,
-        parameter_store,
-        parameter_ids,
     )
     write_file(
         classified_parameters.constrained,
         "constrained",
         path_par,
-        parameter_store,
-        parameter_ids,
         uncertainty,
         constraint_expressions,
+    )
+
+
+def _replace_parameter_ids(
+    expression: str,
+    parameter_names: Mapping[str, ParamName],
+) -> str:
+    """Render stable IDs in one constraint using sealed presentation names."""
+    if not parameter_names:
+        return expression
+    pattern = re.compile(
+        "|".join(
+            re.escape(param_id)
+            for param_id in sorted(parameter_names, key=len, reverse=True)
+        )
+    )
+    return pattern.sub(
+        lambda match: str(parameter_names[match.group(0)]),
+        expression,
     )

--- a/src/chemex/run_info.py
+++ b/src/chemex/run_info.py
@@ -20,7 +20,6 @@ from typing import Literal, cast
 
 from chemex import __version__
 from chemex.atomic import publish_directory_noreplace, write_text_atomic
-from chemex.containers.experiments import Experiments
 from chemex.native_provenance import (
     ArtifactReference,
     ArtifactRole,
@@ -32,9 +31,11 @@ from chemex.native_provenance import (
     serialize_independent_parameters,
     validate_native_step_manifest_bytes,
 )
-from chemex.parameters.database import ParameterStore
-from chemex.parameters.parameterization import SealedParameterModel
-from chemex.parameters.setting import ParamSetting
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    SealedParameterModel,
+)
+from chemex.parameters.sealed import parameter_name_from_definition
 from chemex.parameters.values import AnalysisValuesSnapshot
 
 SCHEMA_VERSION = 1
@@ -259,42 +260,49 @@ def _format_float(value: float | None) -> str:
     return "nan" if value is None else repr(float(value))
 
 
-def _parameter_values(parameter: ParamSetting) -> str:
+def _parameter_values(
+    param_id: str,
+    parameter_model: SealedParameterModel,
+    starting_values: AnalysisValuesSnapshot,
+    brute_steps: Mapping[str, float],
+) -> str:
+    configuration = parameter_model.configuration[param_id]
     values = [
-        _format_float(parameter.value),
-        _format_float(parameter.min),
-        _format_float(parameter.max),
+        _format_float(starting_values[param_id]),
+        _format_float(configuration.lower_bound),
+        _format_float(configuration.upper_bound),
     ]
-    if parameter.brute_step is not None:
-        values.append(_format_float(parameter.brute_step))
+    if param_id in brute_steps:
+        values.append(_format_float(brute_steps[param_id]))
     return "[" + ", ".join(values) + "]"
 
 
 def _parameter_sections(
-    experiments: Experiments,
-    parameter_store: ParameterStore,
-) -> Mapping[str, Mapping[str, ParamSetting]]:
-    sections: defaultdict[str, dict[str, ParamSetting]] = defaultdict(dict)
-    parameters = parameter_store.get_parameters(experiments.param_ids)
-
-    for parameter in sorted(parameters.values(), key=lambda item: item.param_name):
-        if parameter.expr:
+    parameter_model: SealedParameterModel,
+    parameterization: ActiveParameterization,
+) -> Mapping[str, Mapping[str, str]]:
+    sections: defaultdict[str, dict[str, str]] = defaultdict(dict)
+    independent_ids = set(parameterization.independent_ids)
+    for definition in parameter_model.definitions:
+        if definition.param_id not in independent_ids:
             continue
-        param_name = parameter.param_name
+        param_name = parameter_name_from_definition(definition)
         if param_name.spin_system:
             section = param_name.section
             key = str(param_name.spin_system)
         else:
             section = "GLOBAL"
             key = param_name.section_res
-        sections[section][key] = parameter
+        sections[section][key] = definition.param_id
 
     return sections
 
 
 def _serialize_parameters(
-    experiments: Experiments,
-    parameter_store: ParameterStore,
+    parameter_model: SealedParameterModel,
+    parameterization: ActiveParameterization,
+    starting_values: AnalysisValuesSnapshot,
+    brute_steps: Mapping[str, float],
 ) -> str:
     lines = [
         "# Starting independent parameters used by ChemEx for this fit.",
@@ -307,13 +315,14 @@ def _serialize_parameters(
     ]
 
     for section, parameters in _parameter_sections(
-        experiments,
-        parameter_store,
+        parameter_model,
+        parameterization,
     ).items():
         lines.append(f"[{_quote_key(section)}]")
         lines.extend(
-            f"{_quote_key(key)} = {_parameter_values(parameter)}"
-            for key, parameter in parameters.items()
+            f"{_quote_key(key)} = "
+            f"{_parameter_values(param_id, parameter_model, starting_values, brute_steps)}"
+            for key, param_id in parameters.items()
         )
         lines.append("")
 
@@ -634,8 +643,11 @@ def write_run_outcome(
 
 def write_run_info(
     args: Namespace,
-    experiments: Experiments,
     *,
+    parameter_model: SealedParameterModel,
+    parameterization: ActiveParameterization,
+    starting_values: AnalysisValuesSnapshot,
+    brute_steps: Mapping[str, float],
     argv: Sequence[str] | None = None,
     working_directory: Path | None = None,
     timestamp: datetime | None = None,
@@ -659,8 +671,10 @@ def write_run_info(
         staging_path = Path(staging_directory)
         copied_inputs = _copy_inputs(input_files, staging_path)
         parameters_text = _serialize_parameters(
-            experiments,
-            experiments.parameter_store,
+            parameter_model,
+            parameterization,
+            starting_values,
+            brute_steps,
         )
         (staging_path / "parameters_used.toml").write_text(
             parameters_text,

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -132,10 +132,6 @@ class AnalysisSession:
                 configuration,
                 _native_initial_values=initial_values,
             )
-            resolved_values = self.resolve_current_values(
-                set(parameter_model.declarations)
-            )
-            self.sync_parameter_store_from_analysis_values(dict(resolved_values))
         except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
             self.parameter_factory.disable_native_candidate(error)
             return False
@@ -196,18 +192,6 @@ class AnalysisSession:
         parameterization = self.compile_parameterization(Method(), required_ids)
         frame = parameterization.frame_from_snapshot(self.analysis_values.snapshot())
         return parameterization.resolve(frame)
-
-    def sync_parameter_store_from_analysis_values(
-        self,
-        resolved_values: dict[str, float] | None = None,
-    ) -> None:
-        """Mirror committed and resolved native values into current output state."""
-        snapshot = self.analysis_values.snapshot()
-        values = dict(snapshot.items()) if resolved_values is None else resolved_values
-        parameters = self.parameters.get_parameters(values)
-        for parameter in parameters.values():
-            parameter.stderr = None
-        self.parameters.database.set_values(values)
 
 
 def ensure_plugins_registered() -> None:

--- a/tests/experiments/test_experiment_types.py
+++ b/tests/experiments/test_experiment_types.py
@@ -368,7 +368,7 @@ def test_representative_family_builds_complete_experiment(
     assert result.experiment.profiles
     assert isinstance(result.experiment.printer, printer_type)
     assert isinstance(result.experiment.plotter, plotter_type)
-    assert result.experiment.parameter_store is session.parameters
+    assert not hasattr(result.experiment, "parameter_store")
 
 
 def test_exsy_explicit_support_builds_complete_experiment(tmp_path: Path) -> None:
@@ -450,7 +450,7 @@ def test_selection_precedes_profile_and_parameter_construction(
     assert excluded_session.parameters.get_parameters(expected_parameter_ids) == {}
 
 
-def test_cpmg_parameter_ids_identity_and_mutation_remain_stable() -> None:
+def test_cpmg_parameter_ids_and_construction_identity_remain_stable() -> None:
     register_experiments()
     filename = ROOT / "examples/Experiments/CPMG_15N_IP/Experiments/500mhz.toml"
     selection = Selection(
@@ -484,8 +484,6 @@ def test_cpmg_parameter_ids_identity_and_mutation_remain_stable() -> None:
 
     parameter_id = "__R2_A_10N_500_0MHZ"
     parameter = session.parameters.get_parameters([parameter_id])[parameter_id]
-    session.parameters.set_values({parameter_id: 17.25})
-
     second = experiment_types.build(
         source,
         selection=selection,
@@ -496,7 +494,7 @@ def test_cpmg_parameter_ids_identity_and_mutation_remain_stable() -> None:
 
     assert second.experiment.profiles[0].param_ids == expected_ids
     assert rebuilt_parameter is parameter
-    assert rebuilt_parameter.value == pytest.approx(17.25)
+    assert rebuilt_parameter.value == parameter.value
 
 
 def test_programming_error_from_catalog_adapter_propagates(

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -29,7 +29,6 @@ from chemex.configuration.methods import McmcSettings, Method, Selection, Statis
 from chemex.experiments import builder as builder_module
 from chemex.nmr.basis import Basis
 from chemex.optimize import fitting as fitting_module
-from chemex.optimize import helper as helper_module
 from chemex.optimize import resampling as resampling_module
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
@@ -70,6 +69,21 @@ class StubParameters:
     def sort(self) -> None:
         self.sort_calls += 1
 
+    def get_parameters(self, _param_ids: object) -> dict[str, ParamSetting]:
+        return {}
+
+
+class StubParameterization:
+    independent_ids: tuple[str, ...] = ()
+
+    @staticmethod
+    def frame_from_snapshot(snapshot: object) -> object:
+        return snapshot
+
+    @staticmethod
+    def resolve(_frame: object) -> dict[str, float]:
+        return {}
+
 
 class StubParameterFactory:
     def __init__(self) -> None:
@@ -77,6 +91,7 @@ class StubParameterFactory:
         self.seal_definition_calls = 0
         self.seal_configuration_calls = 0
         self.native_sealing_succeeds = True
+        self.sealed_parameter_model = object()
 
     def clear_cache(self) -> None:
         self.clear_calls += 1
@@ -99,6 +114,7 @@ class StubSession:
         self.model = SimpleNamespace(spec=object())
         self.model_names: list[str] = []
         self.parameter_factory = StubParameterFactory()
+        self.analysis_values = SimpleNamespace(snapshot=lambda: object())
         self.execution = ExecutionSettings()
         self.build_analysis_values_calls = 0
 
@@ -112,40 +128,21 @@ class StubSession:
     def resolve_current_values(self, _required_ids: set[str]) -> dict[str, float]:
         return {}
 
+    def compile_parameterization(
+        self,
+        _method: Method,
+        _required_ids: set[str],
+    ) -> StubParameterization:
+        return StubParameterization()
+
     def validate_method_plan(self, _plan: MethodPlan) -> None:
         return None
 
 
-class WriterParameterStore:
-    def __init__(self, parameters: dict[str, ParamSetting]) -> None:
-        self.parameters = parameters
-
-    def get_parameters(self, param_ids: object) -> dict[str, ParamSetting]:
-        return {
-            param_id: parameter
-            for param_id, parameter in self.parameters.items()
-            if param_id in set(param_ids)
-        }
-
-
-class StatisticsParameterStore(StubParameters):
-    def get_parameters(self, param_ids: object) -> dict[str, ParamSetting]:
-        parameters = {
-            "__PB": ParamSetting(ParamName("PB"), value=0.15, vary=True),
-            "__KEX_AB": ParamSetting(ParamName("KEX_AB"), value=250.0, vary=True),
-        }
-        return {
-            param_id: parameter
-            for param_id, parameter in parameters.items()
-            if param_id in set(param_ids)
-        }
-
-
 class FakeExperiments:
-    def __init__(self, parameter_store: object | None = None) -> None:
+    def __init__(self) -> None:
         self.filtered = 0
         self.selections: list[Selection] = []
-        self.parameter_store = parameter_store
         self.param_ids: set[str] = set()
 
     def filter(self) -> None:
@@ -162,8 +159,8 @@ class FakeExperiments:
 
 
 class EmptyAfterSelectExperiments(FakeExperiments):
-    def __init__(self, parameter_store: object | None = None) -> None:
-        super().__init__(parameter_store=parameter_store)
+    def __init__(self) -> None:
+        super().__init__()
         self.has_profiles = True
 
     def select(self, selection: Selection) -> None:
@@ -283,7 +280,7 @@ def test_ensure_plugins_registered_runs_once(monkeypatch: pytest.MonkeyPatch) ->
     np.testing.assert_equal(calls, ["models", "experiments"])
 
 
-def test_build_experiments_uses_session_parameter_store(
+def test_build_experiments_uses_session_construction_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = StubSession()
@@ -347,7 +344,7 @@ def test_run_uses_explicit_session_for_fit_flow(
 ) -> None:
     defaults = object()
     session = StubSession()
-    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments = FakeExperiments()
     recorded: dict[str, object] = {}
     recorded_env: dict[str, str] = {}
 
@@ -417,7 +414,7 @@ def test_run_fails_closed_when_native_configuration_is_unavailable(
 ) -> None:
     session = StubSession()
     session.parameter_factory.native_sealing_succeeds = False
-    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments = FakeExperiments()
     fit_ran: list[bool] = []
 
     monkeypatch.setattr(
@@ -451,7 +448,7 @@ def test_run_uses_explicit_session_for_simulation_flow(
 ) -> None:
     defaults = object()
     session = StubSession()
-    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments = FakeExperiments()
     recorded: dict[str, object] = {}
 
     def fake_build_experiments(
@@ -468,12 +465,16 @@ def test_run_uses_explicit_session_for_simulation_flow(
         path: Path,
         *,
         parameter_values: object,
+        parameter_model: object,
+        parameterization: object,
         plot: bool = False,
     ) -> None:
         recorded["simulation"] = (
             experiments_arg,
             path,
             parameter_values,
+            parameter_model,
+            parameterization,
             plot,
         )
 
@@ -487,40 +488,13 @@ def test_run_uses_explicit_session_for_simulation_flow(
     np.testing.assert_equal(session.parameters.defaults_calls, [defaults])
     np.testing.assert_equal(session.parameter_factory.seal_configuration_calls, 1)
     np.testing.assert_equal(session.build_analysis_values_calls, 1)
-    np.testing.assert_equal(session.parameters.fix_all_calls, 1)
+    np.testing.assert_equal(session.parameters.fix_all_calls, 0)
     np.testing.assert_equal(recorded["build"][2], session)
-    assert recorded["simulation"] == (experiments, Path("Output"), {}, True)
-
-
-def test_run_rejects_experiments_built_under_a_different_session(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = StubSession()
-    mismatched_store = StubParameters()
-    experiments = FakeExperiments(parameter_store=mismatched_store)
-
-    def fake_build_experiments(
-        filenames: list[Path] | None,
-        selection: Selection,
-        *,
-        session: StubSession | None = None,
-    ) -> FakeExperiments:
-        return experiments
-
-    def fail_run_methods(*_args, **_kwargs) -> None:
-        pytest.fail("run_methods should not run for a mismatched parameter store")
-
-    def fail_execute_simulation(*_args, **_kwargs) -> None:
-        pytest.fail(
-            "execute_simulation should not run for a mismatched parameter store"
-        )
-
-    monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
-    monkeypatch.setattr(chemex_module, "run_methods", fail_run_methods)
-    monkeypatch.setattr(chemex_module, "execute_simulation", fail_execute_simulation)
-
-    with pytest.raises(ValueError, match="does not match the active session"):
-        chemex_module.run(make_args("fit"), session=session)
+    simulation = recorded["simulation"]
+    assert simulation[:3] == (experiments, Path("Output"), {})
+    assert simulation[3] is session.parameter_factory.sealed_parameter_model
+    assert isinstance(simulation[4], StubParameterization)
+    assert simulation[5] is True
 
 
 def test_main_bootstraps_plugins_for_non_run_commands(
@@ -585,7 +559,7 @@ def test_run_methods_skips_fit_when_selection_removes_all_profiles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = StubSession()
-    experiments = EmptyAfterSelectExperiments(parameter_store=session.parameters)
+    experiments = EmptyAfterSelectExperiments()
     calls: list[str] = []
 
     monkeypatch.setattr(
@@ -661,7 +635,7 @@ def test_v2_omitted_selection_restores_the_step_local_all_profiles_baseline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = StubSession()
-    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments = FakeExperiments()
     plan = MethodPlan(
         FormatOrigin.V2,
         (
@@ -692,7 +666,7 @@ def test_canonical_grid_runs_requested_statistics_independently_of_origin(
     origin: FormatOrigin,
 ) -> None:
     session = StubSession()
-    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments = FakeExperiments()
     source = SourceRef(Path("method.toml"), "STEP", "SEARCH.GRID.AXES", 0)
     selector = ParameterSelector("PB", source=source)
     plan = MethodPlan(
@@ -764,7 +738,7 @@ def test_failed_step_cannot_change_effective_roles_seen_by_a_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = StubSession()
-    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments = FakeExperiments()
     experiments.param_ids = {"__PB"}
     source = SourceRef(Path("method.toml"), "STEP", "ROLES")
     fixed = FixAction((ParameterSelector("PB"),), source)
@@ -816,7 +790,7 @@ def test_run_methods_compiles_each_canonical_step_without_origin_or_store_state(
     origin: FormatOrigin,
 ) -> None:
     session = StubSession()
-    experiments = FakeExperiments(parameter_store=session.parameters)
+    experiments = FakeExperiments()
     experiments.param_ids = {"__PB"}
     source = SourceRef(Path("method.toml"), "STEP", "ROLES")
     selector = ParameterSelector("PB")
@@ -879,17 +853,8 @@ def test_run_methods_compiles_each_canonical_step_without_origin_or_store_state(
 
 
 def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None:
-    store = WriterParameterStore(
-        {
-            "__PB": ParamSetting(ParamName("PB"), value=0.15, vary=True),
-            "__KEX_AB": ParamSetting(ParamName("KEX_AB"), value=250.0, vary=True),
-        },
-    )
     samples = np.array([[0.1, 200.0], [0.3, 300.0], [0.5, 400.0]])
-    parameter_names = resampling_module._format_parameter_names(
-        ["__PB", "__KEX_AB"],
-        store,
-    )
+    parameter_names = ("[PB]", "[KEX_AB]")
 
     resampling_module._write_resampling_summary(
         tmp_path,
@@ -914,37 +879,15 @@ def test_resampling_summary_and_correlations_are_written(tmp_path: Path) -> None
     assert "1.00000e+00" in correlations
 
 
-def test_execute_post_fit_writes_parameters_from_experiments_store(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    param = ParamSetting(ParamName("PB"), value=0.15, vary=False)
-    experiments = SimpleNamespace(
-        param_ids=[param.id_],
-        parameter_store=WriterParameterStore({param.id_: param}),
-        write=lambda _path: None,
-    )
-    monkeypatch.setattr(helper_module, "print_writing_results", lambda _path: None)
-    monkeypatch.setattr(
-        helper_module,
-        "_write_statistics",
-        lambda *_args, **_kwargs: None,
-    )
-
-    helper_module.execute_post_fit(
-        experiments,
-        tmp_path,
-        residuals=np.array([], dtype=float),
-        nvarys=0,
-    )
-
-    np.testing.assert_equal(int((tmp_path / "Parameters" / "fixed.toml").exists()), 1)
-
-
 def test_write_file_rejects_unknown_parameter_status(tmp_path: Path) -> None:
     parameter = ParamSetting(ParamName("PB"), value=0.15, vary=False)
+    report_parameter = parameter_printer_module.ReportParameter(
+        parameter.id_,
+        parameter.param_name,
+        parameter.value,
+    )
     parameters = parameter_printer_module.GlobalLocalParameters(
-        {parameter.param_name: parameter},
+        {parameter.param_name: report_parameter},
         {},
     )
 
@@ -953,5 +896,16 @@ def test_write_file_rejects_unknown_parameter_status(tmp_path: Path) -> None:
             parameters,
             "typo",
             tmp_path,
-            WriterParameterStore({}),
         )
+
+
+def test_constraint_output_replaces_prefix_colliding_parameter_ids_atomically() -> None:
+    rendered = parameter_printer_module._replace_parameter_ids(
+        "__A_SPIN + __A",
+        {
+            "__A": ParamName("A"),
+            "__A_SPIN": ParamName("A_SPIN"),
+        },
+    )
+
+    assert rendered == "[A_SPIN] + [A]"

--- a/tests/test_analysis_values.py
+++ b/tests/test_analysis_values.py
@@ -97,11 +97,6 @@ def test_revision_zero_model_values_and_constraints_resolve_without_lmfit() -> N
     assert constrained["__KAB"] == pytest.approx(16.0)
     assert constrained["__KBA"] == pytest.approx(384.0)
 
-    stored = session.parameters.get_parameters({"__PB", "__PA", "__KAB", "__KBA"})
-    assert stored["__PA"].value == pytest.approx(0.93)
-    assert stored["__KAB"].value == pytest.approx(28.0)
-    assert stored["__KBA"].value == pytest.approx(372.0)
-
 
 def _shipped_args(command: str, output: Path) -> Namespace:
     args = Namespace(
@@ -259,12 +254,16 @@ def test_invalid_or_incomplete_commits_leave_values_and_revision_unchanged(
 def test_real_shipped_configuration_initializes_session_values() -> None:
     session = _build_shipped_session()
     snapshot = session.analysis_values.snapshot()
+    parameter_model = session.parameter_factory.sealed_parameter_model
 
     assert snapshot.revision == 0
-    assert tuple(snapshot) == tuple(session.parameters.database._parameters)
+    assert parameter_model is not None
+    assert tuple(snapshot) == tuple(
+        config.param_id for config in parameter_model.configuration
+    )
     assert all(
-        value == session.parameters.get_value(param_id)
-        for param_id, value in snapshot.items()
+        snapshot[config.param_id] == config.effective_value
+        for config in parameter_model.configuration
     )
 
 
@@ -341,7 +340,7 @@ def test_model_change_is_rejected_after_analysis_values_are_initialized() -> Non
     assert session.analysis_values.snapshot() == snapshot
 
 
-def test_shipped_fit_is_native_authoritative_and_mirrors_committed_values(
+def test_shipped_fit_commits_native_authoritative_values(
     tmp_path: Path,
 ) -> None:
     candidate_output = tmp_path / "candidate-enabled"
@@ -351,10 +350,6 @@ def test_shipped_fit_is_native_authoritative_and_mirrors_committed_values(
 
     snapshot = session.analysis_values.snapshot()
     assert snapshot.revision == 1
-    assert all(
-        value == session.parameters.get_value(param_id)
-        for param_id, value in snapshot.items()
-    )
     assert list((candidate_output / "Data").rglob("*.dat"))
     assert list((candidate_output / "Parameters").rglob("*.toml"))
 
@@ -371,10 +366,6 @@ def test_shipped_simulation_fails_closed_on_native_initialization_failure(
 
     snapshot = session.analysis_values.snapshot()
     assert snapshot.revision == 0
-    assert all(
-        value == session.parameters.get_value(param_id)
-        for param_id, value in snapshot.items()
-    )
 
     def fail_native_initialization(*_args: object, **_kwargs: object) -> None:
         msg = "native initialization failed"

--- a/tests/test_experiments_selection.py
+++ b/tests/test_experiments_selection.py
@@ -25,7 +25,7 @@ class SelectableExperiment:
 def test_experiments_become_false_when_selection_removes_all_profiles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    experiments = Experiments(parameter_store=object())  # type: ignore[arg-type]
+    experiments = Experiments()
     experiments.add(SelectableExperiment(Path("a.toml"), 2))
     experiments.add(SelectableExperiment(Path("b.toml"), 1))
 

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -14,29 +14,57 @@ from chemex.optimize.mcmc import (
     resolve_mcmc_settings,
     write_mcmc_outputs,
 )
-from chemex.parameters.name import ParamName
-from chemex.parameters.setting import ParamSetting
+from chemex.parameters.parameterization import (
+    ParameterDeclaration,
+    SealedParameterDeclarations,
+    SealedParameterModel,
+)
+from chemex.parameters.sealed import (
+    ParamConfig,
+    ParamDefinition,
+    SealedConfiguration,
+    SealedDefinitions,
+)
 from chemex.runtime import ExecutionSettings
 
 
-class DummyParameterStore:
-    def __init__(self) -> None:
-        self.parameters = {
-            "__PB": ParamSetting(ParamName("PB"), value=0.1, min=0.0, max=1.0),
-            "__KEX_AB": ParamSetting(
-                ParamName("KEX_AB"),
-                value=200.0,
-                min=1.0,
-                max=5000.0,
+def _parameter_model() -> SealedParameterModel:
+    definitions = SealedDefinitions(
+        (
+            ParamDefinition("__PB", "PB", "", (), 0.1, 0.0, 1.0),
+            ParamDefinition(
+                "__KEX_AB",
+                "KEX_AB",
+                "",
+                (),
+                200.0,
+                1.0,
+                5000.0,
             ),
-        }
-
-    def get_parameters(self, param_ids: tuple[str, ...]) -> dict[str, ParamSetting]:
-        return {
-            param_id: parameter
-            for param_id, parameter in self.parameters.items()
-            if param_id in param_ids
-        }
+        ),
+        {},
+    )
+    configuration = SealedConfiguration(
+        (
+            ParamConfig("__PB", 0.1, 0.0, 1.0),
+            ParamConfig("__KEX_AB", 200.0, 1.0, 5000.0),
+        ),
+        {},
+        definitions.identity,
+    )
+    declarations = SealedParameterDeclarations(
+        (
+            ParameterDeclaration("__PB", True, "", False),
+            ParameterDeclaration("__KEX_AB", True, "", False),
+        )
+    )
+    return SealedParameterModel(
+        "test",
+        "test-model",
+        definitions,
+        configuration,
+        declarations,
+    )
 
 
 def test_resolve_mcmc_settings_defaults_walkers_from_varying_parameters() -> None:
@@ -110,7 +138,7 @@ def test_apply_sample_window_keeps_samples_when_auto_burn_unavailable() -> None:
 
 
 def test_write_mcmc_outputs(tmp_path: Path) -> None:
-    store = DummyParameterStore()
+    parameter_model = _parameter_model()
     settings = EffectiveMcmcSettings(
         steps=4,
         burn="auto",
@@ -169,7 +197,7 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
         result,
         settings,
         tmp_path,
-        store,
+        parameter_model,
         timings={"sampling_seconds": 1.25, "result_processing_seconds": 0.5},
     )
 
@@ -227,7 +255,7 @@ def test_write_mcmc_outputs(tmp_path: Path) -> None:
 def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
     tmp_path: Path,
 ) -> None:
-    store = DummyParameterStore()
+    parameter_model = _parameter_model()
     settings = EffectiveMcmcSettings(
         steps=10,
         burn="auto",
@@ -272,7 +300,7 @@ def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
         raw_lnprob=np.arange(20.0).reshape(10, 2),
     )
 
-    write_mcmc_outputs(result, settings, tmp_path, store)
+    write_mcmc_outputs(result, settings, tmp_path, parameter_model)
 
     diagnostics = (tmp_path / "Statistics" / "MCMC" / "diagnostics.toml").read_text(
         encoding="utf-8"

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -194,20 +194,23 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
 
     run(_fit_arguments(output, plot_level="normal"), session=session)
 
-    assert session.analysis_values.snapshot().revision == 1
+    committed = session.analysis_values.snapshot()
+    assert committed.revision == 1
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
     fitted_record = next(line for line in fitted.splitlines() if "=" in line)
     fitted_value = float(fitted_record.split("=", 1)[1].split()[0])
     assert fitted_value == pytest.approx(2.34742, rel=5.0e-6)
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    fitted_id = next(
+        definition.param_id
+        for definition in parameter_model.definitions
+        if definition.name == "R1A_A" and definition.spin_system_name == "G2N-H"
+    )
+    assert fitted_value == pytest.approx(committed[fitted_id], rel=5.0e-6)
     assert "# ±" in fitted_record
     fitted_error = float(fitted_record.split("±", 1)[1])
     assert fitted_error == pytest.approx(0.083366086, rel=3.0e-6)
-    assert all(
-        parameter.stderr is None
-        for parameter in session.parameters.get_parameters(
-            session.analysis_values.snapshot()
-        ).values()
-    )
     covariance = output / "Statistics" / "Covariance" / "evidence.json"
     assert covariance.is_file()
     constrained = (output / "Parameters" / "constrained.toml").read_text(
@@ -241,6 +244,46 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     time_2, intensity_2 = curve[-1]
     fitted_curve_rate = -math.log(intensity_2 / intensity_1) / (time_2 - time_1)
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
+
+
+def test_ordinary_fit_requires_no_post_seal_parameter_store_value_access(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    session = AnalysisSession.create()
+    build_analysis_values = session.try_build_analysis_values
+
+    def seal_then_reject_store_value_mutation() -> bool:
+        initialized = build_analysis_values()
+
+        def reject_store_value_mutation(_values: object) -> None:
+            raise AssertionError("post-seal ParameterStore value mutation")
+
+        monkeypatch.setattr(
+            session.parameters.database,
+            "_set_values",
+            reject_store_value_mutation,
+        )
+
+        def reject_store_value_read(_param_ids: object) -> object:
+            raise AssertionError("post-seal ParameterStore value read")
+
+        monkeypatch.setattr(
+            session.parameters,
+            "get_parameters",
+            reject_store_value_read,
+        )
+        return initialized
+
+    monkeypatch.setattr(
+        session,
+        "try_build_analysis_values",
+        seal_then_reject_store_value_mutation,
+    )
+
+    run(_fit_arguments(tmp_path / "Output"), session=session)
+
+    assert session.analysis_values.snapshot().revision == 1
 
 
 def test_v2_role_change_keeps_the_prior_committed_value_without_store_roles(
@@ -279,6 +322,81 @@ ROLES = [{ FIX = ["R1A_A"] }]
 
     assert session.analysis_values.snapshot().revision == 1
     assert second_value == pytest.approx(first_value, rel=1.0e-12)
+
+
+def test_constrained_value_becomes_the_next_independent_start(
+    tmp_path: Path,
+) -> None:
+    method = tmp_path / "method-v2.toml"
+    method.write_text(
+        """
+FORMAT_VERSION = 2
+[CONSTRAINED]
+ROLES = [
+  { FIX = ["PB", "KEX_AB"] },
+  { CONSTRAIN = ["[R1A_A, NUC->G2N-H] = 2.0"] },
+]
+
+[INDEPENDENT]
+ROLES = [{ FIX = ["PB", "KEX_AB"] }]
+""",
+        encoding="utf-8",
+    )
+    starts: list[tuple[float, ...]] = []
+    real_least_squares = direct_trf_module.least_squares
+
+    def record_start(*args, **kwargs):
+        starts.append(tuple(float(value) for value in args[1]))
+        return real_least_squares(*args, **kwargs)
+
+    session = AnalysisSession.create()
+    with patch(
+        "chemex.optimize.direct_trf.least_squares",
+        side_effect=record_start,
+    ):
+        run(_fit_arguments(tmp_path / "Output", method), session=session)
+
+    assert starts == [(2.0,)]
+    assert session.analysis_values.snapshot().revision == 2
+
+
+def test_independent_constrained_independent_transition_uses_latest_resolved_value(
+    tmp_path: Path,
+) -> None:
+    method = tmp_path / "method-v2.toml"
+    method.write_text(
+        """
+FORMAT_VERSION = 2
+[FIRST_INDEPENDENT]
+ROLES = [{ FIX = ["PB", "KEX_AB"] }]
+
+[CONSTRAINED]
+ROLES = [
+  { FIX = ["PB", "KEX_AB"] },
+  { CONSTRAIN = ["[R1A_A, NUC->G2N-H] = 3.0"] },
+]
+
+[SECOND_INDEPENDENT]
+ROLES = [{ FIX = ["PB", "KEX_AB"] }]
+""",
+        encoding="utf-8",
+    )
+    starts: list[tuple[float, ...]] = []
+    real_least_squares = direct_trf_module.least_squares
+
+    def record_start(*args, **kwargs):
+        starts.append(tuple(float(value) for value in args[1]))
+        return real_least_squares(*args, **kwargs)
+
+    session = AnalysisSession.create()
+    with patch(
+        "chemex.optimize.direct_trf.least_squares",
+        side_effect=record_start,
+    ):
+        run(_fit_arguments(tmp_path / "Output", method), session=session)
+
+    assert starts[1] == (3.0,)
+    assert session.analysis_values.snapshot().revision == 3
 
 
 def test_relaxation_product_covariance_matches_absolute_sigma_reference(
@@ -1905,10 +2023,29 @@ FIX = ["PB", "KEX_AB"]
         encoding="utf-8",
     )
     session = AnalysisSession.create()
+    starts: list[tuple[float, ...]] = []
+    real_least_squares = direct_trf_module.least_squares
 
-    run(_fit_arguments(output, method), session=session)
+    def record_start(*args, **kwargs):
+        starts.append(tuple(float(value) for value in args[1]))
+        return real_least_squares(*args, **kwargs)
+
+    with patch(
+        "chemex.optimize.direct_trf.least_squares",
+        side_effect=record_start,
+    ):
+        run(_fit_arguments(output, method), session=session)
 
     assert session.analysis_values.snapshot().revision == 2
+    first_fitted = (output / "STEP1" / "Parameters" / "fitted.toml").read_text(
+        encoding="utf-8"
+    )
+    first_value = float(
+        next(line for line in first_fitted.splitlines() if "G2N-H" in line)
+        .split("=", 1)[1]
+        .split()[0]
+    )
+    assert starts[1] == pytest.approx((first_value,), rel=5.0e-6)
     for step in ("STEP1", "STEP2"):
         fitted = (output / step / "Parameters" / "fitted.toml").read_text(
             encoding="utf-8"

--- a/tests/test_output_paths.py
+++ b/tests/test_output_paths.py
@@ -31,7 +31,7 @@ class RecordingExperiment:
 
 
 def test_experiments_write_and_plot_use_unique_output_stems(tmp_path: Path) -> None:
-    experiments = Experiments(parameter_store=object())  # type: ignore[arg-type]
+    experiments = Experiments()
     experiment_a = RecordingExperiment(Path("set_a/experiment.toml"))
     experiment_b = RecordingExperiment(Path("set_b/experiment.toml"))
     experiments.add(experiment_a)
@@ -63,7 +63,7 @@ def test_experiments_write_and_plot_use_unique_output_stems(tmp_path: Path) -> N
 def test_experiments_keep_simple_stems_when_basenames_are_unique(
     tmp_path: Path,
 ) -> None:
-    experiments = Experiments(parameter_store=object())  # type: ignore[arg-type]
+    experiments = Experiments()
     experiment_a = RecordingExperiment(Path("set_a/alpha.toml"))
     experiment_b = RecordingExperiment(Path("set_b/beta.toml"))
     experiments.add(experiment_a)
@@ -78,7 +78,7 @@ def test_experiments_keep_simple_stems_when_basenames_are_unique(
 def test_experiments_fall_back_to_hashed_stems_for_path_sentinel_collisions(
     tmp_path: Path,
 ) -> None:
-    experiments = Experiments(parameter_store=object())  # type: ignore[arg-type]
+    experiments = Experiments()
     experiment_a = RecordingExperiment(Path("__absolute__/set/experiment.toml"))
     experiment_b = RecordingExperiment(Path("/set/experiment.toml"))
     experiments.add(experiment_a)

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -5,38 +5,120 @@ import tomllib
 from argparse import Namespace
 from datetime import UTC, datetime
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
 from chemex import __version__
-from chemex import chemex as chemex_module
 from chemex import run_info as run_info_module
+from chemex.configuration.methods import Method
 from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import (
+    ParameterDeclaration,
+    SealedParameterDeclarations,
+    SealedParameterModel,
+    compile_active_parameterization,
+)
+from chemex.parameters.sealed import (
+    ParamConfig,
+    ParamDefinition,
+    SealedConfiguration,
+    SealedDefinitions,
+    extract_condition_entries,
+)
 from chemex.parameters.setting import ParamSetting
 from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.values import AnalysisValuesSnapshot
 
 
-class ParameterStore:
-    def __init__(self, parameters: dict[str, ParamSetting]) -> None:
-        self.parameters = parameters
+def _parameter_inputs(
+    parameters: tuple[ParamSetting, ...] = (),
+) -> dict[str, object]:
+    if not parameters:
+        parameters = (ParamSetting(ParamName("PB"), value=0.15, min=0.0, max=1.0),)
+    ordered = tuple(sorted(parameters, key=lambda parameter: parameter.param_name))
+    definitions = SealedDefinitions(
+        tuple(
+            ParamDefinition(
+                parameter.id_,
+                parameter.param_name.name,
+                str(parameter.param_name.spin_system),
+                extract_condition_entries(parameter.param_name.conditions),
+                parameter.value,
+                parameter.min,
+                parameter.max,
+            )
+            for parameter in ordered
+        ),
+        {},
+    )
+    configuration = SealedConfiguration(
+        tuple(
+            ParamConfig(
+                parameter.id_,
+                parameter.value,
+                parameter.min,
+                parameter.max,
+            )
+            for parameter in ordered
+        ),
+        {},
+        definitions.identity,
+    )
+    declarations = SealedParameterDeclarations(
+        tuple(
+            ParameterDeclaration(
+                parameter.id_,
+                parameter.vary,
+                parameter.expr,
+                bool(parameter.expr),
+            )
+            for parameter in ordered
+        )
+    )
+    parameter_model = SealedParameterModel(
+        "test",
+        "test-model",
+        definitions,
+        configuration,
+        declarations,
+    )
+    starting_values = AnalysisValuesSnapshot(
+        "test-occurrence",
+        "test-model",
+        definitions.identity,
+        configuration.identity,
+        0,
+        tuple((parameter.id_, parameter.value) for parameter in ordered),
+    )
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        starting_values,
+        Method(),
+        set(declarations),
+    )
+    return {
+        "parameter_model": parameter_model,
+        "parameterization": parameterization,
+        "starting_values": starting_values,
+        "brute_steps": {
+            parameter.id_: parameter.brute_step
+            for parameter in ordered
+            if parameter.brute_step is not None
+        },
+    }
 
-    def get_parameters(self, param_ids: object) -> dict[str, ParamSetting]:
-        return {
-            param_id: parameter
-            for param_id, parameter in self.parameters.items()
-            if param_id in set(param_ids)
-        }
 
-
-class FitExperiments:
-    def __init__(self, parameter_store: ParameterStore, param_ids: set[str]) -> None:
-        self.parameter_store = parameter_store
-        self.param_ids = param_ids
-        self.filter_calls = 0
-
-    def filter_from_values(self, _values: object) -> None:
-        self.filter_calls += 1
+def _write_run_info(
+    args: Namespace,
+    *,
+    parameters: tuple[ParamSetting, ...] = (),
+    **kwargs: object,
+) -> None:
+    run_info_module.write_run_info(
+        args,
+        **_parameter_inputs(parameters),  # ty: ignore[invalid-argument-type]
+        **kwargs,  # ty: ignore[invalid-argument-type]
+    )
 
 
 def _write_input(path: Path, content: str = "[input]\nvalue = 1\n") -> Path:
@@ -75,11 +157,6 @@ def test_write_run_info_captures_inputs_parameters_and_runtime(
         value=0.85,
         expr=f"1.0 - {pb.id_}",
     )
-    store = ParameterStore({pb.id_: pb, dw.id_: dw, pa.id_: pa})
-    experiments = SimpleNamespace(
-        param_ids={pb.id_, dw.id_, pa.id_},
-        parameter_store=store,
-    )
     args = Namespace(
         experiments=[Path("experiment.toml")],
         parameters=[Path("parameters.toml")],
@@ -97,9 +174,9 @@ def test_write_run_info_captures_inputs_parameters_and_runtime(
 
     monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
 
-    run_info_module.write_run_info(
+    _write_run_info(
         args,
-        experiments,
+        parameters=(pb, dw, pa),
         argv=argv,
         working_directory=tmp_path,
         timestamp=datetime(2026, 6, 24, 12, 30, tzinfo=UTC),
@@ -161,20 +238,15 @@ def test_archived_tomls_are_immutable_byte_copies_alongside_outcome(
     for category, source in sources.items():
         source.write_bytes(original_bytes[category])
     output = tmp_path / "Output"
-    experiments = SimpleNamespace(
-        param_ids=set(),
-        parameter_store=ParameterStore({}),
-    )
     monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
 
-    run_info_module.write_run_info(
+    _write_run_info(
         Namespace(
             experiments=[sources["experiments"]],
             parameters=[sources["parameters"]],
             method=[sources["methods"]],
             output=output,
         ),
-        experiments,
         argv=["chemex", "fit"],
         working_directory=tmp_path,
     )
@@ -215,15 +287,10 @@ def test_run_info_uses_chemex_path_semantics_for_literal_tilde(
         method=None,
         output=Path("~/Output"),
     )
-    experiments = SimpleNamespace(
-        param_ids=set(),
-        parameter_store=ParameterStore({}),
-    )
     monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
 
-    run_info_module.write_run_info(
+    _write_run_info(
         args,
-        experiments,
         argv=["chemex", "fit", "--output", "~/Output"],
         working_directory=tmp_path,
         timestamp=datetime(2026, 6, 24, 12, 30, tzinfo=UTC),
@@ -263,15 +330,10 @@ def test_input_files_with_same_basename_are_copied_without_collision(
         method=None,
         output=output,
     )
-    experiments = SimpleNamespace(
-        param_ids=set(),
-        parameter_store=ParameterStore({}),
-    )
     monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
 
-    run_info_module.write_run_info(
+    _write_run_info(
         args,
-        experiments,
         argv=["chemex", "fit"],
         working_directory=tmp_path,
         timestamp=datetime(2026, 6, 24, 12, 30, tzinfo=UTC),
@@ -290,9 +352,8 @@ def test_input_files_with_same_basename_are_copied_without_collision(
         experiment_b.read_text(encoding="utf-8")
     )
 
-    run_info_module.write_run_info(
+    _write_run_info(
         args,
-        experiments,
         argv=["chemex", "fit"],
         working_directory=tmp_path,
         timestamp=datetime(2026, 6, 24, 12, 30, tzinfo=UTC),
@@ -304,67 +365,6 @@ def test_input_files_with_same_basename_are_copied_without_collision(
         item["copied_path"] for item in repeated_run["inputs"]["experiments"]
     ]
     assert repeated_paths == copied_paths
-
-
-def test_run_fit_creates_run_info(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    experiment_file = _write_input(tmp_path / "experiment.toml")
-    parameters_file = _write_input(tmp_path / "parameters.toml")
-    parameter = ParamSetting(ParamName("PB"), value=0.2)
-    store = ParameterStore({parameter.id_: parameter})
-    experiments = FitExperiments(store, {parameter.id_})
-    output = tmp_path / "Output"
-    args = Namespace(
-        experiments=[experiment_file],
-        parameters=[parameters_file],
-        method=None,
-        output=output,
-        plot="nothing",
-    )
-    run_methods_calls: list[Path] = []
-
-    monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
-    monkeypatch.setattr(chemex_module, "print_start_fit", lambda: None)
-
-    def observe_running_outcome(
-        _experiments: object,
-        _methods: object,
-        path: Path,
-        _plot: object,
-        **_kwargs: object,
-    ) -> None:
-        outcome = tomllib.loads(
-            (path / "run_info" / "outcome.toml").read_text(encoding="utf-8")
-        )
-        assert outcome == {"schema_version": 1, "status": "running"}
-        run_methods_calls.append(path)
-
-    monkeypatch.setattr(
-        chemex_module,
-        "run_methods",
-        observe_running_outcome,
-    )
-
-    chemex_module.run_fit(
-        args,
-        experiments,
-        SimpleNamespace(
-            execution=None,
-            resolve_current_values=lambda *_args: {parameter.id_: parameter.value},
-        ),
-        argv=["chemex", "fit"],
-    )
-
-    assert experiments.filter_calls == 1
-    assert run_methods_calls == [output]
-    assert (output / "run_info" / "run.toml").exists()
-    assert (output / "run_info" / "parameters_used.toml").exists()
-    outcome = tomllib.loads(
-        (output / "run_info" / "outcome.toml").read_text(encoding="utf-8")
-    )
-    assert outcome == {"schema_version": 1, "status": "complete"}
 
 
 def test_git_metadata_is_optional_when_git_is_unavailable(
@@ -411,20 +411,15 @@ def test_same_output_rerun_can_use_archived_inputs(
 ) -> None:
     output = tmp_path / "Output"
     original_input = _write_input(tmp_path / "experiment.toml")
-    experiments = SimpleNamespace(
-        param_ids=set(),
-        parameter_store=ParameterStore({}),
-    )
     monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
 
-    run_info_module.write_run_info(
+    _write_run_info(
         Namespace(
             experiments=[original_input],
             parameters=[],
             method=None,
             output=output,
         ),
-        experiments,
         argv=["chemex", "fit"],
         working_directory=tmp_path,
     )
@@ -432,14 +427,13 @@ def test_same_output_rerun_can_use_archived_inputs(
         output / "run_info" / "inputs" / "experiments" / original_input.name
     )
 
-    run_info_module.write_run_info(
+    _write_run_info(
         Namespace(
             experiments=[archived_input],
             parameters=[],
             method=None,
             output=output,
         ),
-        experiments,
         argv=["chemex", "fit"],
         working_directory=tmp_path,
     )
@@ -460,21 +454,16 @@ def test_failed_staging_preserves_existing_run_info(
     existing_run = run_info_path / "run.toml"
     existing_run.write_text("schema_version = 1\n", encoding="utf-8")
     missing_input = tmp_path / "missing.toml"
-    experiments = SimpleNamespace(
-        param_ids=set(),
-        parameter_store=ParameterStore({}),
-    )
     monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
 
     with pytest.raises(FileNotFoundError):
-        run_info_module.write_run_info(
+        _write_run_info(
             Namespace(
                 experiments=[missing_input],
                 parameters=[],
                 method=None,
                 output=output,
             ),
-            experiments,
             argv=["chemex", "fit"],
             working_directory=tmp_path,
         )

--- a/tests/test_sealed_parameters.py
+++ b/tests/test_sealed_parameters.py
@@ -1,7 +1,7 @@
 """Tests for sealed canonical parameter definitions and configuration (#582).
 
 Primary seam: real construction path through AnalysisSession, ParameterFactory,
-and shipped experiment inputs. Verified against the legacy-authoritative catalog.
+and shipped experiment inputs. Verified against the construction catalog.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #684

## Summary

- make `AnalysisValues` the only mutable post-seal central-value state
- remove accepted-fit and initialization mirroring into `ParameterStore`
- preserve revision-checked atomic commits and derived/independent continuity
- remove `Experiment`/`Experiments` ownership of `ParameterStore`
- pass sealed metadata and committed/resolved values explicitly to parameter, GRID, resampling, MCMC, simulation, and run-info output
- retain `ParameterStore` only for construction/configuration concerns such as defaults, model-free seeding, selector/grid parsing, and pre-seal brute-step metadata

## Ownership trace

- construction/configuration: parameter registration/defaults, model-free auxiliary seeding, sealing, selector/grid parsing, brute-step metadata
- compatibility mirrors removed: initialization and accepted-fit synchronization, store stderr clearing
- output/presentation rewired: fixed/fitted/constrained files, GRID labels/markers, resampling and MCMC names/bounds, run-info starting values
- runtime authority removed: experiment store ownership and store-derived dependency closure; `ActiveParameterization` owns constraint closure

## Compatibility and scientific behavior

- CLI, TOML, parameter IDs, output paths, residuals, optimizer, uncertainty, and scientific calculations are unchanged
- internal Python helpers now require explicit sealed metadata and authoritative values
- obsolete `ParameterStore.get_value`/`set_values` and experiment store/subset bridges are removed
- constrained to independent and independent to constrained to independent continuity is preserved through atomic resolved-scope commits
- rejected, stale, interrupted, and statistical work does not mutate central state

## Validation

- focused ownership, continuity, output, GRID, MC/BS/BSN/MCMC, covariance, and run-info tests: passed
- full suite: `1127 passed`
- `uv run ty check`: passed
- `uvx ruff check .`: passed
- `uvx ruff format --check .`: passed
- `git diff --check`: passed
- `uv build`: passed
- `website/npm run build`: passed
- `graphify update .`: passed
- independent standards and #684 specification reviews: passed after findings were resolved

Not included: DE execution (#682), MethodStepWorkflow collapse (#685), or provenance/publication cleanup (#687).