### PR TITLE
Separate default parameter roles from estimation capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   commit, requested statistics analyze the committed deterministic result.
 
 ### Fixed
+- Restored explicit method `FIT`/`FIX` overrides for user-overridable spin
+  parameters whose ordinary baseline is a state-A equality, such as `J_B` in
+  the shipped N15 NH RDC analysis. Scientific estimation capability is now
+  declared separately from whether an experiment fits the parameter by
+  default; model-owned derivations and unsupported parameters remain protected.
 - Restored target-relative constraint resolution across companion spins at the
   same molecular group and atom site. Exact spin context remains preferred,
   companion context outranks global fallback, and unrelated or genuinely

--- a/src/chemex/configuration/method_validation.py
+++ b/src/chemex/configuration/method_validation.py
@@ -218,8 +218,7 @@ def _reject_unestimable(
     unestimable = tuple(
         param_id
         for param_id in matches
-        if model.declarations[param_id].model_expression
-        and not model.declarations[param_id].supports_estimation
+        if not model.declarations[param_id].supports_estimation
     )
     if unestimable:
         raise MethodFormatError(

--- a/src/chemex/models/kinetic/settings_2st_hd.py
+++ b/src/chemex/models/kinetic/settings_2st_hd.py
@@ -22,6 +22,7 @@ def make_settings_2st_hd(conditions: Conditions) -> dict[str, ParamLocalSetting]
             value=d2o,
             min=0.0,
             max=1.0,
+            supports_estimation=True,
         ),
         "kdh": ParamLocalSetting(
             name_setting=NameSetting("kdh", "g", ("temperature",)),

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -196,6 +196,8 @@ class ParameterFactory:
         *,
         contributor: str,
         model_owned_ids: frozenset[str],
+        supports_estimation_ids: set[str],
+        default_fit_ids: set[str],
         contributions: (
             dict[str, list[ParameterDeclarationContribution]] | None
         ) = None,
@@ -206,10 +208,12 @@ class ParameterFactory:
         for param_id, parameter in parameters.items():
             contribution = ParameterDeclarationContribution(
                 param_id=param_id,
-                supports_estimation=parameter.vary,
+                supports_estimation=param_id in supports_estimation_ids,
                 model_expression=parameter.expr,
                 contributor=contributor,
                 model_owned=param_id in model_owned_ids and bool(parameter.expr),
+                requires_independent=not bool(parameter.expr),
+                fits_by_default=param_id in default_fit_ids,
             )
             target.setdefault(param_id, []).append(contribution)
 
@@ -251,6 +255,22 @@ class ParameterFactory:
             construction_context = f"{contributor}; {construction_context}"
         _set_to_fit(parameters, name_map, config.to_be_fitted.rates)
         _set_to_fit(parameters_mf, name_map_mf, config.to_be_fitted.model_free)
+        default_fit_ids = {
+            param_id for param_id, parameter in parameters.items() if parameter.vary
+        }
+        model_free_default_fit_ids = {
+            param_id for param_id, parameter in parameters_mf.items() if parameter.vary
+        }
+        supports_estimation_ids = default_fit_ids | {
+            name_map[name]
+            for name, setting in settings.items()
+            if setting.supports_estimation
+        }
+        model_free_supports_estimation_ids = model_free_default_fit_ids | {
+            name_map_mf[name]
+            for name, setting in settings_mf.items()
+            if setting.supports_estimation
+        }
 
         if self._native_construction_error is None:
             native_parameters = (
@@ -273,6 +293,16 @@ class ParameterFactory:
                     native_parameters,
                     contributor=construction_context,
                     model_owned_ids=model_owned_ids,
+                    supports_estimation_ids=(
+                        model_free_supports_estimation_ids
+                        if self.parameter_store.model.model_free
+                        else supports_estimation_ids
+                    ),
+                    default_fit_ids=(
+                        model_free_default_fit_ids
+                        if self.parameter_store.model.model_free
+                        else default_fit_ids
+                    ),
                 )
                 if not self.parameter_store.model.model_free:
                     model_free_owned_ids = frozenset(
@@ -289,6 +319,8 @@ class ParameterFactory:
                         parameters_mf,
                         contributor=construction_context,
                         model_owned_ids=model_free_owned_ids,
+                        supports_estimation_ids=model_free_supports_estimation_ids,
+                        default_fit_ids=model_free_default_fit_ids,
                         contributions=self._model_free_declaration_contributions,
                     )
             except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -132,32 +132,49 @@ class ModelDerivationOverrideError(ParameterizationError):
 
 @dataclass(frozen=True, slots=True)
 class ParameterDeclarationContribution:
-    """One construction contribution to a parameter's scientific baseline."""
+    """One construction contribution to a parameter's scientific baseline.
+
+    Estimation support is a scientific capability. Requiring an independent
+    value and fitting it by default are separate baseline choices.
+    """
 
     param_id: str
     supports_estimation: bool
     model_expression: str
     contributor: str
     model_owned: bool = False
+    requires_independent: bool = False
+    fits_by_default: bool = False
 
 
 @dataclass(frozen=True, slots=True)
 class ParameterDeclaration:
-    """Sealed scientific inputs used to build each method-local baseline."""
+    """Sealed scientific inputs used to build each method-local baseline.
+
+    Estimation support permits an explicit FIT override. Requiring an
+    independent value chooses baseline FIT/FIX rather than DERIVED, while
+    ``fits_by_default`` distinguishes FIT from FIX.
+    """
 
     param_id: str
     supports_estimation: bool
     model_expression: str = ""
     model_owned: bool = False
+    requires_independent: bool = False
+    fits_by_default: bool = False
 
 
 def baseline_parameter_role(declaration: ParameterDeclaration) -> ParameterRole:
     """Return the authoritative method-local role for one sealed declaration."""
     if declaration.model_expression and (
-        declaration.model_owned or not declaration.supports_estimation
+        declaration.model_owned or not declaration.requires_independent
     ):
         return ParameterRole.DERIVED
-    if declaration.supports_estimation:
+    if (
+        declaration.requires_independent
+        and declaration.fits_by_default
+        and declaration.supports_estimation
+    ):
         return ParameterRole.FIT
     return ParameterRole.FIX
 
@@ -202,6 +219,8 @@ class SealedParameterDeclarations(Mapping[str, ParameterDeclaration]):
                         item.supports_estimation,
                         item.model_expression,
                         item.model_owned,
+                        item.requires_independent,
+                        item.fits_by_default,
                     )
                     for item in items
                 ),
@@ -222,7 +241,7 @@ def seal_parameter_declarations(
     definitions: SealedDefinitions,
     contributions: Mapping[str, Sequence[ParameterDeclarationContribution]],
 ) -> SealedParameterDeclarations:
-    """Seal additive estimation support and model derivations in definition order."""
+    """Seal additive capabilities, baseline independence, and model derivations."""
     items: list[ParameterDeclaration] = []
     for definition in definitions:
         contributed = tuple(contributions.get(definition.param_id, ()))
@@ -245,6 +264,8 @@ def seal_parameter_declarations(
                 expressions=tuple(expressions),
             )
         supports_estimation = any(item.supports_estimation for item in contributed)
+        requires_independent = any(item.requires_independent for item in contributed)
+        fits_by_default = any(item.fits_by_default for item in contributed)
         expression = expressions[0] if expressions else ""
         model_owned = any(
             item.model_owned and item.model_expression.strip() == expression
@@ -256,6 +277,8 @@ def seal_parameter_declarations(
                 supports_estimation,
                 expression,
                 model_owned,
+                requires_independent,
+                fits_by_default,
             )
         )
     return SealedParameterDeclarations(tuple(items))
@@ -1179,9 +1202,7 @@ def _validate_estimation_authority(
         unsupported_matches = tuple(
             param_id
             for param_id in rule.matches
-            if param_id in active_ids
-            and declarations[param_id].model_expression
-            and not declarations[param_id].supports_estimation
+            if param_id in active_ids and not declarations[param_id].supports_estimation
         )
         if unsupported_matches:
             raise IncompatibleParameterizationInputError(

--- a/src/chemex/parameters/setting.py
+++ b/src/chemex/parameters/setting.py
@@ -58,6 +58,8 @@ class ExpressionSetting:
 
 
 class ParamLocalSetting:
+    """Scientific defaults and explicit-estimation capability for one parameter."""
+
     def __init__(
         self,
         name_setting: NameSetting,
@@ -66,6 +68,7 @@ class ParamLocalSetting:
         max: float = np.inf,
         vary: bool = False,
         expr: str = "",
+        supports_estimation: bool = False,
     ) -> None:
         self.__expr: ExpressionSetting = ExpressionSetting(_RE_NAMES)
         self.name_setting = name_setting
@@ -73,6 +76,7 @@ class ParamLocalSetting:
         self.min = min
         self.max = max
         self.vary = vary
+        self.supports_estimation = supports_estimation
         self.expr = expr
 
     @property

--- a/src/chemex/parameters/spins.py
+++ b/src/chemex/parameters/spins.py
@@ -88,7 +88,9 @@ def _add_dw_param_settings(
         vary=True,
     )
     settings[f"cs_i_{state}"].expr = f"{{cs_i_a}} + {{dw_i_a{state}}}"
+    settings[f"cs_i_{state}"].supports_estimation = False
     settings[f"cs_s_{state}"].expr = f"{{cs_s_a}} + {{dw_s_a{state}}}"
+    settings[f"cs_s_{state}"].supports_estimation = False
 
     if basis.model.temp_coef:
         _add_temp_coef_param_settings(settings, state, conditions)
@@ -98,6 +100,15 @@ def _set_equal_to_a(settings: dict[str, ParamLocalSetting]) -> None:
     for name, setting in settings.items():
         if not setting.expr:
             setting.expr = f"{{{name[:-1]}a}}"
+            setting.supports_estimation = True
+
+
+def _declare_independent_estimation_capabilities(
+    settings: dict[str, ParamLocalSetting],
+) -> None:
+    for setting in settings.values():
+        if not setting.expr:
+            setting.supports_estimation = True
 
 
 def create_base_param_settings(
@@ -263,6 +274,7 @@ def create_base_param_settings(
     }
 
     _update_expr_for_proton_exchange(settings, state, basis)
+    _declare_independent_estimation_capabilities(settings)
 
     if state != "a":
         _set_equal_to_a(settings)
@@ -281,6 +293,7 @@ def _build_model_free_settings(
     for name, setting in settings_mf.items():
         if name in model_free_expressions:
             setting.expr = model_free_expressions[name]
+            setting.supports_estimation = False
 
     return settings_mf
 

--- a/tests/configuration/test_method_plan.py
+++ b/tests/configuration/test_method_plan.py
@@ -40,6 +40,8 @@ def _parameter_model(
     *definitions: ParamDefinition,
     supports_estimation: bool = True,
     model_expression: str = "",
+    requires_independent: bool | None = None,
+    fits_by_default: bool | None = None,
 ) -> SealedParameterModel:
     sealed_definitions = SealedDefinitions(tuple(definitions), {})
     configuration = SealedConfiguration(
@@ -61,6 +63,16 @@ def _parameter_model(
                 definition.param_id,
                 supports_estimation,
                 model_expression,
+                requires_independent=(
+                    not bool(model_expression)
+                    if requires_independent is None
+                    else requires_independent
+                ),
+                fits_by_default=(
+                    supports_estimation and not bool(model_expression)
+                    if fits_by_default is None
+                    else fits_by_default
+                ),
             )
             for definition in definitions
         )
@@ -129,6 +141,39 @@ def test_v1_and_v2_validate_same_group_companion_constraints(
     )
     version = "" if format_version == 1 else "FORMAT_VERSION = 2\n"
     method = _write(tmp_path / "method.toml", f"{version}[STEP]\n{roles}\n")
+
+    read_method_plan([method]).validate(model)
+
+
+@pytest.mark.parametrize("format_version", (1, 2))
+def test_v1_and_v2_allow_supported_default_derivation_role_overrides(
+    tmp_path: Path,
+    format_version: int,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition("j-a", "J_A", "3N-H", (), -90.0, -120.0, -60.0),
+        ParamDefinition("j-b", "J_B", "3N-H", (), -90.0, -120.0, -60.0),
+        supports_estimation=True,
+        model_expression="j-a",
+        requires_independent=False,
+    )
+    if format_version == 1:
+        contents = """[STEP1]
+FIX = ["J_B"]
+
+[STEP2]
+FIT = ["J_B"]
+"""
+    else:
+        contents = """FORMAT_VERSION = 2
+[STEP1]
+ROLES = [{ FIX = ["J_B"] }]
+
+[STEP2]
+ROLES_FROM = "STEP1"
+ROLES = [{ FIT = ["J_B"] }]
+"""
+    method = _write(tmp_path / "method.toml", contents)
 
     read_method_plan([method]).validate(model)
 
@@ -788,6 +833,23 @@ def test_fit_cannot_override_a_structurally_unestimable_parameter(
     )
     method = _write(
         tmp_path / "unestimable.toml",
+        'FORMAT_VERSION = 2\n[STEP]\nROLES = [{ FIT = ["PB"] }]\n',
+    )
+
+    with pytest.raises(MethodFormatError, match="do not support estimation"):
+        read_method_plan([method]).validate(model)
+
+
+def test_fit_cannot_override_an_independent_unsupported_parameter(
+    tmp_path: Path,
+) -> None:
+    model = _parameter_model(
+        ParamDefinition("pb", "PB", "", (), 0.1, 0.0, 1.0),
+        supports_estimation=False,
+        requires_independent=True,
+    )
+    method = _write(
+        tmp_path / "unsupported.toml",
         'FORMAT_VERSION = 2\n[STEP]\nROLES = [{ FIT = ["PB"] }]\n',
     )
 

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -56,8 +56,12 @@ def _parameter_model() -> SealedParameterModel:
     )
     declarations = SealedParameterDeclarations(
         (
-            ParameterDeclaration("__PB", True, "", False),
-            ParameterDeclaration("__KEX_AB", True, "", False),
+            ParameterDeclaration(
+                "__PB", True, requires_independent=True, fits_by_default=True
+            ),
+            ParameterDeclaration(
+                "__KEX_AB", True, requires_independent=True, fits_by_default=True
+            ),
         )
     )
     return SealedParameterModel(

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -99,6 +99,10 @@ METHYL_ROOT = ROOT / "examples/Combinations/CPMG_CH3_1H_DQ_TQ"
 METHYL_EXPERIMENTS = tuple(sorted((METHYL_ROOT / "Experiments").glob("*.toml")))
 METHYL_PARAMETERS = METHYL_ROOT / "Parameters/parameters.toml"
 METHYL_METHOD = METHYL_ROOT / "Methods/method.toml"
+RDC_ROOT = ROOT / "examples/Combinations/N15_NH_RDC"
+RDC_EXPERIMENTS = tuple(sorted((RDC_ROOT / "Experiments").glob("*.toml")))
+RDC_PARAMETERS = RDC_ROOT / "Parameters/parameters.toml"
+RDC_METHOD = RDC_ROOT / "Methods/method.toml"
 _METHOD_SOURCE = SourceRef(Path("method.toml"), "STEP", "ROLES")
 
 _BINDING_STEP1_R2_B_IDS = {
@@ -246,6 +250,24 @@ def _build_fit_session() -> tuple[AnalysisSession, set[str]]:
     return session, experiments.param_ids
 
 
+def _build_rdc_session() -> tuple[AnalysisSession, set[str]]:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    experiments = build_experiments(
+        RDC_EXPERIMENTS,
+        Selection(
+            include=[SpinSystem.from_name("3N-HN")],
+            exclude=None,
+        ),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([RDC_PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    return session, experiments.param_ids
+
+
 def _native_fixture(
     declarations: tuple[ParameterDeclaration, ...],
     *,
@@ -331,9 +353,15 @@ def _compile_context_constraint(
 
 def test_canonical_ordered_actions_compile_complete_replacement_roles() -> None:
     declarations = (
-        ParameterDeclaration("__DW_AB_24N", True),
-        ParameterDeclaration("__DW_AB_31N", True),
-        ParameterDeclaration("__DW_AB_40N", True),
+        ParameterDeclaration(
+            "__DW_AB_24N", True, requires_independent=True, fits_by_default=True
+        ),
+        ParameterDeclaration(
+            "__DW_AB_31N", True, requires_independent=True, fits_by_default=True
+        ),
+        ParameterDeclaration(
+            "__DW_AB_40N", True, requires_independent=True, fits_by_default=True
+        ),
     )
     definitions = tuple(
         ParamDefinition(
@@ -389,7 +417,11 @@ def test_canonical_ordered_actions_compile_complete_replacement_roles() -> None:
 def test_canonical_fit_or_fix_removes_an_earlier_constraint(
     replacement: type[FitAction] | type[FixAction],
 ) -> None:
-    declarations = (ParameterDeclaration("__PB", True),)
+    declarations = (
+        ParameterDeclaration(
+            "__PB", True, requires_independent=True, fits_by_default=True
+        ),
+    )
     parameter_model, snapshot = _native_fixture(declarations)
     selector = ParameterSelector("PB")
     actions = (
@@ -442,8 +474,12 @@ def test_method_plan_resolves_explicit_and_baseline_role_actions_immutably() -> 
 
 def test_inherited_canonical_action_outside_selected_scope_is_inert() -> None:
     declarations = (
-        ParameterDeclaration("__DW_AB_24N", True),
-        ParameterDeclaration("__DW_AB_31N", True),
+        ParameterDeclaration(
+            "__DW_AB_24N", True, requires_independent=True, fits_by_default=True
+        ),
+        ParameterDeclaration(
+            "__DW_AB_31N", True, requires_independent=True, fits_by_default=True
+        ),
     )
     definitions = (
         ParamDefinition("__DW_AB_24N", "DW_AB", "24N", (), 1.0, -10.0, 10.0),
@@ -597,6 +633,138 @@ def test_non_model_owned_baseline_expression_can_compile_as_fit() -> None:
     assert parameterization.role("__B") is ParameterRole.FIT
 
 
+def test_shipped_rdc_j_b_default_is_derived_but_explicitly_estimable(
+    tmp_path: Path,
+) -> None:
+    session, required_ids = _build_rdc_session()
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    j_b = next(
+        definition
+        for definition in parameter_model.definitions
+        if definition.name == "J_B" and definition.spin_system_name == "3N-H"
+    )
+    j_a = next(
+        definition
+        for definition in parameter_model.definitions
+        if definition.name == "J_A" and definition.spin_system_name == "3N-H"
+    )
+    declaration = parameter_model.declarations[j_b.param_id]
+    baseline = session.compile_parameterization(Method(), required_ids)
+
+    assert declaration.model_expression == "__J_A_3N_H"
+    assert declaration.supports_estimation
+    assert not declaration.requires_independent
+    assert not declaration.model_owned
+    assert baseline.role(j_b.param_id) is ParameterRole.DERIVED
+    assert parameter_model.declarations[j_a.param_id].supports_estimation
+    assert baseline.role(j_a.param_id) is ParameterRole.FIX
+    assert j_b.param_id in {
+        constraint.target_id for constraint in baseline.program.constraints
+    }
+
+    v1_method = tmp_path / "method-v1.toml"
+    v1_method.write_text(
+        '[STEP1]\nFIX = ["J_B"]\n\n[STEP2]\nFIT = ["J_B"]\n',
+        encoding="utf-8",
+    )
+    plans = (
+        read_method_plan([v1_method]),
+        read_method_plan([RDC_METHOD]),
+    )
+    for plan in plans:
+        session.validate_method_plan(plan)
+        actions = plan.effective_role_actions()
+        step1 = session.compile_parameterization_from_actions(
+            actions["STEP1"],
+            required_ids,
+        )
+        step2 = session.compile_parameterization_from_actions(
+            actions["STEP2"],
+            required_ids,
+        )
+
+        assert step1.role(j_b.param_id) is ParameterRole.FIX
+        assert j_b.param_id in step1.independent_ids
+        assert step2.role(j_b.param_id) is ParameterRole.FIT
+        assert j_b.param_id in step2.independent_ids
+        assert j_b.param_id not in {
+            constraint.target_id for constraint in step1.program.constraints
+        }
+        assert j_b.param_id not in {
+            constraint.target_id for constraint in step2.program.constraints
+        }
+
+
+def test_shipped_dcest_explicit_fit_targets_declare_capability() -> None:
+    session, required_ids = _build_dcest_session()
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    plan = read_method_plan([DCEST_METHOD])
+    baseline = session.compile_parameterization(Method(), required_ids)
+
+    session.validate_method_plan(plan)
+
+    declarations = parameter_model.declarations
+    explicit_fit_names = {"D2O", "CS_A"}
+    explicit_fit_ids = {
+        definition.param_id
+        for definition in parameter_model.definitions
+        if definition.name in explicit_fit_names
+    }
+    assert all(
+        declarations[param_id].supports_estimation for param_id in explicit_fit_ids
+    )
+    assert all(
+        baseline.role(param_id) is ParameterRole.FIX for param_id in explicit_fit_ids
+    )
+
+
+def test_fixed_default_derivation_continues_into_later_explicit_fit() -> None:
+    declarations = (
+        ParameterDeclaration("__J_A", False),
+        ParameterDeclaration(
+            "__J_B",
+            True,
+            "__J_A",
+            model_owned=False,
+            requires_independent=False,
+        ),
+        ParameterDeclaration(
+            "__X", True, requires_independent=True, fits_by_default=True
+        ),
+    )
+    parameter_model, _snapshot = _native_fixture(
+        declarations,
+        values={"__J_A": -90.0, "__J_B": -91.0, "__X": 1.0},
+    )
+    values = AnalysisValues()
+    values.initialize(parameter_model.model_identity, parameter_model.configuration)
+    initial = values.snapshot()
+    fixed = compile_active_parameterization(
+        parameter_model,
+        initial,
+        Method(fix=("J_B",)),
+        {"__J_B", "__X"},
+    )
+    committed = values.commit(
+        {"__J_B": -91.0, "__X": 2.0},
+        expected=initial,
+        scope=fixed.scope_ids,
+    )
+    fitted = compile_active_parameterization(
+        parameter_model,
+        committed,
+        Method(fit=("J_B",)),
+        {"__J_B", "__X"},
+    )
+    next_frame = fitted.frame_from_snapshot(committed)
+
+    assert fixed.role("__J_B") is ParameterRole.FIX
+    assert fitted.role("__J_B") is ParameterRole.FIT
+    assert dict(next_frame.ordered_items())["__J_B"] == -91.0
+
+
 def test_non_model_owned_baseline_expression_remains_active_constraint() -> None:
     declarations = (
         ParameterDeclaration("__A", False),
@@ -655,6 +823,21 @@ def test_non_estimable_declaration_cannot_compile_as_fit() -> None:
         ParameterDeclaration("__A", False),
         ParameterDeclaration("__B", False, "__A", model_owned=False),
     )
+    parameter_model, snapshot = _native_fixture(declarations)
+
+    with pytest.raises(IncompatibleParameterizationInputError) as raised:
+        compile_active_parameterization(
+            parameter_model,
+            snapshot,
+            Method(fit=("B",)),
+            {"__B"},
+        )
+
+    assert raised.value.context["param_ids"] == ("__B",)
+
+
+def test_independent_unsupported_declaration_cannot_compile_as_fit() -> None:
+    declarations = (ParameterDeclaration("__B", False, requires_independent=True),)
     parameter_model, snapshot = _native_fixture(declarations)
 
     with pytest.raises(IncompatibleParameterizationInputError) as raised:
@@ -729,7 +912,7 @@ def test_binding_current_roles_compile_all_estimable_r2_b_coordinates() -> None:
 
 def test_constraint_chain_is_deterministic_and_freshly_reresolves() -> None:
     declarations = (
-        ParameterDeclaration("__A", False),
+        ParameterDeclaration("__A", True),
         ParameterDeclaration("__B", False),
         ParameterDeclaration("__C", False),
     )
@@ -759,7 +942,7 @@ def test_constraint_chain_is_deterministic_and_freshly_reresolves() -> None:
 def test_legacy_constraints_fix_fit_precedence_uses_final_fit_role() -> None:
     declarations = (
         ParameterDeclaration("__A", False),
-        ParameterDeclaration("__B", False),
+        ParameterDeclaration("__B", True),
     )
     parameter_model, snapshot = _native_fixture(
         declarations,
@@ -864,6 +1047,26 @@ def test_real_model_free_scientific_expression_matches_legacy_resolution() -> No
     )
 
 
+def test_model_free_rate_expression_remains_unestimable() -> None:
+    session, required_ids = _build_mf_session()
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    r2_b = next(
+        definition
+        for definition in parameter_model.definitions
+        if definition.name == "R2_B" and definition.spin_system_name == "G23N"
+    )
+    declaration = parameter_model.declarations[r2_b.param_id]
+
+    assert declaration.model_expression
+    assert not declaration.supports_estimation
+    with pytest.raises(IncompatibleParameterizationInputError):
+        session.compile_parameterization(
+            Method(fit=("R2_B",)),
+            required_ids,
+        )
+
+
 @pytest.mark.parametrize("model_name", ("2st_binding", "2st_eyring"))
 def test_registered_scientific_model_expression_compiles_through_restricted_language(
     model_name: str,
@@ -958,7 +1161,11 @@ def test_finite_derived_value_outside_configured_bounds_commits() -> None:
 
 
 def test_derived_continuity_value_becomes_the_next_independent_value() -> None:
-    declarations = (ParameterDeclaration("__A", True),)
+    declarations = (
+        ParameterDeclaration(
+            "__A", True, requires_independent=True, fits_by_default=True
+        ),
+    )
     parameter_model, _snapshot = _native_fixture(
         declarations,
         values={"__A": 0.5},

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -70,6 +70,8 @@ def _parameter_inputs(
                 parameter.vary,
                 parameter.expr,
                 bool(parameter.expr),
+                requires_independent=not bool(parameter.expr),
+                fits_by_default=parameter.vary,
             )
             for parameter in ordered
         )


### PR DESCRIPTION
Closes #706.

## Scientific/product correction

Restores the #570 distinction between an experiment's ordinary parameterization and the scientific capability for an explicit method `FIT`.

Native declarations now seal three independent additive facts:

- `requires_independent`: DERIVED versus independent baseline;
- `fits_by_default`: FIT versus FIX baseline;
- `supports_estimation`: whether an explicit method FIT is allowed.

Consequently, the shipped RDC workflow keeps `J_B = J_A` as its ordinary default, STEP1 may replace that default with an independently held `J_B`, and STEP2 may release the same committed `J_B` values for Direct TRF. Model-owned and unsupported derivations remain protected. Both canonical v2 validation and native compilation now fail closed for every unsupported FIT, including expression-free independent quantities.

This is implemented through the existing local setting → experiment contribution → sealed declaration architecture. It does not restore mutable `ParameterStore` authority and contains no `J_B` exception.

## Broader catalog audit

- State-B/C/etc. spin relationships introduced by `_set_equal_to_a()` declare capability generally without becoming default-fitted.
- Independent spin parameters declare explicit-fit capability while retaining their experiment-selected default FIT/FIX roles.
- The demonstrated default-fixed `D2O` kinetic coordinate declares capability explicitly.
- Model-free relaxation expressions and temperature-coefficient derived DW quantities do not retain stale capability from an earlier setting.
- All 30 canonical shipped method files and their FIT selectors were audited.
- Existing binding baseline counts remain 53 fitted coordinates in STEP1 and 312 in STEP2.

`N15_NH_RDC` was the only current shipped failure because the pre-fix expression guard already enforced the incorrect capability metadata for `J_B`; the audit also closed latent declaration gaps so enforcement is now uniform.

## Shipped workflow and historical comparison

`examples/Combinations/N15_NH_RDC/run.sh` succeeds across all six datasets and both steps:

| Step | J_B authority | Profiles | chi-square |
| --- | --- | ---: | ---: |
| STEP1 | independent, fixed | 138 | 6052.6 |
| STEP2 | independent, fitted | 138 | 5446.86 |

ChemEx 2026.06.1 explicitly reported `J_B fixed 23` followed by `J_B fitted 23`; its chi-square values were 6052.6 and 5446.9. Across the 23 fitted `J_B` coordinates, native and historical values differ by at most 0.0002 Hz.

## Tests

- focused parameter authority/method/model-free suite: 210 passed;
- full pytest: 1001 passed;
- representative Direct/grouped Direct/DE/execution suite: 188 passed;
- `uv run ty check`;
- `uv run ruff check .`;
- `uv run ruff format --check .`;
- `git diff --check main`;
- `uv build`;
- `graphify update .`.

Two independent reviews were performed. Initial findings concerning expression-free unsupported FIT, stale model-free capability, and accidental baseline FIT promotion were fixed; the final standards/design and scientific/spec reviews are clean.
