### PR TITLE
Do not apply configured bounds to derived commit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   commit, requested statistics analyze the committed deterministic result.
 
 ### Fixed
+- Fixed native fit commits rejecting finite expression-derived parameter values
+  solely because they fall outside configured numerical-coordinate bounds.
+  Independent TRF, GRID, DE, and MCMC coordinates remain bounded at their
+  numerical-problem boundaries; derived values continue to follow constraint
+  evaluator domains and scientific postconditions without clipping.
 - Automatic MCMC burn selection now fails closed when autocorrelation evidence
   cannot establish a defensible retained window. ChemEx preserves the completed
   raw chain and incomplete diagnostics but withholds posterior summaries,

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -810,6 +810,26 @@ def _validate_candidate_feasibility(
     return full_values
 
 
+def build_bounded_independent_frame(
+    parameterization: ActiveParameterization,
+    configuration: SealedConfiguration,
+    snapshot: AnalysisValuesSnapshot,
+) -> IndependentValueFrame:
+    """Build one independent frame after enforcing configured coordinate bounds."""
+    if configuration.identity != snapshot.configuration_identity:
+        raise DirectTrfConstructionError(
+            "Configuration and starting snapshot identities differ"
+        )
+    frame = parameterization.frame_from_snapshot(snapshot)
+    for param_id, value in frame.ordered_items():
+        item = configuration[param_id]
+        if not item.lower_bound <= value <= item.upper_bound:
+            raise DirectTrfConstructionError(
+                f"Independent parameter {param_id!r} is outside its effective bounds"
+            )
+    return frame
+
+
 @dataclass(frozen=True, slots=True)
 class OptimizationProblem:
     """One immutable canonical external-coordinate fit and commit context."""
@@ -985,11 +1005,11 @@ class OptimizationProblem:
             )
         if plan.retained_observation_count < 1:
             raise DirectTrfConstructionError("Residual objective cannot be empty")
-        if configuration.identity != snapshot.configuration_identity:
-            raise DirectTrfConstructionError(
-                "Configuration and starting snapshot identities differ"
-            )
-        frame = parameterization.frame_from_snapshot(snapshot)
+        frame = build_bounded_independent_frame(
+            parameterization,
+            configuration,
+            snapshot,
+        )
         independent_items = frame.ordered_items()
         controlled_ids = tuple(
             param_id
@@ -1010,12 +1030,6 @@ class OptimizationProblem:
         upper = tuple(
             configuration[param_id].upper_bound for param_id in controlled_ids
         )
-        for param_id, value in held_items:
-            item = configuration[param_id]
-            if not item.lower_bound <= value <= item.upper_bound:
-                raise DirectTrfConstructionError(
-                    f"Held parameter {param_id!r} is outside its effective bounds"
-                )
         return cls(
             plan.identity,
             parameterization.identity,

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -41,6 +41,7 @@ from chemex.optimize.direct_trf import (
     FitCommitOperation,
     FitCommitTerminal,
     OptimizationProblem,
+    build_bounded_independent_frame,
     execute_fit_commit,
 )
 from chemex.optimize.grid_direct_trf import (
@@ -706,9 +707,14 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
     starting_snapshot = session.analysis_values.snapshot()
     if not _has_controlled_parameters(parameterization):
+        independent_frame = build_bounded_independent_frame(
+            parameterization,
+            configuration,
+            starting_snapshot,
+        )
         frame = EvaluationFrame.from_lifecycle_frame(
             parameterization,
-            parameterization.frame_from_snapshot(starting_snapshot),
+            independent_frame,
         )
         evaluated = engine.new_evaluator().evaluate(frame)
         if isinstance(evaluated, EvaluationFailure):

--- a/src/chemex/parameters/values.py
+++ b/src/chemex/parameters/values.py
@@ -139,7 +139,6 @@ class AnalysisValues:
         self._definitions_identity = ""
         self._configuration_identity = ""
         self._items: tuple[tuple[str, float], ...] = ()
-        self._bounds: Mapping[str, tuple[float, float]] = MappingProxyType({})
         self._revision: int | None = None
         self._lock = RLock()
 
@@ -204,12 +203,6 @@ class AnalysisValues:
             self._definitions_identity = configuration.definitions_identity
             self._configuration_identity = configuration.identity
             self._items = tuple(items)
-            self._bounds = MappingProxyType(
-                {
-                    config.param_id: (config.lower_bound, config.upper_bound)
-                    for config in configuration
-                }
-            )
             self._revision = 0
 
     def snapshot(self) -> AnalysisValuesSnapshot:
@@ -298,11 +291,7 @@ class AnalysisValues:
                 msg = f"Invalid central value for {param_id!r}: {value!r}"
                 raise InvalidAnalysisValuesCommitError(msg)
             numeric_value = float(value)
-            lower_bound, upper_bound = self._bounds[param_id]
-            if (
-                not math.isfinite(numeric_value)
-                or not lower_bound <= numeric_value <= upper_bound
-            ):
+            if not math.isfinite(numeric_value):
                 msg = f"Invalid central value for {param_id!r}: {value!r}"
                 raise InvalidAnalysisValuesCommitError(msg)
             replacements[param_id] = numeric_value
@@ -322,5 +311,4 @@ class AnalysisValues:
             self._definitions_identity = ""
             self._configuration_identity = ""
             self._items = ()
-            self._bounds = MappingProxyType({})
             self._revision = None

--- a/tests/test_analysis_values.py
+++ b/tests/test_analysis_values.py
@@ -230,7 +230,6 @@ def test_concurrent_disjoint_commits_use_one_conservative_global_revision() -> N
         ({"__PB": "not-a-number"}, ("__PB",)),
         ({"__PB": float("nan")}, ("__PB",)),
         ({"__PB": float("inf")}, ("__PB",)),
-        ({"__PB": 1.01}, ("__PB",)),
     ],
 )
 def test_invalid_or_incomplete_commits_leave_values_and_revision_unchanged(
@@ -249,6 +248,22 @@ def test_invalid_or_incomplete_commits_leave_values_and_revision_unchanged(
         )
 
     assert values.snapshot() == initial
+
+
+def test_commit_accepts_finite_resolved_values_outside_configured_bounds() -> None:
+    values = AnalysisValues()
+    values.initialize("2st", _configuration())
+    initial = values.snapshot()
+
+    committed = values.commit(
+        {"__PB": 1.01, "__KEX_AB": -1.0},
+        expected=initial,
+        scope=("__PB", "__KEX_AB"),
+    )
+
+    assert committed.revision == 1
+    assert committed["__PB"] == 1.01
+    assert committed["__KEX_AB"] == -1.0
 
 
 def test_real_shipped_configuration_initializes_session_values() -> None:

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -201,7 +201,7 @@ def test_problem_construction_rejects_out_of_bounds_held_independent_value() -> 
         ),
     )
 
-    with pytest.raises(DirectTrfConstructionError, match="Held parameter"):
+    with pytest.raises(DirectTrfConstructionError, match="Independent parameter"):
         OptimizationProblem.from_native(
             engine.plan,
             parameterization,

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -181,6 +181,35 @@ def test_lifecycle_frame_rejects_exact_box_and_affine_infeasibility() -> None:
         problem.lifecycle_frame((problem.lower_bounds[0] - 1.0,), parameterization)
 
 
+def test_problem_construction_rejects_out_of_bounds_held_independent_value() -> None:
+    session, _experiments, parameterization, engine, problem, _invocation = (
+        _qualification_fit()
+    )
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    held_id = next(
+        param_id
+        for param_id, _value in problem.held_items
+        if math.isfinite(configuration[param_id].lower_bound)
+    )
+    invalid_value = configuration[held_id].lower_bound - 1.0
+    invalid_snapshot = dataclasses.replace(
+        problem.source_snapshot,
+        _items=tuple(
+            (param_id, invalid_value if param_id == held_id else value)
+            for param_id, value in problem.source_snapshot.items()
+        ),
+    )
+
+    with pytest.raises(DirectTrfConstructionError, match="Held parameter"):
+        OptimizationProblem.from_native(
+            engine.plan,
+            parameterization,
+            configuration,
+            invalid_snapshot,
+        )
+
+
 def test_root_owned_child_derivation_preserves_context_and_rejects_forgery() -> None:
     _session, _experiments, _parameterization, _engine, problem, _invocation = (
         _qualification_fit()

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -28,6 +28,7 @@ from chemex.optimize.mcmc import NativeMcmcIncompleteError
 from chemex.optimize.progress import ProgressPhase
 from chemex.optimize.resampling import NativeResamplingIncompleteError
 from chemex.optimize.uncertainty import ParameterUnit
+from chemex.parameters.values import AnalysisValuesSnapshot
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
 
@@ -42,6 +43,10 @@ DCEST_PARAMETERS = DCEST_EXAMPLE / "Parameters/parameters.toml"
 THREE_STATE_DCEST_EXAMPLE = ROOT / "examples/Experiments/DCEST_15N_3States"
 THREE_STATE_DCEST_EXPERIMENT = THREE_STATE_DCEST_EXAMPLE / "Experiments/1.25hz.toml"
 THREE_STATE_DCEST_PARAMETERS = THREE_STATE_DCEST_EXAMPLE / "Parameters/parameters.toml"
+CEST_1HN_IP_AP_EXAMPLE = ROOT / "examples/Experiments/CEST_1HN_IP_AP"
+CEST_1HN_IP_AP_EXPERIMENT = CEST_1HN_IP_AP_EXAMPLE / "Experiments/30hz.toml"
+CEST_1HN_IP_AP_PARAMETERS = CEST_1HN_IP_AP_EXAMPLE / "Parameters/parameters.toml"
+CEST_1HN_IP_AP_METHOD = CEST_1HN_IP_AP_EXAMPLE / "Methods/method.toml"
 
 
 def _fit_arguments(
@@ -111,6 +116,32 @@ def _three_state_dcest_arguments(output: Path, method: Path):
             "--plot",
             "nothing",
             "--workers",
+            "1",
+        ]
+    )
+
+
+def _cest_1hn_ip_ap_arguments(output: Path):
+    return build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            str(CEST_1HN_IP_AP_EXPERIMENT),
+            "-p",
+            str(CEST_1HN_IP_AP_PARAMETERS),
+            "-m",
+            str(CEST_1HN_IP_AP_METHOD),
+            "-o",
+            str(output),
+            "--model",
+            "2st.rs",
+            "--include",
+            "4",
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+            "--native-threads",
             "1",
         ]
     )
@@ -273,6 +304,46 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     time_2, intensity_2 = curve[-1]
     fitted_curve_rate = -math.log(intensity_2 / intensity_1) / (time_2 - time_1)
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
+
+
+def test_cest_1hn_ip_ap_commits_finite_negative_derived_r2a_b(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+    committed_snapshots: list[AnalysisValuesSnapshot] = []
+    real_publish = run_info_module.RunInfo.publish_restart
+
+    def record_restart(run_info, snapshot):
+        real_publish(run_info, snapshot)
+        committed_snapshots.append(snapshot)
+
+    with patch.object(
+        run_info_module.RunInfo,
+        "publish_restart",
+        autospec=True,
+        side_effect=record_restart,
+    ):
+        run(_cest_1hn_ip_ap_arguments(output), session=session)
+
+    snapshot = session.analysis_values.snapshot()
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    r2a_b = next(
+        definition
+        for definition in parameter_model.definitions
+        if definition.name == "R2A_B" and definition.spin_system_name == "4H"
+    )
+    configuration = parameter_model.configuration[r2a_b.param_id]
+    assert configuration.lower_bound == 0.0
+    assert [item.revision for item in committed_snapshots] == [1, 2]
+    assert committed_snapshots[0][r2a_b.param_id] == pytest.approx(
+        -0.42454801400787906,
+        rel=1.0e-10,
+        abs=1.0e-12,
+    )
+    assert committed_snapshots[0][r2a_b.param_id] < configuration.lower_bound
+    assert snapshot.revision == 2
 
 
 def test_product_fit_rejects_a_stale_aggregate_commit_atomically(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -337,10 +337,13 @@ def test_cest_1hn_ip_ap_commits_finite_negative_derived_r2a_b(
     configuration = parameter_model.configuration[r2a_b.param_id]
     assert configuration.lower_bound == 0.0
     assert [item.revision for item in committed_snapshots] == [1, 2]
+    # This is the one-profile form of the shipped regression. A 2e-7 relative
+    # tolerance covers backend/finite-difference rounding while remaining seven
+    # orders of magnitude from the configured zero bound and lmfit's old clipping.
     assert committed_snapshots[0][r2a_b.param_id] == pytest.approx(
         -0.42454801400787906,
-        rel=1.0e-10,
-        abs=1.0e-12,
+        rel=2.0e-7,
+        abs=1.0e-9,
     )
     assert committed_snapshots[0][r2a_b.param_id] < configuration.lower_bound
     assert snapshot.revision == 2
@@ -573,6 +576,44 @@ ROLES = [{ FIX = ["PB", "KEX_AB"] }]
     assert [revision for revision, _text in published] == [1, 2, 3]
     assert '"G2N-H" = [3.0,' in published[1][1]
     assert _read_outcome(output)["restart_revision"] == 3
+
+
+def test_out_of_bounds_derived_continuity_cannot_become_held_independent(
+    tmp_path: Path,
+) -> None:
+    method = tmp_path / "method-v2.toml"
+    method.write_text(
+        """
+FORMAT_VERSION = 2
+[DERIVED]
+ROLES = [
+  { FIX = ["PB", "KEX_AB"] },
+  { CONSTRAIN = ["[R1A_A, NUC->G2N-H] = -1.0"] },
+]
+
+[HELD]
+ROLES = [{ FIX = ["PB", "KEX_AB", "R1A_A"] }]
+""",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+
+    with pytest.raises(
+        direct_trf_module.DirectTrfConstructionError,
+        match="Independent parameter .* outside its effective bounds",
+    ):
+        run(_fit_arguments(tmp_path / "Output", method), session=session)
+
+    committed = session.analysis_values.snapshot()
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    r1a_a = next(
+        item.param_id
+        for item in parameter_model.definitions
+        if item.name == "R1A_A" and item.spin_system_name == "G2N-H"
+    )
+    assert committed.revision == 1
+    assert committed[r1a_a] == -1.0
 
 
 def test_relaxation_product_covariance_matches_absolute_sigma_reference(

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -73,7 +73,7 @@ from chemex.parameters.sealed import (
 )
 from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.userfunctions import user_function_registry
-from chemex.parameters.values import AnalysisValuesSnapshot
+from chemex.parameters.values import AnalysisValues, AnalysisValuesSnapshot
 from chemex.runtime import AnalysisSession
 
 ROOT = Path(__file__).parent.parent
@@ -246,6 +246,7 @@ def _native_fixture(
     *,
     values: dict[str, float] | None = None,
     definitions: tuple[ParamDefinition, ...] | None = None,
+    configuration_bounds: dict[str, tuple[float, float]] | None = None,
     model_name: str = "2st",
     occurrence_identity: str = "occurrence-a",
 ) -> tuple[SealedParameterModel, AnalysisValuesSnapshot]:
@@ -267,8 +268,13 @@ def _native_fixture(
         {item.param_id: index for index, item in enumerate(definitions)},
     )
     current = values or {item.param_id: 1.0 for item in declarations}
+    bounds = configuration_bounds or {}
     configs = tuple(
-        ParamConfig(item.param_id, current[item.param_id], -float("inf"), float("inf"))
+        ParamConfig(
+            item.param_id,
+            current[item.param_id],
+            *bounds.get(item.param_id, (-float("inf"), float("inf"))),
+        )
         for item in declarations
     )
     configuration = SealedConfiguration(
@@ -887,6 +893,78 @@ def test_supported_arithmetic_has_explicit_precedence_and_unary_semantics() -> N
     resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
 
     assert resolved["__B"] == -2.0
+
+
+def test_finite_derived_value_outside_configured_bounds_commits() -> None:
+    declarations = (
+        ParameterDeclaration("__R2", False),
+        ParameterDeclaration("__R1", False),
+        ParameterDeclaration("__R2A", False, "__R2 - __R1", model_owned=True),
+    )
+    parameter_model, _snapshot = _native_fixture(
+        declarations,
+        values={"__R2": 1.0, "__R1": 2.0, "__R2A": 12.0},
+        configuration_bounds={"__R2A": (0.0, float("inf"))},
+    )
+    values = AnalysisValues()
+    values.initialize(parameter_model.model_identity, parameter_model.configuration)
+    initial = values.snapshot()
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        initial,
+        Method(),
+        {"__R2A"},
+    )
+
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(initial))
+    committed = values.commit(
+        dict(resolved.items()),
+        expected=initial,
+        scope=parameterization.scope_ids,
+    )
+
+    assert parameterization.role("__R2A") is ParameterRole.DERIVED
+    assert resolved["__R2A"] == -1.0
+    assert committed["__R2A"] == -1.0
+    assert committed.revision == 1
+
+
+def test_derived_continuity_value_becomes_the_next_independent_value() -> None:
+    declarations = (ParameterDeclaration("__A", True),)
+    parameter_model, _snapshot = _native_fixture(
+        declarations,
+        values={"__A": 0.5},
+        configuration_bounds={"__A": (0.0, 1.0)},
+    )
+    values = AnalysisValues()
+    values.initialize(parameter_model.model_identity, parameter_model.configuration)
+    initial = values.snapshot()
+    derived = compile_active_parameterization(
+        parameter_model,
+        initial,
+        Method(constraints=("[A] = 2.0",)),
+        {"__A"},
+    )
+    resolved = derived.resolve(derived.frame_from_snapshot(initial))
+    committed = values.commit(
+        dict(resolved.items()),
+        expected=initial,
+        scope=derived.scope_ids,
+    )
+
+    independent = compile_active_parameterization(
+        parameter_model,
+        committed,
+        Method(),
+        {"__A"},
+    )
+    next_frame = independent.frame_from_snapshot(committed)
+    next_values = dict(next_frame.ordered_items())
+
+    assert derived.role("__A") is ParameterRole.DERIVED
+    assert independent.role("__A") is ParameterRole.FIT
+    assert next_values["__A"] == 2.0
+    assert next_values["__A"] != parameter_model.configuration["__A"].effective_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #700 by allowing complete, finite expression-derived values to cross the authoritative central-value commit boundary even when they lie outside configured numerical-coordinate bounds.

## Root cause and authority

The native evaluator correctly resolved a finite negative `R2A_B`, but `AnalysisValues.commit()` applied configuration bounds role-blindly to the complete resolved snapshot and rejected the accepted fit. This contradicted frozen #570: configured bounds define numerical-problem feasibility, not implicit expression domains. It also blocked #569's requirement that successful workflows atomically commit complete resolved snapshots for multi-step continuity.

## Change

- `AnalysisValues` now owns identity, occurrence/configuration compatibility, revision freshness, exact non-empty scope and coverage, finite real scalar values, atomic replacement, and one revision increment—without owning role-aware numerical bounds.
- `build_bounded_independent_frame()` validates the canonical complete independent frame at deterministic problem construction, including controlled and held coordinates and all-FIX evaluation-only steps.
- A derived value may therefore remain out of configured bounds while derived, but a later step that makes it independent rejects that starting coordinate clearly before optimization. There is no clipping or reseeding.

Ordinary/grouped TRF share this bounded root problem. GRID seeds are checked against it, DE ranges must remain inside it and the full restart is revalidated, and MCMC samples inherit its frozen bounds. MC/BS/BSN and MCMC do not mutate committed central values.

## Compatibility and scientific exposure

This deliberately supersedes historical lmfit clipping for derived expressions. With the shipped one-profile CEST case, ChemEx 2026.06.1/lmfit completed step 1 with `R2A_B(4H) = 0.0`; native evaluation resolves approximately `-0.424548` and now commits it unchanged.

The audit covered `R2A = R2 - R1` relaxation quantities, model-free rates, population complements, Eyring, binding, and HD-derived quantities. Existing operator/function domains, convergence checks, and scientific postconditions remain unchanged; independent-coordinate feasibility remains enforced.

No CLI, TOML, parameter-ID, or output-schema migration is introduced. The changelog records the intentional compatibility correction; shipped inputs and documentation require no changes.

## Validation

- Focused implementation matrix: 38 passed
- Independent final adversarial review matrix: 34 passed
- Full suite: 992 passed
- Python 3.13 and 3.14 CI: passed
- Type checks on Python 3.13 and 3.14: passed
- Ruff lint/format, `git diff --check`, package build, and CodeQL: passed
- Full shipped `examples/Experiments/CEST_1HN_IP_AP/run.sh`: both steps completed; revision 2 published; negative finite derived values were retained with truthful uncertainty output
- Fresh independent Standards and #569/#570 Spec reviews: no findings

No remaining derived-bound work or follow-up issue is required for #700.
