### PR TITLE
Resolve companion-spin constraint references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   commit, requested statistics analyze the committed deterministic result.
 
 ### Fixed
+- Restored target-relative constraint resolution across companion spins at the
+  same molecular group and atom site. Exact spin context remains preferred,
+  companion context outranks global fallback, and unrelated or genuinely
+  ambiguous candidates still fail closed without encoded-ID similarity.
 - Restored GRID as exact profiled chi-square surface analysis. Declared grid
   coordinates remain held at every point while the remaining independent
   fitted coordinates are optimized with native TRF; exact objective

--- a/src/chemex/configuration/method_validation.py
+++ b/src/chemex/configuration/method_validation.py
@@ -140,11 +140,17 @@ def _resolve_constraint_reference(
         raise MethodFormatError(
             f"No context-compatible parameter matches [{selector.render()}]", source
         )
-    minimum_extras = min(context[1] for _candidate, context in ranked)
-    eligible = tuple(
-        (candidate, context[0])
+    maximum_spin_specificity = max(context[0] for _candidate, context in ranked)
+    spin_eligible = tuple(
+        (candidate, context)
         for candidate, context in ranked
-        if context[1] == minimum_extras
+        if context[0] == maximum_spin_specificity
+    )
+    minimum_extras = min(context[2] for _candidate, context in spin_eligible)
+    eligible = tuple(
+        (candidate, context[1])
+        for candidate, context in spin_eligible
+        if context[2] == minimum_extras
     )
     maximal = tuple(
         candidate

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -1212,8 +1212,10 @@ def compatible_reference_context(
     candidate: ParamDefinition,
     target: ParamDefinition,
     selector: ParamName,
-) -> tuple[frozenset[str], int] | None:
+) -> tuple[int, frozenset[str], int] | None:
+    """Return spin specificity, matching condition fields, and extra context."""
     matched: set[str] = set()
+    spin_specificity = 0
     extras = 0
     candidate_spin = SpinSystem.from_name(candidate.spin_system_name)
     target_spin = SpinSystem.from_name(target.spin_system_name)
@@ -1223,7 +1225,9 @@ def compatible_reference_context(
             or candidate_spin.match(target_spin)
             or target_spin.match(candidate_spin)
         ):
-            matched.add("spin_system")
+            spin_specificity = 2
+        elif target_spin and candidate_spin.shares_group_site(target_spin):
+            spin_specificity = 1
         elif target_spin:
             return None
         else:
@@ -1241,7 +1245,7 @@ def compatible_reference_context(
             matched.add(name)
         else:
             return None
-    return frozenset(matched), extras
+    return spin_specificity, frozenset(matched), extras
 
 
 def _resolve_reference(
@@ -1281,11 +1285,17 @@ def _resolve_reference(
             selector=selector_text,
             target_id=target_id,
         )
-    minimum_extras = min(context[1] for _candidate, context in ranked)
-    eligible = tuple(
-        (candidate, context[0])
+    maximum_spin_specificity = max(context[0] for _candidate, context in ranked)
+    spin_eligible = tuple(
+        (candidate, context)
         for candidate, context in ranked
-        if context[1] == minimum_extras
+        if context[0] == maximum_spin_specificity
+    )
+    minimum_extras = min(context[2] for _candidate, context in spin_eligible)
+    eligible = tuple(
+        (candidate, context[1])
+        for candidate, context in spin_eligible
+        if context[2] == minimum_extras
     )
     maximal = tuple(
         candidate

--- a/src/chemex/parameters/spin_system/atom.py
+++ b/src/chemex/parameters/spin_system/atom.py
@@ -53,6 +53,10 @@ class Atom:
         """
         return other.name.startswith(self.name)
 
+    def shares_site(self, other: Self) -> bool:
+        """Return whether atoms identify the same site across nucleus types."""
+        return bool(self) and bool(other) and self.name[1:] == other.name[1:]
+
     def __hash__(self) -> int:
         """Generates a hash value for an Atom instance.
 

--- a/src/chemex/parameters/spin_system/spin_system.py
+++ b/src/chemex/parameters/spin_system/spin_system.py
@@ -145,6 +145,16 @@ class SpinSystem(BaseModel):
         spin_pairs = zip(self.spins.values(), other.spins.values(), strict=False)
         return all(spin.match(other_spin) for spin, other_spin in spin_pairs)
 
+    def shares_group_site(self, other: Self) -> bool:
+        """Return whether two systems contain spins at the same molecular site."""
+        return any(
+            spin.group
+            and spin.group == other_spin.group
+            and spin.atom.shares_site(other_spin.atom)
+            for spin in self.spins.values()
+            for other_spin in other.spins.values()
+        )
+
     def part_of(self, selection: Sequence[Self] | str) -> bool:
         if isinstance(selection, str):
             return selection.lower() in ("all", "*")

--- a/tests/configuration/test_method_plan.py
+++ b/tests/configuration/test_method_plan.py
@@ -106,6 +106,70 @@ ROLES = [
     assert v1_plan.steps == v2_plan.steps
 
 
+@pytest.mark.parametrize("format_version", (1, 2))
+def test_v1_and_v2_validate_same_group_companion_constraints(
+    tmp_path: Path,
+    format_version: int,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition(
+            "r2adq-a", "R2ADQ_A", "I3HD1", (("h_larmor_frq", 700.2),), 0.0, 0.0, 100.0
+        ),
+        ParamDefinition(
+            "r2dq-a", "R2DQ_A", "I3HD1", (("h_larmor_frq", 700.2),), 20.0, 0.0, 100.0
+        ),
+        ParamDefinition(
+            "r1-a", "R1_A", "I3CD1", (("h_larmor_frq", 700.2),), 1.5, 0.0, 10.0
+        ),
+    )
+    roles = (
+        'CONSTRAINTS = ["[R2ADQ_A] = [R2DQ_A] - [R1_A] / 3.0"]'
+        if format_version == 1
+        else 'ROLES = [{ CONSTRAIN = ["[R2ADQ_A] = [R2DQ_A] - [R1_A] / 3.0"] }]'
+    )
+    version = "" if format_version == 1 else "FORMAT_VERSION = 2\n"
+    method = _write(tmp_path / "method.toml", f"{version}[STEP]\n{roles}\n")
+
+    read_method_plan([method]).validate(model)
+
+
+@pytest.mark.parametrize("format_version", (1, 2))
+def test_v1_and_v2_rank_spin_context_before_condition_specificity(
+    tmp_path: Path,
+    format_version: int,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition(
+            "target",
+            "TARGET",
+            "I3HD1",
+            (("h_larmor_frq", 800.0),),
+            0.0,
+            0.0,
+            100.0,
+        ),
+        ParamDefinition("companion", "VALUE", "I3CD1", (), 1.0, 0.0, 10.0),
+        ParamDefinition(
+            "global",
+            "VALUE",
+            "",
+            (("h_larmor_frq", 800.0),),
+            2.0,
+            0.0,
+            10.0,
+        ),
+    )
+    roles = (
+        'CONSTRAINTS = ["[TARGET] = [VALUE]"]'
+        if format_version == 1
+        else 'ROLES = [{ CONSTRAIN = ["[TARGET] = [VALUE]"] }]'
+    )
+    version = "" if format_version == 1 else "FORMAT_VERSION = 2\n"
+    method = _write(tmp_path / "method.toml", f"{version}[STEP]\n{roles}\n")
+
+    read_method_plan([method]).validate(model)
+
+
 def test_v1_and_v2_grid_statistics_normalize_to_the_same_step_semantics(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -43,6 +43,7 @@ from chemex.models.factory import model_factory
 from chemex.parameters.database import ParameterIndex
 from chemex.parameters.name import ParamName
 from chemex.parameters.parameterization import (
+    ActiveParameterization,
     AmbiguousParameterReferenceError,
     ConstraintCycleError,
     ConstraintDomainError,
@@ -94,6 +95,10 @@ BINDING_ROOT = ROOT / "examples/Combinations/2stBinding"
 BINDING_EXPERIMENTS = tuple(sorted((BINDING_ROOT / "Experiments").glob("*.toml")))
 BINDING_PARAMETERS = BINDING_ROOT / "Parameters/params.toml"
 BINDING_METHOD = BINDING_ROOT / "Methods/method.toml"
+METHYL_ROOT = ROOT / "examples/Combinations/CPMG_CH3_1H_DQ_TQ"
+METHYL_EXPERIMENTS = tuple(sorted((METHYL_ROOT / "Experiments").glob("*.toml")))
+METHYL_PARAMETERS = METHYL_ROOT / "Parameters/parameters.toml"
+METHYL_METHOD = METHYL_ROOT / "Methods/method.toml"
 _METHOD_SOURCE = SourceRef(Path("method.toml"), "STEP", "ROLES")
 
 _BINDING_STEP1_R2_B_IDS = {
@@ -299,6 +304,29 @@ def _native_fixture(
         _items=tuple(current.items()),
     )
     return parameter_model, snapshot
+
+
+def _compile_context_constraint(
+    definitions: tuple[ParamDefinition, ...],
+    expression: str,
+    target_id: str = "__TARGET",
+) -> ActiveParameterization:
+    declarations = tuple(
+        ParameterDeclaration(definition.param_id, False) for definition in definitions
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        definitions=definitions,
+        values={
+            definition.param_id: definition.default_value for definition in definitions
+        },
+    )
+    return compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(constraints=(expression,)),
+        {target_id},
+    )
 
 
 def test_canonical_ordered_actions_compile_complete_replacement_roles() -> None:
@@ -1119,7 +1147,7 @@ def test_parameter_selectors_use_legacy_exact_name_matching(
         )
 
 
-def test_contextually_incomparable_reference_is_ambiguity() -> None:
+def test_exact_spin_reference_outranks_condition_specific_global() -> None:
     definitions = (
         ParamDefinition("__A_SPIN", "A", "G1N-HN", (), 1.0, -10.0, 10.0),
         ParamDefinition(
@@ -1137,16 +1165,225 @@ def test_contextually_incomparable_reference_is_ambiguity() -> None:
         definitions=definitions,
     )
 
-    with pytest.raises(AmbiguousParameterReferenceError) as raised:
-        compile_active_parameterization(
-            parameter_model,
-            snapshot,
-            Method(constraints=("[T] = [A]",)),
-            {"__T"},
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(constraints=("[T] = [A]",)),
+        {"__T"},
+    )
+
+    assert parameterization.program.constraints[0].dependencies == ("__A_SPIN",)
+
+
+def test_shipped_methyl_constraint_resolves_companion_spin_for_both_states() -> None:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        METHYL_EXPERIMENTS,
+        Selection(
+            include=[
+                SpinSystem.from_name("I3HD1-CD1"),
+                SpinSystem.from_name("V75HG1-CG1"),
+                SpinSystem.from_name("V75HG2-CG2"),
+            ],
+            exclude=None,
+        ),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([METHYL_PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    plan = read_method_plan([METHYL_METHOD])
+    session.validate_method_plan(plan)
+    parameterization = session.compile_parameterization_from_actions(
+        plan.effective_role_actions()["STEP1"],
+        experiments.param_ids,
+    )
+
+    dependencies = {
+        constraint.target_id: constraint.dependencies
+        for constraint in parameterization.program.constraints
+    }
+    assert dependencies["__R2ADQ_A_I3HD1_700_2MHZ"] == (
+        "__R2DQ_A_I3HD1_700_2MHZ",
+        "__R1_A_I3CD1_700_2MHZ",
+    )
+    assert dependencies["__R2ADQ_B_I3HD1_700_2MHZ"] == (
+        "__R2DQ_B_I3HD1_700_2MHZ",
+        "__R1_B_I3CD1_700_2MHZ",
+    )
+    assert dependencies["__R2ADQ_A_V75HG1_700_2MHZ"][-1] == ("__R1_A_V75CG1_700_2MHZ")
+    assert dependencies["__R2ADQ_A_V75HG2_700_2MHZ"][-1] == ("__R1_A_V75CG2_700_2MHZ")
+    assert dependencies["__R2ADQ_B_V75HG1_700_2MHZ"][-1] == ("__R1_B_V75CG1_700_2MHZ")
+    assert dependencies["__R2ADQ_B_V75HG2_700_2MHZ"][-1] == ("__R1_B_V75CG2_700_2MHZ")
+    resolved = parameterization.resolve(
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot())
+    )
+    assert resolved["__R2ADQ_A_I3HD1_700_2MHZ"] == pytest.approx(
+        resolved["__R2DQ_A_I3HD1_700_2MHZ"] - resolved["__R1_A_I3CD1_700_2MHZ"] / 3.0
+    )
+    assert resolved["__R2ADQ_B_I3HD1_700_2MHZ"] == pytest.approx(
+        resolved["__R2DQ_B_I3HD1_700_2MHZ"] - resolved["__R1_B_I3CD1_700_2MHZ"] / 3.0
+    )
+
+
+def test_exact_spin_reference_outranks_same_group_companion() -> None:
+    parameterization = _compile_context_constraint(
+        (
+            ParamDefinition("__TARGET", "TARGET", "I3HD1", (), 0.0, -10.0, 10.0),
+            ParamDefinition("__VALUE_EXACT", "VALUE", "I3HD1", (), 2.0, -10.0, 10.0),
+            ParamDefinition(
+                "__VALUE_COMPANION", "VALUE", "I3CD1", (), 3.0, -10.0, 10.0
+            ),
+        ),
+        "[TARGET] = [VALUE]",
+    )
+
+    assert parameterization.program.constraints[0].dependencies == ("__VALUE_EXACT",)
+
+
+def test_explicit_spin_selector_remains_authoritative() -> None:
+    parameterization = _compile_context_constraint(
+        (
+            ParamDefinition("__TARGET", "TARGET", "I3HD1", (), 0.0, -10.0, 10.0),
+            ParamDefinition("__VALUE_EXACT", "VALUE", "I3HD1", (), 2.0, -10.0, 10.0),
+            ParamDefinition(
+                "__VALUE_COMPANION", "VALUE", "I3CD1", (), 3.0, -10.0, 10.0
+            ),
+        ),
+        "[TARGET] = [VALUE, NUC->I3CD1]",
+    )
+
+    assert parameterization.program.constraints[0].dependencies == (
+        "__VALUE_COMPANION",
+    )
+
+
+def test_same_group_companion_reference_outranks_global_fallback() -> None:
+    parameterization = _compile_context_constraint(
+        (
+            ParamDefinition("__TARGET", "TARGET", "I3HD1", (), 0.0, -10.0, 10.0),
+            ParamDefinition(
+                "__VALUE_COMPANION", "VALUE", "I3CD1", (), 3.0, -10.0, 10.0
+            ),
+            ParamDefinition("__VALUE_GLOBAL", "VALUE", "", (), 4.0, -10.0, 10.0),
+        ),
+        "[TARGET] = [VALUE]",
+    )
+
+    assert parameterization.program.constraints[0].dependencies == (
+        "__VALUE_COMPANION",
+    )
+
+
+def test_same_group_companion_outranks_condition_specific_global() -> None:
+    parameterization = _compile_context_constraint(
+        (
+            ParamDefinition(
+                "__TARGET",
+                "TARGET",
+                "I3HD1",
+                (("h_larmor_frq", 800.0),),
+                0.0,
+                -10.0,
+                10.0,
+            ),
+            ParamDefinition(
+                "__VALUE_COMPANION", "VALUE", "I3CD1", (), 3.0, -10.0, 10.0
+            ),
+            ParamDefinition(
+                "__VALUE_GLOBAL",
+                "VALUE",
+                "",
+                (("h_larmor_frq", 800.0),),
+                4.0,
+                -10.0,
+                10.0,
+            ),
+        ),
+        "[TARGET] = [VALUE]",
+    )
+
+    assert parameterization.program.constraints[0].dependencies == (
+        "__VALUE_COMPANION",
+    )
+
+
+def test_unrelated_group_reference_is_rejected() -> None:
+    with pytest.raises(NoParameterMatchError, match="context-compatible"):
+        _compile_context_constraint(
+            (
+                ParamDefinition("__TARGET", "TARGET", "I3HD1", (), 0.0, -10.0, 10.0),
+                ParamDefinition(
+                    "__VALUE_OTHER", "VALUE", "L7CD2", (), 3.0, -10.0, 10.0
+                ),
+            ),
+            "[TARGET] = [VALUE]",
         )
 
-    assert raised.value.code == "ambiguity"
-    assert raised.value.context["candidate_ids"] == ("__A_SPIN", "__A_FIELD")
+
+def test_equally_specific_same_group_companions_remain_ambiguous() -> None:
+    with pytest.raises(AmbiguousParameterReferenceError) as raised:
+        _compile_context_constraint(
+            (
+                ParamDefinition("__TARGET", "TARGET", "I3HD1", (), 0.0, -10.0, 10.0),
+                ParamDefinition("__VALUE_CD1", "VALUE", "I3CD1", (), 2.0, -10.0, 10.0),
+                ParamDefinition("__VALUE_MD1", "VALUE", "I3MD1", (), 3.0, -10.0, 10.0),
+            ),
+            "[TARGET] = [VALUE]",
+        )
+
+    assert raised.value.context["candidate_ids"] == (
+        "__VALUE_CD1",
+        "__VALUE_MD1",
+    )
+
+
+def test_condition_specificity_is_preserved_for_same_group_companions() -> None:
+    parameterization = _compile_context_constraint(
+        (
+            ParamDefinition(
+                "__TARGET",
+                "TARGET",
+                "I3HD1",
+                (("h_larmor_frq", 800.0),),
+                0.0,
+                -10.0,
+                10.0,
+            ),
+            ParamDefinition(
+                "__VALUE_800",
+                "VALUE",
+                "I3CD1",
+                (("h_larmor_frq", 800.0),),
+                2.0,
+                -10.0,
+                10.0,
+            ),
+            ParamDefinition(
+                "__VALUE_GLOBAL_CONDITION",
+                "VALUE",
+                "I3CD1",
+                (),
+                3.0,
+                -10.0,
+                10.0,
+            ),
+            ParamDefinition(
+                "__VALUE_600",
+                "VALUE",
+                "I3CD1",
+                (("h_larmor_frq", 600.0),),
+                4.0,
+                -10.0,
+                10.0,
+            ),
+        ),
+        "[TARGET] = [VALUE]",
+    )
+
+    assert parameterization.program.constraints[0].dependencies == ("__VALUE_800",)
 
 
 def test_direct_self_reference_is_rejected_before_evaluation() -> None:

--- a/tests/test_spin_system.py
+++ b/tests/test_spin_system.py
@@ -52,3 +52,11 @@ def test_strict_spin_system_parser_accepts_every_registered_atom_name() -> None:
         spin_system = SpinSystem.from_name_strict(f"G23{atom_name}")
 
         assert spin_system.atoms["i"].name == atom_name
+
+
+def test_spin_system_group_site_identifies_cross_nucleus_companions() -> None:
+    target = SpinSystem.from_name("V75HG1")
+
+    assert target.shares_group_site(SpinSystem.from_name("V75CG1"))
+    assert not target.shares_group_site(SpinSystem.from_name("V75CG2"))
+    assert not target.shares_group_site(SpinSystem.from_name("V71CG1"))


### PR DESCRIPTION
Closes #704

## Summary

- resolve target-relative constraint references through an explicit structural spin tier: exact/matching target spin, then same-group same-site companion spin, then unscoped/global fallback
- keep explicit selector fields authoritative and preserve existing condition specificity and fail-closed ambiguity within the selected spin tier
- share the corrected context logic across canonical v1/v2 method validation and native constraint compilation without restoring RapidFuzz or encoded-ID matching
- cover the shipped methyl A/B relationships, V75 methyl-site separation, exact/companion/global precedence, unrelated groups, ambiguity, conditions, and domain-level group/site semantics

## Root cause

`compatible_reference_context()` rejected every scoped spin context that did not exactly match the constraint target. The established methyl expression therefore could not resolve proton-side `R2ADQ_A` to carbon-side `R1_A` in the same methyl group. During review, the initial fix also exposed that spin and condition matches must be ranked lexicographically rather than as one unordered field set; this PR now ranks exact spin > companion spin > global before applying the existing condition rules.

## Shipped behavior and historical comparison

The complete `examples/Combinations/CPMG_CH3_1H_DQ_TQ/run.sh` workflow succeeds with all 30 profiles. For `I3HD1-CD1`, native resolution is:

```text
R2ADQ_A(I3HD1) = R2DQ_A(I3HD1) - R1_A(I3CD1) / 3
R2ADQ_B(I3HD1) = R2DQ_B(I3HD1) - R1_B(I3CD1) / 3
```

The same structural mapping is emitted for every methyl in 2026.06.1 and the amended native head, including independent `V75HG1 -> V75CG1` and `V75HG2 -> V75CG2` mappings. The representative I3 constrained value is 70.6334 in 2026.06.1 and 70.6230 on native TRF. Aggregate minima differ (lmfit chi-square 1796.58; native TRF chi-square 4034.87), as expected from the already-migrated solver; this PR asserts structural constraint equivalence, not lmfit numerical identity.

The 30 canonical shipped methods were audited. Five declare constraints; the four non-methyl cases are same-spin state relationships. The methyl combination is the only shipped cross-spin/cross-nucleus target-relative case.

## Validation

- focused constraint, method-plan, expression, and spin-system tests: 125 passed
- full pytest: 992 passed; the sole local failure was the pre-existing shipped-method count test seeing 13 ignored `Output*/run_info` copies, and that test passed separately with generated output directories temporarily stashed and restored
- shipped methyl workflow: passed, 30 profiles, 1,876 evaluations, chi-square 4034.87
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv build`
- `git diff --check main...HEAD`
- `graphify update .`

## Independent review

- standards/design: clean
- scientific/spec: identified and prompted the lexicographic spin-tier correction and additional mixed condition/spin and state-B coverage; clean after amendment
