### PR TITLE
Enforce physical relaxation-rate feasibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   statistics; DE failures never fall back to the old committed start.
 
 ### Changed
+- Relaxation and cross-correlation rates used together in an NMR basis now obey
+  the positive-semidefinite domain of their represented relaxation block before
+  scientific evaluation. Native fitting uses private feasible coordinates while
+  preserving public `ETAXY`, `ETAZ`, `SIGMA`, `MU`, `R1`, and `R2` parameter
+  names, restart files, and output. The proton-exchange contribution `KHH` and
+  diffusion coefficient `D` are non-negative. Invalid fixed starting states fail
+  before the kernel; adaptive Jacobian scaling and fail-closed kernel exceptions
+  are unchanged.
 - Changed native local TRF refinement to one versioned adaptive inverse-Jacobian-
   column-norm scaling policy across Direct, grouped Direct, GRID nuisance fits,
   DE polishing, and resampling refits. Sensitivity-based trust-region geometry

--- a/src/chemex/nmr/basis.py
+++ b/src/chemex/nmr/basis.py
@@ -359,6 +359,16 @@ def _freeze_vectors(vectors: DictArray) -> VectorMap:
     return MappingProxyType(frozen_vectors)
 
 
+@dataclass(frozen=True, slots=True)
+class RelaxationPsdSpec:
+    """NMR-owned local-name description of one symmetric relaxation block."""
+
+    family: str
+    state: str
+    diagonal_names: tuple[str, ...]
+    off_diagonal_names: tuple[tuple[int, int, str], ...]
+
+
 @dataclass(frozen=True)
 class Basis:
     type: str
@@ -403,6 +413,71 @@ class Basis:
         required_names = set(self.matrices)
         required_names |= {f"p{state}" for state in self.model.states}
         return required_names
+
+    @property
+    def relaxation_psd_specs(self) -> tuple[RelaxationPsdSpec, ...]:
+        """Describe dissipative blocks represented by this basis's transitions."""
+        specs: list[RelaxationPsdSpec] = []
+        components = set(self.components)
+        for state in self.model.states:
+            candidates = (
+                (
+                    "transverse-i",
+                    ("ix", "2ixsz"),
+                    (f"r2_i_{state}", f"r2a_i_{state}"),
+                    ((0, 1, f"etaxy_i_{state}"),),
+                ),
+                (
+                    "transverse-s",
+                    ("sx", "2izsx"),
+                    (f"r2_s_{state}", f"r2a_s_{state}"),
+                    ((0, 1, f"etaxy_s_{state}"),),
+                ),
+                (
+                    "multiple-quantum",
+                    ("2ixsx", "2iysy"),
+                    (f"r2mq_is_{state}", f"r2mq_is_{state}"),
+                    ((0, 1, f"mu_is_{state}"),),
+                ),
+            )
+            specs.extend(
+                RelaxationPsdSpec(family, state, diagonals, off_diagonals)
+                for family, modes, diagonals, off_diagonals in candidates
+                if set(modes) <= components
+            )
+            longitudinal_modes = tuple(
+                mode for mode in ("iz", "sz", "2izsz") if mode in components
+            )
+            if len(longitudinal_modes) < 2:
+                continue
+            diagonal_names = {
+                "iz": f"r1_i_{state}",
+                "sz": f"r1_s_{state}",
+                "2izsz": f"r1a_is_{state}",
+            }
+            cross_names = {
+                frozenset(("iz", "sz")): f"sigma_is_{state}",
+                frozenset(("iz", "2izsz")): f"etaz_i_{state}",
+                frozenset(("sz", "2izsz")): f"etaz_s_{state}",
+            }
+            specs.append(
+                RelaxationPsdSpec(
+                    "longitudinal",
+                    state,
+                    tuple(diagonal_names[mode] for mode in longitudinal_modes),
+                    tuple(
+                        (
+                            row,
+                            column,
+                            cross_names[frozenset((left, right))],
+                        )
+                        for row, left in enumerate(longitudinal_modes)
+                        for column, right in enumerate(longitudinal_modes)
+                        if row < column
+                    ),
+                )
+            )
+        return tuple(specs)
 
     def copy_matrices(self) -> DictArray:
         return {name: matrix.copy() for name, matrix in self.matrices.items()}

--- a/src/chemex/optimize/de_direct_trf.py
+++ b/src/chemex/optimize/de_direct_trf.py
@@ -491,7 +491,7 @@ class DeSearchInvocation:
         )
 
     @classmethod
-    def _for_problem_with_policy(
+    def _for_problem_with_policy(  # noqa: C901 - closed DE construction policy
         cls,
         problem: OptimizationProblem,
         *,
@@ -571,23 +571,56 @@ class DeSearchInvocation:
             if param_id not in selected
         )
         start = tuple(root_starts[param_id] for param_id in canonical_selected_ids)
-        search_specification_identity = _identity(
-            "native-de-search-specification",
-            tuple(item.identity for item in coordinates),
-        )
-        derivation = DeSearchProblemDerivation(
-            problem.identity,
-            problem.affine_feasibility_identity,
-            search_specification_identity,
-            canonical_selected_ids,
-            held_items,
-            start,
-        )
-        search_problem = problem.derive_child(
-            controlled_ids=canonical_selected_ids,
-            start=start,
-            derivation=derivation,
-        )
+
+        def derive_search_problem() -> OptimizationProblem:
+            search_specification_identity = _identity(
+                "native-de-search-specification",
+                tuple(item.identity for item in coordinates),
+            )
+            derivation = DeSearchProblemDerivation(
+                problem.identity,
+                problem.affine_feasibility_identity,
+                search_specification_identity,
+                canonical_selected_ids,
+                held_items,
+                start,
+            )
+            return problem.derive_child(
+                controlled_ids=canonical_selected_ids,
+                start=start,
+                derivation=derivation,
+            )
+
+        search_problem = derive_search_problem()
+        feasible = search_problem.feasible_coordinates
+        if feasible is not None and not feasible.supports_box_only_algorithms:
+            raise DirectTrfConstructionError(
+                "DE search over relaxation-feasibility coordinates is not yet "
+                "qualified; use Direct TRF for this method section"
+            )
+        if feasible is not None:
+            feasible_lower, feasible_upper = feasible.solver_bounds
+            child_indices = {
+                param_id: index
+                for index, param_id in enumerate(search_problem.controlled_ids)
+            }
+            coordinates = tuple(
+                DeSearchCoordinate(
+                    item.param_id,
+                    max(
+                        item.physical_lower,
+                        feasible_lower[child_indices[item.param_id]],
+                    ),
+                    min(
+                        item.physical_upper,
+                        feasible_upper[child_indices[item.param_id]],
+                    ),
+                    item.semantics,
+                    item.declaration_ordinal,
+                )
+                for item in coordinates
+            )
+            search_problem = derive_search_problem()
         population = DePopulation(
             len(coordinates),
             population_multiplier,

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -2786,9 +2786,9 @@ class _LiveAttempt:
                 name="solver vector",
             )
             feasible = self.problem.feasible_coordinates
-            if feasible is None:
+            if feasible is None or not feasible.has_coordinate_transform:
                 vector = private_vector
-                if any(
+                if feasible is None and any(
                     not lower <= value <= upper
                     for value, lower, upper in zip(
                         vector,
@@ -2997,41 +2997,33 @@ def _normalize_backend(
         raise ValueError("SciPy final Jacobian evidence has the wrong shape")
     feasible = problem.feasible_coordinates
     final_residual_jacobian: FinalResidualJacobianEvidence | None = None
-    if feasible is None:
+    if feasible is None or not feasible.has_coordinate_transform:
         final_vector = private_final_vector
         jacobian_source = ResidualJacobianSource.SCIPY_FINAL_2_POINT
         derivative_method = "numerical 2-point"
+        differential_has_full_rank = True
     else:
         final_vector = feasible.decode(private_final_vector).vector
         differential = feasible.differential(private_final_vector)
-        if (
+        differential_has_full_rank = (
             np.linalg.matrix_rank(
                 differential,
                 rtol=_FEASIBILITY_DIFFERENTIAL_RANK_RTOL,
             )
             == dimension
-        ):
+        )
+        if differential_has_full_rank:
             jacobian_array = np.linalg.solve(
                 differential.T,
                 jacobian_array.T,
             ).T
             jacobian_source = (
-                ResidualJacobianSource.SCIPY_FINAL_2_POINT
-                if not feasible.has_coordinate_transform
-                else ResidualJacobianSource.SCIPY_FINAL_2_POINT_FEASIBILITY_PUSHFORWARD
+                ResidualJacobianSource.SCIPY_FINAL_2_POINT_FEASIBILITY_PUSHFORWARD
             )
             derivative_method = (
-                "numerical 2-point"
-                if not feasible.has_coordinate_transform
-                else "solver-coordinate 2-point with exact feasibility pushforward"
+                "solver-coordinate 2-point with exact feasibility pushforward"
             )
-    if feasible is None or (
-        np.linalg.matrix_rank(
-            differential,
-            rtol=_FEASIBILITY_DIFFERENTIAL_RANK_RTOL,
-        )
-        == dimension
-    ):
+    if differential_has_full_rank:
         final_residual_jacobian = FinalResidualJacobianEvidence(
             jacobian_source,
             controlled_ids,

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -34,6 +34,10 @@ from chemex.evaluation.native import (
     EvaluationResult,
 )
 from chemex.optimize.progress import ProgressEvent, ProgressObserver, ProgressPhase
+from chemex.parameters.feasible_coordinates import (
+    FeasibleCoordinates,
+    compile_feasible_coordinates,
+)
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     IndependentValueFrame,
@@ -73,12 +77,16 @@ _BACKEND_SETTINGS = (
     ("verbose", 0),
 )
 _BACKEND_JACOBIAN_VERSION = "scipy-final-residual-jacobian-v2"
+_FEASIBILITY_DIFFERENTIAL_RANK_RTOL = math.sqrt(np.finfo(np.float64).eps)
 
 
 class ResidualJacobianSource(StrEnum):
     """Closed origins for a retained accepted-point residual Jacobian."""
 
     SCIPY_FINAL_2_POINT = "scipy-final-2-point"
+    SCIPY_FINAL_2_POINT_FEASIBILITY_PUSHFORWARD = (
+        "scipy-final-2-point-feasibility-pushforward"
+    )
     FIT_PARTITION_COMPOSITION = "fit-partition-composition"
 
 
@@ -141,7 +149,11 @@ class FinalResidualJacobianEvidence:
         ):
             raise ValueError("Final residual Jacobian has inconsistent scope")
         if (
-            self.derivative_method != "numerical 2-point"
+            self.derivative_method
+            not in {
+                "numerical 2-point",
+                "solver-coordinate 2-point with exact feasibility pushforward",
+            }
             or self.diff_step_policy != "scipy-default-relative-step"
             or self.loss_policy != "linear"
             or not self.backend_identity.startswith("scipy-")
@@ -896,6 +908,11 @@ class OptimizationProblem:
     scalarization_version: str = _SCALARIZATION_VERSION
     affine_half_spaces: tuple[AffineHalfSpace, ...] = ()
     affine_equalities: tuple[AffineEquality, ...] = ()
+    feasible_coordinates: FeasibleCoordinates | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:  # noqa: C901 - complete problem invariant
@@ -1027,6 +1044,17 @@ class OptimizationProblem:
                     *derivation_record,
                     self.scalarization_version,
                     *feasibility_record,
+                    *(
+                        ()
+                        if self.feasible_coordinates is None
+                        or self.feasible_coordinates.is_noop
+                        else (
+                            (
+                                "relaxation-feasible-coordinates",
+                                self.feasible_coordinates.identity,
+                            ),
+                        )
+                    ),
                 ),
             ),
         )
@@ -1079,6 +1107,13 @@ class OptimizationProblem:
         upper = tuple(
             configuration[param_id].upper_bound for param_id in controlled_ids
         )
+        feasible_coordinates = compile_feasible_coordinates(
+            parameterization,
+            frame,
+            controlled_ids,
+            lower,
+            upper,
+        )
         return cls(
             plan.identity,
             parameterization.identity,
@@ -1093,6 +1128,7 @@ class OptimizationProblem:
             lower,
             upper,
             parameterization.scope_ids,
+            feasible_coordinates=feasible_coordinates,
         )
 
     def validate_parameterization(
@@ -1136,6 +1172,30 @@ class OptimizationProblem:
             if isinstance(derivation, ComponentProblemDerivation)
             else self.evaluation_plan_identity
         )
+        child_lower = tuple(
+            self.lower_bounds[root_indices[param_id]] for param_id in controlled_ids
+        )
+        child_upper = tuple(
+            self.upper_bounds[root_indices[param_id]] for param_id in controlled_ids
+        )
+        root_feasible = self.feasible_coordinates
+        frame = (
+            root_feasible.frame_with_updates(
+                dict(zip(controlled_ids, start, strict=True))
+            )
+            if root_feasible is not None
+            else None
+        )
+        feasible_coordinates = (
+            root_feasible.derive(
+                frame,
+                controlled_ids,
+                child_lower,
+                child_upper,
+            )
+            if root_feasible is not None and frame is not None
+            else None
+        )
         child = OptimizationProblem(
             evaluation_plan_identity,
             self.parameterization_identity,
@@ -1147,17 +1207,14 @@ class OptimizationProblem:
             controlled_ids,
             held_items,
             start,
-            tuple(
-                self.lower_bounds[root_indices[param_id]] for param_id in controlled_ids
-            ),
-            tuple(
-                self.upper_bounds[root_indices[param_id]] for param_id in controlled_ids
-            ),
+            child_lower,
+            child_upper,
             self.commit_scope,
             derivation,
             self.scalarization_version,
             self.affine_half_spaces,
             self.affine_equalities,
+            feasible_coordinates,
         )
         self.validate_derived_problem(child)
         return child
@@ -1215,6 +1272,28 @@ class OptimizationProblem:
             controlled_ids,
             independent_items,
         )
+        child_lower = tuple(
+            self.lower_bounds[root_indices[param_id]] for param_id in controlled_ids
+        )
+        child_upper = tuple(
+            self.upper_bounds[root_indices[param_id]] for param_id in controlled_ids
+        )
+        root_feasible = self.feasible_coordinates
+        frame = (
+            root_feasible.frame_with_updates(dict(independent_items))
+            if root_feasible is not None
+            else None
+        )
+        feasible_coordinates = (
+            root_feasible.derive(
+                frame,
+                controlled_ids,
+                child_lower,
+                child_upper,
+            )
+            if root_feasible is not None and frame is not None
+            else None
+        )
         child = OptimizationProblem(
             projected_plan_identity,
             self.parameterization_identity,
@@ -1226,17 +1305,14 @@ class OptimizationProblem:
             controlled_ids,
             held_items,
             tuple(independent_values[param_id] for param_id in controlled_ids),
-            tuple(
-                self.lower_bounds[root_indices[param_id]] for param_id in controlled_ids
-            ),
-            tuple(
-                self.upper_bounds[root_indices[param_id]] for param_id in controlled_ids
-            ),
+            child_lower,
+            child_upper,
             self.commit_scope,
             derivation,
             self.scalarization_version,
             self.affine_half_spaces,
             self.affine_equalities,
+            feasible_coordinates,
         )
         self.validate_derived_problem(child)
         return child
@@ -1247,6 +1323,23 @@ class OptimizationProblem:
             raise DirectTrfConstructionError(
                 "Only a complete root problem can create a full-coordinate restart"
             )
+        frame = (
+            self.feasible_coordinates.frame_with_updates(
+                dict(zip(self.controlled_ids, start, strict=True))
+            )
+            if self.feasible_coordinates is not None
+            else None
+        )
+        feasible_coordinates = (
+            self.feasible_coordinates.derive(
+                frame,
+                self.controlled_ids,
+                self.lower_bounds,
+                self.upper_bounds,
+            )
+            if frame is not None and self.feasible_coordinates is not None
+            else None
+        )
         return OptimizationProblem(
             self.evaluation_plan_identity,
             self.parameterization_identity,
@@ -1264,6 +1357,7 @@ class OptimizationProblem:
             scalarization_version=self.scalarization_version,
             affine_half_spaces=self.affine_half_spaces,
             affine_equalities=self.affine_equalities,
+            feasible_coordinates=feasible_coordinates,
         )
 
     def validate_derived_problem(self, child: OptimizationProblem) -> None:
@@ -1631,15 +1725,9 @@ class BackendEvidence:
     cost: float
     optimality: float
     active_mask: tuple[int, ...]
-    final_residual_jacobian: FinalResidualJacobianEvidence
-
-    @property
-    def final_vector(self) -> tuple[float, ...]:
-        return self.final_residual_jacobian.final_vector
-
-    @property
-    def final_residuals(self) -> tuple[float, ...]:
-        return self.final_residual_jacobian.final_residuals
+    final_vector: tuple[float, ...]
+    final_residuals: tuple[float, ...]
+    final_residual_jacobian: FinalResidualJacobianEvidence | None
 
     @property
     def identity(self) -> str:
@@ -1654,7 +1742,11 @@ class BackendEvidence:
                 _float_token(self.cost),
                 _float_token(self.optimality),
                 self.active_mask,
-                self.final_residual_jacobian.identity,
+                self.final_vector,
+                self.final_residuals,
+                None
+                if self.final_residual_jacobian is None
+                else self.final_residual_jacobian.identity,
             ),
         )
 
@@ -2688,22 +2780,31 @@ class _LiveAttempt:
             )
         self.accepted += 1
         try:
-            vector = _canonical_vector(
+            private_vector = _canonical_vector(
                 solver_vector,
                 dimension=len(self.problem.controlled_ids),
                 name="solver vector",
             )
-            if any(
-                not lower <= value <= upper
-                for value, lower, upper in zip(
-                    vector,
-                    self.problem.lower_bounds,
-                    self.problem.upper_bounds,
-                    strict=True,
-                )
-            ):
-                raise ValueError("SciPy supplied an out-of-bounds external candidate")
-            lifecycle = self.problem.lifecycle_frame(vector, self.parameterization)
+            feasible = self.problem.feasible_coordinates
+            if feasible is None:
+                vector = private_vector
+                if any(
+                    not lower <= value <= upper
+                    for value, lower, upper in zip(
+                        vector,
+                        self.problem.lower_bounds,
+                        self.problem.upper_bounds,
+                        strict=True,
+                    )
+                ):
+                    raise ValueError(
+                        "SciPy supplied an out-of-bounds external candidate"
+                    )
+                lifecycle = self.problem.lifecycle_frame(vector, self.parameterization)
+            else:
+                point = feasible.decode(private_vector)
+                vector = point.vector
+                lifecycle = self.problem.lifecycle_frame(vector, self.parameterization)
             frame = EvaluationFrame.from_lifecycle_frame(
                 self.parameterization,
                 lifecycle,
@@ -2847,9 +2948,10 @@ def _backend_int(value: object, *, name: str, optional: bool = False) -> int | N
 def _normalize_backend(
     result: object,
     *,
-    controlled_ids: tuple[str, ...],
+    problem: OptimizationProblem,
     residual_count: int,
 ) -> BackendEvidence:
+    controlled_ids = problem.controlled_ids
     dimension = len(controlled_ids)
     status_value = _backend_int(getattr(result, "status", None), name="status")
     if status_value is None:
@@ -2872,7 +2974,7 @@ def _normalize_backend(
     )
     if cost < 0.0 or optimality < 0.0:
         raise ValueError("SciPy cost and optimality cannot be negative")
-    final_vector = _canonical_vector(
+    private_final_vector = _canonical_vector(
         getattr(result, "x", None),
         dimension=dimension,
         name="SciPy final vector",
@@ -2893,14 +2995,52 @@ def _normalize_backend(
     jacobian_array = np.asarray(getattr(result, "jac", None), dtype=np.float64)
     if jacobian_array.shape != (residual_count, dimension):
         raise ValueError("SciPy final Jacobian evidence has the wrong shape")
-    final_residual_jacobian = FinalResidualJacobianEvidence(
-        ResidualJacobianSource.SCIPY_FINAL_2_POINT,
-        controlled_ids,
-        final_vector,
-        final_residuals,
-        (residual_count, dimension),
-        tuple(tuple(float(value) for value in row) for row in jacobian_array),
-    )
+    feasible = problem.feasible_coordinates
+    final_residual_jacobian: FinalResidualJacobianEvidence | None = None
+    if feasible is None:
+        final_vector = private_final_vector
+        jacobian_source = ResidualJacobianSource.SCIPY_FINAL_2_POINT
+        derivative_method = "numerical 2-point"
+    else:
+        final_vector = feasible.decode(private_final_vector).vector
+        differential = feasible.differential(private_final_vector)
+        if (
+            np.linalg.matrix_rank(
+                differential,
+                rtol=_FEASIBILITY_DIFFERENTIAL_RANK_RTOL,
+            )
+            == dimension
+        ):
+            jacobian_array = np.linalg.solve(
+                differential.T,
+                jacobian_array.T,
+            ).T
+            jacobian_source = (
+                ResidualJacobianSource.SCIPY_FINAL_2_POINT
+                if not feasible.has_coordinate_transform
+                else ResidualJacobianSource.SCIPY_FINAL_2_POINT_FEASIBILITY_PUSHFORWARD
+            )
+            derivative_method = (
+                "numerical 2-point"
+                if not feasible.has_coordinate_transform
+                else "solver-coordinate 2-point with exact feasibility pushforward"
+            )
+    if feasible is None or (
+        np.linalg.matrix_rank(
+            differential,
+            rtol=_FEASIBILITY_DIFFERENTIAL_RANK_RTOL,
+        )
+        == dimension
+    ):
+        final_residual_jacobian = FinalResidualJacobianEvidence(
+            jacobian_source,
+            controlled_ids,
+            final_vector,
+            final_residuals,
+            (residual_count, dimension),
+            tuple(tuple(float(value) for value in row) for row in jacobian_array),
+            derivative_method=derivative_method,
+        )
     return BackendEvidence(
         status_value,
         bool(success),
@@ -2910,6 +3050,8 @@ def _normalize_backend(
         cost,
         optimality,
         tuple(int(value) for value in active_array),
+        final_vector,
+        final_residuals,
         final_residual_jacobian,
     )
 
@@ -2961,15 +3103,21 @@ def _invoke_least_squares(
     invocation: DirectTrfInvocation,
 ) -> object:
     execution = invocation.execution_settings
+    feasible = problem.feasible_coordinates
+    start, lower, upper = (
+        (problem.start, problem.lower_bounds, problem.upper_bounds)
+        if feasible is None
+        else feasible.solver_domain
+    )
     with native_thread_environment(
         execution.native_thread_env(parallel=execution.is_parallel)
     ):
         return least_squares(
             live.objective,
-            np.asarray(problem.start, dtype=np.float64),
+            np.asarray(start, dtype=np.float64),
             bounds=(
-                np.asarray(problem.lower_bounds, dtype=np.float64),
-                np.asarray(problem.upper_bounds, dtype=np.float64),
+                np.asarray(lower, dtype=np.float64),
+                np.asarray(upper, dtype=np.float64),
             ),
             method="trf",
             jac="2-point",
@@ -3023,7 +3171,7 @@ def _process_backend_result(
     try:
         backend = _normalize_backend(
             backend_result,
-            controlled_ids=problem.controlled_ids,
+            problem=problem,
             residual_count=residual_count,
         )
     except Exception as error:  # noqa: BLE001 - malformed third-party result boundary

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -2788,12 +2788,17 @@ class _LiveAttempt:
             feasible = self.problem.feasible_coordinates
             if feasible is None or not feasible.has_coordinate_transform:
                 vector = private_vector
-                if feasible is None and any(
+                lower_bounds, upper_bounds = (
+                    (self.problem.lower_bounds, self.problem.upper_bounds)
+                    if feasible is None
+                    else feasible.solver_bounds
+                )
+                if any(
                     not lower <= value <= upper
                     for value, lower, upper in zip(
                         vector,
-                        self.problem.lower_bounds,
-                        self.problem.upper_bounds,
+                        lower_bounds,
+                        upper_bounds,
                         strict=True,
                     )
                 ):

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -174,6 +174,7 @@ def _profile_dependency_paths(
 def _ordered_component_controls(
     controlled_ids: tuple[str, ...],
     profile_dependencies: tuple[frozenset[str], ...],
+    feasibility_dependencies: tuple[frozenset[str], ...] = (),
 ) -> tuple[tuple[str, ...], ...]:
     parent = {param_id: param_id for param_id in controlled_ids}
 
@@ -183,7 +184,7 @@ def _ordered_component_controls(
             param_id = parent[param_id]
         return param_id
 
-    for dependencies in profile_dependencies:
+    for dependencies in (*profile_dependencies, *feasibility_dependencies):
         ordered = tuple(
             param_id for param_id in controlled_ids if param_id in dependencies
         )
@@ -477,9 +478,27 @@ class FitDecomposition:
             engine,
         )
         components_list: list[FitComponent] = []
+        resolver = _ControlledDependencyResolver(
+            problem.controlled_ids,
+            parameterization,
+        )
+        feasible = problem.feasible_coordinates
+        feasibility_dependencies = (
+            ()
+            if feasible is None
+            else tuple(
+                frozenset(
+                    controlled_id
+                    for param_id in parameter_ids
+                    for controlled_id, _path in resolver.paths(param_id)
+                )
+                for parameter_ids in feasible.domain_parameter_groups
+            )
+        )
         for component_ids in _ordered_component_controls(
             problem.controlled_ids,
             profile_dependencies,
+            feasibility_dependencies,
         ):
             _check_grouped_cancellation(cancellation)
             component = _build_component(

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -16,6 +16,7 @@ from chemex.optimize.uncertainty import (
     RootAnchoredBlockCovarianceEvidence,
     UncertaintyEvidence,
 )
+from chemex.parameters.feasible_coordinates import validate_relaxation_state
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     SealedParameterModel,
@@ -219,6 +220,7 @@ def execute_simulation(
     parameterization: ActiveParameterization,
     plot: bool = False,
 ) -> None:
+    validate_relaxation_state(parameterization, parameter_values)
     experiments.prepare_for_simulation(parameter_values)
     _write_simulation_files(
         experiments,

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -69,6 +69,7 @@ from chemex.optimize.uncertainty import (
     derive_root_anchored_block_covariance,
     derive_uncertainty_evidence,
 )
+from chemex.parameters.feasible_coordinates import validate_relaxation_state
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     ParameterRole,
@@ -584,6 +585,10 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
             parameterization,
             configuration,
             starting_snapshot,
+        )
+        validate_relaxation_state(
+            parameterization,
+            parameterization.resolve(independent_frame),
         )
         frame = EvaluationFrame.from_lifecycle_frame(
             parameterization,

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -745,6 +745,15 @@ def resolve_product_mcmc_policy(
     )
 
 
+def _mcmc_box_bounds(
+    problem: OptimizationProblem,
+) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    feasible = problem.feasible_coordinates
+    if feasible is not None and feasible.supports_box_only_algorithms:
+        return feasible.solver_bounds
+    return problem.lower_bounds, problem.upper_bounds
+
+
 @dataclass(frozen=True, slots=True)
 class McmcAcceptedAnchor:
     """Exact occurrence-owned scientific context for one MCMC request."""
@@ -803,6 +812,7 @@ class McmcAcceptedAnchor:
         engine: EvaluationEngine,
     ) -> None:
         """Reject any live object outside the exact frozen accepted lineage."""
+        live_lower, live_upper = _mcmc_box_bounds(problem)
         expected = (
             self.accepted_semantic_identity,
             self.accepted_occurrence_identity,
@@ -833,8 +843,8 @@ class McmcAcceptedAnchor:
             engine.plan.identity,
             tuple(self.coordinate_units),
             problem.held_items,
-            problem.lower_bounds,
-            problem.upper_bounds,
+            live_lower,
+            live_upper,
             problem.affine_feasibility_identity,
             accepted.vector,
             accepted.evaluation_result.identity,
@@ -946,8 +956,13 @@ class McmcPlan:
             raise McmcConstructionError(
                 "Native MCMC qualification currently supports box-bounded problems"
             )
-        lower = tuple(problem.lower_bounds)
-        upper = tuple(problem.upper_bounds)
+        feasible = problem.feasible_coordinates
+        if feasible is not None and not feasible.supports_box_only_algorithms:
+            raise McmcConstructionError(
+                "Native MCMC has not qualified the Jacobian measure for private "
+                "relaxation-feasibility coordinates"
+            )
+        lower, upper = _mcmc_box_bounds(problem)
         if self.policy.initialization is InitializationKind.ACCEPTED_POINT_JITTER:
             initial = build_accepted_point_ensemble(
                 accepted.vector,

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -43,6 +43,7 @@ from chemex.optimize.direct_trf import (
     accepted_occurrence_is_authoritative,
 )
 from chemex.optimize.grouped_direct_trf import FitPartitionProof
+from chemex.parameters.feasible_coordinates import relaxation_state_is_on_boundary
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     BinaryExpression,
@@ -1145,6 +1146,7 @@ class ResidualJacobianEvidence:
                 or retained.source
                 not in {
                     ResidualJacobianSource.SCIPY_FINAL_2_POINT,
+                    ResidualJacobianSource.SCIPY_FINAL_2_POINT_FEASIBILITY_PUSHFORWARD,
                     ResidualJacobianSource.FIT_PARTITION_COMPOSITION,
                 }
                 or retained.controlled_ids != self.controlled_ids
@@ -6518,7 +6520,21 @@ def _derive_covariance_branch(  # noqa: C901 - ordered cancellation phase ledger
     residual_failure: EvidenceFailure | None = None
     residual_terminal: OperationTerminal | None = None
     try:
-        if policy.residual_jacobian_strategy == "retained-backend-or-accepted-2-point":
+        if relaxation_state_is_on_boundary(
+            parameterization,
+            accepted.evaluation_result.resolved_values,
+            controlled_ids=problem.controlled_ids,
+        ):
+            residual_failure = EvidenceFailure(
+                "residual_linearization",
+                "active_relaxation_feasibility_boundary",
+                "Symmetric public-coordinate covariance is unavailable on an "
+                "active positive-semidefinite relaxation boundary",
+                accepted.identity,
+            )
+        elif policy.residual_jacobian_strategy == (
+            "retained-backend-or-accepted-2-point"
+        ):
             residual_jacobian, _retained_failure = _retained_residual_jacobian(
                 accepted,
                 problem=problem,

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -13,6 +13,7 @@ from chemex.parameters.parameterization import (
     SealedParameterModel,
     seal_parameter_declarations,
 )
+from chemex.parameters.relaxation import RelaxationPsdBlock, SealedRelaxationDomains
 from chemex.parameters.sealed import (
     DefinitionContribution,
     ParamDefinition,
@@ -97,6 +98,10 @@ class ParameterFactory:
         str,
         list[ParameterDeclarationContribution],
     ] = field(default_factory=dict)
+    _relaxation_blocks: set[RelaxationPsdBlock] = field(default_factory=set)
+    _model_free_relaxation_blocks: set[RelaxationPsdBlock] = field(
+        default_factory=set,
+    )
     _sealed_definitions: SealedDefinitions | None = field(default=None, repr=False)
     _sealed_configuration: SealedConfiguration | None = field(default=None, repr=False)
     _sealed_parameter_model: SealedParameterModel | None = field(
@@ -189,6 +194,24 @@ class ParameterFactory:
                 contributor=contributor,
             )
             target.setdefault(param_id, []).append(contribution)
+
+    @staticmethod
+    def _relaxation_blocks_for_basis(
+        basis: Basis,
+        name_map: dict[str, str],
+    ) -> tuple[RelaxationPsdBlock, ...]:
+        return tuple(
+            RelaxationPsdBlock(
+                f"{basis.spin_system}:{specification.family}:{specification.state}",
+                specification.state,
+                tuple(name_map[item] for item in specification.diagonal_names),
+                tuple(
+                    (row, column, name_map[item])
+                    for row, column, item in specification.off_diagonal_names
+                ),
+            )
+            for specification in basis.relaxation_psd_specs
+        )
 
     def _collect_declarations(
         self,
@@ -304,6 +327,9 @@ class ParameterFactory:
                         else default_fit_ids
                     ),
                 )
+                self._relaxation_blocks.update(
+                    self._relaxation_blocks_for_basis(basis, native_name_map)
+                )
                 if not self.parameter_store.model.model_free:
                     model_free_owned_ids = frozenset(
                         name_map_mf[name]
@@ -322,6 +348,9 @@ class ParameterFactory:
                         supports_estimation_ids=model_free_supports_estimation_ids,
                         default_fit_ids=model_free_default_fit_ids,
                         contributions=self._model_free_declaration_contributions,
+                    )
+                    self._model_free_relaxation_blocks.update(
+                        self._relaxation_blocks_for_basis(basis, name_map_mf)
                     )
             except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
                 self._native_construction_error = error
@@ -381,6 +410,7 @@ class ParameterFactory:
             definitions=self._sealed_definitions,
             configuration=configuration,
             declarations=declarations,
+            relaxation_domains=SealedRelaxationDomains(tuple(self._relaxation_blocks)),
         )
 
     def build_model_free_parameter_model(self) -> SealedParameterModel | None:
@@ -404,6 +434,9 @@ class ParameterFactory:
             definitions=definitions,
             configuration=configuration,
             declarations=declarations,
+            relaxation_domains=SealedRelaxationDomains(
+                tuple(self._model_free_relaxation_blocks)
+            ),
         )
 
     def try_seal_definitions(self) -> bool:
@@ -451,6 +484,8 @@ class ParameterFactory:
         self._declaration_contributions.clear()
         self._model_free_definition_contributions.clear()
         self._model_free_declaration_contributions.clear()
+        self._relaxation_blocks.clear()
+        self._model_free_relaxation_blocks.clear()
         self._sealed_definitions = None
         self._sealed_configuration = None
         self._sealed_parameter_model = None

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -1,0 +1,972 @@
+"""Exact private solver coordinates for model-owned relaxation feasibility."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+import numpy as np
+
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    BinaryExpression,
+    CompiledConstraint,
+    FunctionExpression,
+    IndependentValueFrame,
+    LiteralExpression,
+    ReferenceExpression,
+    UnaryExpression,
+)
+from chemex.parameters.relaxation import RelaxationPsdBlock
+from chemex.typing import Array
+
+# Eigenvalue and Schur checks operate on tiny (2x2/3x3) symmetric binary64
+# matrices. These tolerances admit eigvalsh round-off at a semidefinite boundary
+# while remaining six orders tighter than the scientific regression tolerances.
+_PSD_EIGENVALUE_RTOL = 1.0e-11
+_SCHUR_RANGE_RTOL = 1.0e-11
+_SCHUR_RANGE_ATOL = 1.0e-12
+_DIFFERENTIAL_STEP_RELATIVE = math.sqrt(np.finfo(np.float64).eps)
+
+
+class ScientificFeasibilityError(ValueError):
+    """A public ChemEx state violates a model-owned scientific domain."""
+
+
+class FeasibleCoordinateConstructionError(ValueError):
+    """The active FIT/FIX partition lacks an exact supported chart."""
+
+
+def _identity(records: object) -> str:
+    encoded = json.dumps(records, ensure_ascii=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _matrix(block: RelaxationPsdBlock, values: Mapping[str, float]) -> Array:
+    matrix = np.diag([values[param_id] for param_id in block.diagonal_ids])
+    for row, column, param_id in block.off_diagonal_ids:
+        matrix[row, column] = matrix[column, row] = values[param_id]
+    return matrix
+
+
+def _validate_blocks(
+    blocks: Sequence[RelaxationPsdBlock],
+    values: Mapping[str, float],
+) -> None:
+    for block in blocks:
+        matrix = _matrix(block, values)
+        scale = max(1.0, float(np.max(np.abs(matrix))))
+        smallest = float(np.linalg.eigvalsh(matrix)[0])
+        if smallest < -_PSD_EIGENVALUE_RTOL * scale:
+            raise ScientificFeasibilityError(
+                "Relaxation block is not positive semidefinite: "
+                f"domain={block.domain_id!r}, state={block.state!r}, "
+                f"diagonal_ids={block.diagonal_ids!r}, "
+                f"off_diagonal_ids={block.off_diagonal_ids!r}, "
+                f"minimum_eigenvalue={smallest!r}"
+            )
+
+
+def _conditional_interval(
+    block: RelaxationPsdBlock,
+    cross_id: str,
+    values: Mapping[str, float],
+) -> tuple[float, float]:
+    entries = [
+        (row, column)
+        for row, column, param_id in block.off_diagonal_ids
+        if param_id == cross_id
+    ]
+    if len(entries) != 1:
+        raise FeasibleCoordinateConstructionError(
+            f"Relaxation cross-rate {cross_id!r} has an ambiguous block entry"
+        )
+    row, column = entries[0]
+    diagonals = [values[param_id] for param_id in block.diagonal_ids]
+    if any(value < 0.0 for value in diagonals):
+        return (1.0, -1.0)
+    pair_limit = math.sqrt(diagonals[row] * diagonals[column])
+    lower, upper = -pair_limit, pair_limit
+    if len(diagonals) == 2:
+        return lower, upper
+    other = 3 - row - column
+    pivot = diagonals[other]
+    fixed = {
+        frozenset((left, right)): values[param_id]
+        for left, right, param_id in block.off_diagonal_ids
+        if param_id != cross_id
+    }
+    left_other = fixed.get(frozenset((row, other)), 0.0)
+    right_other = fixed.get(frozenset((column, other)), 0.0)
+    if pivot == 0.0:
+        if left_other != 0.0 or right_other != 0.0:
+            return (1.0, -1.0)
+        return lower, upper
+    left_margin = diagonals[row] * pivot - left_other * left_other
+    right_margin = diagonals[column] * pivot - right_other * right_other
+    if left_margin < 0.0 or right_margin < 0.0:
+        return (1.0, -1.0)
+    radius = math.sqrt(max(0.0, left_margin * right_margin)) / pivot
+    center = left_other * right_other / pivot
+    return max(lower, center - radius), min(upper, center + radius)
+
+
+def _conditional_diagonal_floor(
+    block: RelaxationPsdBlock,
+    diagonal_id: str,
+    values: Mapping[str, float],
+) -> float:
+    """Return the exact Schur-complement floor for one free diagonal."""
+    index = block.diagonal_ids.index(diagonal_id)
+    matrix = _matrix(block, values)
+    keep = [position for position in range(len(matrix)) if position != index]
+    principal = matrix[np.ix_(keep, keep)]
+    scale = max(1.0, float(np.max(np.abs(principal))))
+    if float(np.linalg.eigvalsh(principal)[0]) < -_PSD_EIGENVALUE_RTOL * scale:
+        return math.inf
+    coupling = matrix[index, keep]
+    inverse = np.linalg.pinv(principal, hermitian=True)
+    if not np.allclose(
+        principal @ inverse @ coupling,
+        coupling,
+        rtol=_SCHUR_RANGE_RTOL,
+        atol=_SCHUR_RANGE_ATOL * scale,
+    ):
+        return math.inf
+    return max(0.0, float(coupling @ inverse @ coupling))
+
+
+@dataclass(frozen=True, slots=True)
+class FeasiblePoint:
+    """One decoded public state that is safe to send to scientific evaluation."""
+
+    frame: IndependentValueFrame
+    vector: tuple[float, ...]
+
+
+class RateFloorKind(StrEnum):
+    """Closed exact two-mode PSD floor forms supported by the private chart."""
+
+    OTHER_DIAGONAL = "other-diagonal"
+    DERIVED_AFFINE = "derived-affine"
+    REPEATED_DIAGONAL = "repeated-diagonal"
+
+
+@dataclass(frozen=True, slots=True)
+class RateFloor:
+    """One exact lower envelope imposed on a controlled public rate."""
+
+    rate_id: str
+    kind: RateFloorKind
+    other_id: str
+    cross_id: str
+
+
+def _rate_floor(specification: RateFloor, values: Mapping[str, float]) -> float:
+    cross = values[specification.cross_id]
+    if specification.kind is RateFloorKind.REPEATED_DIAGONAL:
+        return abs(cross)
+    other = values[specification.other_id]
+    if specification.kind is RateFloorKind.OTHER_DIAGONAL:
+        if other <= 0.0:
+            return 0.0 if cross == 0.0 else math.inf
+        return cross * cross / other
+    intercept = other - values[specification.rate_id]
+    discriminant = math.sqrt(intercept * intercept + 4.0 * cross * cross)
+    return 0.5 * (-intercept + discriminant)
+
+
+@dataclass(frozen=True, slots=True)
+class FeasibleCoordinates:
+    """Role-aware exact chart over the represented relaxation PSD domains."""
+
+    parameterization: ActiveParameterization = field(repr=False, compare=False)
+    base_frame: IndependentValueFrame = field(repr=False, compare=False)
+    controlled_ids: tuple[str, ...]
+    public_lower_bounds: tuple[float, ...]
+    public_upper_bounds: tuple[float, ...]
+    rate_excess_ids: tuple[tuple[str, str], ...]
+    rate_floors: tuple[RateFloor, ...]
+    static_rate_floors: tuple[tuple[str, float], ...]
+    cross_rate_ids: tuple[str, ...]
+    blocks: tuple[RelaxationPsdBlock, ...]
+    solver_start: tuple[float, ...]
+    solver_lower_bounds: tuple[float, ...]
+    solver_upper_bounds: tuple[float, ...]
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _identity(
+                (
+                    self.parameterization.evaluator_identity,
+                    self.controlled_ids,
+                    self.public_lower_bounds,
+                    self.public_upper_bounds,
+                    self.rate_excess_ids,
+                    tuple(
+                        (item.rate_id, item.kind, item.other_id, item.cross_id)
+                        for item in self.rate_floors
+                    ),
+                    self.static_rate_floors,
+                    self.cross_rate_ids,
+                    tuple(block.domain_id for block in self.blocks),
+                    self.solver_start,
+                    self.solver_lower_bounds,
+                    self.solver_upper_bounds,
+                )
+            ),
+        )
+
+    @property
+    def has_coordinate_transform(self) -> bool:
+        return bool(self.rate_excess_ids or self.rate_floors or self.cross_rate_ids)
+
+    @property
+    def is_noop(self) -> bool:
+        return (
+            not self.rate_excess_ids
+            and not self.rate_floors
+            and not self.cross_rate_ids
+            and self.solver_lower_bounds == self.public_lower_bounds
+            and self.solver_upper_bounds == self.public_upper_bounds
+        )
+
+    @property
+    def supports_box_only_algorithms(self) -> bool:
+        """Return whether public and private coordinates differ only by box bounds."""
+        return not self.has_coordinate_transform
+
+    @property
+    def solver_domain(
+        self,
+    ) -> tuple[tuple[float, ...], tuple[float, ...], tuple[float, ...]]:
+        """Return the private start, lower bounds, and upper bounds."""
+        return self.solver_start, self.solver_lower_bounds, self.solver_upper_bounds
+
+    @property
+    def solver_bounds(self) -> tuple[tuple[float, ...], tuple[float, ...]]:
+        """Return private lower and upper bounds for box-only consumers."""
+        return self.solver_lower_bounds, self.solver_upper_bounds
+
+    @property
+    def domain_parameter_groups(self) -> tuple[frozenset[str], ...]:
+        """Return parameter-ID hyperedges that must remain in one fit component."""
+        return tuple(
+            frozenset(
+                (
+                    *block.diagonal_ids,
+                    *(item[2] for item in block.off_diagonal_ids),
+                )
+            )
+            for block in self.blocks
+        )
+
+    def frame_with_updates(self, updates: Mapping[str, float]) -> IndependentValueFrame:
+        """Return a compatible source frame with independent public updates."""
+        return self.base_frame.with_updates(updates)
+
+    def derive(
+        self,
+        frame: IndependentValueFrame,
+        controlled_ids: tuple[str, ...],
+        lower_bounds: tuple[float, ...],
+        upper_bounds: tuple[float, ...],
+    ) -> FeasibleCoordinates:
+        """Compile a role-aware child chart without exposing model internals."""
+        return compile_feasible_coordinates(
+            self.parameterization,
+            frame,
+            controlled_ids,
+            lower_bounds,
+            upper_bounds,
+        )
+
+    def decode(  # noqa: C901 - complete feasibility decode and verification
+        self,
+        solver_vector: Sequence[float],
+    ) -> FeasiblePoint:
+        if len(solver_vector) != len(self.controlled_ids):
+            raise ValueError("Feasible solver vector has the wrong dimension")
+        public = {
+            param_id: float(value)
+            for param_id, value in zip(self.controlled_ids, solver_vector, strict=True)
+        }
+        rate_excess = {item[0] for item in self.rate_excess_ids}
+        floor_rate_ids = {item.rate_id for item in self.rate_floors}
+        static_rate_floors = dict(self.static_rate_floors)
+        cross_rates = set(self.cross_rate_ids)
+        raw_updates = {
+            param_id: value
+            for param_id, value in public.items()
+            if param_id not in rate_excess
+            and param_id not in floor_rate_ids
+            and param_id not in cross_rates
+        }
+        frame = self.base_frame.with_updates(raw_updates)
+        resolved = self.parameterization.resolve(frame)
+        lower_by_id = dict(
+            zip(self.controlled_ids, self.public_lower_bounds, strict=True)
+        )
+        upper_by_id = dict(
+            zip(self.controlled_ids, self.public_upper_bounds, strict=True)
+        )
+        excess_by_rate = {
+            rate_id: tuple(
+                diagonal_id
+                for candidate, diagonal_id in self.rate_excess_ids
+                if candidate == rate_id
+            )
+            for rate_id in self.controlled_ids
+        }
+        for rate_id in self.controlled_ids:
+            diagonal_ids = excess_by_rate.get(rate_id, ())
+            if not diagonal_ids:
+                continue
+            floor = max(
+                lower_by_id[rate_id],
+                static_rate_floors.get(rate_id, -math.inf),
+                *(resolved[rate_id] - resolved[item] for item in diagonal_ids),
+            )
+            public[rate_id] = floor + public[rate_id]
+        frame = self.base_frame.with_updates(
+            {key: value for key, value in public.items() if key not in cross_rates}
+        )
+        resolved = self.parameterization.resolve(frame)
+        floors_by_rate = {
+            rate_id: tuple(item for item in self.rate_floors if item.rate_id == rate_id)
+            for rate_id in self.controlled_ids
+        }
+        for rate_id in self.controlled_ids:
+            specifications = floors_by_rate.get(rate_id, ())
+            if not specifications:
+                continue
+            floor = max(
+                lower_by_id[rate_id],
+                static_rate_floors.get(rate_id, -math.inf),
+                *(_rate_floor(item, resolved) for item in specifications),
+            )
+            if not math.isfinite(floor):
+                raise ScientificFeasibilityError(
+                    f"Relaxation rate {rate_id!r} has no finite PSD floor"
+                )
+            public[rate_id] = floor + public[rate_id]
+            frame = frame.with_updates({rate_id: public[rate_id]})
+            resolved = self.parameterization.resolve(frame)
+        for cross_id in self.cross_rate_ids:
+            lower = lower_by_id[cross_id]
+            upper = upper_by_id[cross_id]
+            values = dict(resolved)
+            for block in self.blocks:
+                if any(item[2] == cross_id for item in block.off_diagonal_ids):
+                    block_lower, block_upper = _conditional_interval(
+                        block, cross_id, values
+                    )
+                    lower = max(lower, block_lower)
+                    upper = min(upper, block_upper)
+            if lower > upper:
+                raise ScientificFeasibilityError(
+                    f"Relaxation cross-rate {cross_id!r} has an empty feasible interval"
+                )
+            rho = public[cross_id]
+            public[cross_id] = 0.5 * ((1.0 - rho) * lower + (1.0 + rho) * upper)
+            frame = frame.with_updates({cross_id: public[cross_id]})
+            resolved = self.parameterization.resolve(frame)
+        vector = tuple(public[param_id] for param_id in self.controlled_ids)
+        for value, lower, upper in zip(
+            vector,
+            self.public_lower_bounds,
+            self.public_upper_bounds,
+            strict=True,
+        ):
+            if not lower <= value <= upper:
+                raise ScientificFeasibilityError(
+                    "Feasible-coordinate decode violated a public scalar bound"
+                )
+        _validate_blocks(self.blocks, resolved)
+        return FeasiblePoint(frame, vector)
+
+    def differential(self, solver_vector: Sequence[float]) -> Array:
+        """Return d(public coordinates)/d(private solver coordinates)."""
+        point = np.asarray(solver_vector, dtype=np.float64)
+        dimension = len(point)
+        result = np.empty((dimension, dimension), dtype=np.float64)
+        eps = _DIFFERENTIAL_STEP_RELATIVE
+        lower = np.asarray(self.solver_lower_bounds)
+        upper = np.asarray(self.solver_upper_bounds)
+        for column in range(dimension):
+            step = eps * max(1.0, abs(point[column]))
+            left = point.copy()
+            right = point.copy()
+            if (
+                point[column] - step >= lower[column]
+                and point[column] + step <= upper[column]
+            ):
+                left[column] -= step
+                right[column] += step
+                denominator = 2.0 * step
+            elif point[column] + step <= upper[column]:
+                right[column] += step
+                denominator = step
+            else:
+                left[column] -= step
+                denominator = step
+            left_value = np.asarray(self.decode(tuple(left)).vector)
+            right_value = np.asarray(self.decode(tuple(right)).vector)
+            result[:, column] = (right_value - left_value) / denominator
+        return result
+
+
+def _reference_coefficient(
+    expression: object,
+    param_id: str,
+    constraints: Mapping[str, CompiledConstraint] | None = None,
+    seen: frozenset[str] = frozenset(),
+) -> float | None:
+    if isinstance(expression, ReferenceExpression):
+        reference_id = expression.param_id
+        if reference_id == param_id:
+            return 1.0
+        constraint = None if constraints is None else constraints.get(reference_id)
+        if constraint is None or reference_id in seen:
+            return 0.0
+        return _reference_coefficient(
+            constraint.expression,
+            param_id,
+            constraints,
+            seen | {reference_id},
+        )
+    if isinstance(expression, BinaryExpression) and expression.operator in {
+        "add",
+        "subtract",
+    }:
+        left = _reference_coefficient(expression.left, param_id, constraints, seen)
+        right = _reference_coefficient(expression.right, param_id, constraints, seen)
+        if left is None or right is None:
+            return None
+        return left + right if expression.operator == "add" else left - right
+    return None
+
+
+def _is_additive_reference_expression(expression: object) -> bool:
+    if isinstance(expression, ReferenceExpression):
+        return True
+    return (
+        isinstance(expression, BinaryExpression)
+        and expression.operator == "add"
+        and _is_additive_reference_expression(expression.left)
+        and _is_additive_reference_expression(expression.right)
+    )
+
+
+def _derived_diagonal_transforms(
+    parameterization: ActiveParameterization,
+    controlled: set[str],
+    blocks: Sequence[RelaxationPsdBlock],
+) -> tuple[tuple[str, str], ...]:
+    diagonal_ids = {param_id for block in blocks for param_id in block.diagonal_ids}
+    transforms: set[tuple[str, str]] = set()
+    constraints = {
+        item.target_id: item for item in parameterization.program.constraints
+    }
+    for diagonal_id in diagonal_ids:
+        constraint = constraints.get(diagonal_id)
+        if constraint is None:
+            continue
+        expression = constraint.expression
+        if _is_additive_reference_expression(expression):
+            continue
+        dependencies = controlled & set(constraint.dependencies)
+        supported = {
+            param_id
+            for param_id in dependencies
+            if _reference_coefficient(expression, param_id, constraints) == 1.0
+        }
+        if len(supported) == 1:
+            transforms.add((supported.pop(), diagonal_id))
+        elif dependencies:
+            raise FeasibleCoordinateConstructionError(
+                "A fitted relaxation diagonal has an unsupported affine controller: "
+                f"{diagonal_id!r}"
+            )
+    return tuple(sorted(transforms))
+
+
+def _effective_blocks(
+    parameterization: ActiveParameterization,
+    blocks: Sequence[RelaxationPsdBlock],
+) -> tuple[RelaxationPsdBlock, ...]:
+    """Map expression-shared cross-rates to their independent controller IDs."""
+    constraints = {
+        item.target_id: item for item in parameterization.program.constraints
+    }
+
+    def controller(param_id: str) -> str:
+        seen: set[str] = set()
+        while param_id in constraints and param_id not in seen:
+            seen.add(param_id)
+            expression = constraints[param_id].expression
+            if not isinstance(expression, ReferenceExpression):
+                break
+            param_id = expression.param_id
+        return param_id
+
+    return tuple(
+        RelaxationPsdBlock(
+            block.domain_id,
+            block.state,
+            tuple(controller(param_id) for param_id in block.diagonal_ids),
+            tuple(
+                (row, column, controller(param_id))
+                for row, column, param_id in block.off_diagonal_ids
+            ),
+        )
+        for block in blocks
+    )
+
+
+def active_relaxation_blocks(
+    parameterization: ActiveParameterization,
+) -> tuple[RelaxationPsdBlock, ...]:
+    """Return represented PSD blocks after active-scope controller resolution."""
+    active = set(parameterization.scope_ids)
+    return _effective_blocks(
+        parameterization,
+        tuple(
+            block
+            for block in parameterization.program.relaxation_domains.blocks
+            if {*block.diagonal_ids, *(item[2] for item in block.off_diagonal_ids)}
+            <= active
+        ),
+    )
+
+
+def validate_relaxation_state(
+    parameterization: ActiveParameterization,
+    values: Mapping[str, float],
+) -> None:
+    """Reject an inadmissible public state before scientific kernel execution."""
+    _validate_blocks(active_relaxation_blocks(parameterization), values)
+
+
+def relaxation_state_is_on_boundary(
+    parameterization: ActiveParameterization,
+    values: Mapping[str, float],
+    *,
+    controlled_ids: Sequence[str] | None = None,
+) -> bool:
+    """Return whether a represented PSD block has a numerically active boundary."""
+    controlled = set(controlled_ids or ())
+    for block in active_relaxation_blocks(parameterization):
+        if controlled and not any(
+            _controlled_dependencies(parameterization, param_id, controlled)
+            for param_id in (
+                *block.diagonal_ids,
+                *(item[2] for item in block.off_diagonal_ids),
+            )
+        ):
+            continue
+        matrix = _matrix(block, values)
+        scale = max(1.0, float(np.max(np.abs(matrix))))
+        if float(np.linalg.eigvalsh(matrix)[0]) <= _PSD_EIGENVALUE_RTOL * scale:
+            return True
+    return False
+
+
+def _controlled_dependencies(
+    parameterization: ActiveParameterization,
+    param_id: str,
+    controlled: set[str],
+    seen: frozenset[str] = frozenset(),
+) -> frozenset[str]:
+    if param_id in controlled:
+        return frozenset((param_id,))
+    if param_id in seen:
+        return frozenset()
+    constraint = next(
+        (
+            item
+            for item in parameterization.program.constraints
+            if item.target_id == param_id
+        ),
+        None,
+    )
+    if constraint is None:
+        return frozenset()
+    dependencies: set[str] = set()
+    for dependency in constraint.dependencies:
+        dependencies.update(
+            _controlled_dependencies(
+                parameterization,
+                dependency,
+                controlled,
+                seen | {param_id},
+            )
+        )
+    return frozenset(dependencies)
+
+
+def _is_intrinsic_rate_derivation(
+    parameterization: ActiveParameterization,
+    param_id: str,
+    seen: frozenset[str] = frozenset(),
+) -> bool:
+    constraints = {
+        item.target_id: item for item in parameterization.program.constraints
+    }
+    constraint = constraints.get(param_id)
+    if (
+        constraint is None
+        or constraint.source not in {"baseline", "model"}
+        or param_id in seen
+    ):
+        return False
+
+    def intrinsic(expression: object) -> bool:
+        if isinstance(expression, FunctionExpression):
+            return True
+        if isinstance(expression, LiteralExpression):
+            return True
+        if isinstance(expression, ReferenceExpression):
+            return _is_intrinsic_rate_derivation(
+                parameterization,
+                expression.param_id,
+                seen | {param_id},
+            )
+        if isinstance(expression, UnaryExpression):
+            return intrinsic(expression.operand)
+        if isinstance(expression, BinaryExpression):
+            return intrinsic(expression.left) and intrinsic(expression.right)
+        return False
+
+    return intrinsic(constraint.expression)
+
+
+def _is_intrinsic_relaxation_block(
+    parameterization: ActiveParameterization,
+    block: RelaxationPsdBlock,
+) -> bool:
+    return all(
+        _is_intrinsic_rate_derivation(parameterization, param_id)
+        for param_id in (
+            *block.diagonal_ids,
+            *(item[2] for item in block.off_diagonal_ids),
+        )
+    )
+
+
+def _derived_pair_floor(
+    parameterization: ActiveParameterization,
+    rate_id: str,
+    other_diagonal_id: str,
+    cross_id: str,
+) -> RateFloor | None:
+    constraints = {
+        item.target_id: item for item in parameterization.program.constraints
+    }
+    constraint = constraints.get(other_diagonal_id)
+    if constraint is None:
+        return None
+    expression = constraint.expression
+    if _reference_coefficient(expression, rate_id, constraints) == 1.0:
+        return RateFloor(
+            rate_id,
+            RateFloorKind.DERIVED_AFFINE,
+            other_diagonal_id,
+            cross_id,
+        )
+    return None
+
+
+def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
+    parameterization: ActiveParameterization,
+    frame: IndependentValueFrame,
+    controlled_ids: tuple[str, ...],
+    lower_bounds: tuple[float, ...],
+    upper_bounds: tuple[float, ...],
+) -> FeasibleCoordinates:
+    """Compile an exact supported chart for the active relaxation domains."""
+    blocks = active_relaxation_blocks(parameterization)
+    chart_blocks = tuple(
+        block
+        for block in blocks
+        if not _is_intrinsic_relaxation_block(parameterization, block)
+    )
+    controlled = set(controlled_ids)
+    rate_excess_ids = _derived_diagonal_transforms(
+        parameterization,
+        controlled,
+        chart_blocks,
+    )
+    cross_rate_ids: list[str] = []
+    for block in chart_blocks:
+        fitted = {
+            param_id
+            for _row, _column, param_id in block.off_diagonal_ids
+            if param_id in controlled
+        }
+        if len(fitted) > 1:
+            raise FeasibleCoordinateConstructionError(
+                "Jointly fitted cross-rates in one relaxation block require a "
+                f"whole-block chart: domain={block.domain_id!r}, ids={sorted(fitted)!r}"
+            )
+        cross_rate_ids.extend(fitted)
+    cross_ids = tuple(
+        param_id for param_id in controlled_ids if param_id in cross_rate_ids
+    )
+    rate_floors: list[RateFloor] = []
+    static_rate_floors: dict[str, float] = {}
+    resolved_initial = parameterization.resolve(frame)
+
+    def register_rate_floor(specification: RateFloor) -> None:
+        dependencies = _controlled_dependencies(
+            parameterization,
+            specification.other_id,
+            controlled,
+        ) | _controlled_dependencies(
+            parameterization,
+            specification.cross_id,
+            controlled,
+        )
+        if dependencies <= {specification.rate_id}:
+            floor = _rate_floor(specification, resolved_initial)
+            static_rate_floors[specification.rate_id] = max(
+                static_rate_floors.get(specification.rate_id, 0.0),
+                floor,
+            )
+        else:
+            rate_floors.append(specification)
+
+    for block in chart_blocks:
+        if len(block.diagonal_ids) == 3:
+            fitted_crosses = {
+                item[2] for item in block.off_diagonal_ids if item[2] in controlled
+            }
+            diagonal_dependencies = set().union(
+                *(
+                    _controlled_dependencies(parameterization, item, controlled)
+                    for item in block.diagonal_ids
+                )
+            )
+            if fitted_crosses and diagonal_dependencies:
+                raise FeasibleCoordinateConstructionError(
+                    "Jointly fitted longitudinal cross-rates and diagonals require "
+                    f"a whole-block chart: domain={block.domain_id!r}"
+                )
+            if fitted_crosses:
+                continue
+            resolved = parameterization.resolve(frame)
+            if not any(resolved[item[2]] != 0.0 for item in block.off_diagonal_ids):
+                continue
+            fitted_diagonals = tuple(
+                item for item in block.diagonal_ids if item in controlled
+            )
+            if len(diagonal_dependencies) != 1 or len(fitted_diagonals) != 1:
+                if diagonal_dependencies:
+                    raise FeasibleCoordinateConstructionError(
+                        "Coupled longitudinal diagonal dependencies require a "
+                        f"whole-block chart: domain={block.domain_id!r}"
+                    )
+                continue
+            rate_id = fitted_diagonals[0]
+            if any(
+                rate_id in _controlled_dependencies(parameterization, item, controlled)
+                for item in block.diagonal_ids
+                if item != rate_id
+            ):
+                raise FeasibleCoordinateConstructionError(
+                    "A fitted diagonal changes several entries of a coupled "
+                    f"longitudinal block: domain={block.domain_id!r}"
+                )
+            floor = _conditional_diagonal_floor(block, rate_id, resolved)
+            if not math.isfinite(floor):
+                raise ScientificFeasibilityError(
+                    f"Longitudinal block {block.domain_id!r} has no finite PSD floor"
+                )
+            static_rate_floors[rate_id] = max(
+                static_rate_floors.get(rate_id, 0.0), floor
+            )
+            continue
+        if len(block.diagonal_ids) != 2 or len(block.off_diagonal_ids) != 1:
+            continue
+        _row, _column, cross_id = block.off_diagonal_ids[0]
+        if cross_id in controlled:
+            continue
+        resolved = parameterization.resolve(frame)
+        if resolved[cross_id] == 0.0:
+            continue
+        if block.diagonal_ids[0] == block.diagonal_ids[1]:
+            rate_id = block.diagonal_ids[0]
+            if rate_id in controlled:
+                register_rate_floor(
+                    RateFloor(
+                        rate_id,
+                        RateFloorKind.REPEATED_DIAGONAL,
+                        rate_id,
+                        cross_id,
+                    )
+                )
+            continue
+        fitted_diagonals = [item for item in block.diagonal_ids if item in controlled]
+        dependencies = {
+            item: _controlled_dependencies(parameterization, item, controlled)
+            for item in block.diagonal_ids
+        }
+        if fitted_diagonals:
+            if len(fitted_diagonals) > 1:
+                raise FeasibleCoordinateConstructionError(
+                    "Two independently fitted relaxation diagonals with a held "
+                    f"cross-rate need a joint chart: domain={block.domain_id!r}"
+                )
+            rate_id = next(item for item in controlled_ids if item in fitted_diagonals)
+            other_id = next(
+                param_id for param_id in block.diagonal_ids if param_id != rate_id
+            )
+            derived = _derived_pair_floor(
+                parameterization,
+                rate_id,
+                other_id,
+                cross_id,
+            )
+            if derived is not None:
+                register_rate_floor(derived)
+            elif rate_id not in dependencies[other_id]:
+                register_rate_floor(
+                    RateFloor(
+                        rate_id,
+                        RateFloorKind.OTHER_DIAGONAL,
+                        other_id,
+                        cross_id,
+                    )
+                )
+            else:
+                raise FeasibleCoordinateConstructionError(
+                    "A fitted relaxation diagonal has an unsupported coupled form: "
+                    f"domain={block.domain_id!r}, rate={rate_id!r}"
+                )
+        elif set().union(*dependencies.values()):
+            raise FeasibleCoordinateConstructionError(
+                "A controlled parameter can invalidate a derived held relaxation "
+                f"diagonal: domain={block.domain_id!r}"
+            )
+    floor_rate_ids = {item.rate_id for item in rate_floors}
+    rate_excess_ids = tuple(
+        item for item in rate_excess_ids if item[0] not in floor_rate_ids
+    )
+    public_start = dict(frame.ordered_items())
+    resolved_start = parameterization.resolve(frame)
+    _validate_blocks(blocks, resolved_start)
+    rate_map = {
+        param_id: tuple(
+            diagonal_id
+            for rate_id, diagonal_id in rate_excess_ids
+            if rate_id == param_id
+        )
+        for param_id in controlled_ids
+    }
+    floors_by_rate = {
+        param_id: tuple(item for item in rate_floors if item.rate_id == param_id)
+        for param_id in controlled_ids
+    }
+    solver_start: list[float] = []
+    solver_lower: list[float] = []
+    solver_upper: list[float] = []
+    lower_by_id = dict(zip(controlled_ids, lower_bounds, strict=True))
+    upper_by_id = dict(zip(controlled_ids, upper_bounds, strict=True))
+    for param_id in controlled_ids:
+        if rate_map[param_id]:
+            floor = max(
+                lower_by_id[param_id],
+                static_rate_floors.get(param_id, -math.inf),
+                *(
+                    resolved_start[param_id] - resolved_start[diagonal_id]
+                    for diagonal_id in rate_map[param_id]
+                ),
+            )
+            excess = public_start[param_id] - floor
+            if excess < 0.0:
+                raise ScientificFeasibilityError(
+                    f"Derived relaxation diagonal for {param_id!r} is negative"
+                )
+            if upper_by_id[param_id] < np.finfo(np.float64).max:
+                raise FeasibleCoordinateConstructionError(
+                    f"Finite upper bound for transformed relaxation rate {param_id!r} "
+                    "is not yet supported exactly"
+                )
+            solver_start.append(excess)
+            solver_lower.append(0.0)
+            solver_upper.append(upper_by_id[param_id])
+        elif floors_by_rate[param_id]:
+            if upper_by_id[param_id] < np.finfo(np.float64).max:
+                raise FeasibleCoordinateConstructionError(
+                    f"Finite upper bound for transformed relaxation rate {param_id!r} "
+                    "is not yet supported exactly"
+                )
+            floor = max(
+                lower_by_id[param_id],
+                static_rate_floors.get(param_id, -math.inf),
+                *(
+                    _rate_floor(item, resolved_start)
+                    for item in floors_by_rate[param_id]
+                ),
+            )
+            if not math.isfinite(floor):
+                raise ScientificFeasibilityError(
+                    f"Relaxation rate {param_id!r} has no finite PSD floor"
+                )
+            excess = public_start[param_id] - floor
+            if excess < 0.0:
+                raise ScientificFeasibilityError(
+                    f"Relaxation rate {param_id!r} is below its PSD floor"
+                )
+            solver_start.append(excess)
+            solver_lower.append(0.0)
+            solver_upper.append(upper_by_id[param_id])
+        elif param_id in cross_ids:
+            lower = lower_by_id[param_id]
+            upper = upper_by_id[param_id]
+            values = dict(resolved_start)
+            for block in blocks:
+                if any(item[2] == param_id for item in block.off_diagonal_ids):
+                    block_lower, block_upper = _conditional_interval(
+                        block, param_id, values
+                    )
+                    lower = max(lower, block_lower)
+                    upper = min(upper, block_upper)
+            width = upper - lower
+            value = public_start[param_id]
+            if width < 0.0 or not lower <= value <= upper:
+                raise ScientificFeasibilityError(
+                    f"Initial cross-rate {param_id!r} is outside its PSD interval"
+                )
+            rho = 0.0 if width == 0.0 else (2.0 * value - lower - upper) / width
+            solver_start.append(rho)
+            solver_lower.append(-1.0)
+            solver_upper.append(1.0)
+        else:
+            solver_start.append(public_start[param_id])
+            solver_lower.append(
+                max(lower_by_id[param_id], static_rate_floors.get(param_id, -math.inf))
+            )
+            solver_upper.append(upper_by_id[param_id])
+    return FeasibleCoordinates(
+        parameterization,
+        frame,
+        controlled_ids,
+        lower_bounds,
+        upper_bounds,
+        rate_excess_ids,
+        tuple(rate_floors),
+        tuple(sorted(static_rate_floors.items())),
+        cross_ids,
+        blocks,
+        tuple(solver_start),
+        tuple(solver_lower),
+        tuple(solver_upper),
+    )

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -278,7 +278,7 @@ class FeasibleCoordinates:
         controlled_ids: tuple[str, ...],
         lower_bounds: tuple[float, ...],
         upper_bounds: tuple[float, ...],
-    ) -> FeasibleCoordinates:
+    ) -> FeasibleCoordinates | None:
         """Compile a role-aware child chart without exposing model internals."""
         return compile_feasible_coordinates(
             self.parameterization,
@@ -690,7 +690,7 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
     controlled_ids: tuple[str, ...],
     lower_bounds: tuple[float, ...],
     upper_bounds: tuple[float, ...],
-) -> FeasibleCoordinates:
+) -> FeasibleCoordinates | None:
     """Compile an exact supported chart for the active relaxation domains."""
     blocks = active_relaxation_blocks(parameterization)
     chart_blocks = tuple(
@@ -955,7 +955,7 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
                 max(lower_by_id[param_id], static_rate_floors.get(param_id, -math.inf))
             )
             solver_upper.append(upper_by_id[param_id])
-    return FeasibleCoordinates(
+    chart = FeasibleCoordinates(
         parameterization,
         frame,
         controlled_ids,
@@ -970,3 +970,4 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
         tuple(solver_lower),
         tuple(solver_upper),
     )
+    return None if chart.is_noop else chart

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -46,6 +46,7 @@ from chemex.configuration.method_plan import (
 from chemex.configuration.methods import Method
 from chemex.nmr.rates import rate_functions
 from chemex.parameters.name import ParamName, matches_parameter_index_selector
+from chemex.parameters.relaxation import SealedRelaxationDomains
 from chemex.parameters.sealed import (
     ParamDefinition,
     SealedConfiguration,
@@ -293,6 +294,9 @@ class SealedParameterModel:
     definitions: SealedDefinitions
     configuration: SealedConfiguration
     declarations: SealedParameterDeclarations
+    relaxation_domains: SealedRelaxationDomains = field(
+        default_factory=SealedRelaxationDomains,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -317,6 +321,7 @@ class SealedParameterModel:
                     self.definitions.identity,
                     self.configuration.identity,
                     self.declarations.identity,
+                    self.relaxation_domains.identity,
                 ),
             ),
         )
@@ -652,6 +657,9 @@ class ConstraintProgram:
     derived_ids: tuple[str, ...]
     constraints: tuple[CompiledConstraint, ...]
     evaluation_order: tuple[str, ...]
+    relaxation_domains: SealedRelaxationDomains = field(
+        default_factory=SealedRelaxationDomains,
+    )
     fingerprint: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -673,6 +681,7 @@ class ConstraintProgram:
                 for item in self.constraints
             ),
             self.evaluation_order,
+            self.relaxation_domains.identity,
         )
         object.__setattr__(
             self, "fingerprint", _fingerprint("constraint-program", records)
@@ -1851,6 +1860,14 @@ def _compile_active_parameterization_from_rules(
         derived_ids=derived_ids,
         constraints=constraints,
         evaluation_order=evaluation_order,
+        relaxation_domains=SealedRelaxationDomains(
+            tuple(
+                block
+                for block in parameter_model.relaxation_domains.blocks
+                if {*block.diagonal_ids, *(item[2] for item in block.off_diagonal_ids)}
+                <= active
+            )
+        ),
     )
     return ActiveParameterization(
         program=program,

--- a/src/chemex/parameters/relaxation.py
+++ b/src/chemex/parameters/relaxation.py
@@ -1,0 +1,55 @@
+"""Model-owned physical feasibility declarations for relaxation operators."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class RelaxationPsdBlock:
+    """One symmetric relaxation-rate block that must remain PSD."""
+
+    domain_id: str
+    state: str
+    diagonal_ids: tuple[str, ...]
+    off_diagonal_ids: tuple[tuple[int, int, str], ...]
+
+    def __post_init__(self) -> None:
+        size = len(self.diagonal_ids)
+        if size not in {2, 3}:
+            raise ValueError("Relaxation PSD block has invalid diagonal scope")
+        if any(
+            not 0 <= row < column < size or not param_id
+            for row, column, param_id in self.off_diagonal_ids
+        ):
+            raise ValueError("Relaxation PSD block has invalid off-diagonal scope")
+
+
+def relaxation_blocks_identity(blocks: tuple[RelaxationPsdBlock, ...]) -> str:
+    """Return a stable identity for canonical relaxation-domain declarations."""
+    records = tuple(
+        (
+            block.domain_id,
+            block.state,
+            block.diagonal_ids,
+            block.off_diagonal_ids,
+        )
+        for block in blocks
+    )
+    encoded = json.dumps(records, ensure_ascii=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class SealedRelaxationDomains:
+    """Canonical immutable relaxation-domain declarations."""
+
+    blocks: tuple[RelaxationPsdBlock, ...] = ()
+    identity: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        blocks = tuple(sorted(set(self.blocks)))
+        object.__setattr__(self, "blocks", blocks)
+        object.__setattr__(self, "identity", relaxation_blocks_identity(blocks))

--- a/src/chemex/parameters/spins.py
+++ b/src/chemex/parameters/spins.py
@@ -131,6 +131,7 @@ def create_base_param_settings(
         f"khh_{state}": ParamLocalSetting(
             name_setting=NameSetting(f"khh_{state}", "g", ("temperature",)),
             value=0.0,
+            min=0.0,
         ),
         f"r2_i_{state}": ParamLocalSetting(
             name_setting=NameSetting(
@@ -270,6 +271,7 @@ def create_base_param_settings(
         f"d_{state}": ParamLocalSetting(
             name_setting=NameSetting(f"d_{state}", "", ("temperature",)),
             value=0.0,
+            min=0.0,
         ),
     }
 

--- a/tests/nmr/test_rates.py
+++ b/tests/nmr/test_rates.py
@@ -7,6 +7,7 @@ from chemex.configuration.conditions import Conditions
 from chemex.models.model import ModelSpec
 from chemex.nmr.basis import Basis
 from chemex.nmr.rates import get_model_free_expressions, rate_functions
+from chemex.parameters.spins import create_base_param_settings
 
 _SWAPPED_COMPONENTS = {
     "r2_i": "r2_s",
@@ -77,6 +78,54 @@ def test_nh_hn_expressions_canonicalize_physical_n_and_h_components() -> None:
         == hn["r1_i_a"]
         == ("nh(799.708, {tauc_a}, {s2_a}, {khh_a})['r1_s']")
     )
+
+
+def test_diffusion_coefficient_is_non_negative() -> None:
+    basis = Basis(type="ixyzsxyz_diff", spin_system="ch", model=ModelSpec())
+
+    settings = create_base_param_settings(basis, "a", Conditions())
+
+    assert settings["d_a"].min == 0.0
+
+
+def test_relaxation_psd_specs_match_the_actual_basis_transition_support() -> None:
+    basis = Basis(
+        type="ixyzsxyz_eq",
+        spin_system="nh",
+        model=ModelSpec(),
+    )
+    non_equilibrium = tuple(
+        index
+        for index, component in enumerate(basis.components_states)
+        if not component.startswith(("ie_", "se_"))
+    )
+
+    for specification in basis.relaxation_psd_specs:
+        diagonal_supports = []
+        for name in specification.diagonal_names:
+            matrix = basis.matrices[name]
+            diagonal_supports.append(
+                {index for index in non_equilibrium if matrix[index, index] < 0.0}
+            )
+        for row, column, name in specification.off_diagonal_names:
+            matrix = basis.matrices[name]
+            observed = {
+                (left, right)
+                for left in non_equilibrium
+                for right in non_equilibrium
+                if left != right and matrix[left, right] != 0.0
+            }
+            expected_support = {
+                (left, right)
+                for left in diagonal_supports[row]
+                for right in diagonal_supports[column]
+            } | {
+                (right, left)
+                for left in diagonal_supports[row]
+                for right in diagonal_supports[column]
+            }
+            assert observed
+            assert observed <= expected_support
 
 
 @pytest.mark.parametrize("component", ("r2mq_is", "r1a_is", "sigma_is", "mu_is"))

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -148,8 +148,46 @@ def test_captured_value_outside_search_range_is_valid_and_not_clipped() -> None:
     )
 
     assert invocation.search_problem.start == (captured,)
+    effective = invocation.search_coordinates[0]
+    assert effective.physical_lower > 1.0
     assert invocation.search_coordinates[0].solver_initial == pytest.approx(
-        math.log(2.0)
+        0.5 * math.log(effective.physical_lower * effective.physical_upper)
+    )
+
+
+def test_mixed_domain_de_uses_the_derived_child_psd_bound() -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(
+            Method(
+                fit=["ETAZ_A", "R1A_A"],
+                fix=["R1_A", "PB", "KEX_AB"],
+            )
+        )
+    )
+    root_feasible = problem.feasible_coordinates
+    assert root_feasible is not None
+    assert root_feasible.has_coordinate_transform
+    selected_id = next(item for item in problem.controlled_ids if "__R1A_A" in item)
+    selected_index = problem.controlled_ids.index(selected_id)
+
+    invocation = DeSearchInvocation.for_product_problem(
+        problem,
+        search_coordinates=(
+            (
+                selected_id,
+                problem.lower_bounds[selected_index],
+                5.0,
+                "linear",
+            ),
+        ),
+        root_seed=597,
+    )
+
+    child_feasible = invocation.search_problem.feasible_coordinates
+    assert child_feasible is not None
+    assert not child_feasible.has_coordinate_transform
+    assert invocation.search_coordinates[0].physical_lower == pytest.approx(
+        child_feasible.solver_lower_bounds[0]
     )
 
 

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -1230,6 +1230,49 @@ def test_non_convergence_keeps_last_iterate_diagnostic_and_commits_nothing() -> 
     assert _presentation_values(session, problem.commit_scope) == presentation_before
 
 
+def test_box_only_feasibility_uses_public_coordinates_without_decode() -> None:
+    _session, _experiments, parameterization, engine, problem, invocation = (
+        _qualification_fit()
+    )
+    feasible = problem.feasible_coordinates
+    assert feasible is not None
+    assert not feasible.has_coordinate_transform
+    observed_solver_domain: list[tuple[Array, tuple[Array, Array]]] = []
+
+    def non_converged(
+        fun: Callable[[Array], Array], x0: Array, **settings: object
+    ) -> object:
+        bounds = settings["bounds"]
+        assert isinstance(bounds, tuple)
+        observed_solver_domain.append((x0, bounds))
+        residuals = fun(x0)
+        return _backend_result(
+            x0,
+            residuals,
+            status=0,
+            success=False,
+            message="measurement stop",
+            optimality=1.0,
+        )
+
+    with (
+        patch.object(
+            type(feasible),
+            "decode",
+            side_effect=AssertionError("box-only feasibility decode"),
+        ),
+        patch("chemex.optimize.direct_trf.least_squares", non_converged),
+    ):
+        outcome = execute_direct_trf(problem, invocation, parameterization, engine)
+
+    assert outcome.terminal is DirectTrfOutcomeTerminal.SOLVER_UNSUCCESSFUL
+    assert outcome.execution.terminal is DirectTrfTerminal.NON_CONVERGED
+    [(start, bounds)] = observed_solver_domain
+    np.testing.assert_array_equal(start, problem.start)
+    np.testing.assert_array_equal(bounds[0], feasible.solver_lower_bounds)
+    np.testing.assert_array_equal(bounds[1], feasible.solver_upper_bounds)
+
+
 def test_execution_fingerprints_the_ordered_solver_request_trajectory() -> None:
     _session, _experiments, parameterization, engine, problem, invocation = (
         _qualification_fit()

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -1188,8 +1188,10 @@ def test_non_convergence_keeps_last_iterate_diagnostic_and_commits_nothing() -> 
     ) -> object:
         bounds = settings.pop("bounds")
         assert isinstance(bounds, tuple)
-        np.testing.assert_array_equal(bounds[0], problem.lower_bounds)
-        np.testing.assert_array_equal(bounds[1], problem.upper_bounds)
+        feasible = problem.feasible_coordinates
+        assert feasible is not None
+        np.testing.assert_array_equal(bounds[0], feasible.solver_lower_bounds)
+        np.testing.assert_array_equal(bounds[1], feasible.solver_upper_bounds)
         assert settings.pop("x_scale") == "jac"
         assert settings == {
             "method": "trf",

--- a/tests/test_native_direct_trf.py
+++ b/tests/test_native_direct_trf.py
@@ -1273,6 +1273,36 @@ def test_box_only_feasibility_uses_public_coordinates_without_decode() -> None:
     np.testing.assert_array_equal(bounds[1], feasible.solver_upper_bounds)
 
 
+def test_box_only_feasibility_rejects_candidate_below_effective_floor() -> None:
+    _session, _experiments, parameterization, engine, problem, invocation = (
+        _qualification_fit()
+    )
+    feasible = problem.feasible_coordinates
+    assert feasible is not None
+    assert not feasible.has_coordinate_transform
+    assert len(problem.controlled_ids) == 1
+    public_lower = problem.lower_bounds[0]
+    effective_lower = feasible.solver_lower_bounds[0]
+    assert public_lower < effective_lower < problem.start[0]
+    invalid = np.array([0.5 * (public_lower + effective_lower)])
+
+    def supply_invalid(
+        fun: Callable[[Array], Array], _x0: Array, **_settings: object
+    ) -> object:
+        fun(invalid)
+        raise AssertionError("out-of-effective-box candidate was evaluated")
+
+    with patch("chemex.optimize.direct_trf.least_squares", supply_invalid):
+        outcome = execute_direct_trf(problem, invocation, parameterization, engine)
+
+    assert outcome.execution.terminal is DirectTrfTerminal.IMPLEMENTATION_FAILURE
+    assert outcome.execution.counters.solver_requests_received == 1
+    assert outcome.execution.counters.objective_requests_accepted == 1
+    assert outcome.execution.counters.objective_evaluations_completed == 0
+    assert outcome.execution.failure is not None
+    assert outcome.execution.failure.category == "candidate_contract_failure"
+
+
 def test_execution_fingerprints_the_ordered_solver_request_trajectory() -> None:
     _session, _experiments, parameterization, engine, problem, invocation = (
         _qualification_fit()

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -267,6 +267,16 @@ def test_grouped_components_preserve_root_affine_feasibility() -> None:
             dataclasses.replace(component.problem, affine_half_spaces=())
 
 
+def test_relaxation_feasibility_hyperedge_merges_separate_profile_controls() -> None:
+    components = grouped_direct_trf_owner._ordered_component_controls(
+        ("r2", "eta", "pb"),
+        (frozenset(("r2",)), frozenset(("eta",)), frozenset(("pb",))),
+        (frozenset(("r2", "eta")),),
+    )
+
+    assert components == (("pb",), ("r2", "eta"))
+
+
 def test_all_masked_unscaled_profile_cannot_supply_a_control_dependency() -> None:
     session, experiments, parameterization, _engine, _problem = _grouped_problem()
     profile = next(iter(experiments)).profiles[0]

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -422,6 +422,52 @@ def test_product_policy_initializes_from_exact_accepted_fit() -> None:
     )
 
 
+def test_mcmc_rejects_private_relaxation_coordinates_without_measure() -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    transformed_problem = dataclasses.replace(
+        problem,
+        feasible_coordinates=SimpleNamespace(
+            is_noop=False,
+            identity="private-relaxation-chart",
+            supports_box_only_algorithms=False,
+            solver_bounds=(problem.lower_bounds, problem.upper_bounds),
+        ),
+    )
+    compatible = AcceptedFitResult.for_qualification(
+        occurrence_identity="relaxation-chart-accepted",
+        problem_identity=transformed_problem.identity,
+        invocation_identity=accepted.invocation_identity,
+        execution_identity=accepted.execution_identity,
+        materialization_identity=accepted.materialization_identity,
+        parameterization_identity=accepted.parameterization_identity,
+        evaluator_parameterization_identity=(
+            accepted.evaluator_parameterization_identity
+        ),
+        source_occurrence_identity=accepted.source_occurrence_identity,
+        source_revision=accepted.source_revision,
+        controlled_ids=accepted.controlled_ids,
+        vector=accepted.vector,
+        chi_square=accepted.chi_square,
+        evaluation_result=accepted.evaluation_result,
+        commit_scope=accepted.commit_scope,
+        commit_items=accepted.commit_items,
+        origin_context_identity=accepted.origin_context_identity,
+    )
+
+    with pytest.raises(McmcConstructionError, match="Jacobian measure"):
+        McmcPlan.for_accepted(
+            compatible,
+            source_problem=transformed_problem,
+            parameterization=parameterization,
+            source_engine=engine,
+            policy=_resolved_policy(),
+            coordinate_units=(
+                ("A", ParameterUnit.DIMENSIONLESS),
+                ("B", ParameterUnit.DIMENSIONLESS),
+            ),
+        )
+
+
 @pytest.mark.parametrize("walkers", (2, 3))
 def test_one_dimensional_product_policy_preserves_two_walker_minimum(
     walkers: int,

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -29,6 +29,7 @@ from chemex.optimize.mcmc import NativeMcmcIncompleteError
 from chemex.optimize.progress import ProgressPhase
 from chemex.optimize.resampling import NativeResamplingIncompleteError
 from chemex.optimize.uncertainty import ParameterUnit
+from chemex.parameters.feasible_coordinates import ScientificFeasibilityError
 from chemex.parameters.values import AnalysisValuesSnapshot
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
@@ -48,6 +49,54 @@ CEST_1HN_IP_AP_EXAMPLE = ROOT / "examples/Experiments/CEST_1HN_IP_AP"
 CEST_1HN_IP_AP_EXPERIMENT = CEST_1HN_IP_AP_EXAMPLE / "Experiments/30hz.toml"
 CEST_1HN_IP_AP_PARAMETERS = CEST_1HN_IP_AP_EXAMPLE / "Parameters/parameters.toml"
 CEST_1HN_IP_AP_METHOD = CEST_1HN_IP_AP_EXAMPLE / "Methods/method.toml"
+CPMG_15N_TR_EXAMPLE = ROOT / "examples/Experiments/CPMG_15N_TR"
+CPMG_15N_TR_EXPERIMENT = CPMG_15N_TR_EXAMPLE / "Experiments/500mhz.toml"
+CPMG_15N_TR_PARAMETERS = CPMG_15N_TR_EXAMPLE / "Parameters/parameters.toml"
+CEST_15N_CW_EXAMPLE = ROOT / "examples/Experiments/CEST_15N_CW"
+CEST_15N_CW_EXPERIMENT = CEST_15N_CW_EXAMPLE / "Experiments/dec.toml"
+CEST_15N_CW_PARAMETERS = CEST_15N_CW_EXAMPLE / "Parameters/parameters.toml"
+CEST_15N_CW_METHOD = CEST_15N_CW_EXAMPLE / "Methods/method.toml"
+CEST_1HN_IP_AP_SELECTION = (
+    "3",
+    "4",
+    "12",
+    "13",
+    "14",
+    "30",
+    "32",
+    "65",
+    "68",
+    "70",
+    "72",
+    "74",
+    "75",
+    "78",
+    "80",
+    "91",
+    "100",
+    "101",
+    "103",
+    "104",
+    "105",
+    "108",
+    "110",
+    "111",
+    "113",
+    "115",
+    "116",
+    "117",
+    "118",
+    "119",
+    "121",
+    "122",
+    "137",
+    "138",
+    "139",
+    "141",
+    "142",
+    "146",
+    "149",
+)
 
 
 def _fit_arguments(
@@ -122,7 +171,11 @@ def _three_state_dcest_arguments(output: Path, method: Path):
     )
 
 
-def _cest_1hn_ip_ap_arguments(output: Path):
+def _cest_1hn_ip_ap_arguments(
+    output: Path,
+    *,
+    include: tuple[str, ...] = ("74",),
+):
     return build_parser().parse_args(
         [
             "fit",
@@ -137,12 +190,56 @@ def _cest_1hn_ip_ap_arguments(output: Path):
             "--model",
             "2st.rs",
             "--include",
-            "4",
+            *include,
             "--plot",
             "nothing",
             "--workers",
             "1",
             "--native-threads",
+            "1",
+        ]
+    )
+
+
+def _cpmg_15n_tr_arguments(output: Path):
+    return build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            str(CPMG_15N_TR_EXPERIMENT),
+            "-p",
+            str(CPMG_15N_TR_PARAMETERS),
+            "-o",
+            str(output),
+            "--include",
+            "8",
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+        ]
+    )
+
+
+def _cest_15n_cw_model_free_arguments(output: Path):
+    return build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            str(CEST_15N_CW_EXPERIMENT),
+            "-p",
+            str(CEST_15N_CW_PARAMETERS),
+            "-m",
+            str(CEST_15N_CW_METHOD),
+            "-o",
+            str(output),
+            "--model",
+            "2st.mf",
+            "--include",
+            "52",
+            "--plot",
+            "nothing",
+            "--workers",
             "1",
         ]
     )
@@ -318,7 +415,7 @@ def test_real_direct_fit_uses_native_trf_and_commits_product_output(
     assert fitted_curve_rate == pytest.approx(fitted_value, rel=1.0e-3)
 
 
-def test_cest_1hn_ip_ap_commits_finite_negative_derived_r2a_b(
+def test_cest_1hn_ip_ap_commits_psd_transverse_relaxation_block(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -344,21 +441,88 @@ def test_cest_1hn_ip_ap_commits_finite_negative_derived_r2a_b(
     r2a_b = next(
         definition
         for definition in parameter_model.definitions
-        if definition.name == "R2A_B" and definition.spin_system_name == "4H"
+        if definition.name == "R2A_B" and definition.spin_system_name == "74H"
     )
     configuration = parameter_model.configuration[r2a_b.param_id]
+    r2_b = next(
+        definition
+        for definition in parameter_model.definitions
+        if definition.name == "R2_B" and definition.spin_system_name == "74H"
+    )
+    etaxy_b = next(
+        definition
+        for definition in parameter_model.definitions
+        if definition.name == "ETAXY_B" and definition.spin_system_name == "74H"
+    )
     assert configuration.lower_bound == 0.0
     assert [item.revision for item in committed_snapshots] == [1, 2]
-    # This is the one-profile form of the shipped regression. A 2e-7 relative
-    # tolerance covers backend/finite-difference rounding while remaining seven
-    # orders of magnitude from the configured zero bound and lmfit's old clipping.
-    assert committed_snapshots[0][r2a_b.param_id] == pytest.approx(
-        -0.42454801400787906,
-        rel=2.0e-7,
-        abs=1.0e-9,
+    first = committed_snapshots[0]
+    assert first[r2a_b.param_id] >= configuration.lower_bound
+    determinant = (
+        first[r2_b.param_id] * first[r2a_b.param_id] - first[etaxy_b.param_id] ** 2
     )
-    assert committed_snapshots[0][r2a_b.param_id] < configuration.lower_bound
+    assert determinant >= -1.0e-10
+    stage_one_parameters = (
+        output / "1_FIX_R1" / "Parameters" / "fitted.toml"
+    ).read_text(encoding="utf-8")
+    assert "error unavailable: Jacobian unavailable" in stage_one_parameters
+    stage_one_covariance = json.loads(
+        (output / "1_FIX_R1" / "Statistics" / "Covariance" / "evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert any(
+        failure["category"] == "active_relaxation_feasibility_boundary"
+        for failure in stage_one_covariance["failures"]
+    )
     assert snapshot.revision == 2
+    final_statistics = tomllib.loads(
+        (output / "2_FIT_R1" / "statistics.toml").read_text(encoding="utf-8")
+    )
+    assert final_statistics["chi-square"] == pytest.approx(52.4331, rel=2.0e-5)
+
+
+def test_complete_cest_1hn_ip_ap_shipped_selection_finishes_both_steps(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+
+    run(
+        _cest_1hn_ip_ap_arguments(
+            output,
+            include=CEST_1HN_IP_AP_SELECTION,
+        ),
+        session=AnalysisSession.create(),
+    )
+
+    first = tomllib.loads(
+        (output / "1_FIX_R1" / "statistics.toml").read_text(encoding="utf-8")
+    )
+    second = tomllib.loads(
+        (output / "2_FIT_R1" / "statistics.toml").read_text(encoding="utf-8")
+    )
+    assert first["chi-square"] == pytest.approx(11938.9, rel=2.0e-5)
+    assert second["chi-square"] == pytest.approx(3877.57, rel=2.0e-5)
+
+
+def test_cpmg_15n_tr_nested_antiphase_rate_remains_feasible(tmp_path: Path) -> None:
+    output = tmp_path / "Output"
+
+    run(_cpmg_15n_tr_arguments(output), session=AnalysisSession.create())
+
+    statistics = tomllib.loads((output / "statistics.toml").read_text(encoding="utf-8"))
+    assert statistics["chi-square"] == pytest.approx(38.8201, rel=2.0e-5)
+
+
+def test_cest_15n_cw_model_free_rates_preserve_intrinsic_psd_domain(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+
+    run(_cest_15n_cw_model_free_arguments(output), session=AnalysisSession.create())
+
+    statistics = tomllib.loads((output / "statistics.toml").read_text(encoding="utf-8"))
+    assert statistics["chi-square"] == pytest.approx(88.0553, rel=2.0e-5)
 
 
 def test_product_fit_rejects_a_stale_aggregate_commit_atomically(
@@ -590,7 +754,7 @@ ROLES = [{ FIX = ["PB", "KEX_AB"] }]
     assert _read_outcome(output)["restart_revision"] == 3
 
 
-def test_out_of_bounds_derived_continuity_cannot_become_held_independent(
+def test_invalid_derived_relaxation_state_fails_before_commit(
     tmp_path: Path,
 ) -> None:
     method = tmp_path / "method-v2.toml"
@@ -610,10 +774,7 @@ ROLES = [{ FIX = ["PB", "KEX_AB", "R1A_A"] }]
     )
     session = AnalysisSession.create()
 
-    with pytest.raises(
-        direct_trf_module.DirectTrfConstructionError,
-        match="Independent parameter .* outside its effective bounds",
-    ):
+    with pytest.raises(ScientificFeasibilityError, match="positive semidefinite"):
         run(_fit_arguments(tmp_path / "Output", method), session=session)
 
     committed = session.analysis_values.snapshot()
@@ -624,8 +785,8 @@ ROLES = [{ FIX = ["PB", "KEX_AB", "R1A_A"] }]
         for item in parameter_model.definitions
         if item.name == "R1A_A" and item.spin_system_name == "G2N-H"
     )
-    assert committed.revision == 1
-    assert committed[r1a_a] == -1.0
+    assert committed.revision == 0
+    assert committed[r1a_a] > 0.0
 
 
 def test_relaxation_product_covariance_matches_absolute_sigma_reference(
@@ -3168,8 +3329,10 @@ COORDINATES = [
 
     assert session.analysis_values.snapshot().revision == 1
     assert len(trf_starts) == 2
+    # The declared DE interval starts just below the exact ETAZ/R1 PSD floor;
+    # its effective search box begins at the physical boundary.
     assert sorted(start[0] for start in trf_starts) == pytest.approx(
-        (2.0, 6.87922079444668)
+        (2.006856537329346, 6.87922079444668)
     )
     assert trf_scale_policies == ["jac", "jac"]
 

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -522,7 +522,7 @@ def test_cest_15n_cw_model_free_rates_preserve_intrinsic_psd_domain(
     run(_cest_15n_cw_model_free_arguments(output), session=AnalysisSession.create())
 
     statistics = tomllib.loads((output / "statistics.toml").read_text(encoding="utf-8"))
-    assert statistics["chi-square"] == pytest.approx(88.0553, rel=2.0e-5)
+    assert statistics["chi-square"] == pytest.approx(88.0553, rel=1.0e-4)
 
 
 def test_product_fit_rejects_a_stale_aggregate_commit_atomically(

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -1662,7 +1662,7 @@ def test_multivariate_simple_bound_warning_is_coordinate_specific(zeta: float) -
     assert view.warning(kab_id) == "boundary may make uncertainty asymmetric"
 
 
-def test_unrepresentable_centered_interval_falls_back_to_inward_stencil() -> None:
+def test_invalid_relaxation_anchor_has_no_public_uncertainty_stencil() -> None:
     _session, parameterization, engine, problem, _accepted = _accepted_relaxation_fit()
     controlled_id = problem.controlled_ids[0]
     interior = (float(np.nextafter(0.0, 1.0)),)
@@ -1682,8 +1682,11 @@ def test_unrepresentable_centered_interval_falls_back_to_inward_stencil() -> Non
         resolved_environment_identity="local-qualification-environment",
     )
 
-    assert evidence.residual_jacobian is not None
-    assert evidence.residual_jacobian.columns[0].orientation == "one_sided_positive"
+    assert evidence.residual_jacobian is None
+    assert any(
+        failure.category == "active_relaxation_feasibility_boundary"
+        for failure in evidence.failures
+    )
 
 
 def test_nonfinite_boundary_separation_is_indeterminate() -> None:

--- a/tests/test_relaxation_feasibility.py
+++ b/tests/test_relaxation_feasibility.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from chemex.optimize.helper import execute_simulation
+from chemex.parameters.feasible_coordinates import (
+    ScientificFeasibilityError,
+    _conditional_interval,
+    _validate_blocks,
+    compile_feasible_coordinates,
+    relaxation_state_is_on_boundary,
+)
+from chemex.parameters.parameterization import (
+    BinaryExpression,
+    CompiledConstraint,
+    IndependentValueFrame,
+    ReferenceExpression,
+)
+from chemex.parameters.relaxation import (
+    RelaxationPsdBlock,
+    SealedRelaxationDomains,
+)
+
+
+def test_two_state_shared_cross_rate_uses_the_limiting_psd_block() -> None:
+    blocks = (
+        RelaxationPsdBlock("transverse-a", "a", ("r2a", "r2aa"), ((0, 1, "eta"),)),
+        RelaxationPsdBlock("transverse-b", "b", ("r2b", "r2ab"), ((0, 1, "eta"),)),
+    )
+    values = {"r2a": 34.0, "r2aa": 33.5, "r2b": 31.0, "r2ab": 30.5, "eta": 0.0}
+    limits = [_conditional_interval(block, "eta", values)[1] for block in blocks]
+    limit = min(limits)
+
+    values["eta"] = limit
+    _validate_blocks(blocks, values)
+    values["eta"] = limit * (1.0 + 1.0e-9)
+    with pytest.raises(ScientificFeasibilityError, match="positive semidefinite"):
+        _validate_blocks(blocks, values)
+
+
+def test_longitudinal_cross_interval_enforces_the_complete_three_mode_block() -> None:
+    block = RelaxationPsdBlock(
+        "longitudinal-a",
+        "a",
+        ("r1i", "r1s", "r1a"),
+        ((0, 1, "sigma"), (0, 2, "etai"), (1, 2, "etas")),
+    )
+    values = {
+        "r1i": 3.0,
+        "r1s": 2.0,
+        "r1a": 4.0,
+        "sigma": 1.0,
+        "etai": 0.0,
+        "etas": 1.0,
+    }
+    lower, upper = _conditional_interval(block, "etai", values)
+
+    values["etai"] = upper
+    _validate_blocks((block,), values)
+    values["etai"] = upper + 1.0e-6
+    with pytest.raises(ScientificFeasibilityError, match="longitudinal-a"):
+        _validate_blocks((block,), values)
+    assert lower < upper < np.sqrt(values["r1i"] * values["r1a"])
+
+
+@pytest.mark.parametrize("mu", [-12.0, 12.0])
+def test_mu_boundary_is_absolute_r2mq(mu: float) -> None:
+    block = RelaxationPsdBlock(
+        "multiple-quantum-a",
+        "a",
+        ("r2mq", "r2mq"),
+        ((0, 1, "mu"),),
+    )
+    values = {"r2mq": 12.0, "mu": mu}
+    _validate_blocks((block,), values)
+    values["mu"] = np.copysign(12.000001, mu)
+    with pytest.raises(ScientificFeasibilityError, match="multiple-quantum-a"):
+        _validate_blocks((block,), values)
+
+
+def _affine_parameterization():
+    block = RelaxationPsdBlock(
+        "transverse-a",
+        "a",
+        ("r2", "r2a"),
+        ((0, 1, "eta"),),
+    )
+    constraint = CompiledConstraint(
+        "r2a",
+        BinaryExpression(
+            "subtract",
+            ReferenceExpression("r2"),
+            ReferenceExpression("r1"),
+        ),
+        ("r2", "r1"),
+        "r2 - r1",
+        "r2 - r1",
+    )
+
+    class Parameterization:
+        scope_ids = ("r2", "r1", "eta", "r2a")
+        evaluator_identity = "relaxation-test-evaluator"
+        program = SimpleNamespace(
+            constraints=(constraint,),
+            relaxation_domains=SealedRelaxationDomains((block,)),
+        )
+
+        @staticmethod
+        def resolve(frame):
+            values = dict(frame.ordered_items())
+            values.setdefault("r2", 0.0)
+            values.setdefault("r1", 0.0)
+            values["r2a"] = values["r2"] - values["r1"]
+            return values
+
+    return Parameterization()
+
+
+def test_compiled_dynamic_affine_floor_spans_only_the_exact_psd_domain() -> None:
+    parameterization = _affine_parameterization()
+    frame = IndependentValueFrame(
+        "parameterization",
+        "program",
+        "occurrence",
+        0,
+        (("r2", 5.0), ("r1", 2.0), ("eta", 3.0)),
+    )
+    maximum = float(np.finfo(np.float64).max)
+    chart = compile_feasible_coordinates(
+        parameterization,
+        frame,
+        ("r2", "r1"),
+        (0.0, 0.0),
+        (maximum, maximum),
+    )
+
+    boundary = chart.decode((0.0, 10.0))
+    values = parameterization.resolve(boundary.frame)
+    assert values["r2"] == pytest.approx(0.5 * (10.0 + np.sqrt(136.0)))
+    assert values["r2"] * values["r2a"] == pytest.approx(9.0)
+    _validate_blocks(chart.blocks, values)
+
+
+def test_compiled_static_affine_floor_supersedes_nonnegative_rate_excess() -> None:
+    parameterization = _affine_parameterization()
+    frame = IndependentValueFrame(
+        "parameterization",
+        "program",
+        "occurrence",
+        0,
+        (("r2", 5.0), ("r1", 2.0), ("eta", 3.0)),
+    )
+    maximum = float(np.finfo(np.float64).max)
+    chart = compile_feasible_coordinates(
+        parameterization,
+        frame,
+        ("r2",),
+        (0.0,),
+        (maximum,),
+    )
+
+    boundary = chart.decode((0.0,))
+    values = parameterization.resolve(boundary.frame)
+    assert values["r2"] == pytest.approx(0.5 * (2.0 + np.sqrt(40.0)))
+    assert values["r2"] * values["r2a"] == pytest.approx(9.0)
+
+
+def test_collapsed_cross_rate_chart_has_singular_public_differential() -> None:
+    parameterization = _affine_parameterization()
+    frame = IndependentValueFrame(
+        "parameterization",
+        "program",
+        "occurrence",
+        0,
+        (("eta", 0.0),),
+    )
+    maximum = float(np.finfo(np.float64).max)
+    chart = compile_feasible_coordinates(
+        parameterization,
+        frame,
+        ("eta",),
+        (-maximum,),
+        (maximum,),
+    )
+
+    assert np.linalg.matrix_rank(chart.differential(chart.solver_start)) == 0
+    values = parameterization.resolve(chart.decode((1.0,)).frame)
+    assert values["eta"] == 0.0
+    assert relaxation_state_is_on_boundary(
+        parameterization,
+        values,
+    )
+
+
+def test_invalid_simulation_state_fails_before_experiment_execution(
+    tmp_path: Path,
+) -> None:
+    block = RelaxationPsdBlock(
+        "transverse-a",
+        "a",
+        ("r2", "r2a"),
+        ((0, 1, "eta"),),
+    )
+    parameterization = SimpleNamespace(
+        scope_ids=("r2", "r2a", "eta"),
+        program=SimpleNamespace(
+            constraints=(),
+            relaxation_domains=SealedRelaxationDomains((block,)),
+        ),
+    )
+
+    class Experiments:
+        @staticmethod
+        def prepare_for_simulation(_values):
+            raise AssertionError("scientific execution must not be reached")
+
+    with pytest.raises(ScientificFeasibilityError, match="positive semidefinite"):
+        execute_simulation(
+            Experiments(),  # ty: ignore[invalid-argument-type]
+            tmp_path,
+            parameter_values={"r2": 1.0, "r2a": 1.0, "eta": 2.0},
+            parameter_model=SimpleNamespace(),  # ty: ignore[invalid-argument-type]
+            parameterization=parameterization,  # ty: ignore[invalid-argument-type]
+        )
+
+
+def test_unrelated_fixed_psd_boundary_does_not_block_fitted_uncertainty() -> None:
+    block = RelaxationPsdBlock(
+        "transverse-a",
+        "a",
+        ("r2", "r2a"),
+        ((0, 1, "eta"),),
+    )
+    parameterization = SimpleNamespace(
+        scope_ids=("r2", "r2a", "eta", "pb"),
+        program=SimpleNamespace(
+            constraints=(),
+            relaxation_domains=SealedRelaxationDomains((block,)),
+        ),
+    )
+    values = {"r2": 1.0, "r2a": 1.0, "eta": 1.0, "pb": 0.1}
+
+    assert relaxation_state_is_on_boundary(parameterization, values)
+    assert not relaxation_state_is_on_boundary(
+        parameterization,
+        values,
+        controlled_ids=("pb",),
+    )

--- a/tests/test_relaxation_feasibility.py
+++ b/tests/test_relaxation_feasibility.py
@@ -120,6 +120,38 @@ def _affine_parameterization():
     return Parameterization()
 
 
+def test_compiler_returns_no_chart_when_feasibility_has_no_execution_effect() -> None:
+    class Parameterization:
+        evaluator_identity = "uncoupled-test-evaluator"
+        scope_ids = ("rate",)
+        program = SimpleNamespace(
+            constraints=(),
+            relaxation_domains=SealedRelaxationDomains(()),
+        )
+
+        @staticmethod
+        def resolve(frame):
+            return dict(frame.ordered_items())
+
+    frame = IndependentValueFrame(
+        "parameterization",
+        "program",
+        "occurrence",
+        0,
+        (("rate", 5.0),),
+    )
+
+    chart = compile_feasible_coordinates(
+        Parameterization(),
+        frame,
+        ("rate",),
+        (0.0,),
+        (10.0,),
+    )
+
+    assert chart is None
+
+
 def test_compiled_dynamic_affine_floor_spans_only_the_exact_psd_domain() -> None:
     parameterization = _affine_parameterization()
     frame = IndependentValueFrame(
@@ -138,6 +170,8 @@ def test_compiled_dynamic_affine_floor_spans_only_the_exact_psd_domain() -> None
         (maximum, maximum),
     )
 
+    assert chart is not None
+    assert chart.has_coordinate_transform
     boundary = chart.decode((0.0, 10.0))
     values = parameterization.resolve(boundary.frame)
     assert values["r2"] == pytest.approx(0.5 * (10.0 + np.sqrt(136.0)))
@@ -163,6 +197,7 @@ def test_compiled_static_affine_floor_supersedes_nonnegative_rate_excess() -> No
         (maximum,),
     )
 
+    assert chart is not None
     boundary = chart.decode((0.0,))
     values = parameterization.resolve(boundary.frame)
     assert values["r2"] == pytest.approx(0.5 * (2.0 + np.sqrt(40.0)))
@@ -187,6 +222,8 @@ def test_collapsed_cross_rate_chart_has_singular_public_differential() -> None:
         (maximum,),
     )
 
+    assert chart is not None
+    assert chart.has_coordinate_transform
     assert np.linalg.matrix_rank(chart.differential(chart.solver_start)) == 0
     values = parameterization.resolve(chart.decode((1.0,)).frame)
     assert values["eta"] == 0.0


### PR DESCRIPTION
Closes #713.

## Summary

- describe relaxation PSD blocks from each NMR basis and seal their resolved parameter IDs into the native parameter model
- map supported coupled fitting domains to private feasible coordinates before local TRF, while keeping public `ETAXY`, `ETAZ`, `SIGMA`, `MU`, `R1`, and `R2` values in TOML, restarts, results, and evaluator inputs
- enforce exact 2x2 conditions and the complete longitudinal 3x3 PSD condition before scientific kernels
- apply exact non-negative scalar domains to the model-free proton-exchange contribution `KHH` and diffusion coefficient `D`
- merge coupled controls into grouped-fit components; apply exact static floors to box-only DE/MCMC paths and fail closed where a transformed statistical measure has not been qualified
- preserve adaptive `x_scale="jac"` and fatal kernel-exception handling

## Root cause

The canonical `CEST_1HN_IP_AP` failure is a scientifically inadmissible optimizer trial, not an unstable propagator and not an independent adaptive-scaling defect.

For 74H component request 9 (aggregate request 3834), the controlled vector was:

```text
[8.027708373571649, -0.3480114775483399,
 39.36185937863324, 4.3591366595599865,
 0.003305319921433028, 34.45927195356211,
 31.166629760898893]
```

in the order `CS_A`, `DW_AB`, `ETAXY_A`, `ETAZ_A`, `PB`, `R2_A`, `R2_B`.

The shared transverse cross-correlation rate violates both state-specific PSD domains:

```text
ETAXY^2 = 1549.3559737432977
A: R2_i * R2a_i = 1172.811807171226
B: R2_i * R2a_i =  958.1270790468643
```

The resulting 74H Liouvillian has largest eigenvalue `4.411823303431147 + 5956.648060146612j s^-1`. NumPy, SciPy, and the ChemEx eigensystem agree; the eigensystem condition number is 5.83 and the custom propagator agrees with `scipy.linalg.expm` on feasible cases. The overflow therefore reflects a positive-growth relaxation mode permitted by the old parameter domain.

For a represented 2x2 relaxation block, PSD is exactly equivalent to non-negative diagonals and `eta^2 <= R_a R_b`. Shared cross-rates use the intersection of all state-specific intervals. The full longitudinal block uses all principal minors, including its determinant. `MU` obeys `|MU| <= R2MQ`.

ChemEx 2026.06.1 used lmfit `leastsq`/LM and also entered the invalid domain. Its warning/NaN path was handled differently and wrote a partial physically inadmissible state; it did not impose an implicit feasibility constraint. Detached start-magnitude TRF happens to complete but also visits invalid trials. This is a latent feasibility-domain problem exposed by the post-#711 trajectory, so the production Jacobian scaling policy is unchanged.

## Compatibility and failure semantics

- public parameter IDs, values, TOML, restart files, and output remain compatible
- invalid fixed or derived relaxation states now fail before scientific execution
- negative `KHH` and `D` are newly rejected as physically invalid
- active PSD boundaries do not claim a symmetric public-coordinate covariance
- arbitrary kernel exceptions remain fatal; there is no clipping, penalty residual, NaN conversion, retry, or best-so-far commit
- transformed-domain MCMC is rejected until its Jacobian measure is scientifically qualified

## Qualification

- complete 39-profile, two-step `CEST_1HN_IP_AP` workflow: step chi-square `11938.9`, then `3877.57`
- exact 74H regression: completes both steps; final local chi-square `52.4331`
- `CEST_15N_CW` model-free regression: chi-square `88.0553`
- representative `CPMG_15N_TR`, `CEST_13C_LABEL_CN`, `CPMG_CH3_1H_SQ`, and `CPMG_HN_DQ_ZQ` coverage
- Direct, grouped Direct, GRID, DE, resampling, MCMC qualification/rejection, covariance-boundary, invalid-fixed-state, and basis-metadata tests
- exact failing, nearby feasible, boundary-feasible, and well-conditioned propagator comparisons
- `uv run pytest -q tests -p no:cacheprovider`: `1044 passed`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `git diff --check`
- `uv build`

Independent standards/spec and scientific/numerical reviews were run after the final corrections and found no remaining actionable issues.
