### PR TITLE
Canonicalize model-free rates across reversed basis orientations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   commit, requested statistics analyze the committed deterministic result.
 
 ### Fixed
+- Canonicalized model-free relaxation derivations by physical N-H and C-H
+  orientation, so experiments that reverse their local `i`/`s` basis ordering
+  now contribute one unambiguous model-owned expression. Single-spin
+  components follow the physical nucleus, symmetric components remain shared,
+  and deuteration and proton-exchange contributions retain their established
+  semantics.
 - Restored explicit method `FIT`/`FIX` overrides for user-overridable spin
   parameters whose ordinary baseline is a state-A equality, such as `J_B` in
   the shipped N15 NH RDC analysis. Scientific estimation capability is now

--- a/src/chemex/nmr/rates.py
+++ b/src/chemex/nmr/rates.py
@@ -324,6 +324,36 @@ _RATE_NAMES = [
     "mu_is",
 ]
 
+_CANONICAL_REVERSED_ORIENTATIONS = {
+    "hn": "nh",
+    "hc": "ch",
+}
+
+_REVERSED_RATE_COMPONENTS = {
+    "r2_i": "r2_s",
+    "r2_s": "r2_i",
+    "r1_i": "r1_s",
+    "r1_s": "r1_i",
+    "r2a_i": "r2a_s",
+    "r2a_s": "r2a_i",
+    "r2mq_is": "r2mq_is",
+    "r1a_is": "r1a_is",
+    "etaxy_i": "etaxy_s",
+    "etaxy_s": "etaxy_i",
+    "etaz_i": "etaz_s",
+    "etaz_s": "etaz_i",
+    "sigma_is": "sigma_is",
+    "mu_is": "mu_is",
+}
+
+
+def _canonical_rate_identity(spin_system: str, component: str) -> tuple[str, str]:
+    """Return the physical rate-function orientation and component identity."""
+    canonical_orientation = _CANONICAL_REVERSED_ORIENTATIONS.get(spin_system)
+    if canonical_orientation is None:
+        return spin_system, component
+    return canonical_orientation, _REVERSED_RATE_COMPONENTS[component]
+
 
 def get_model_free_expressions(basis: Basis, conditions: Conditions) -> dict[str, str]:
     """Generate expressions for model-free analysis based on basis and conditions.
@@ -337,17 +367,20 @@ def get_model_free_expressions(basis: Basis, conditions: Conditions) -> dict[str
 
     """
     deuterated_extension = "_d" if conditions.is_deuterated else ""
-    rate_function_name = f"{basis.spin_system}{deuterated_extension}"
-
     h_frq_str = f"{conditions.h_larmor_frq}"
     has_h_exchange = basis.spin_system in {"nh", "hn"}
 
     model_free_expr: dict[str, str] = {}
     for state, name in product(basis.model.states, _RATE_NAMES):
         rate_name = f"{name}_{state}"
+        rate_orientation, rate_component = _canonical_rate_identity(
+            basis.spin_system,
+            name,
+        )
+        rate_function_name = f"{rate_orientation}{deuterated_extension}"
         khh = f", {{khh_{state}}}" if has_h_exchange else ""
         arguments = f"{h_frq_str}, {{tauc_{state}}}, {{s2_{state}}}{khh}"
-        expr = f"{rate_function_name}({arguments})['{name}']"
+        expr = f"{rate_function_name}({arguments})['{rate_component}']"
         model_free_expr[rate_name] = expr
 
     return model_free_expr

--- a/tests/nmr/test_rates.py
+++ b/tests/nmr/test_rates.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from chemex.configuration.conditions import Conditions
+from chemex.models.model import ModelSpec
+from chemex.nmr.basis import Basis
+from chemex.nmr.rates import get_model_free_expressions, rate_functions
+
+_SWAPPED_COMPONENTS = {
+    "r2_i": "r2_s",
+    "r2_s": "r2_i",
+    "r1_i": "r1_s",
+    "r1_s": "r1_i",
+    "r2a_i": "r2a_s",
+    "r2a_s": "r2a_i",
+    "r2mq_is": "r2mq_is",
+    "r1a_is": "r1a_is",
+    "etaxy_i": "etaxy_s",
+    "etaxy_s": "etaxy_i",
+    "etaz_i": "etaz_s",
+    "etaz_s": "etaz_i",
+    "sigma_is": "sigma_is",
+    "mu_is": "mu_is",
+}
+
+
+def _model_free_expressions(
+    spin_system: str,
+    *,
+    deuterated: bool = False,
+) -> dict[str, str]:
+    basis = Basis(
+        type="ixyzsxyz",
+        spin_system=spin_system,
+        model=ModelSpec(),
+    )
+    label = ("2h",) if deuterated else ()
+    return get_model_free_expressions(
+        basis,
+        Conditions(h_larmor_frq=799.708, label=label),
+    )
+
+
+@pytest.mark.parametrize(
+    ("canonical_orientation", "reversed_orientation"),
+    (("nh", "hn"), ("ch", "hc")),
+)
+@pytest.mark.parametrize("state", ("a", "b"))
+def test_reversed_orientation_expressions_use_one_physical_identity(
+    canonical_orientation: str,
+    reversed_orientation: str,
+    state: str,
+) -> None:
+    canonical = _model_free_expressions(canonical_orientation)
+    reversed_ = _model_free_expressions(reversed_orientation)
+
+    for component, reversed_component in _SWAPPED_COMPONENTS.items():
+        assert (
+            canonical[f"{component}_{state}"]
+            == reversed_[f"{reversed_component}_{state}"]
+        )
+
+
+def test_nh_hn_expressions_canonicalize_physical_n_and_h_components() -> None:
+    nh = _model_free_expressions("nh")
+    hn = _model_free_expressions("hn")
+
+    assert (
+        nh["r1_i_a"]
+        == hn["r1_s_a"]
+        == ("nh(799.708, {tauc_a}, {s2_a}, {khh_a})['r1_i']")
+    )
+    assert (
+        nh["r1_s_a"]
+        == hn["r1_i_a"]
+        == ("nh(799.708, {tauc_a}, {s2_a}, {khh_a})['r1_s']")
+    )
+
+
+@pytest.mark.parametrize("component", ("r2mq_is", "r1a_is", "sigma_is", "mu_is"))
+def test_reversed_orientation_preserves_symmetric_is_component(
+    component: str,
+) -> None:
+    nh = _model_free_expressions("nh")
+    hn = _model_free_expressions("hn")
+
+    assert nh[f"{component}_a"] == hn[f"{component}_a"]
+
+
+@pytest.mark.parametrize(
+    ("canonical_orientation", "reversed_orientation"),
+    (("nh", "hn"), ("ch", "hc")),
+)
+def test_deuterated_reversed_orientation_expressions_are_canonical(
+    canonical_orientation: str,
+    reversed_orientation: str,
+) -> None:
+    canonical = _model_free_expressions(canonical_orientation, deuterated=True)
+    reversed_ = _model_free_expressions(reversed_orientation, deuterated=True)
+
+    for component, reversed_component in _SWAPPED_COMPONENTS.items():
+        assert canonical[f"{component}_a"] == reversed_[f"{reversed_component}_a"]
+        assert f"{canonical_orientation}_d(" in canonical[f"{component}_a"]
+
+
+@pytest.mark.parametrize(
+    ("canonical_orientation", "reversed_orientation", "arguments"),
+    (
+        ("nh", "hn", (799.708, 8.7, 0.83, 2.4)),
+        ("nh_d", "hn_d", (799.708, 8.7, 0.83, 2.4)),
+        ("ch", "hc", (799.708, 8.7, 0.83)),
+        ("ch_d", "hc_d", (799.708, 8.7, 0.83)),
+    ),
+)
+def test_reversed_rate_functions_are_numerically_equivalent(
+    canonical_orientation: str,
+    reversed_orientation: str,
+    arguments: tuple[float, ...],
+) -> None:
+    canonical = rate_functions[canonical_orientation](*arguments)
+    reversed_ = rate_functions[reversed_orientation](*arguments)
+
+    for component, reversed_component in _SWAPPED_COMPONENTS.items():
+        np.testing.assert_allclose(
+            canonical[component],
+            reversed_[reversed_component],
+            rtol=1e-13,
+            atol=0.0,
+        )
+
+
+def test_khh_remains_attached_to_the_physical_proton() -> None:
+    nh_without_exchange = rate_functions["nh"](799.708, 8.7, 0.83)
+    nh_with_exchange = rate_functions["nh"](799.708, 8.7, 0.83, 2.4)
+    hn_without_exchange = rate_functions["hn"](799.708, 8.7, 0.83)
+    hn_with_exchange = rate_functions["hn"](799.708, 8.7, 0.83, 2.4)
+
+    assert nh_with_exchange["r1_s"] - nh_without_exchange["r1_s"] == pytest.approx(
+        2.4,
+    )
+    assert hn_with_exchange["r1_i"] - hn_without_exchange["r1_i"] == pytest.approx(
+        2.4,
+    )
+    assert nh_with_exchange["r1_i"] == nh_without_exchange["r1_i"]
+    assert hn_with_exchange["r1_s"] == hn_without_exchange["r1_s"]

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -103,6 +103,12 @@ RDC_ROOT = ROOT / "examples/Combinations/N15_NH_RDC"
 RDC_EXPERIMENTS = tuple(sorted((RDC_ROOT / "Experiments").glob("*.toml")))
 RDC_PARAMETERS = RDC_ROOT / "Parameters/parameters.toml"
 RDC_METHOD = RDC_ROOT / "Methods/method.toml"
+SHIFTS_ROOT = ROOT / "examples/Combinations/Shifts"
+SHIFTS_OPPOSITE_ORIENTATION_EXPERIMENTS = (
+    SHIFTS_ROOT / "Experiments/cpmg_15n_800.toml",
+    SHIFTS_ROOT / "Experiments/cpmg_1hn_800.toml",
+)
+SHIFTS_PARAMETERS = SHIFTS_ROOT / "Parameters/parameters.toml"
 _METHOD_SOURCE = SourceRef(Path("method.toml"), "STEP", "ROLES")
 
 _BINDING_STEP1_R2_B_IDS = {
@@ -1045,6 +1051,75 @@ def test_real_model_free_scientific_expression_matches_legacy_resolution() -> No
         item.param_id in parameterization.derived_ids and item.name.startswith("R2")
         for item in definitions
     )
+
+
+def test_real_opposite_orientation_contributions_share_one_model_derivation() -> None:
+    session = AnalysisSession.create()
+    session.set_model("2st")
+    build_experiments(
+        list(SHIFTS_OPPOSITE_ORIENTATION_EXPERIMENTS),
+        Selection(include=[SpinSystem.from_name("11")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([SHIFTS_PARAMETERS]))
+
+    r1_n_id = "__R1_A_11N_799_7MHZ"
+    contributions = session.parameter_factory._model_free_declaration_contributions[
+        r1_n_id
+    ]
+    expected_expression = "nh(799.708, __TAUC_A_11, __S2_A_11, __KHH_A_11)['r1_i']"
+
+    assert len(contributions) == 2
+    assert {item.model_expression for item in contributions} == {
+        expected_expression,
+    }
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    model_free_model = session.parameter_factory.build_model_free_parameter_model()
+    assert model_free_model is not None
+    assert (
+        model_free_model.declarations[r1_n_id].model_expression == expected_expression
+    )
+
+
+def test_sealing_still_rejects_genuinely_different_model_owned_expressions() -> None:
+    definition = ParamDefinition(
+        "__R1_A_11N_799_7MHZ",
+        "R1_A",
+        "11N",
+        (("h_larmor_frq", 799.7),),
+        1.5,
+        0.0,
+        float("inf"),
+    )
+    definitions = SealedDefinitions((definition,), {definition.param_id: 0})
+
+    with pytest.raises(
+        IncompatibleParameterizationInputError,
+        match="Contributors disagree on a model-owned expression",
+    ):
+        seal_parameter_declarations(
+            definitions,
+            {
+                definition.param_id: (
+                    ParameterDeclarationContribution(
+                        definition.param_id,
+                        False,
+                        "nh(800.0, __TAUC_A_11, __S2_A_11)['r1_i']",
+                        "experiment-a",
+                        True,
+                    ),
+                    ParameterDeclarationContribution(
+                        definition.param_id,
+                        False,
+                        "other_rate(800.0, __TAUC_A_11)['r1_i']",
+                        "experiment-b",
+                        True,
+                    ),
+                ),
+            },
+        )
 
 
 def test_model_free_rate_expression_remains_unestimable() -> None:


### PR DESCRIPTION
Closes #708.

## Scientific correction

Model-free derivation identity now follows the physical two-spin system rather than an experiment's incidental local `i`/`s` ordering:

- `nh` is canonical for the proven `nh`/`hn` orientation pair;
- `ch` is canonical for the proven `ch`/`hc` orientation pair;
- reversed orientations exchange single-spin `i`/`s` components;
- symmetric `is` components retain the same canonical component;
- deuteration remains part of the function identity;
- NH proton-exchange/KHH remains attached to the physical proton.

No symbolic-equivalence engine or numerical-equivalence heuristic is introduced. `cn` and other orientations without a proven reverse alias remain unchanged, and strict duplicate model-expression conflict detection remains fail-closed.

## Shipped regression

For `R1_A(11N, 799.708 MHz)` in `examples/Combinations/Shifts`:

```text
before:
  nh(..., __KHH_A_11)['r1_i']
  hn(..., __KHH_A_11)['r1_s']

after (both contributors):
  nh(..., __KHH_A_11)['r1_i']
```

The same correction applies to the state-B declaration. The complete shipped workflow now retains all five experiments and 56 profiles, fitting 620 data points with 62 variables.

## Exposure and historical comparison

- All 14 model-free rate components were audited structurally and numerically for NH/HN and CH/HC, including deuterated variants.
- `Combinations/Shifts` is the only current shipped run root combining opposite basis orientations; no shipped mixed CH/HC or deuterated reverse-orientation workflow was found.
- ChemEx 2026.06.1 silently retained the first `nh` contribution. Its shipped workflow and this repaired native workflow both produce chi-square 1039.63 and reduced chi-square 1.86314, with the same 620 data points and 62 variables. KEX and representative rates match printed precision; PB differs by 7e-7. Exact optimizer identity is not claimed.

## Validation

- focused model-free/rate/parameter/sealing tests: 155 passed;
- complete `examples/Combinations/Shifts/run.sh`: passed;
- full pytest: 1019 passed;
- `uv run ty check`: passed;
- `uv run ruff check .`: passed;
- `uv run ruff format --check .`: passed;
- `git diff --check`: passed;
- wheel and sdist build: passed;
- `graphify update .`: completed.

Fresh standards/design and scientific/spec reviews found no actionable issues.
