### PR TITLE
Fail closed when automatic MCMC burn cannot retain a defensible posterior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,12 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   parameter containers. After successful GRID aggregate acceptance and atomic
   commit, requested statistics analyze the committed deterministic result.
 
+### Fixed
+- Automatic MCMC burn selection now fails closed when autocorrelation evidence
+  cannot establish a defensible retained window. ChemEx preserves the completed
+  raw chain and incomplete diagnostics but withholds posterior summaries,
+  retained samples, correlations, and plots instead of silently using zero burn.
+
 ### Infrastructure
 - Removed the unused `B1FieldConfig` model and its `default_distribution_config`
   helper from `b1_config.py`; the flat-table `b1_frq` schema it implemented was

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -7,7 +7,7 @@ from importlib.metadata import PackageNotFoundError, version
 from math import ceil
 from pathlib import Path
 from time import perf_counter
-from typing import cast
+from typing import NoReturn, cast
 
 import emcee.autocorr as emcee_autocorr
 import numpy as np
@@ -107,10 +107,12 @@ class NativeMcmcIncompleteError(RuntimeError):
         *,
         terminal: str = "failed",
         completed_steps: int = 0,
+        preserve_raw_evidence: bool = False,
     ) -> None:
         super().__init__(message)
         self.terminal = terminal
         self.completed_steps = completed_steps
+        self.preserve_raw_evidence = preserve_raw_evidence
 
 
 def resolve_mcmc_settings(
@@ -241,33 +243,34 @@ def _resolve_discarded_steps(
     burn: McmcBurnSetting,
     *,
     nsteps: int,
+    nparameters: int,
     autocorrelation_time: Array | None,
     autocorrelation_time_reliable: bool = True,
+    autocorrelation_failure_reason: str | None = None,
 ) -> tuple[int, str | None]:
     if burn != "auto":
         return int(burn), None
+
+    def fail(reason: str) -> NoReturn:
+        raise NativeMcmcIncompleteError(
+            f"automatic burn-in failed because {reason}; authoritative MCMC "
+            "posterior summarization was withheld",
+            completed_steps=nsteps,
+            preserve_raw_evidence=True,
+        )
+
     if autocorrelation_time is None:
-        return 0, "autocorrelation time unavailable; automatic burn-in was not applied"
+        fail(autocorrelation_failure_reason or "autocorrelation time unavailable")
+    if autocorrelation_time.shape != (nparameters,):
+        fail("autocorrelation time has an invalid shape")
     max_tau = float(np.max(autocorrelation_time))
     if not np.isfinite(max_tau) or max_tau <= 0.0:
-        return 0, "autocorrelation time invalid; automatic burn-in was not applied"
+        fail("autocorrelation time invalid")
+    if not autocorrelation_time_reliable:
+        fail("the autocorrelation time estimate is unreliable")
     discarded_steps = ceil(2.0 * max_tau)
     if discarded_steps >= nsteps:
-        return (
-            0,
-            (
-                "estimated automatic burn-in is longer than the chain; "
-                "automatic burn-in was not applied"
-            ),
-        )
-    if not autocorrelation_time_reliable:
-        return (
-            discarded_steps,
-            (
-                "autocorrelation time estimate is unreliable; "
-                "tentative automatic burn-in was applied"
-            ),
-        )
+        fail("the calculated discard does not leave a retained chain")
     return discarded_steps, None
 
 
@@ -279,12 +282,15 @@ def _apply_sample_window(
     thin: int,
     autocorrelation_time: Array | None,
     autocorrelation_time_reliable: bool = True,
+    autocorrelation_failure_reason: str | None = None,
 ) -> tuple[Array, Array, int, str | None]:
     discarded_steps, warning = _resolve_discarded_steps(
         burn,
         nsteps=chain.shape[0],
+        nparameters=chain.shape[2],
         autocorrelation_time=autocorrelation_time,
         autocorrelation_time_reliable=autocorrelation_time_reliable,
+        autocorrelation_failure_reason=autocorrelation_failure_reason,
     )
     retained_chain = chain[discarded_steps::thin]
     retained_lnprob = lnprob[discarded_steps::thin]
@@ -498,6 +504,24 @@ def _write_samples(
         np.savetxt(fileout, values, fmt="%.5e", delimiter="\t")
 
 
+def _write_raw_chain_evidence(
+    evidence: McmcEvidence,
+    path: Path,
+    parameter_model: SealedParameterModel,
+) -> None:
+    parameter_names = _format_parameter_ids(evidence.coordinate_ids, parameter_model)
+    with (path / "raw_chain.tsv").open("w", encoding="utf-8") as fileout:
+        fileout.write("\t".join(("step", "walker", *parameter_names, "lnprob")) + "\n")
+        for step, state in enumerate(evidence.states[1:], start=1):
+            for walker, (position, lnprob) in enumerate(
+                zip(state.positions, state.log_densities, strict=True),
+            ):
+                values = "\t".join(_format_toml_float(value) for value in position)
+                fileout.write(
+                    f"{step}\t{walker}\t{values}\t{_format_toml_float(lnprob)}\n"
+                )
+
+
 def _write_correlations(
     result: McmcResult,
     path: Path,
@@ -621,6 +645,7 @@ def _clear_mcmc_artifacts(path: Path) -> None:
         "correlations.tsv",
         "diagnostics.toml",
         "plots.pdf",
+        "raw_chain.tsv",
     ):
         (path / name).unlink(missing_ok=True)
 
@@ -635,6 +660,8 @@ def _write_native_mcmc_state_diagnostics(
     terminal: str | None = None,
     completed_steps: int | None = None,
     failure: BaseException | None = None,
+    raw_steps: int | None = None,
+    raw_samples: int | None = None,
 ) -> None:
     requested_burn = '"auto"' if settings.burn == "auto" else str(settings.burn)
     lines = [
@@ -661,21 +688,33 @@ def _write_native_mcmc_state_diagnostics(
                 f"failure_message = {_quote_toml_string(message)}",
             )
         )
+    if raw_steps is not None and raw_samples is not None:
+        lines.extend(
+            (
+                'raw_evidence = "diagnostic_chain"',
+                'raw_chain_file = "raw_chain.tsv"',
+                f"raw_steps = {raw_steps}",
+                f"raw_samples = {raw_samples}",
+            )
+        )
     (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _raw_arrays_from_evidence(evidence: McmcEvidence) -> tuple[Array, Array]:
+    return (
+        np.asarray([state.positions for state in evidence.states[1:]], dtype=float),
+        np.asarray(
+            [state.log_densities for state in evidence.states[1:]],
+            dtype=float,
+        ),
+    )
 
 
 def _native_result_from_evidence(
     evidence: McmcEvidence,
     settings: EffectiveMcmcSettings,
 ) -> McmcResult:
-    raw_chain = np.asarray(
-        [state.positions for state in evidence.states[1:]],
-        dtype=float,
-    )
-    raw_lnprob = np.asarray(
-        [state.log_densities for state in evidence.states[1:]],
-        dtype=float,
-    )
+    raw_chain, raw_lnprob = _raw_arrays_from_evidence(evidence)
     diagnostics = derive_mcmc_diagnostics(evidence)
     if (
         diagnostics.status is not McmcDiagnosticStatus.AVAILABLE
@@ -702,6 +741,7 @@ def _native_result_from_evidence(
             thin=settings.thin,
             autocorrelation_time=burn_autocorrelation_time,
             autocorrelation_time_reliable=autocorrelation_time is not None,
+            autocorrelation_failure_reason=autocorrelation_warning,
         )
     )
     samples = retained_chain.reshape((-1, len(evidence.coordinate_ids)))
@@ -792,6 +832,7 @@ def run_native_mcmc(
 
     timings: dict[str, float] = {}
     completed_steps = 0
+    mcmc_evidence: McmcEvidence | None = None
     try:
         policy = resolve_product_mcmc_policy(
             dimension=len(fit.problem.controlled_ids),
@@ -819,6 +860,7 @@ def run_native_mcmc(
                 native_threads=effective.native_threads,
             ),
         )
+        mcmc_evidence = operation.evidence
         timings["sampling_seconds"] = perf_counter() - phase_start
         completed_steps = (
             0
@@ -849,6 +891,14 @@ def run_native_mcmc(
         )
     except (Exception, KeyboardInterrupt) as error:
         _clear_mcmc_artifacts(statistic_path)
+        raw_evidence = (
+            mcmc_evidence
+            if isinstance(error, NativeMcmcIncompleteError)
+            and error.preserve_raw_evidence
+            else None
+        )
+        if raw_evidence is not None:
+            _write_raw_chain_evidence(raw_evidence, statistic_path, fit.parameter_model)
         terminal = (
             error.terminal
             if isinstance(error, NativeMcmcIncompleteError)
@@ -870,6 +920,16 @@ def run_native_mcmc(
             terminal=terminal,
             completed_steps=failure_completed_steps,
             failure=error,
+            raw_steps=(
+                raw_evidence.completed_transition_count
+                if raw_evidence is not None
+                else None
+            ),
+            raw_samples=(
+                raw_evidence.completed_transition_count * effective.walkers
+                if raw_evidence is not None
+                else None
+            ),
         )
         raise
     else:

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -108,11 +108,17 @@ class NativeMcmcIncompleteError(RuntimeError):
         terminal: str = "failed",
         completed_steps: int = 0,
         preserve_raw_evidence: bool = False,
+        autocorrelation_time: Array | None = None,
+        autocorrelation_time_reliable: bool = False,
+        autocorrelation_warning: str | None = None,
     ) -> None:
         super().__init__(message)
         self.terminal = terminal
         self.completed_steps = completed_steps
         self.preserve_raw_evidence = preserve_raw_evidence
+        self.autocorrelation_time = autocorrelation_time
+        self.autocorrelation_time_reliable = autocorrelation_time_reliable
+        self.autocorrelation_warning = autocorrelation_warning
 
 
 def resolve_mcmc_settings(
@@ -200,10 +206,13 @@ def _correlation_matrix(samples: Array) -> Array:
 
 
 def _valid_autocorrelation_time(autocorrelation_time: object) -> Array | None:
-    autocorrelation_time = np.asarray(
-        cast("Array", autocorrelation_time),
-        dtype=float,
-    )
+    try:
+        autocorrelation_time = np.asarray(
+            cast("Array", autocorrelation_time),
+            dtype=float,
+        )
+    except (TypeError, ValueError, OverflowError):
+        return None
     if (
         autocorrelation_time.ndim != 1
         or not np.all(np.isfinite(autocorrelation_time))
@@ -230,8 +239,13 @@ def _estimate_autocorrelation_time(
                 "tentative estimate reported"
             ),
         )
-    except (FloatingPointError, ValueError):
-        return None, None, "autocorrelation time unavailable"
+    except Exception as error:  # noqa: BLE001 - optional diagnostic boundary
+        message = str(error).replace("\n", " ")
+        return (
+            None,
+            None,
+            (f"autocorrelation calculation failed: {type(error).__name__}: {message}"),
+        )
 
     autocorrelation_time = _valid_autocorrelation_time(autocorrelation_time)
     if autocorrelation_time is None:
@@ -257,6 +271,9 @@ def _resolve_discarded_steps(
             "posterior summarization was withheld",
             completed_steps=nsteps,
             preserve_raw_evidence=True,
+            autocorrelation_time=autocorrelation_time,
+            autocorrelation_time_reliable=autocorrelation_time_reliable,
+            autocorrelation_warning=autocorrelation_failure_reason or reason,
         )
 
     if autocorrelation_time is None:
@@ -512,14 +529,89 @@ def _write_raw_chain_evidence(
     parameter_names = _format_parameter_ids(evidence.coordinate_ids, parameter_model)
     with (path / "raw_chain.tsv").open("w", encoding="utf-8") as fileout:
         fileout.write("\t".join(("step", "walker", *parameter_names, "lnprob")) + "\n")
-        for step, state in enumerate(evidence.states[1:], start=1):
+        for state in evidence.states[1:]:
             for walker, (position, lnprob) in enumerate(
                 zip(state.positions, state.log_densities, strict=True),
             ):
                 values = "\t".join(_format_toml_float(value) for value in position)
                 fileout.write(
-                    f"{step}\t{walker}\t{values}\t{_format_toml_float(lnprob)}\n"
+                    f"{state.ordinal}\t{walker}\t{values}\t"
+                    f"{_format_toml_float(lnprob)}\n"
                 )
+
+
+def _extend_acceptance_diagnostics(lines: list[str], acceptance: Array) -> None:
+    lines.extend(
+        (
+            (
+                "acceptance_fraction_mean = "
+                f"{_format_toml_float(float(np.mean(acceptance)))}"
+            ),
+            (
+                "acceptance_fraction_min = "
+                f"{_format_toml_float(float(np.min(acceptance)))}"
+            ),
+            (
+                "acceptance_fraction_max = "
+                f"{_format_toml_float(float(np.max(acceptance)))}"
+            ),
+        )
+    )
+
+
+def _extend_incomplete_autocorrelation_diagnostics(
+    lines: list[str],
+    error: NativeMcmcIncompleteError,
+    *,
+    nparameters: int,
+    sampled_steps: int,
+) -> None:
+    autocorrelation_time = error.autocorrelation_time
+    valid_shape = autocorrelation_time is not None and autocorrelation_time.shape == (
+        nparameters,
+    )
+    if not valid_shape:
+        status = "invalid" if autocorrelation_time is not None else "unavailable"
+        lines.extend(
+            (
+                f"autocorrelation_status = {_quote_toml_string(status)}",
+                (
+                    "autocorrelation_warning = "
+                    f"{_quote_toml_string(error.autocorrelation_warning or 'not available')}"
+                ),
+            )
+        )
+        return
+
+    reliable = error.autocorrelation_time_reliable
+    suffix = "" if reliable else "_tentative"
+    status = "reliable" if reliable else "unreliable_short_chain"
+    max_tau = float(np.max(autocorrelation_time))
+    lines.extend(
+        (
+            f"autocorrelation_status = {_quote_toml_string(status)}",
+            (
+                f"autocorrelation_time{suffix} = "
+                f"{_format_toml_float_list(autocorrelation_time.tolist())}"
+            ),
+            f"max_autocorrelation_time{suffix} = {_format_toml_float(max_tau)}",
+            (
+                "steps_over_max_autocorrelation_time = "
+                f"{_format_toml_float(sampled_steps / max_tau)}"
+            ),
+            f"recommended_min_steps_50tau = {ceil(50.0 * max_tau)}",
+            f"recommended_min_steps_100tau = {ceil(100.0 * max_tau)}",
+            (
+                "autocorrelation_warning = "
+                f"{_quote_toml_string(error.autocorrelation_warning or str(error))}"
+            ),
+        )
+    )
+    if not reliable:
+        lines.append(
+            'effective_sample_size_warning = "not reported: autocorrelation time '
+            'estimate is unreliable"'
+        )
 
 
 def _write_correlations(
@@ -572,11 +664,9 @@ def _write_diagnostics(
         'summary_file = "summary.toml"',
         'correlations_file = "correlations.tsv"',
         'plots_file = "plots.pdf"',
-        f"acceptance_fraction_mean = {_format_toml_float(float(np.mean(acceptance)))}",
-        f"acceptance_fraction_min = {_format_toml_float(float(np.min(acceptance)))}",
-        f"acceptance_fraction_max = {_format_toml_float(float(np.max(acceptance)))}",
-        "unbounded_parameters = []",
     ]
+    _extend_acceptance_diagnostics(lines, acceptance)
+    lines.append("unbounded_parameters = []")
     if root_seed is not None:
         lines.append(f"root_seed = {root_seed}")
     if result.burn_in_warning is not None:
@@ -660,8 +750,8 @@ def _write_native_mcmc_state_diagnostics(
     terminal: str | None = None,
     completed_steps: int | None = None,
     failure: BaseException | None = None,
-    raw_steps: int | None = None,
-    raw_samples: int | None = None,
+    raw_evidence: McmcEvidence | None = None,
+    timings: Mapping[str, float] | None = None,
 ) -> None:
     requested_burn = '"auto"' if settings.burn == "auto" else str(settings.burn)
     lines = [
@@ -688,15 +778,44 @@ def _write_native_mcmc_state_diagnostics(
                 f"failure_message = {_quote_toml_string(message)}",
             )
         )
-    if raw_steps is not None and raw_samples is not None:
+    if raw_evidence is not None:
+        raw_steps = raw_evidence.completed_transition_count
+        raw_samples = sum(len(state.positions) for state in raw_evidence.states[1:])
         lines.extend(
             (
+                (
+                    "sampling_terminal = "
+                    f"{_quote_toml_string(raw_evidence.terminal.value)}"
+                ),
+                'posterior_retention = "failed"',
+                'posterior_summary = "withheld"',
                 'raw_evidence = "diagnostic_chain"',
                 'raw_chain_file = "raw_chain.tsv"',
                 f"raw_steps = {raw_steps}",
                 f"raw_samples = {raw_samples}",
+                f"emcee_version = {_quote_toml_string(_package_version('emcee'))}",
+                'convergence_diagnostic = "integrated_autocorrelation_time"',
+                'rhat = "not computed: emcee ensemble walkers are not independent chains"',
             )
         )
+        diagnostics = derive_mcmc_diagnostics(raw_evidence)
+        if (
+            diagnostics.status is McmcDiagnosticStatus.AVAILABLE
+            and diagnostics.acceptance_fractions is not None
+        ):
+            _extend_acceptance_diagnostics(
+                lines,
+                np.asarray(diagnostics.acceptance_fractions, dtype=float),
+            )
+        if isinstance(failure, NativeMcmcIncompleteError):
+            _extend_incomplete_autocorrelation_diagnostics(
+                lines,
+                failure,
+                nparameters=len(parameter_ids),
+                sampled_steps=raw_steps,
+            )
+    if timings is not None:
+        _extend_timing_diagnostics(lines, timings)
     (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -878,8 +997,10 @@ def run_native_mcmc(
             )
             raise error
         phase_start = perf_counter()
-        result = _native_result_from_evidence(operation.evidence, effective)
-        timings["result_processing_seconds"] = perf_counter() - phase_start
+        try:
+            result = _native_result_from_evidence(operation.evidence, effective)
+        finally:
+            timings["result_processing_seconds"] = perf_counter() - phase_start
         write_mcmc_outputs(
             result,
             effective,
@@ -920,16 +1041,8 @@ def run_native_mcmc(
             terminal=terminal,
             completed_steps=failure_completed_steps,
             failure=error,
-            raw_steps=(
-                raw_evidence.completed_transition_count
-                if raw_evidence is not None
-                else None
-            ),
-            raw_samples=(
-                raw_evidence.completed_transition_count * effective.walkers
-                if raw_evidence is not None
-                else None
-            ),
+            raw_evidence=raw_evidence,
+            timings=timings,
         )
         raise
     else:

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -10,6 +10,7 @@ from chemex.optimize.mcmc import (
     EffectiveMcmcSettings,
     McmcResult,
     McmcSummary,
+    NativeMcmcIncompleteError,
     _apply_sample_window,
     resolve_mcmc_settings,
     write_mcmc_outputs,
@@ -26,6 +27,7 @@ from chemex.parameters.sealed import (
     SealedDefinitions,
 )
 from chemex.runtime import ExecutionSettings
+from chemex.typing import Array
 
 
 def _parameter_model() -> SealedParameterModel:
@@ -119,22 +121,78 @@ def test_apply_sample_window_uses_auto_burn_from_autocorrelation_time() -> None:
     assert np.array_equal(retained_lnprob, lnprob[4::2])
 
 
-def test_apply_sample_window_keeps_samples_when_auto_burn_unavailable() -> None:
+def test_apply_sample_window_fails_closed_when_auto_burn_unavailable() -> None:
     chain = np.arange(12.0).reshape(3, 2, 2)
     lnprob = np.arange(6.0).reshape(3, 2)
+
+    with pytest.raises(
+        NativeMcmcIncompleteError,
+        match="automatic burn-in.*autocorrelation time unavailable",
+    ):
+        _apply_sample_window(
+            chain,
+            lnprob,
+            burn="auto",
+            thin=1,
+            autocorrelation_time=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("autocorrelation_time", "reason"),
+    [
+        (np.array([np.nan, 1.0]), "autocorrelation time invalid"),
+        (np.array([1.5, 1.0]), "does not leave a retained chain"),
+    ],
+)
+def test_apply_sample_window_fails_closed_for_invalid_automatic_window(
+    autocorrelation_time: Array,
+    reason: str,
+) -> None:
+    chain = np.arange(12.0).reshape(3, 2, 2)
+    lnprob = np.arange(6.0).reshape(3, 2)
+
+    with pytest.raises(NativeMcmcIncompleteError, match=reason):
+        _apply_sample_window(
+            chain,
+            lnprob,
+            burn="auto",
+            thin=1,
+            autocorrelation_time=autocorrelation_time,
+        )
+
+
+def test_apply_sample_window_fails_closed_for_unreliable_automatic_burn() -> None:
+    chain = np.arange(20.0).reshape(10, 2, 1)
+    lnprob = np.arange(20.0).reshape(10, 2)
+
+    with pytest.raises(NativeMcmcIncompleteError, match="estimate is unreliable"):
+        _apply_sample_window(
+            chain,
+            lnprob,
+            burn="auto",
+            thin=1,
+            autocorrelation_time=np.array([1.6]),
+            autocorrelation_time_reliable=False,
+        )
+
+
+def test_apply_sample_window_preserves_explicit_integer_burn_contract() -> None:
+    chain = np.arange(20.0).reshape(5, 2, 2)
+    lnprob = np.arange(10.0).reshape(5, 2)
 
     retained_chain, retained_lnprob, discarded_steps, warning = _apply_sample_window(
         chain,
         lnprob,
-        burn="auto",
-        thin=1,
+        burn=2,
+        thin=2,
         autocorrelation_time=None,
     )
 
-    assert discarded_steps == 0
-    assert "autocorrelation time unavailable" in str(warning)
-    assert np.array_equal(retained_chain, chain)
-    assert np.array_equal(retained_lnprob, lnprob)
+    assert discarded_steps == 2
+    assert warning is None
+    assert np.array_equal(retained_chain, chain[2::2])
+    assert np.array_equal(retained_lnprob, lnprob[2::2])
 
 
 def test_write_mcmc_outputs(tmp_path: Path) -> None:
@@ -258,7 +316,7 @@ def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
     parameter_model = _parameter_model()
     settings = EffectiveMcmcSettings(
         steps=10,
-        burn="auto",
+        burn=4,
         thin=1,
         walkers=2,
         seed=None,
@@ -287,10 +345,7 @@ def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
         acceptance_fraction=np.array([0.25, 0.50]),
         autocorrelation_time=None,
         discarded_steps=4,
-        burn_in_warning=(
-            "autocorrelation time estimate is unreliable; "
-            "tentative automatic burn-in was applied"
-        ),
+        burn_in_warning=None,
         tentative_autocorrelation_time=np.array([1.6]),
         autocorrelation_warning=(
             "chain shorter than 50 times the autocorrelation time; "
@@ -310,6 +365,7 @@ def test_write_mcmc_outputs_reports_tentative_autocorrelation_time(
     )
 
     assert "effective_sample_size" not in summary
+    assert "requested_burn = 4" in diagnostics
     assert 'autocorrelation_status = "unreliable_short_chain"' in diagnostics
     assert "autocorrelation_time_tentative = [1.60000e+00]" in diagnostics
     assert "max_autocorrelation_time_tentative = 1.60000e+00" in diagnostics

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -29,6 +29,7 @@ from chemex.optimize.progress import ProgressPhase
 from chemex.optimize.resampling import NativeResamplingIncompleteError
 from chemex.optimize.uncertainty import ParameterUnit
 from chemex.runtime import AnalysisSession
+from chemex.typing import Array
 
 ROOT = Path(__file__).parent.parent
 EXAMPLE = ROOT / "examples/Experiments/RELAXATION_HZNZ"
@@ -1641,6 +1642,146 @@ WORKERS = {workers}
     return path
 
 
+def _automatic_mcmc_method(path: Path, *, steps: int = 5) -> Path:
+    path.write_text(
+        f"""FORMAT_VERSION = 2
+
+[DEFAULT]
+ROLES = [{{ FIX = ["PB", "KEX_AB"] }}]
+
+[DEFAULT.STATISTICS.MCMC]
+STEPS = {steps}
+SEED = 698
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_valid_automatic_mcmc_burn_publishes_normal_posterior_outputs(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _automatic_mcmc_method(tmp_path / "method.toml")
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    session = AnalysisSession.create()
+    committed_snapshots = []
+
+    def valid_autocorrelation_time(_chain: Array, **_kwargs) -> Array:
+        committed_snapshots.append(session.analysis_values.snapshot())
+        return np.array([1.0])
+
+    with patch.object(
+        mcmc_module.emcee_autocorr,
+        "integrated_time",
+        side_effect=valid_autocorrelation_time,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=session,
+        )
+
+    assert len(committed_snapshots) == 1
+    assert session.analysis_values.snapshot() == committed_snapshots[0]
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "complete"
+    assert diagnostics["discarded_steps"] == 2
+    assert diagnostics["retained_steps"] == 3
+    assert (statistics / "summary.toml").is_file()
+    assert (statistics / "samples.tsv").is_file()
+    assert (statistics / "correlations.tsv").is_file()
+    assert (statistics / "plots.pdf").stat().st_size > 0
+    assert not (statistics / "raw_chain.tsv").exists()
+
+
+@pytest.mark.parametrize(
+    ("autocorrelation_outcome", "failure_reason"),
+    [
+        (ValueError("autocorrelation calculation failed"), "unavailable"),
+        (
+            mcmc_module.emcee_autocorr.AutocorrError(np.array([1.0])),
+            "unreliable",
+        ),
+        (np.array([np.nan]), "invalid"),
+        (np.array([3.0]), "does not leave a retained chain"),
+    ],
+    ids=("unavailable", "unreliable", "invalid", "no-retained-window"),
+)
+def test_automatic_mcmc_burn_failure_preserves_only_incomplete_raw_evidence(
+    tmp_path: Path,
+    autocorrelation_outcome: BaseException | Array,
+    failure_reason: str,
+) -> None:
+    central_output = tmp_path / "Central"
+    failed_output = tmp_path / "Failed"
+    method = _automatic_mcmc_method(tmp_path / "method.toml")
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    central_session = AnalysisSession.create()
+    failed_session = AnalysisSession.create()
+
+    run(
+        _fit_arguments(central_output, parameters=parameters),
+        session=central_session,
+    )
+    patch_kwargs = (
+        {"side_effect": autocorrelation_outcome}
+        if isinstance(autocorrelation_outcome, BaseException)
+        else {"return_value": autocorrelation_outcome}
+    )
+    with (
+        patch.object(
+            mcmc_module.emcee_autocorr,
+            "integrated_time",
+            **patch_kwargs,
+        ),
+        pytest.raises(
+            NativeMcmcIncompleteError,
+            match="authoritative MCMC posterior summarization was withheld",
+        ),
+    ):
+        run(
+            _fit_arguments(failed_output, method, parameters=parameters),
+            session=failed_session,
+        )
+
+    central = central_session.analysis_values.snapshot()
+    failed = failed_session.analysis_values.snapshot()
+    assert central.revision == failed.revision == 1
+    assert central.items() == failed.items()
+    statistics = failed_output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "incomplete"
+    assert diagnostics["terminal"] == "failed"
+    assert diagnostics["completed_steps"] == 5
+    assert diagnostics["raw_evidence"] == "diagnostic_chain"
+    assert diagnostics["raw_chain_file"] == "raw_chain.tsv"
+    assert diagnostics["raw_steps"] == 5
+    assert diagnostics["raw_samples"] == 160
+    assert (
+        "authoritative MCMC posterior summarization was withheld"
+        in diagnostics["failure_message"]
+    )
+    assert failure_reason in diagnostics["failure_message"]
+    raw_chain = (statistics / "raw_chain.tsv").read_text(encoding="utf-8")
+    header = raw_chain.splitlines()[0]
+    assert header.startswith("step\twalker\t[R1A_A")
+    assert header.endswith("\tlnprob")
+    assert len(raw_chain.splitlines()) == 161
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "samples.tsv").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+    outcome = _read_outcome(failed_output)
+    assert outcome["latest_committed_revision"] == 1
+    assert outcome["restart_revision"] == 1
+    assert outcome["failure_stage"] == "statistics"
+
+
 def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     tmp_path: Path,
 ) -> None:
@@ -1652,6 +1793,11 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     generated_seed = 0x1234_5678_90AB_CDEF
     with (
         patch.object(mcmc_module.secrets, "randbits", return_value=generated_seed),
+        patch.object(
+            mcmc_module.emcee_autocorr,
+            "integrated_time",
+            return_value=np.array([0.25]),
+        ),
         patch.object(
             mcmc_module,
             "execute_mcmc_evidence",
@@ -1691,21 +1837,29 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     assert plan.coordinate_units[0][1] is ParameterUnit.UNSPECIFIED
 
 
-def test_compact_mcmc_form_runs_through_real_chemex_cli(tmp_path: Path) -> None:
+def test_short_compact_mcmc_form_fails_closed_through_real_chemex_cli(
+    tmp_path: Path,
+) -> None:
     output = tmp_path / "Output"
     method = _statistics_method(tmp_path / "method.toml", '"MCMC" = 2')
     parameters = _bounded_parameters(tmp_path / "parameters.toml")
 
-    _run_real_fit_cli(output, method, parameters)
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_real_fit_cli(output, method, parameters)
 
+    statistics = output / "Statistics" / "MCMC"
     diagnostics = tomllib.loads(
-        (output / "Statistics" / "MCMC" / "diagnostics.toml").read_text(
-            encoding="utf-8"
-        )
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
     )
-    assert diagnostics["status"] == "complete"
+    assert diagnostics["status"] == "incomplete"
     assert diagnostics["engine"] == "native MCMC"
     assert diagnostics["steps"] == 2
+    assert diagnostics["raw_evidence"] == "diagnostic_chain"
+    assert (statistics / "raw_chain.tsv").is_file()
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "samples.tsv").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
 
 
 def test_seeded_nested_mcmc_settings_run_through_real_chemex_cli(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -1698,22 +1698,47 @@ def test_valid_automatic_mcmc_burn_publishes_normal_posterior_outputs(
 
 
 @pytest.mark.parametrize(
-    ("autocorrelation_outcome", "failure_reason"),
+    ("autocorrelation_outcome", "failure_reason", "autocorrelation_status"),
     [
-        (ValueError("autocorrelation calculation failed"), "unavailable"),
+        (
+            ValueError("autocorrelation calculation failed"),
+            "calculation failed",
+            "unavailable",
+        ),
+        (
+            RuntimeError("unexpected autocorrelation failure\nwith context"),
+            "RuntimeError",
+            "unavailable",
+        ),
+        (object(), "invalid", "unavailable"),
         (
             mcmc_module.emcee_autocorr.AutocorrError(np.array([1.0])),
             "unreliable",
+            "unreliable_short_chain",
         ),
-        (np.array([np.nan]), "invalid"),
-        (np.array([3.0]), "does not leave a retained chain"),
+        (np.array([1.0, 1.0]), "invalid shape", "invalid"),
+        (np.array([np.nan]), "invalid", "unavailable"),
+        (np.array([0.0]), "invalid", "unavailable"),
+        (np.array([-1.0]), "invalid", "unavailable"),
+        (np.array([3.0]), "does not leave a retained chain", "reliable"),
     ],
-    ids=("unavailable", "unreliable", "invalid", "no-retained-window"),
+    ids=(
+        "calculation-failure",
+        "unexpected-calculation-failure",
+        "malformed",
+        "unreliable",
+        "wrong-shape",
+        "non-finite",
+        "zero",
+        "negative",
+        "no-retained-window",
+    ),
 )
 def test_automatic_mcmc_burn_failure_preserves_only_incomplete_raw_evidence(
     tmp_path: Path,
-    autocorrelation_outcome: BaseException | Array,
+    autocorrelation_outcome: object,
     failure_reason: str,
+    autocorrelation_status: str,
 ) -> None:
     central_output = tmp_path / "Central"
     failed_output = tmp_path / "Failed"
@@ -1721,6 +1746,18 @@ def test_automatic_mcmc_burn_failure_preserves_only_incomplete_raw_evidence(
     parameters = _bounded_parameters(tmp_path / "parameters.toml")
     central_session = AnalysisSession.create()
     failed_session = AnalysisSession.create()
+    stale_statistics = failed_output / "Statistics" / "MCMC"
+    stale_statistics.mkdir(parents=True)
+    for name in (
+        "summary.toml",
+        "samples.tsv",
+        "correlations.tsv",
+        "plots.pdf",
+        "raw_chain.tsv",
+    ):
+        (stale_statistics / name).write_text(
+            "stale posterior artifact\n", encoding="utf-8"
+        )
 
     run(
         _fit_arguments(central_output, parameters=parameters),
@@ -1758,20 +1795,46 @@ def test_automatic_mcmc_burn_failure_preserves_only_incomplete_raw_evidence(
     assert diagnostics["status"] == "incomplete"
     assert diagnostics["terminal"] == "failed"
     assert diagnostics["completed_steps"] == 5
+    assert diagnostics["sampling_terminal"] == "completed"
+    assert diagnostics["posterior_retention"] == "failed"
+    assert diagnostics["posterior_summary"] == "withheld"
     assert diagnostics["raw_evidence"] == "diagnostic_chain"
     assert diagnostics["raw_chain_file"] == "raw_chain.tsv"
     assert diagnostics["raw_steps"] == 5
     assert diagnostics["raw_samples"] == 160
+    assert diagnostics["autocorrelation_status"] == autocorrelation_status
+    assert diagnostics["acceptance_fraction_min"] >= 0.0
+    assert diagnostics["acceptance_fraction_max"] <= 1.0
+    assert (
+        diagnostics["acceptance_fraction_min"]
+        <= diagnostics["acceptance_fraction_mean"]
+        <= diagnostics["acceptance_fraction_max"]
+    )
+    assert diagnostics["sampling_seconds"] >= 0.0
+    assert diagnostics["result_processing_seconds"] >= 0.0
     assert (
         "authoritative MCMC posterior summarization was withheld"
         in diagnostics["failure_message"]
     )
     assert failure_reason in diagnostics["failure_message"]
     raw_chain = (statistics / "raw_chain.tsv").read_text(encoding="utf-8")
-    header = raw_chain.splitlines()[0]
+    raw_lines = raw_chain.splitlines()
+    header = raw_lines[0]
     assert header.startswith("step\twalker\t[R1A_A")
     assert header.endswith("\tlnprob")
-    assert len(raw_chain.splitlines()) == 161
+    assert len(raw_lines) == 161
+    observed_indices = [
+        (int(fields[0]), int(fields[1]))
+        for fields in (line.split("\t") for line in raw_lines[1:])
+    ]
+    assert observed_indices == [
+        (step, walker) for step in range(1, 6) for walker in range(32)
+    ]
+    assert all(
+        np.all(np.isfinite([float(value) for value in line.split("\t")[2:]]))
+        for line in raw_lines[1:]
+    )
+    assert "stale posterior artifact" not in raw_chain
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "samples.tsv").exists()
     assert not (statistics / "correlations.tsv").exists()
@@ -1780,6 +1843,36 @@ def test_automatic_mcmc_burn_failure_preserves_only_incomplete_raw_evidence(
     assert outcome["latest_committed_revision"] == 1
     assert outcome["restart_revision"] == 1
     assert outcome["failure_stage"] == "statistics"
+
+
+def test_explicit_mcmc_burn_survives_autocorrelation_calculation_failure(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+
+    with patch.object(
+        mcmc_module.emcee_autocorr,
+        "integrated_time",
+        side_effect=RuntimeError("autocorrelation backend failed"),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "complete"
+    assert diagnostics["requested_burn"] == 1
+    assert diagnostics["autocorrelation_status"] == "unavailable"
+    assert "RuntimeError" in diagnostics["autocorrelation_warning"]
+    assert (statistics / "summary.toml").is_file()
+    assert (statistics / "samples.tsv").is_file()
+    assert not (statistics / "raw_chain.tsv").exists()
 
 
 def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -262,9 +262,11 @@ autocorrelation estimates. Failed or interrupted MCMC suppresses every
 authoritative posterior product. If automatic burn selection cannot establish a
 retained window, `raw_chain.tsv` preserves the completed sampler chain as
 diagnostic evidence while `diagnostics.toml` explicitly marks the analysis
-incomplete; the raw chain is not a retained-posterior sample file. Other failures
-leave only the evidence available at their failure stage and an explicit
-incomplete diagnostic. These diagnostics are the best place to confirm that
+incomplete, distinguishes completed sampling from failed posterior retention,
+and retains acceptance, autocorrelation, and timing diagnostics. The raw chain
+is not a retained-posterior sample file. Other failures leave only the evidence
+available at their failure stage and an explicit incomplete diagnostic. These
+diagnostics are the best place to confirm that
 [`--workers`](multicore_execution.md) was applied as intended.
 
 MC, BS, and BSN `summary.toml` files describe their empirical fitted-sample

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -259,8 +259,12 @@ the diagnostic as incomplete. MCMC diagnostics also
 include the direct emcee sampler engine, timing information, effective worker
 count and root seed, acceptance fractions, burn-in decisions, and
 autocorrelation estimates. Failed or interrupted MCMC suppresses every
-complete-chain product and leaves only an explicit incomplete diagnostic. These
-diagnostics are the best place to confirm that
+authoritative posterior product. If automatic burn selection cannot establish a
+retained window, `raw_chain.tsv` preserves the completed sampler chain as
+diagnostic evidence while `diagnostics.toml` explicitly marks the analysis
+incomplete; the raw chain is not a retained-posterior sample file. Other failures
+leave only the evidence available at their failure stage and an explicit
+incomplete diagnostic. These diagnostics are the best place to confirm that
 [`--workers`](multicore_execution.md) was applied as intended.
 
 MC, BS, and BSN `summary.toml` files describe their empirical fitted-sample


### PR DESCRIPTION
## Summary

- fail closed when automatic MCMC burn selection lacks a reliable, valid autocorrelation estimate or would consume the available chain
- preserve the completed sampler chain as explicitly diagnostic `raw_chain.tsv` evidence with incomplete lifecycle diagnostics
- withhold authoritative `summary.toml`, retained `samples.tsv`, `correlations.tsv`, and `plots.pdf` products on automatic-retention failure
- keep valid automatic burn and explicit integer `BURN` behavior unchanged
- clarify the observable incomplete-output behavior and add an unreleased correctness entry

The deterministic fit commits before MCMC and remains unchanged on both MCMC success and automatic-burn failure. Tentative autocorrelation estimates from `AutocorrError` remain available for diagnostics and for explicit-burn analyses, but cannot authorize automatic posterior retention.

## Validation

- `uv run pytest -q tests/test_mcmc.py tests/test_native_mcmc.py tests/test_native_production_fitting.py -k "mcmc or statistics or incomplete or publication"` — 104 passed
- `QT_QPA_PLATFORM=offscreen MPLBACKEND=Agg uv run pytest -q -p no:cacheprovider` — 981 passed
- `uv run ty check` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `git diff --check` — passed
- `uv build` — wheel and sdist built
- `npm run build` in `website/` — passed
- independent standards review — no findings
- independent frozen #680 decision 12 / #698 spec review — no findings

Closes #698

References #680, #611, and #677.