### PR TITLE
Optimize grouped Direct TRF startup

### DIFF
--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -1531,8 +1531,11 @@ class EvaluationEngine:
         )
         return cls(plan, parameterization, sources)
 
-    def project_profiles(self, profile_indices: Sequence[int]) -> EvaluationEngine:
-        """Project complete Profiles in root order into an isolated child engine."""
+    def _projected_population(
+        self,
+        profile_indices: Sequence[int],
+    ) -> tuple[EvaluationPlan, tuple[tuple[int, int, Profile], ...]]:
+        """Build the immutable plan and trusted sources for a profile projection."""
         indices = tuple(profile_indices)
         if (
             not indices
@@ -1589,6 +1592,16 @@ class EvaluationEngine:
             failure_version=self.plan.failure_version,
             diagnostics_version=self.plan.diagnostics_version,
         )
+        return plan, tuple(sources)
+
+    def projected_plan_identity(self, profile_indices: Sequence[int]) -> str:
+        """Return a canonical child-plan identity without constructing its engine."""
+        plan, _sources = self._projected_population(profile_indices)
+        return plan.identity
+
+    def project_profiles(self, profile_indices: Sequence[int]) -> EvaluationEngine:
+        """Project complete Profiles in root order into an isolated child engine."""
+        plan, sources = self._projected_population(profile_indices)
         return EvaluationEngine(plan, self._parameterization, sources)
 
     def resampled_observation_metadata(self, binding: ResampledProfileBinding) -> str:

--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -559,6 +559,11 @@ class EvaluationPlan:
         )
 
     @property
+    def compatibility_identity(self) -> str:
+        """Return the runtime compatibility identity sealed by this plan."""
+        return _compatibility_identity(self)
+
+    @property
     def observation_count(self) -> int:
         return sum(item.observation_count for item in self.profiles)
 

--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -1594,11 +1594,6 @@ class EvaluationEngine:
         )
         return plan, tuple(sources)
 
-    def projected_plan_identity(self, profile_indices: Sequence[int]) -> str:
-        """Return a canonical child-plan identity without constructing its engine."""
-        plan, _sources = self._projected_population(profile_indices)
-        return plan.identity
-
     def project_profiles(self, profile_indices: Sequence[int]) -> EvaluationEngine:
         """Project complete Profiles in root order into an isolated child engine."""
         plan, sources = self._projected_population(profile_indices)

--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -1599,6 +1599,11 @@ class EvaluationEngine:
         plan, sources = self._projected_population(profile_indices)
         return EvaluationEngine(plan, self._parameterization, sources)
 
+    def project_plan(self, profile_indices: Sequence[int]) -> EvaluationPlan:
+        """Project an immutable child plan without compiling its runtime engine."""
+        plan, _sources = self._projected_population(profile_indices)
+        return plan
+
     def resampled_observation_metadata(self, binding: ResampledProfileBinding) -> str:
         """Return the canonical metadata descriptor for exact selected root rows."""
         if binding.root_profile_index >= len(self._templates):

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1151,7 +1151,37 @@ class OptimizationProblem:
         controlled_ids: tuple[str, ...],
         start: tuple[float, ...],
         derivation: ProblemDerivation,
-        feasibility_dependencies: tuple[frozenset[str], ...] | None = None,
+    ) -> OptimizationProblem:
+        """Construct a general child, recompiling feasibility for its state."""
+        return self._derive_child(
+            controlled_ids=controlled_ids,
+            start=start,
+            derivation=derivation,
+            project_root_feasibility=False,
+        )
+
+    def derive_grouped_component(
+        self,
+        *,
+        controlled_ids: tuple[str, ...],
+        start: tuple[float, ...],
+        derivation: ComponentProblemDerivation,
+    ) -> OptimizationProblem:
+        """Construct one proven root-state grouped component by exact projection."""
+        return self._derive_child(
+            controlled_ids=controlled_ids,
+            start=start,
+            derivation=derivation,
+            project_root_feasibility=True,
+        )
+
+    def _derive_child(
+        self,
+        *,
+        controlled_ids: tuple[str, ...],
+        start: tuple[float, ...],
+        derivation: ProblemDerivation,
+        project_root_feasibility: bool,
     ) -> OptimizationProblem:
         """Construct one child while retaining every root-owned invariant."""
         controlled = set(controlled_ids)
@@ -1188,7 +1218,9 @@ class OptimizationProblem:
             else None
         )
         if (
-            root_feasible is not None
+            project_root_feasibility
+            and isinstance(derivation, ComponentProblemDerivation)
+            and root_feasible is not None
             and controlled_ids == self.controlled_ids
             and start == self.start
             and child_lower == self.lower_bounds
@@ -1196,17 +1228,16 @@ class OptimizationProblem:
         ):
             feasible_coordinates = root_feasible
         elif (
-            root_feasible is not None
+            project_root_feasibility
+            and root_feasible is not None
             and frame is not None
             and isinstance(derivation, ComponentProblemDerivation)
-            and feasibility_dependencies is not None
         ):
             feasible_coordinates = root_feasible.project_component(
                 frame,
                 controlled_ids,
                 child_lower,
                 child_upper,
-                feasibility_dependencies,
             )
         else:
             feasible_coordinates = (

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1168,6 +1168,10 @@ class OptimizationProblem:
         derivation: ComponentProblemDerivation,
     ) -> OptimizationProblem:
         """Construct one proven root-state grouped component by exact projection."""
+        if not self.acceptance_authority:
+            raise DirectTrfConstructionError(
+                "Grouped feasibility projection requires one complete root problem"
+            )
         return self._derive_child(
             controlled_ids=controlled_ids,
             start=start,
@@ -1184,6 +1188,10 @@ class OptimizationProblem:
         upper_bounds: tuple[float, ...],
     ) -> FeasibleCoordinates | None:
         """Project the sealed root chart for one exact root-state component."""
+        if not self.acceptance_authority:
+            raise DirectTrfConstructionError(
+                "Grouped feasibility projection requires one complete root problem"
+            )
         root_feasible = self.feasible_coordinates
         if root_feasible is None:
             return None

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1175,6 +1175,35 @@ class OptimizationProblem:
             project_root_feasibility=True,
         )
 
+    def project_grouped_feasibility(
+        self,
+        *,
+        controlled_ids: tuple[str, ...],
+        start: tuple[float, ...],
+        lower_bounds: tuple[float, ...],
+        upper_bounds: tuple[float, ...],
+    ) -> FeasibleCoordinates | None:
+        """Project the sealed root chart for one exact root-state component."""
+        root_feasible = self.feasible_coordinates
+        if root_feasible is None:
+            return None
+        frame = root_feasible.frame_with_updates(
+            dict(zip(controlled_ids, start, strict=True))
+        )
+        if (
+            controlled_ids == self.controlled_ids
+            and start == self.start
+            and lower_bounds == self.lower_bounds
+            and upper_bounds == self.upper_bounds
+        ):
+            return root_feasible
+        return root_feasible.project_component(
+            frame,
+            controlled_ids,
+            lower_bounds,
+            upper_bounds,
+        )
+
     def _derive_child(
         self,
         *,
@@ -1217,27 +1246,14 @@ class OptimizationProblem:
             if root_feasible is not None
             else None
         )
-        if (
-            project_root_feasibility
-            and isinstance(derivation, ComponentProblemDerivation)
-            and root_feasible is not None
-            and controlled_ids == self.controlled_ids
-            and start == self.start
-            and child_lower == self.lower_bounds
-            and child_upper == self.upper_bounds
+        if project_root_feasibility and isinstance(
+            derivation, ComponentProblemDerivation
         ):
-            feasible_coordinates = root_feasible
-        elif (
-            project_root_feasibility
-            and root_feasible is not None
-            and frame is not None
-            and isinstance(derivation, ComponentProblemDerivation)
-        ):
-            feasible_coordinates = root_feasible.project_component(
-                frame,
-                controlled_ids,
-                child_lower,
-                child_upper,
+            feasible_coordinates = self.project_grouped_feasibility(
+                controlled_ids=controlled_ids,
+                start=start,
+                lower_bounds=child_lower,
+                upper_bounds=child_upper,
             )
         else:
             feasible_coordinates = (

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1151,6 +1151,7 @@ class OptimizationProblem:
         controlled_ids: tuple[str, ...],
         start: tuple[float, ...],
         derivation: ProblemDerivation,
+        feasibility_dependencies: tuple[frozenset[str], ...] | None = None,
     ) -> OptimizationProblem:
         """Construct one child while retaining every root-owned invariant."""
         controlled = set(controlled_ids)
@@ -1186,16 +1187,38 @@ class OptimizationProblem:
             if root_feasible is not None
             else None
         )
-        feasible_coordinates = (
-            root_feasible.derive(
+        if (
+            root_feasible is not None
+            and controlled_ids == self.controlled_ids
+            and start == self.start
+            and child_lower == self.lower_bounds
+            and child_upper == self.upper_bounds
+        ):
+            feasible_coordinates = root_feasible
+        elif (
+            root_feasible is not None
+            and frame is not None
+            and isinstance(derivation, ComponentProblemDerivation)
+            and feasibility_dependencies is not None
+        ):
+            feasible_coordinates = root_feasible.project_component(
                 frame,
                 controlled_ids,
                 child_lower,
                 child_upper,
+                feasibility_dependencies,
             )
-            if root_feasible is not None and frame is not None
-            else None
-        )
+        else:
+            feasible_coordinates = (
+                root_feasible.derive(
+                    frame,
+                    controlled_ids,
+                    child_lower,
+                    child_upper,
+                )
+                if root_feasible is not None and frame is not None
+                else None
+            )
         child = OptimizationProblem(
             evaluation_plan_identity,
             self.parameterization_identity,

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1195,6 +1195,7 @@ class OptimizationProblem:
         root_feasible = self.feasible_coordinates
         if root_feasible is None:
             return None
+        root_feasible.require_root_projection_authority()
         _ = root_feasible.controlled_domain_groups
         frame = root_feasible.frame_with_updates(
             dict(zip(controlled_ids, start, strict=True))

--- a/src/chemex/optimize/direct_trf.py
+++ b/src/chemex/optimize/direct_trf.py
@@ -1187,6 +1187,7 @@ class OptimizationProblem:
         root_feasible = self.feasible_coordinates
         if root_feasible is None:
             return None
+        _ = root_feasible.controlled_domain_groups
         frame = root_feasible.frame_with_updates(
             dict(zip(controlled_ids, start, strict=True))
         )

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -226,7 +226,7 @@ def _build_component(
         for index, dependencies in enumerate(profile_dependencies)
         if dependencies and dependencies.issubset(component_set)
     )
-    child_engine = engine.project_profiles(profile_indices)
+    child_plan = engine.project_plan(profile_indices)
     bounds = {
         param_id: (start, lower, upper)
         for param_id, start, lower, upper in zip(
@@ -256,7 +256,7 @@ def _build_component(
         problem.affine_feasibility_identity,
         component_identity,
         _PROJECTION_POLICY,
-        child_engine.plan.identity,
+        child_plan.identity,
         component_ids,
         held_items,
     )
@@ -878,6 +878,7 @@ def _validate_grouped_context(
             not isinstance(derivation, ComponentProblemDerivation)
             or component.identity != expected_identity
             or derivation.component_identity != component.identity
+            or derivation.projection_policy != _PROJECTION_POLICY
             or component.problem.start != expected_start
             or derivation.projected_plan_identity
             != component.problem.evaluation_plan_identity

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -219,6 +219,7 @@ def _build_component(
     engine: EvaluationEngine,
     component_ids: tuple[str, ...],
     profile_dependencies: tuple[frozenset[str], ...],
+    feasibility_dependencies: tuple[frozenset[str], ...],
 ) -> FitComponent:
     component_set = set(component_ids)
     profile_indices = tuple(
@@ -272,6 +273,7 @@ def _build_component(
         controlled_ids=component_ids,
         start=start,
         derivation=derivation,
+        feasibility_dependencies=feasibility_dependencies,
     )
     return FitComponent(
         component_ids,
@@ -506,6 +508,7 @@ class FitDecomposition:
                 engine,
                 component_ids,
                 profile_dependencies,
+                feasibility_dependencies,
             )
             _check_grouped_cancellation(cancellation)
             components_list.append(component)
@@ -750,24 +753,114 @@ def _validate_grouped_context(
     _check_grouped_cancellation(cancellation)
     problem.validate_parameterization(parameterization)
     _check_grouped_cancellation(cancellation)
-    expected_decomposition = FitDecomposition.from_root(
+    if engine.plan.identity != problem.evaluation_plan_identity:
+        raise DirectTrfConstructionError("Root evaluator belongs to another problem")
+    # Recheck the cheap semantic partition records without rebuilding child
+    # evaluators or their feasibility charts. Component execution validates each
+    # projected plan against the already sealed child problem before evaluation.
+    profile_dependencies = _profile_dependencies(
         problem,
         parameterization,
         engine,
-        cancellation=cancellation,
     )
     _check_grouped_cancellation(cancellation)
+    profile_paths = _profile_dependency_paths(
+        problem,
+        parameterization,
+        engine,
+    )
+    resolver = _ControlledDependencyResolver(
+        problem.controlled_ids,
+        parameterization,
+    )
+    feasible = problem.feasible_coordinates
+    feasibility_dependencies = (
+        ()
+        if feasible is None
+        else tuple(
+            frozenset(
+                controlled_id
+                for param_id in parameter_ids
+                for controlled_id, _path in resolver.paths(param_id)
+            )
+            for parameter_ids in feasible.domain_parameter_groups
+        )
+    )
+    expected_component_controls = _ordered_component_controls(
+        problem.controlled_ids,
+        profile_dependencies,
+        feasibility_dependencies,
+    )
+    expected_component_profiles = tuple(
+        tuple(
+            index
+            for index, dependencies in enumerate(profile_dependencies)
+            if dependencies and dependencies.issubset(set(component_ids))
+        )
+        for component_ids in expected_component_controls
+    )
+    expected_constant_indices = tuple(
+        index
+        for index, dependencies in enumerate(profile_dependencies)
+        if not dependencies and engine.plan.profiles[index].retained_observation_indices
+    )
+    expected_non_objective_indices = tuple(
+        index
+        for index, profile in enumerate(engine.plan.profiles)
+        if not profile.retained_observation_indices
+    )
+    expected_profile_records = tuple(
+        (
+            profile.identity,
+            profile.param_ids,
+            tuple(
+                param_id
+                for param_id in problem.controlled_ids
+                if param_id in profile_dependencies[index]
+            ),
+            profile_paths[index],
+        )
+        for index, profile in enumerate(engine.plan.profiles)
+    )
+    proof = decomposition.partition_proof
     if (
         decomposition.root_problem_identity != problem.identity
         or decomposition.root_plan_identity != engine.plan.identity
+        or proof.root_plan_identity != engine.plan.identity
+        or proof.constraint_program_identity != problem.constraint_program_identity
+        or proof.controlled_ids != problem.controlled_ids
+        or proof.profile_records != expected_profile_records
+        or tuple(component.controlled_ids for component in decomposition.components)
+        != expected_component_controls
+        or tuple(
+            component.root_profile_indices for component in decomposition.components
+        )
+        != expected_component_profiles
+        or decomposition.constant_profile_indices != expected_constant_indices
+        or decomposition.non_objective_profile_indices != expected_non_objective_indices
         or invocation.root_problem_identity != problem.identity
         or invocation.decomposition_identity != decomposition.identity
         or len(invocation.component_invocations) != len(decomposition.components)
-        or decomposition.identity != expected_decomposition.identity
     ):
         raise DirectTrfConstructionError(
             "Grouped Direct TRF context is not rooted in one problem"
         )
+    for component, component_invocation in zip(
+        decomposition.components,
+        invocation.component_invocations,
+        strict=True,
+    ):
+        _check_grouped_cancellation(cancellation)
+        problem.validate_derived_problem(component.problem)
+        derivation = component.problem.derivation
+        if (
+            not isinstance(derivation, ComponentProblemDerivation)
+            or derivation.component_identity != component.identity
+            or component_invocation.problem_identity != component.problem.identity
+        ):
+            raise DirectTrfConstructionError(
+                "Grouped Direct TRF context is not rooted in one problem"
+            )
 
 
 def _not_started(component: FitComponent) -> FitComponentOutcome:

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -14,7 +14,7 @@ from enum import StrEnum
 
 import numpy as np
 
-from chemex.evaluation.native import EvaluationEngine, EvaluationResult
+from chemex.evaluation.native import EvaluationEngine, EvaluationPlan, EvaluationResult
 from chemex.optimize import direct_trf as direct_trf_owner
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
@@ -481,6 +481,10 @@ class FitDecomposition:
         cancellation: CancellationToken | None = None,
     ) -> FitDecomposition:
         """Derive exact components from semantic Profile and constraint paths."""
+        if not problem.acceptance_authority:
+            raise DirectTrfConstructionError(
+                "Grouped decomposition requires one complete root problem"
+            )
         problem.validate_parameterization(parameterization)
         if engine.plan.identity != problem.evaluation_plan_identity:
             raise DirectTrfConstructionError(
@@ -658,6 +662,12 @@ class FitComponentOutcome:
         repr=False,
         compare=False,
     )
+    evaluation_plan: EvaluationPlan | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        kw_only=True,
+    )
     final_residual_jacobian: FinalResidualJacobianEvidence | None = field(
         default=None,
         repr=False,
@@ -669,9 +679,11 @@ class FitComponentOutcome:
 
     def __post_init__(self) -> None:
         if (self.disposition is ComponentDisposition.SUCCEEDED) != (
-            self.candidate is not None
+            self.candidate is not None and self.evaluation_plan is not None
         ):
-            raise ValueError("Only a successful component may expose a candidate")
+            raise ValueError(
+                "Only a successful component may expose a candidate and plan"
+            )
         if self.final_residual_jacobian is not None and (
             self.candidate is None
             or self.final_residual_jacobian.controlled_ids != self.controlled_ids
@@ -697,6 +709,9 @@ class FitComponentOutcome:
                     self.disposition.value,
                     self.execution_identity,
                     None if self.candidate is None else self.candidate.identity,
+                    None
+                    if self.evaluation_plan is None
+                    else self.evaluation_plan.identity,
                     None
                     if self.final_residual_jacobian is None
                     else self.final_residual_jacobian.identity,
@@ -746,6 +761,25 @@ class GroupedDirectTrfOutcome:
             raise ValueError("Unaccepted grouped execution cannot expose fit authority")
 
 
+def _grouped_context_validation_identity(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    invocation: GroupedDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+) -> str:
+    return _identity(
+        "native-grouped-context-validation",
+        (
+            problem.identity,
+            decomposition.identity,
+            invocation.identity,
+            parameterization.identity,
+            engine.plan.identity,
+        ),
+    )
+
+
 def _validate_grouped_context(
     problem: OptimizationProblem,
     decomposition: FitDecomposition,
@@ -753,7 +787,7 @@ def _validate_grouped_context(
     parameterization: ActiveParameterization,
     engine: EvaluationEngine,
     cancellation: CancellationToken,
-) -> None:
+) -> str:
     _check_grouped_cancellation(cancellation)
     problem.validate_parameterization(parameterization)
     _check_grouped_cancellation(cancellation)
@@ -893,6 +927,13 @@ def _validate_grouped_context(
             raise DirectTrfConstructionError(
                 "Grouped Direct TRF context is not rooted in one problem"
             )
+    return _grouped_context_validation_identity(
+        problem,
+        decomposition,
+        invocation,
+        parameterization,
+        engine,
+    )
 
 
 def _not_started(component: FitComponent) -> FitComponentOutcome:
@@ -1017,6 +1058,7 @@ def execute_direct_trf_components(
                     ComponentDisposition.SUCCEEDED,
                     result.execution.identity,
                     result.candidate,
+                    evaluation_plan=child_engine.plan,
                     final_residual_jacobian=(
                         None
                         if result.execution.backend is None
@@ -1067,11 +1109,11 @@ def execute_direct_trf_components(
     return tuple(outcomes)
 
 
-type _ComponentProjection = tuple[EvaluationEngine, EvaluationResult]
+type _ComponentProjection = tuple[EvaluationPlan, EvaluationResult]
 
 
 def _materialized_component_projection(
-    child_engine: EvaluationEngine,
+    child_plan: EvaluationPlan,
     component: FitComponent,
     invocation: DirectTrfInvocation,
     outcome: FitComponentOutcome,
@@ -1100,7 +1142,7 @@ def _materialized_component_projection(
             "Combined component assignment violates the root feasible domain",
         )
     child_result = candidate.evaluation_result
-    expected_compatibility_identity = child_engine.compatibility_identity
+    expected_compatibility_identity = child_plan.compatibility_identity
     try:
         child_chi_square = canonical_chi_square(child_result.residuals)
     except (TypeError, ValueError, ObjectiveScalarizationError):
@@ -1109,7 +1151,8 @@ def _materialized_component_projection(
             "Fresh root objective differs from component evidence",
         )
     if (
-        child_result.plan_identity != child_engine.plan.identity
+        child_result.plan_identity != child_plan.identity
+        or child_plan.identity != component.problem.evaluation_plan_identity
         or child_result.parameterization_identity
         != component.problem.evaluator_parameterization_identity
         or tuple(child_result.resolved_values) != component.problem.commit_scope
@@ -1138,7 +1181,7 @@ def _materialized_component_projection(
             "decomposition_projection_mismatch",
             "Fresh root objective differs from component evidence",
         )
-    return child_engine, child_result
+    return child_plan, child_result
 
 
 def _root_projection_matches(
@@ -1147,10 +1190,10 @@ def _root_projection_matches(
     component: FitComponent,
     projection: _ComponentProjection,
 ) -> bool:
-    child_engine, child_result = projection
+    child_plan, child_result = projection
     for child_index, root_index in enumerate(component.root_profile_indices):
         root_descriptor = root_engine.plan.profiles[root_index]
-        child_descriptor = child_engine.plan.profiles[child_index]
+        child_descriptor = child_plan.profiles[child_index]
         root_profile = root_result.profiles[root_index]
         child_profile = child_result.profiles[child_index]
         root_start = root_descriptor.observation_offset
@@ -1200,7 +1243,6 @@ def _projection_mismatch(
 def _validate_component_projections(
     decomposition: FitDecomposition,
     invocation: GroupedDirectTrfInvocation,
-    engine: EvaluationEngine,
     outcomes: tuple[FitComponentOutcome, ...],
     token: CancellationToken,
 ) -> tuple[_ComponentProjection, ...] | GroupedDirectTrfOutcome:
@@ -1217,14 +1259,18 @@ def _validate_component_projections(
                     GroupedDirectTrfTerminal.CANCELLED,
                     outcomes,
                 )
-            child_engine = engine.project_profiles(component.root_profile_indices)
-            if token.is_cancelled:
+            child_plan = outcome.evaluation_plan
+            if child_plan is None:
                 return GroupedDirectTrfOutcome(
-                    GroupedDirectTrfTerminal.CANCELLED,
+                    GroupedDirectTrfTerminal.DECOMPOSITION_VALIDATION_FAILURE,
                     outcomes,
+                    failure=TerminalFailure(
+                        "decomposition_projection_mismatch",
+                        "Successful component lacks its execution-time plan",
+                    ),
                 )
             projection = _materialized_component_projection(
-                child_engine,
+                child_plan,
                 component,
                 component_invocation,
                 outcome,
@@ -1547,7 +1593,7 @@ def _grouped_materialization_failure(
     )
 
 
-def materialize_grouped_direct_trf(  # noqa: C901 - ordered grouped lifecycle gates
+def materialize_grouped_direct_trf(
     problem: OptimizationProblem,
     decomposition: FitDecomposition,
     invocation: GroupedDirectTrfInvocation,
@@ -1557,11 +1603,11 @@ def materialize_grouped_direct_trf(  # noqa: C901 - ordered grouped lifecycle ga
     *,
     cancellation: CancellationToken | None = None,
 ) -> GroupedDirectTrfOutcome:
-    """Freshly validate one complete aggregate before granting root authority."""
+    """Freshly validate one standalone aggregate before granting authority."""
     outcomes = tuple(components)
     token = CancellationToken() if cancellation is None else cancellation
     try:
-        _validate_grouped_context(
+        validation_identity = _validate_grouped_context(
             problem,
             decomposition,
             invocation,
@@ -1588,6 +1634,47 @@ def materialize_grouped_direct_trf(  # noqa: C901 - ordered grouped lifecycle ga
                 f"{type(error).__name__}: {error}",
             ),
         )
+    return _materialize_grouped_direct_trf_validated(
+        problem,
+        decomposition,
+        invocation,
+        parameterization,
+        engine,
+        outcomes,
+        validation_identity,
+        cancellation=token,
+    )
+
+
+def _materialize_grouped_direct_trf_validated(
+    problem: OptimizationProblem,
+    decomposition: FitDecomposition,
+    invocation: GroupedDirectTrfInvocation,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+    components: Sequence[FitComponentOutcome],
+    validation_identity: str,
+    *,
+    cancellation: CancellationToken | None = None,
+) -> GroupedDirectTrfOutcome:
+    """Materialize one aggregate carrying exact prior context validation."""
+    outcomes = tuple(components)
+    token = CancellationToken() if cancellation is None else cancellation
+    if validation_identity != _grouped_context_validation_identity(
+        problem,
+        decomposition,
+        invocation,
+        parameterization,
+        engine,
+    ):
+        return GroupedDirectTrfOutcome(
+            GroupedDirectTrfTerminal.DECOMPOSITION_VALIDATION_FAILURE,
+            outcomes,
+            failure=TerminalFailure(
+                "decomposition_context_failure",
+                "Grouped context validation belongs to another invocation",
+            ),
+        )
     if tuple(item.component_identity for item in outcomes) != tuple(
         component.identity for component in decomposition.components
     ):
@@ -1600,7 +1687,6 @@ def materialize_grouped_direct_trf(  # noqa: C901 - ordered grouped lifecycle ga
     projections_or_outcome = _validate_component_projections(
         decomposition,
         invocation,
-        engine,
         outcomes,
         token,
     )
@@ -1673,7 +1759,7 @@ def execute_grouped_direct_trf(
     """Execute all exact components, then freshly validate the root aggregate."""
     token = CancellationToken() if cancellation is None else cancellation
     try:
-        _validate_grouped_context(
+        validation_identity = _validate_grouped_context(
             problem,
             decomposition,
             invocation,
@@ -1708,12 +1794,13 @@ def execute_grouped_direct_trf(
         cancellation=token,
         progress_observer=progress_observer,
     )
-    return materialize_grouped_direct_trf(
+    return _materialize_grouped_direct_trf_validated(
         problem,
         decomposition,
         invocation,
         parameterization,
         engine,
         components,
+        validation_identity,
         cancellation=token,
     )

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -77,6 +77,7 @@ class FitComponent:
     controlled_ids: tuple[str, ...]
     root_profile_indices: tuple[int, ...]
     problem: OptimizationProblem = field(repr=False, compare=False)
+    evaluation_plan: EvaluationPlan = field(repr=False, compare=False)
     identity: str
 
 
@@ -248,6 +249,7 @@ def _build_component(
         engine,
         component_ids,
         profile_indices,
+        child_plan.identity,
         lower,
         upper,
     )
@@ -269,6 +271,7 @@ def _build_component(
         component_ids,
         profile_indices,
         child_problem,
+        child_plan,
         component_identity,
     )
 
@@ -278,6 +281,7 @@ def _component_identity(
     engine: EvaluationEngine,
     component_ids: tuple[str, ...],
     profile_indices: tuple[int, ...],
+    projected_plan_identity: str,
     lower_bounds: tuple[float, ...],
     upper_bounds: tuple[float, ...],
 ) -> str:
@@ -295,6 +299,7 @@ def _component_identity(
             ),
             engine.plan.identity,
             profile_indices,
+            projected_plan_identity,
             tuple(float(value).hex() for value in lower_bounds),
             tuple(float(value).hex() for value in upper_bounds),
         ),
@@ -893,11 +898,13 @@ def _validate_grouped_context(
             problem.upper_bounds[root_indices[param_id]]
             for param_id in component.controlled_ids
         )
+        canonical_plan = engine.project_plan(component.root_profile_indices)
         expected_identity = _component_identity(
             problem,
             engine,
             component.controlled_ids,
             component.root_profile_indices,
+            canonical_plan.identity,
             lower_bounds,
             upper_bounds,
         )
@@ -914,8 +921,9 @@ def _validate_grouped_context(
             or derivation.component_identity != component.identity
             or derivation.projection_policy != _PROJECTION_POLICY
             or component.problem.start != expected_start
-            or derivation.projected_plan_identity
-            != component.problem.evaluation_plan_identity
+            or component.evaluation_plan.identity != canonical_plan.identity
+            or derivation.projected_plan_identity != canonical_plan.identity
+            or component.problem.evaluation_plan_identity != canonical_plan.identity
             or (expected_feasible is None) != (actual_feasible is None)
             or (
                 expected_feasible is not None
@@ -981,7 +989,11 @@ def execute_direct_trf_components(
             continue
         try:
             child_engine = engine.project_profiles(component.root_profile_indices)
-            if child_engine.plan.identity != component.problem.evaluation_plan_identity:
+            if (
+                child_engine.plan.identity != component.evaluation_plan.identity
+                or child_engine.plan.identity
+                != component.problem.evaluation_plan_identity
+            ):
                 raise DirectTrfConstructionError(
                     "Component evaluator projection differs from its derivation"
                 )
@@ -1152,6 +1164,7 @@ def _materialized_component_projection(
         )
     if (
         child_result.plan_identity != child_plan.identity
+        or child_plan.identity != component.evaluation_plan.identity
         or child_plan.identity != component.problem.evaluation_plan_identity
         or child_result.parameterization_identity
         != component.problem.evaluator_parameterization_identity

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -219,7 +219,6 @@ def _build_component(
     engine: EvaluationEngine,
     component_ids: tuple[str, ...],
     profile_dependencies: tuple[frozenset[str], ...],
-    feasibility_dependencies: tuple[frozenset[str], ...],
 ) -> FitComponent:
     component_set = set(component_ids)
     profile_indices = tuple(
@@ -244,21 +243,14 @@ def _build_component(
     start = tuple(bounds[param_id][0] for param_id in component_ids)
     lower = tuple(bounds[param_id][1] for param_id in component_ids)
     upper = tuple(bounds[param_id][2] for param_id in component_ids)
-    component_identity = _identity(
-        "native-fit-component",
-        (
-            _DECOMPOSITION_POLICY,
-            _PROJECTION_POLICY,
-            problem.evaluator_parameterization_identity,
-            problem.constraint_program_identity,
-            component_ids,
-            tuple(
-                engine.plan.profiles[index].source_identity for index in profile_indices
-            ),
-            child_engine.plan.identity,
-            tuple(float(value).hex() for value in lower),
-            tuple(float(value).hex() for value in upper),
-        ),
+    component_identity = _component_identity(
+        problem,
+        engine,
+        component_ids,
+        profile_indices,
+        child_engine.plan.identity,
+        lower,
+        upper,
     )
     derivation = ComponentProblemDerivation(
         problem.identity,
@@ -269,17 +261,44 @@ def _build_component(
         component_ids,
         held_items,
     )
-    child_problem = problem.derive_child(
+    child_problem = problem.derive_grouped_component(
         controlled_ids=component_ids,
         start=start,
         derivation=derivation,
-        feasibility_dependencies=feasibility_dependencies,
     )
     return FitComponent(
         component_ids,
         profile_indices,
         child_problem,
         component_identity,
+    )
+
+
+def _component_identity(
+    problem: OptimizationProblem,
+    engine: EvaluationEngine,
+    component_ids: tuple[str, ...],
+    profile_indices: tuple[int, ...],
+    projected_plan_identity: str,
+    lower_bounds: tuple[float, ...],
+    upper_bounds: tuple[float, ...],
+) -> str:
+    """Derive the canonical identity of one exact grouped root projection."""
+    return _identity(
+        "native-fit-component",
+        (
+            _DECOMPOSITION_POLICY,
+            _PROJECTION_POLICY,
+            problem.evaluator_parameterization_identity,
+            problem.constraint_program_identity,
+            component_ids,
+            tuple(
+                engine.plan.profiles[index].source_identity for index in profile_indices
+            ),
+            projected_plan_identity,
+            tuple(float(value).hex() for value in lower_bounds),
+            tuple(float(value).hex() for value in upper_bounds),
+        ),
     )
 
 
@@ -480,22 +499,9 @@ class FitDecomposition:
             engine,
         )
         components_list: list[FitComponent] = []
-        resolver = _ControlledDependencyResolver(
-            problem.controlled_ids,
-            parameterization,
-        )
         feasible = problem.feasible_coordinates
         feasibility_dependencies = (
-            ()
-            if feasible is None
-            else tuple(
-                frozenset(
-                    controlled_id
-                    for param_id in parameter_ids
-                    for controlled_id, _path in resolver.paths(param_id)
-                )
-                for parameter_ids in feasible.domain_parameter_groups
-            )
+            () if feasible is None else feasible.controlled_domain_groups
         )
         for component_ids in _ordered_component_controls(
             problem.controlled_ids,
@@ -508,7 +514,6 @@ class FitDecomposition:
                 engine,
                 component_ids,
                 profile_dependencies,
-                feasibility_dependencies,
             )
             _check_grouped_cancellation(cancellation)
             components_list.append(component)
@@ -769,22 +774,9 @@ def _validate_grouped_context(
         parameterization,
         engine,
     )
-    resolver = _ControlledDependencyResolver(
-        problem.controlled_ids,
-        parameterization,
-    )
     feasible = problem.feasible_coordinates
     feasibility_dependencies = (
-        ()
-        if feasible is None
-        else tuple(
-            frozenset(
-                controlled_id
-                for param_id in parameter_ids
-                for controlled_id, _path in resolver.paths(param_id)
-            )
-            for parameter_ids in feasible.domain_parameter_groups
-        )
+        () if feasible is None else feasible.controlled_domain_groups
     )
     expected_component_controls = _ordered_component_controls(
         problem.controlled_ids,
@@ -853,9 +845,35 @@ def _validate_grouped_context(
         _check_grouped_cancellation(cancellation)
         problem.validate_derived_problem(component.problem)
         derivation = component.problem.derivation
+        root_indices = {
+            param_id: index for index, param_id in enumerate(problem.controlled_ids)
+        }
+        projected_plan_identity = engine.projected_plan_identity(
+            component.root_profile_indices
+        )
+        lower_bounds = tuple(
+            problem.lower_bounds[root_indices[param_id]]
+            for param_id in component.controlled_ids
+        )
+        upper_bounds = tuple(
+            problem.upper_bounds[root_indices[param_id]]
+            for param_id in component.controlled_ids
+        )
+        expected_identity = _component_identity(
+            problem,
+            engine,
+            component.controlled_ids,
+            component.root_profile_indices,
+            projected_plan_identity,
+            lower_bounds,
+            upper_bounds,
+        )
         if (
             not isinstance(derivation, ComponentProblemDerivation)
+            or component.identity != expected_identity
             or derivation.component_identity != component.identity
+            or derivation.projected_plan_identity != projected_plan_identity
+            or component.problem.evaluation_plan_identity != projected_plan_identity
             or component_invocation.problem_identity != component.problem.identity
         ):
             raise DirectTrfConstructionError(

--- a/src/chemex/optimize/grouped_direct_trf.py
+++ b/src/chemex/optimize/grouped_direct_trf.py
@@ -248,7 +248,6 @@ def _build_component(
         engine,
         component_ids,
         profile_indices,
-        child_engine.plan.identity,
         lower,
         upper,
     )
@@ -279,7 +278,6 @@ def _component_identity(
     engine: EvaluationEngine,
     component_ids: tuple[str, ...],
     profile_indices: tuple[int, ...],
-    projected_plan_identity: str,
     lower_bounds: tuple[float, ...],
     upper_bounds: tuple[float, ...],
 ) -> str:
@@ -295,7 +293,8 @@ def _component_identity(
             tuple(
                 engine.plan.profiles[index].source_identity for index in profile_indices
             ),
-            projected_plan_identity,
+            engine.plan.identity,
+            profile_indices,
             tuple(float(value).hex() for value in lower_bounds),
             tuple(float(value).hex() for value in upper_bounds),
         ),
@@ -848,8 +847,9 @@ def _validate_grouped_context(
         root_indices = {
             param_id: index for index, param_id in enumerate(problem.controlled_ids)
         }
-        projected_plan_identity = engine.projected_plan_identity(
-            component.root_profile_indices
+        expected_start = tuple(
+            problem.start[root_indices[param_id]]
+            for param_id in component.controlled_ids
         )
         lower_bounds = tuple(
             problem.lower_bounds[root_indices[param_id]]
@@ -864,16 +864,29 @@ def _validate_grouped_context(
             engine,
             component.controlled_ids,
             component.root_profile_indices,
-            projected_plan_identity,
             lower_bounds,
             upper_bounds,
         )
+        expected_feasible = problem.project_grouped_feasibility(
+            controlled_ids=component.controlled_ids,
+            start=expected_start,
+            lower_bounds=lower_bounds,
+            upper_bounds=upper_bounds,
+        )
+        actual_feasible = component.problem.feasible_coordinates
         if (
             not isinstance(derivation, ComponentProblemDerivation)
             or component.identity != expected_identity
             or derivation.component_identity != component.identity
-            or derivation.projected_plan_identity != projected_plan_identity
-            or component.problem.evaluation_plan_identity != projected_plan_identity
+            or component.problem.start != expected_start
+            or derivation.projected_plan_identity
+            != component.problem.evaluation_plan_identity
+            or (expected_feasible is None) != (actual_feasible is None)
+            or (
+                expected_feasible is not None
+                and actual_feasible is not None
+                and expected_feasible.identity != actual_feasible.identity
+            )
             or component_invocation.problem_identity != component.problem.identity
         ):
             raise DirectTrfConstructionError(

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -21,7 +21,10 @@ from chemex.parameters.parameterization import (
     ReferenceExpression,
     UnaryExpression,
 )
-from chemex.parameters.relaxation import RelaxationPsdBlock
+from chemex.parameters.relaxation import (
+    RelaxationPsdBlock,
+    relaxation_blocks_identity,
+)
 from chemex.typing import Array
 
 # Eigenvalue and Schur checks operate on tiny (2x2/3x3) symmetric binary64
@@ -201,7 +204,9 @@ class FeasibleCoordinates:
     static_rate_floors: tuple[tuple[str, float], ...]
     cross_rate_ids: tuple[str, ...]
     blocks: tuple[RelaxationPsdBlock, ...]
-    _projection_provenance: _FeasibilityProjectionProvenance = field(
+    _projection_provenance: _FeasibilityProjectionProvenance | None = field(
+        default=None,
+        init=False,
         repr=False,
         compare=False,
     )
@@ -211,53 +216,21 @@ class FeasibleCoordinates:
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
-        controlled = frozenset(self.controlled_ids)
-        if len(self.controlled_domain_groups) != len(self.blocks) or any(
-            not dependencies <= controlled
-            for dependencies in self.controlled_domain_groups
-        ):
-            raise FeasibleCoordinateConstructionError(
-                "Feasibility dependency provenance differs from its root chart"
-            )
         object.__setattr__(
             self,
             "identity",
-            _identity(
-                (
-                    self.parameterization.evaluator_identity,
-                    (
-                        self.base_frame.parameterization_identity,
-                        self.base_frame.program_fingerprint,
-                        self.base_frame.occurrence_identity,
-                        self.base_frame.revision,
-                        self.base_frame.ordered_items(),
-                    ),
-                    self.controlled_ids,
-                    self.public_lower_bounds,
-                    self.public_upper_bounds,
-                    self.rate_excess_ids,
-                    tuple(
-                        (item.rate_id, item.kind, item.other_id, item.cross_id)
-                        for item in self.rate_floors
-                    ),
-                    self.static_rate_floors,
-                    self.cross_rate_ids,
-                    tuple(block.domain_id for block in self.blocks),
-                    tuple(
-                        tuple(sorted(dependencies))
-                        for dependencies in self.controlled_domain_groups
-                    ),
-                    self.solver_start,
-                    self.solver_lower_bounds,
-                    self.solver_upper_bounds,
-                )
-            ),
+            _identity(("unsealed-feasibility-chart",)),
         )
 
     @property
     def controlled_domain_groups(self) -> tuple[frozenset[str], ...]:
         """Return private root-compiled controlled-domain closure proofs."""
-        return self._projection_provenance.controlled_domain_groups
+        provenance = self._projection_provenance
+        if provenance is None:
+            raise FeasibleCoordinateConstructionError(
+                "Feasibility chart lacks construction-owned projection provenance"
+            )
+        return provenance.controlled_domain_groups
 
     @property
     def has_coordinate_transform(self) -> bool:
@@ -315,6 +288,7 @@ class FeasibleCoordinates:
         upper_bounds: tuple[float, ...],
     ) -> FeasibleCoordinates | None:
         """Compile a role-aware child chart without exposing model internals."""
+        _ = self.controlled_domain_groups
         return compile_feasible_coordinates(
             self.parameterization,
             frame,
@@ -363,33 +337,36 @@ class FeasibleCoordinates:
             raise FeasibleCoordinateConstructionError(
                 "Component feasibility projection changed root public bounds"
             )
-        projected = type(self)(
-            self.parameterization,
-            frame,
-            controlled_ids,
-            lower_bounds,
-            upper_bounds,
-            tuple(item for item in self.rate_excess_ids if item[0] in selected),
-            tuple(item for item in self.rate_floors if item.rate_id in selected),
-            tuple(item for item in self.static_rate_floors if item[0] in selected),
-            tuple(param_id for param_id in self.cross_rate_ids if param_id in selected),
-            self.blocks,
-            _FeasibilityProjectionProvenance(
+        projected = _seal_projection_provenance(
+            type(self)(
+                self.parameterization,
+                frame,
+                controlled_ids,
+                lower_bounds,
+                upper_bounds,
+                tuple(item for item in self.rate_excess_ids if item[0] in selected),
+                tuple(item for item in self.rate_floors if item.rate_id in selected),
+                tuple(item for item in self.static_rate_floors if item[0] in selected),
                 tuple(
-                    dependencies & selected
-                    for dependencies in self.controlled_domain_groups
-                )
+                    param_id for param_id in self.cross_rate_ids if param_id in selected
+                ),
+                self.blocks,
+                tuple(
+                    self.solver_start[root_indices[param_id]]
+                    for param_id in controlled_ids
+                ),
+                tuple(
+                    self.solver_lower_bounds[root_indices[param_id]]
+                    for param_id in controlled_ids
+                ),
+                tuple(
+                    self.solver_upper_bounds[root_indices[param_id]]
+                    for param_id in controlled_ids
+                ),
             ),
             tuple(
-                self.solver_start[root_indices[param_id]] for param_id in controlled_ids
-            ),
-            tuple(
-                self.solver_lower_bounds[root_indices[param_id]]
-                for param_id in controlled_ids
-            ),
-            tuple(
-                self.solver_upper_bounds[root_indices[param_id]]
-                for param_id in controlled_ids
+                dependencies & selected
+                for dependencies in self.controlled_domain_groups
             ),
         )
         return None if projected.is_noop else projected
@@ -398,6 +375,7 @@ class FeasibleCoordinates:
         self,
         solver_vector: Sequence[float],
     ) -> FeasiblePoint:
+        _ = self.controlled_domain_groups
         if len(solver_vector) != len(self.controlled_ids):
             raise ValueError("Feasible solver vector has the wrong dimension")
         public = {
@@ -500,6 +478,7 @@ class FeasibleCoordinates:
 
     def differential(self, solver_vector: Sequence[float]) -> Array:
         """Return d(public coordinates)/d(private solver coordinates)."""
+        _ = self.controlled_domain_groups
         point = np.asarray(solver_vector, dtype=np.float64)
         dimension = len(point)
         result = np.empty((dimension, dimension), dtype=np.float64)
@@ -836,6 +815,60 @@ def _controlled_dependencies(
             )
         )
     return frozenset(dependencies)
+
+
+def _seal_projection_provenance(
+    chart: FeasibleCoordinates,
+    controlled_domain_groups: tuple[frozenset[str], ...],
+) -> FeasibleCoordinates:
+    """Seal compiler-owned closure proof and complete scientific chart identity."""
+    controlled = frozenset(chart.controlled_ids)
+    if len(controlled_domain_groups) != len(chart.blocks) or any(
+        not dependencies <= controlled for dependencies in controlled_domain_groups
+    ):
+        raise FeasibleCoordinateConstructionError(
+            "Feasibility dependency provenance differs from its root chart"
+        )
+    object.__setattr__(
+        chart,
+        "_projection_provenance",
+        _FeasibilityProjectionProvenance(controlled_domain_groups),
+    )
+    object.__setattr__(
+        chart,
+        "identity",
+        _identity(
+            (
+                chart.parameterization.evaluator_identity,
+                (
+                    chart.base_frame.parameterization_identity,
+                    chart.base_frame.program_fingerprint,
+                    chart.base_frame.occurrence_identity,
+                    chart.base_frame.revision,
+                    chart.base_frame.ordered_items(),
+                ),
+                chart.controlled_ids,
+                chart.public_lower_bounds,
+                chart.public_upper_bounds,
+                chart.rate_excess_ids,
+                tuple(
+                    (item.rate_id, item.kind, item.other_id, item.cross_id)
+                    for item in chart.rate_floors
+                ),
+                chart.static_rate_floors,
+                chart.cross_rate_ids,
+                relaxation_blocks_identity(chart.blocks),
+                tuple(
+                    tuple(sorted(dependencies))
+                    for dependencies in controlled_domain_groups
+                ),
+                chart.solver_start,
+                chart.solver_lower_bounds,
+                chart.solver_upper_bounds,
+            )
+        ),
+    )
+    return chart
 
 
 def _controlled_domain_groups(
@@ -1222,22 +1255,22 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
                 max(lower_by_id[param_id], static_rate_floors.get(param_id, -math.inf))
             )
             solver_upper.append(upper_by_id[param_id])
-    chart = FeasibleCoordinates(
-        parameterization,
-        frame,
-        controlled_ids,
-        lower_bounds,
-        upper_bounds,
-        rate_excess_ids,
-        tuple(rate_floors),
-        tuple(sorted(static_rate_floors.items())),
-        cross_ids,
-        blocks,
-        _FeasibilityProjectionProvenance(
-            _controlled_domain_groups(parameterization, blocks, controlled_ids)
+    chart = _seal_projection_provenance(
+        FeasibleCoordinates(
+            parameterization,
+            frame,
+            controlled_ids,
+            lower_bounds,
+            upper_bounds,
+            rate_excess_ids,
+            tuple(rate_floors),
+            tuple(sorted(static_rate_floors.items())),
+            cross_ids,
+            blocks,
+            tuple(solver_start),
+            tuple(solver_lower),
+            tuple(solver_upper),
         ),
-        tuple(solver_start),
-        tuple(solver_lower),
-        tuple(solver_upper),
+        _controlled_domain_groups(parameterization, blocks, controlled_ids),
     )
     return None if chart.is_noop else chart

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -181,6 +181,13 @@ def _rate_floor(specification: RateFloor, values: Mapping[str, float]) -> float:
 
 
 @dataclass(frozen=True, slots=True)
+class _FeasibilityProjectionProvenance:
+    """Private immutable closure proof compiled with one feasibility chart."""
+
+    controlled_domain_groups: tuple[frozenset[str], ...]
+
+
+@dataclass(frozen=True, slots=True)
 class FeasibleCoordinates:
     """Role-aware exact chart over the represented relaxation PSD domains."""
 
@@ -194,7 +201,7 @@ class FeasibleCoordinates:
     static_rate_floors: tuple[tuple[str, float], ...]
     cross_rate_ids: tuple[str, ...]
     blocks: tuple[RelaxationPsdBlock, ...]
-    controlled_domain_groups: tuple[frozenset[str], ...] = field(
+    _projection_provenance: _FeasibilityProjectionProvenance = field(
         repr=False,
         compare=False,
     )
@@ -218,6 +225,13 @@ class FeasibleCoordinates:
             _identity(
                 (
                     self.parameterization.evaluator_identity,
+                    (
+                        self.base_frame.parameterization_identity,
+                        self.base_frame.program_fingerprint,
+                        self.base_frame.occurrence_identity,
+                        self.base_frame.revision,
+                        self.base_frame.ordered_items(),
+                    ),
                     self.controlled_ids,
                     self.public_lower_bounds,
                     self.public_upper_bounds,
@@ -239,6 +253,11 @@ class FeasibleCoordinates:
                 )
             ),
         )
+
+    @property
+    def controlled_domain_groups(self) -> tuple[frozenset[str], ...]:
+        """Return private root-compiled controlled-domain closure proofs."""
+        return self._projection_provenance.controlled_domain_groups
 
     @property
     def has_coordinate_transform(self) -> bool:
@@ -355,9 +374,11 @@ class FeasibleCoordinates:
             tuple(item for item in self.static_rate_floors if item[0] in selected),
             tuple(param_id for param_id in self.cross_rate_ids if param_id in selected),
             self.blocks,
-            tuple(
-                dependencies & selected
-                for dependencies in self.controlled_domain_groups
+            _FeasibilityProjectionProvenance(
+                tuple(
+                    dependencies & selected
+                    for dependencies in self.controlled_domain_groups
+                )
             ),
             tuple(
                 self.solver_start[root_indices[param_id]] for param_id in controlled_ids
@@ -1212,7 +1233,9 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
         tuple(sorted(static_rate_floors.items())),
         cross_ids,
         blocks,
-        _controlled_domain_groups(parameterization, blocks, controlled_ids),
+        _FeasibilityProjectionProvenance(
+            _controlled_domain_groups(parameterization, blocks, controlled_ids)
+        ),
         tuple(solver_start),
         tuple(solver_lower),
         tuple(solver_upper),

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -288,6 +288,72 @@ class FeasibleCoordinates:
             upper_bounds,
         )
 
+    def project_component(
+        self,
+        frame: IndependentValueFrame,
+        controlled_ids: tuple[str, ...],
+        lower_bounds: tuple[float, ...],
+        upper_bounds: tuple[float, ...],
+        domain_controlled_groups: tuple[frozenset[str], ...],
+    ) -> FeasibleCoordinates | None:
+        """Project an exact root chart onto one closed fit component."""
+        selected = set(controlled_ids)
+        root_indices = {
+            param_id: index for index, param_id in enumerate(self.controlled_ids)
+        }
+        if (
+            frame != self.base_frame
+            or tuple(
+                param_id for param_id in self.controlled_ids if param_id in selected
+            )
+            != controlled_ids
+            or len(selected) != len(controlled_ids)
+            or len(domain_controlled_groups) != len(self.blocks)
+            or any(
+                dependencies & selected and not dependencies <= selected
+                for dependencies in domain_controlled_groups
+            )
+        ):
+            raise FeasibleCoordinateConstructionError(
+                "Component feasibility projection is not a closed root-chart subset"
+            )
+        expected_lower = tuple(
+            self.public_lower_bounds[root_indices[param_id]]
+            for param_id in controlled_ids
+        )
+        expected_upper = tuple(
+            self.public_upper_bounds[root_indices[param_id]]
+            for param_id in controlled_ids
+        )
+        if lower_bounds != expected_lower or upper_bounds != expected_upper:
+            raise FeasibleCoordinateConstructionError(
+                "Component feasibility projection changed root public bounds"
+            )
+        projected = type(self)(
+            self.parameterization,
+            frame,
+            controlled_ids,
+            lower_bounds,
+            upper_bounds,
+            tuple(item for item in self.rate_excess_ids if item[0] in selected),
+            tuple(item for item in self.rate_floors if item.rate_id in selected),
+            tuple(item for item in self.static_rate_floors if item[0] in selected),
+            tuple(param_id for param_id in self.cross_rate_ids if param_id in selected),
+            self.blocks,
+            tuple(
+                self.solver_start[root_indices[param_id]] for param_id in controlled_ids
+            ),
+            tuple(
+                self.solver_lower_bounds[root_indices[param_id]]
+                for param_id in controlled_ids
+            ),
+            tuple(
+                self.solver_upper_bounds[root_indices[param_id]]
+                for param_id in controlled_ids
+            ),
+        )
+        return None if projected.is_noop else projected
+
     def decode(  # noqa: C901 - complete feasibility decode and verification
         self,
         solver_vector: Sequence[float],

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -194,12 +194,24 @@ class FeasibleCoordinates:
     static_rate_floors: tuple[tuple[str, float], ...]
     cross_rate_ids: tuple[str, ...]
     blocks: tuple[RelaxationPsdBlock, ...]
+    controlled_domain_groups: tuple[frozenset[str], ...] = field(
+        repr=False,
+        compare=False,
+    )
     solver_start: tuple[float, ...]
     solver_lower_bounds: tuple[float, ...]
     solver_upper_bounds: tuple[float, ...]
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
+        controlled = frozenset(self.controlled_ids)
+        if len(self.controlled_domain_groups) != len(self.blocks) or any(
+            not dependencies <= controlled
+            for dependencies in self.controlled_domain_groups
+        ):
+            raise FeasibleCoordinateConstructionError(
+                "Feasibility dependency provenance differs from its root chart"
+            )
         object.__setattr__(
             self,
             "identity",
@@ -217,6 +229,10 @@ class FeasibleCoordinates:
                     self.static_rate_floors,
                     self.cross_rate_ids,
                     tuple(block.domain_id for block in self.blocks),
+                    tuple(
+                        tuple(sorted(dependencies))
+                        for dependencies in self.controlled_domain_groups
+                    ),
                     self.solver_start,
                     self.solver_lower_bounds,
                     self.solver_upper_bounds,
@@ -294,7 +310,6 @@ class FeasibleCoordinates:
         controlled_ids: tuple[str, ...],
         lower_bounds: tuple[float, ...],
         upper_bounds: tuple[float, ...],
-        domain_controlled_groups: tuple[frozenset[str], ...],
     ) -> FeasibleCoordinates | None:
         """Project an exact root chart onto one closed fit component."""
         selected = set(controlled_ids)
@@ -308,10 +323,10 @@ class FeasibleCoordinates:
             )
             != controlled_ids
             or len(selected) != len(controlled_ids)
-            or len(domain_controlled_groups) != len(self.blocks)
+            or len(self.controlled_domain_groups) != len(self.blocks)
             or any(
                 dependencies & selected and not dependencies <= selected
-                for dependencies in domain_controlled_groups
+                for dependencies in self.controlled_domain_groups
             )
         ):
             raise FeasibleCoordinateConstructionError(
@@ -340,6 +355,10 @@ class FeasibleCoordinates:
             tuple(item for item in self.static_rate_floors if item[0] in selected),
             tuple(param_id for param_id in self.cross_rate_ids if param_id in selected),
             self.blocks,
+            tuple(
+                dependencies & selected
+                for dependencies in self.controlled_domain_groups
+            ),
             tuple(
                 self.solver_start[root_indices[param_id]] for param_id in controlled_ids
             ),
@@ -798,6 +817,47 @@ def _controlled_dependencies(
     return frozenset(dependencies)
 
 
+def _controlled_domain_groups(
+    parameterization: ActiveParameterization,
+    blocks: Sequence[RelaxationPsdBlock],
+    controlled_ids: Sequence[str],
+) -> tuple[frozenset[str], ...]:
+    """Resolve every PSD domain to immutable root-controlled dependencies."""
+    controlled = frozenset(controlled_ids)
+    constraints = {
+        item.target_id: item for item in parameterization.program.constraints
+    }
+    cache: dict[str, frozenset[str]] = {}
+
+    def resolve(param_id: str, seen: frozenset[str] = frozenset()) -> frozenset[str]:
+        if param_id in cache:
+            return cache[param_id]
+        if param_id in controlled:
+            result = frozenset((param_id,))
+        elif param_id in seen or (constraint := constraints.get(param_id)) is None:
+            result = frozenset()
+        else:
+            result = frozenset(
+                dependency
+                for source in constraint.dependencies
+                for dependency in resolve(source, seen | {param_id})
+            )
+        cache[param_id] = result
+        return result
+
+    return tuple(
+        frozenset(
+            dependency
+            for param_id in (
+                *block.diagonal_ids,
+                *(item[2] for item in block.off_diagonal_ids),
+            )
+            for dependency in resolve(param_id)
+        )
+        for block in blocks
+    )
+
+
 def _is_intrinsic_rate_derivation(
     parameterization: ActiveParameterization,
     param_id: str,
@@ -1152,6 +1212,7 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
         tuple(sorted(static_rate_floors.items())),
         cross_ids,
         blocks,
+        _controlled_domain_groups(parameterization, blocks, controlled_ids),
         tuple(solver_start),
         tuple(solver_lower),
         tuple(solver_upper),

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -188,6 +188,7 @@ class _FeasibilityProjectionProvenance:
     """Private immutable closure proof compiled with one feasibility chart."""
 
     controlled_domain_groups: tuple[frozenset[str], ...]
+    has_root_projection_authority: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -305,6 +306,11 @@ class FeasibleCoordinates:
         upper_bounds: tuple[float, ...],
     ) -> FeasibleCoordinates | None:
         """Project an exact root chart onto one closed fit component."""
+        provenance = self._projection_provenance
+        if provenance is None or not provenance.has_root_projection_authority:
+            raise FeasibleCoordinateConstructionError(
+                "Component feasibility projection requires the compiled root chart"
+            )
         selected = set(controlled_ids)
         root_indices = {
             param_id: index for index, param_id in enumerate(self.controlled_ids)
@@ -368,6 +374,7 @@ class FeasibleCoordinates:
                 dependencies & selected
                 for dependencies in self.controlled_domain_groups
             ),
+            has_root_projection_authority=False,
         )
         return None if projected.is_noop else projected
 
@@ -820,6 +827,8 @@ def _controlled_dependencies(
 def _seal_projection_provenance(
     chart: FeasibleCoordinates,
     controlled_domain_groups: tuple[frozenset[str], ...],
+    *,
+    has_root_projection_authority: bool,
 ) -> FeasibleCoordinates:
     """Seal compiler-owned closure proof and complete scientific chart identity."""
     controlled = frozenset(chart.controlled_ids)
@@ -832,7 +841,10 @@ def _seal_projection_provenance(
     object.__setattr__(
         chart,
         "_projection_provenance",
-        _FeasibilityProjectionProvenance(controlled_domain_groups),
+        _FeasibilityProjectionProvenance(
+            controlled_domain_groups,
+            has_root_projection_authority,
+        ),
     )
     object.__setattr__(
         chart,
@@ -1272,5 +1284,6 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
             tuple(solver_upper),
         ),
         _controlled_domain_groups(parameterization, blocks, controlled_ids),
+        has_root_projection_authority=True,
     )
     return None if chart.is_noop else chart

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -233,6 +233,14 @@ class FeasibleCoordinates:
             )
         return provenance.controlled_domain_groups
 
+    def require_root_projection_authority(self) -> None:
+        """Fail unless this chart is the compiler-owned projection root."""
+        provenance = self._projection_provenance
+        if provenance is None or not provenance.has_root_projection_authority:
+            raise FeasibleCoordinateConstructionError(
+                "Component feasibility projection requires the compiled root chart"
+            )
+
     @property
     def has_coordinate_transform(self) -> bool:
         return bool(self.rate_excess_ids or self.rate_floors or self.cross_rate_ids)
@@ -306,11 +314,7 @@ class FeasibleCoordinates:
         upper_bounds: tuple[float, ...],
     ) -> FeasibleCoordinates | None:
         """Project an exact root chart onto one closed fit component."""
-        provenance = self._projection_provenance
-        if provenance is None or not provenance.has_root_projection_authority:
-            raise FeasibleCoordinateConstructionError(
-                "Component feasibility projection requires the compiled root chart"
-            )
+        self.require_root_projection_authority()
         selected = set(controlled_ids)
         root_indices = {
             param_id: index for index, param_id in enumerate(self.controlled_ids)

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -29,6 +29,7 @@ from chemex.optimize.direct_trf import (
     ObjectiveScalarizationError,
     OptimizationProblem,
 )
+from chemex.parameters.feasible_coordinates import FeasibleCoordinates
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.spin_system import SpinSystem
 from chemex.runtime import AnalysisSession
@@ -99,6 +100,42 @@ def test_product_search_plan_is_bounded_seeded_and_non_authoritative() -> None:
     assert invocation.population.size == 15
     assert invocation.population.maximum_generations == 1000
     assert invocation.de_objective_request_budget == 15 * 1001
+
+
+def test_full_scope_de_recompiles_feasibility_even_at_the_root_start() -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(Method(fit=["PB"], fix=["KEX_AB"]))
+    )
+    assert problem.feasible_coordinates is not None
+    derive_calls = 0
+    original_derive = FeasibleCoordinates.derive
+
+    def track_derive(
+        self: FeasibleCoordinates,
+        *args: object,
+        **kwargs: object,
+    ):
+        nonlocal derive_calls
+        derive_calls += 1
+        return original_derive(self, *args, **kwargs)
+
+    derivation = DeSearchProblemDerivation(
+        problem.identity,
+        problem.affine_feasibility_identity,
+        "full-scope-de-regression",
+        problem.controlled_ids,
+        problem.held_items,
+        problem.start,
+    )
+    with patch.object(FeasibleCoordinates, "derive", track_derive):
+        child = problem.derive_child(
+            controlled_ids=problem.controlled_ids,
+            start=problem.start,
+            derivation=derivation,
+        )
+
+    assert derive_calls == 1
+    assert child.feasible_coordinates is not problem.feasible_coordinates
 
 
 @pytest.mark.parametrize("root_seed", (-1, 2**64, True, None))

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -652,6 +652,26 @@ def test_general_component_derivation_recompiles_feasibility_at_root_start() -> 
     assert child.feasible_coordinates is not root_feasible
 
 
+def test_grouped_exact_domain_rejects_projected_chart_as_forged_root() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    component = decomposition.components[0]
+    assert component.problem.feasible_coordinates is not None
+    forged_root = dataclasses.replace(component.problem, derivation=None)
+    derivation = component.problem.derivation
+    assert isinstance(derivation, ComponentProblemDerivation)
+
+    with pytest.raises(
+        feasible_coordinates_owner.FeasibleCoordinateConstructionError,
+        match="compiled root chart",
+    ):
+        forged_root.derive_grouped_component(
+            controlled_ids=forged_root.controlled_ids,
+            start=forged_root.start,
+            derivation=derivation,
+        )
+
+
 def test_grouped_components_preserve_root_affine_feasibility() -> None:
     _session, _experiments, parameterization, engine, problem = _grouped_problem()
     controlled_id = problem.controlled_ids[0]

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -438,6 +438,86 @@ def test_grouped_validation_rejects_forged_component_feasibility(
     )
 
 
+def test_standalone_materialization_rejects_a_foreign_component_plan() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    original = decomposition.components[0]
+    original_profile = original.evaluation_plan.profiles[0]
+    altered_profile = dataclasses.replace(
+        original_profile,
+        experimental_values=(
+            original_profile.experimental_values[0] + 1.0,
+            *original_profile.experimental_values[1:],
+        ),
+    )
+    altered_plan = dataclasses.replace(
+        original.evaluation_plan,
+        profiles=(altered_profile, *original.evaluation_plan.profiles[1:]),
+    )
+    derivation = original.problem.derivation
+    assert isinstance(derivation, ComponentProblemDerivation)
+    forged_derivation = dataclasses.replace(
+        derivation,
+        projected_plan_identity=altered_plan.identity,
+    )
+    forged_problem = dataclasses.replace(
+        original.problem,
+        evaluation_plan_identity=altered_plan.identity,
+        derivation=forged_derivation,
+    )
+    forged_identity = grouped_direct_trf_owner._component_identity(
+        problem,
+        engine,
+        original.controlled_ids,
+        original.root_profile_indices,
+        altered_plan.identity,
+        original.problem.lower_bounds,
+        original.problem.upper_bounds,
+    )
+    forged_derivation = dataclasses.replace(
+        forged_derivation,
+        component_identity=forged_identity,
+    )
+    forged_problem = dataclasses.replace(
+        forged_problem,
+        derivation=forged_derivation,
+    )
+    forged_component = dataclasses.replace(
+        original,
+        problem=forged_problem,
+        evaluation_plan=altered_plan,
+        identity=forged_identity,
+    )
+    first_record = decomposition.partition_proof.component_records[0]
+    forged_proof = dataclasses.replace(
+        decomposition.partition_proof,
+        component_records=(
+            (forged_identity, *first_record[1:]),
+            *decomposition.partition_proof.component_records[1:],
+        ),
+    )
+    forged_decomposition = dataclasses.replace(
+        decomposition,
+        components=(forged_component, *decomposition.components[1:]),
+        partition_proof=forged_proof,
+    )
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        forged_decomposition,
+        objective_request_budgets=(80,) * len(forged_decomposition.components),
+    )
+
+    outcome = materialize_grouped_direct_trf(
+        problem,
+        forged_decomposition,
+        invocation,
+        parameterization,
+        engine,
+        (),
+    )
+
+    assert outcome.terminal is GroupedDirectTrfTerminal.DECOMPOSITION_VALIDATION_FAILURE
+
+
 def test_grouped_validation_does_not_rebuild_projected_plans() -> None:
     _session, _experiments, parameterization, engine, problem = _grouped_problem()
     decomposition = FitDecomposition.from_root(problem, parameterization, engine)
@@ -445,13 +525,17 @@ def test_grouped_validation_does_not_rebuild_projected_plans() -> None:
         decomposition,
         objective_request_budgets=(80,) * len(decomposition.components),
     )
-    projected_population = engine._projected_population
+    project_plan = engine.project_plan
+    project_profiles = engine.project_profiles
 
-    with patch.object(
-        engine,
-        "_projected_population",
-        wraps=projected_population,
-    ) as projection_calls:
+    with (
+        patch.object(engine, "project_plan", wraps=project_plan) as plan_calls,
+        patch.object(
+            engine,
+            "project_profiles",
+            wraps=project_profiles,
+        ) as engine_calls,
+    ):
         outcome = execute_grouped_direct_trf(
             problem,
             decomposition,
@@ -461,7 +545,8 @@ def test_grouped_validation_does_not_rebuild_projected_plans() -> None:
         )
 
     assert outcome.terminal is GroupedDirectTrfTerminal.ACCEPTED
-    assert projection_calls.call_count == len(decomposition.components)
+    assert plan_calls.call_count == len(decomposition.components)
+    assert engine_calls.call_count == len(decomposition.components)
 
 
 def test_combined_grouped_execution_validates_context_once() -> None:

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -351,7 +351,13 @@ def test_grouped_validation_rejects_a_self_consistent_forged_component_identity(
 
 @pytest.mark.parametrize(
     "mutation",
-    ("missing_chart", "altered_held_frame", "changed_start"),
+    (
+        "missing_chart",
+        "altered_held_frame",
+        "altered_block",
+        "changed_start",
+        "changed_policy",
+    ),
 )
 def test_grouped_validation_rejects_forged_component_feasibility(
     mutation: str,
@@ -375,6 +381,32 @@ def test_grouped_validation_rejects_forged_component_feasibility(
         forged_problem = dataclasses.replace(
             original.problem,
             feasible_coordinates=forged_chart,
+        )
+    elif mutation == "altered_block":
+        block = chart.blocks[0]
+        altered_block = dataclasses.replace(
+            block,
+            off_diagonal_ids=(
+                (*block.off_diagonal_ids[0][:2], block.diagonal_ids[0]),
+                *block.off_diagonal_ids[1:],
+            ),
+        )
+        forged_problem = dataclasses.replace(
+            original.problem,
+            feasible_coordinates=dataclasses.replace(
+                chart,
+                blocks=(altered_block, *chart.blocks[1:]),
+            ),
+        )
+    elif mutation == "changed_policy":
+        derivation = original.problem.derivation
+        assert isinstance(derivation, ComponentProblemDerivation)
+        forged_problem = dataclasses.replace(
+            original.problem,
+            derivation=dataclasses.replace(
+                derivation,
+                projection_policy="forged-projection-policy",
+            ),
         )
     else:
         forged_problem = dataclasses.replace(
@@ -445,6 +477,11 @@ def test_grouped_component_projection_does_not_recompile_feasibility() -> None:
             problem.feasible_coordinates.__class__,
             "derive",
             side_effect=AssertionError("component feasibility used general derivation"),
+        ),
+        patch.object(
+            engine,
+            "project_profiles",
+            side_effect=AssertionError("decomposition compiled child engines"),
         ),
     ):
         decomposition = FitDecomposition.from_root(problem, parameterization, engine)

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 
 import chemex.optimize.grouped_direct_trf as grouped_direct_trf_owner
+import chemex.parameters.feasible_coordinates as feasible_coordinates_owner
 from chemex.configuration.methods import Method, Selection, read_method_plan
 from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
@@ -112,6 +113,7 @@ def test_exact_decomposition_is_deterministic_and_distinguishes_shared_coordinat
         controlled_ids: tuple[str, ...],
         start: tuple[float, ...],
         derivation: ProblemDerivation,
+        feasibility_dependencies: tuple[frozenset[str], ...] | None = None,
     ) -> OptimizationProblem:
         derivations.append(derivation)
         return original_derive_child(
@@ -119,6 +121,7 @@ def test_exact_decomposition_is_deterministic_and_distinguishes_shared_coordinat
             controlled_ids=controlled_ids,
             start=start,
             derivation=derivation,
+            feasibility_dependencies=feasibility_dependencies,
         )
 
     with patch.object(OptimizationProblem, "derive_child", track_derive_child):
@@ -182,6 +185,28 @@ def test_exact_decomposition_is_deterministic_and_distinguishes_shared_coordinat
     assert tuple(component.identity for component in first.components) == tuple(
         component.identity for component in second.components
     )
+    root_chart = problem.feasible_coordinates
+    assert root_chart is not None
+    for component in first.components:
+        frame = root_chart.frame_with_updates(
+            dict(zip(component.controlled_ids, component.problem.start, strict=True))
+        )
+        freshly_compiled = feasible_coordinates_owner.compile_feasible_coordinates(
+            parameterization,
+            frame,
+            component.controlled_ids,
+            component.problem.lower_bounds,
+            component.problem.upper_bounds,
+        )
+        assert component.problem.feasible_coordinates == freshly_compiled
+        assert component.problem.feasible_coordinates is not None
+        assert (
+            component.problem.feasible_coordinates.identity == freshly_compiled.identity
+        )
+        assert (
+            component.problem.feasible_coordinates.solver_domain
+            == freshly_compiled.solver_domain
+        )
     child = first.components[0]
     child_invocation = DirectTrfInvocation.for_problem(
         child.problem,
@@ -206,6 +231,10 @@ def test_exact_decomposition_is_deterministic_and_distinguishes_shared_coordinat
     assert len(shared.components) == 1
     assert set(shared.components[0].controlled_ids) == {"__PB", *expected}
     assert shared.components[0].root_profile_indices == (0, 1, 2, 3, 4)
+    assert (
+        shared.components[0].problem.feasible_coordinates
+        is shared_problem.feasible_coordinates
+    )
 
     profile_record = first.partition_proof.profile_records[0]
     first_path = profile_record[3][0]
@@ -237,6 +266,50 @@ def test_exact_decomposition_is_deterministic_and_distinguishes_shared_coordinat
         component.disposition is ComponentDisposition.NOT_STARTED
         for component in invalid_outcome.components
     )
+
+
+def test_grouped_execution_does_not_rederive_a_supplied_decomposition() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(80,) * len(decomposition.components),
+    )
+
+    with patch.object(
+        FitDecomposition,
+        "from_root",
+        side_effect=AssertionError("grouped execution rederived its decomposition"),
+    ):
+        outcome = execute_grouped_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is GroupedDirectTrfTerminal.ACCEPTED
+
+
+def test_grouped_component_projection_does_not_recompile_feasibility() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+
+    with (
+        patch.object(
+            feasible_coordinates_owner,
+            "compile_feasible_coordinates",
+            side_effect=AssertionError("component feasibility was recompiled"),
+        ),
+        patch.object(
+            problem.feasible_coordinates.__class__,
+            "derive",
+            side_effect=AssertionError("component feasibility used general derivation"),
+        ),
+    ):
+        decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+
+    assert len(decomposition.components) == len(problem.controlled_ids)
 
 
 def test_grouped_components_preserve_root_affine_feasibility() -> None:
@@ -879,7 +952,7 @@ def test_interruption_stops_later_components_without_exposing_partial_authority(
     assert session.analysis_values.snapshot() == before
 
 
-def test_projection_interruption_gives_every_component_a_disposition() -> None:
+def test_projection_interruption_marks_the_in_flight_component() -> None:
     session, _experiments, parameterization, engine, problem = _grouped_problem()
     decomposition = FitDecomposition.from_root(problem, parameterization, engine)
     invocation = GroupedDirectTrfInvocation.for_decomposition(
@@ -898,9 +971,12 @@ def test_projection_interruption_gives_every_component_a_disposition() -> None:
         )
 
     assert outcome.terminal is GroupedDirectTrfTerminal.INTERRUPTED
-    assert all(
-        component.disposition is ComponentDisposition.NOT_STARTED
-        for component in outcome.components
+    assert tuple(component.disposition for component in outcome.components) == (
+        ComponentDisposition.INTERRUPTED,
+        ComponentDisposition.NOT_STARTED,
+        ComponentDisposition.NOT_STARTED,
+        ComponentDisposition.NOT_STARTED,
+        ComponentDisposition.NOT_STARTED,
     )
     assert outcome.accepted_result is None
     assert session.analysis_values.snapshot() == before
@@ -1026,7 +1102,6 @@ def test_cancellation_during_first_evidence_comparison_stops_reconstruction() ->
     token = CancellationToken()
     projection_count = 0
     comparison_count = 0
-    context_projection_count = len(decomposition.components)
     project_profiles = engine.project_profiles
 
     def record_projection(
@@ -1074,7 +1149,7 @@ def test_cancellation_during_first_evidence_comparison_stops_reconstruction() ->
         )
 
     assert outcome.terminal is GroupedDirectTrfTerminal.CANCELLED
-    assert projection_count == context_projection_count + 1
+    assert projection_count == 1
     assert comparison_count == 1
     aggregate_vector.assert_not_called()
     new_root_evaluator.assert_not_called()

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -349,6 +349,89 @@ def test_grouped_validation_rejects_a_self_consistent_forged_component_identity(
     )
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    ("missing_chart", "altered_held_frame", "changed_start"),
+)
+def test_grouped_validation_rejects_forged_component_feasibility(
+    mutation: str,
+) -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    original = decomposition.components[0]
+    chart = original.problem.feasible_coordinates
+    assert chart is not None
+    if mutation == "missing_chart":
+        forged_problem = dataclasses.replace(
+            original.problem,
+            feasible_coordinates=None,
+        )
+    elif mutation == "altered_held_frame":
+        held_id, held_value = original.problem.held_items[0]
+        forged_chart = dataclasses.replace(
+            chart,
+            base_frame=chart.base_frame.with_updates({held_id: held_value + 0.25}),
+        )
+        forged_problem = dataclasses.replace(
+            original.problem,
+            feasible_coordinates=forged_chart,
+        )
+    else:
+        forged_problem = dataclasses.replace(
+            original.problem,
+            start=(original.problem.start[0] + 0.01, *original.problem.start[1:]),
+        )
+    forged_component = dataclasses.replace(original, problem=forged_problem)
+    forged_decomposition = dataclasses.replace(
+        decomposition,
+        components=(forged_component, *decomposition.components[1:]),
+    )
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        forged_decomposition,
+        objective_request_budgets=(10,) * len(forged_decomposition.components),
+    )
+
+    outcome = execute_grouped_direct_trf(
+        problem,
+        forged_decomposition,
+        invocation,
+        parameterization,
+        engine,
+    )
+
+    assert outcome.terminal is GroupedDirectTrfTerminal.EXECUTION_FAILURE
+    assert all(
+        component.disposition is ComponentDisposition.NOT_STARTED
+        for component in outcome.components
+    )
+
+
+def test_grouped_validation_does_not_rebuild_projected_plans() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(80,) * len(decomposition.components),
+    )
+    projected_population = engine._projected_population
+
+    with patch.object(
+        engine,
+        "_projected_population",
+        wraps=projected_population,
+    ) as projection_calls:
+        outcome = execute_grouped_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is GroupedDirectTrfTerminal.ACCEPTED
+    assert projection_calls.call_count == 2 * len(decomposition.components)
+
+
 def test_grouped_component_projection_does_not_recompile_feasibility() -> None:
     _session, _experiments, parameterization, engine, problem = _grouped_problem()
 

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -105,15 +105,14 @@ def test_exact_decomposition_is_deterministic_and_distinguishes_shared_coordinat
     _session, _experiments, parameterization, engine, problem = _grouped_problem()
 
     derivations: list[ProblemDerivation] = []
-    original_derive_child = OptimizationProblem.derive_child
+    original_derive_child = OptimizationProblem.derive_grouped_component
 
     def track_derive_child(
         self: OptimizationProblem,
         *,
         controlled_ids: tuple[str, ...],
         start: tuple[float, ...],
-        derivation: ProblemDerivation,
-        feasibility_dependencies: tuple[frozenset[str], ...] | None = None,
+        derivation: ComponentProblemDerivation,
     ) -> OptimizationProblem:
         derivations.append(derivation)
         return original_derive_child(
@@ -121,10 +120,13 @@ def test_exact_decomposition_is_deterministic_and_distinguishes_shared_coordinat
             controlled_ids=controlled_ids,
             start=start,
             derivation=derivation,
-            feasibility_dependencies=feasibility_dependencies,
         )
 
-    with patch.object(OptimizationProblem, "derive_child", track_derive_child):
+    with patch.object(
+        OptimizationProblem,
+        "derive_grouped_component",
+        track_derive_child,
+    ):
         first = FitDecomposition.from_root(problem, parameterization, engine)
         second = FitDecomposition.from_root(problem, parameterization, engine)
 
@@ -292,6 +294,61 @@ def test_grouped_execution_does_not_rederive_a_supplied_decomposition() -> None:
     assert outcome.terminal is GroupedDirectTrfTerminal.ACCEPTED
 
 
+def test_grouped_validation_rejects_a_self_consistent_forged_component_identity() -> (
+    None
+):
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    original = decomposition.components[0]
+    assert isinstance(original.problem.derivation, ComponentProblemDerivation)
+    forged_identity = "forged-component-identity"
+    forged_derivation = dataclasses.replace(
+        original.problem.derivation,
+        component_identity=forged_identity,
+    )
+    forged_problem = dataclasses.replace(
+        original.problem,
+        derivation=forged_derivation,
+    )
+    forged_component = dataclasses.replace(
+        original,
+        problem=forged_problem,
+        identity=forged_identity,
+    )
+    forged_components = (forged_component, *decomposition.components[1:])
+    first_record = decomposition.partition_proof.component_records[0]
+    forged_proof = dataclasses.replace(
+        decomposition.partition_proof,
+        component_records=(
+            (forged_identity, *first_record[1:]),
+            *decomposition.partition_proof.component_records[1:],
+        ),
+    )
+    forged_decomposition = dataclasses.replace(
+        decomposition,
+        components=forged_components,
+        partition_proof=forged_proof,
+    )
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        forged_decomposition,
+        objective_request_budgets=(10,) * len(forged_components),
+    )
+
+    outcome = execute_grouped_direct_trf(
+        problem,
+        forged_decomposition,
+        invocation,
+        parameterization,
+        engine,
+    )
+
+    assert outcome.terminal is GroupedDirectTrfTerminal.EXECUTION_FAILURE
+    assert all(
+        component.disposition is ComponentDisposition.NOT_STARTED
+        for component in outcome.components
+    )
+
+
 def test_grouped_component_projection_does_not_recompile_feasibility() -> None:
     _session, _experiments, parameterization, engine, problem = _grouped_problem()
 
@@ -310,6 +367,38 @@ def test_grouped_component_projection_does_not_recompile_feasibility() -> None:
         decomposition = FitDecomposition.from_root(problem, parameterization, engine)
 
     assert len(decomposition.components) == len(problem.controlled_ids)
+
+
+def test_general_component_derivation_recompiles_feasibility_at_root_start() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    root_feasible = problem.feasible_coordinates
+    assert root_feasible is not None
+    derivation = ComponentProblemDerivation(
+        problem.identity,
+        problem.affine_feasibility_identity,
+        "resampling-complete-scope",
+        "native-resampling-complete-scope-v1",
+        engine.plan.identity,
+        problem.controlled_ids,
+        problem.held_items,
+    )
+    derive_calls = 0
+    original_derive = type(root_feasible).derive
+
+    def track_derive(*args, **kwargs):
+        nonlocal derive_calls
+        derive_calls += 1
+        return original_derive(*args, **kwargs)
+
+    with patch.object(type(root_feasible), "derive", track_derive):
+        child = problem.derive_child(
+            controlled_ids=problem.controlled_ids,
+            start=problem.start,
+            derivation=derivation,
+        )
+
+    assert derive_calls == 1
+    assert child.feasible_coordinates is not root_feasible
 
 
 def test_grouped_components_preserve_root_affine_feasibility() -> None:

--- a/tests/test_native_grouped_direct_trf.py
+++ b/tests/test_native_grouped_direct_trf.py
@@ -461,7 +461,53 @@ def test_grouped_validation_does_not_rebuild_projected_plans() -> None:
         )
 
     assert outcome.terminal is GroupedDirectTrfTerminal.ACCEPTED
-    assert projection_calls.call_count == 2 * len(decomposition.components)
+    assert projection_calls.call_count == len(decomposition.components)
+
+
+def test_combined_grouped_execution_validates_context_once() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    invocation = GroupedDirectTrfInvocation.for_decomposition(
+        decomposition,
+        objective_request_budgets=(80,) * len(decomposition.components),
+    )
+
+    with patch.object(
+        grouped_direct_trf_owner,
+        "_validate_grouped_context",
+        wraps=grouped_direct_trf_owner._validate_grouped_context,
+    ) as validation_calls:
+        outcome = execute_grouped_direct_trf(
+            problem,
+            decomposition,
+            invocation,
+            parameterization,
+            engine,
+        )
+
+    assert outcome.terminal is GroupedDirectTrfTerminal.ACCEPTED
+    validation_calls.assert_called_once()
+
+
+def test_grouped_decomposition_rejects_a_derived_component_root() -> None:
+    _session, _experiments, parameterization, engine, problem = _grouped_problem()
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    component = decomposition.components[0]
+    child_engine = engine.project_profiles(component.root_profile_indices)
+
+    with (
+        patch.object(
+            grouped_direct_trf_owner,
+            "_profile_dependencies",
+            side_effect=AssertionError("non-root decomposition inspected profiles"),
+        ),
+        pytest.raises(DirectTrfConstructionError, match="complete root"),
+    ):
+        FitDecomposition.from_root(
+            component.problem,
+            parameterization,
+            child_engine,
+        )
 
 
 def test_grouped_component_projection_does_not_recompile_feasibility() -> None:
@@ -1233,7 +1279,7 @@ def test_cancellation_stops_after_in_flight_component_and_commits_nothing() -> N
     assert session.analysis_values.snapshot() == before
 
 
-def test_cancellation_during_first_context_projection_stops_validation() -> None:
+def test_cancellation_during_first_carried_projection_stops_validation() -> None:
     session, _experiments, parameterization, engine, problem = _grouped_problem()
     decomposition = FitDecomposition.from_root(problem, parameterization, engine)
     invocation = GroupedDirectTrfInvocation.for_decomposition(
@@ -1249,22 +1295,22 @@ def test_cancellation_during_first_context_projection_stops_validation() -> None
     )
     token = CancellationToken()
     projection_count = 0
-    project_profiles = engine.project_profiles
+    materialized_projection = (
+        grouped_direct_trf_owner._materialized_component_projection
+    )
 
-    def cancel_during_first_context_projection(
-        profile_indices: tuple[int, ...],
-    ) -> EvaluationEngine:
+    def cancel_during_first_carried_projection(*args, **kwargs):
         nonlocal projection_count
         projection_count += 1
-        projected = project_profiles(profile_indices)
+        projected = materialized_projection(*args, **kwargs)
         token.cancel()
         return projected
 
     with (
         patch.object(
-            engine,
-            "project_profiles",
-            side_effect=cancel_during_first_context_projection,
+            grouped_direct_trf_owner,
+            "_materialized_component_projection",
+            side_effect=cancel_during_first_carried_projection,
         ),
         patch(
             "chemex.optimize.grouped_direct_trf._aggregate_vector",
@@ -1309,16 +1355,7 @@ def test_cancellation_during_first_evidence_comparison_stops_reconstruction() ->
         engine,
     )
     token = CancellationToken()
-    projection_count = 0
     comparison_count = 0
-    project_profiles = engine.project_profiles
-
-    def record_projection(
-        profile_indices: tuple[int, ...],
-    ) -> EvaluationEngine:
-        nonlocal projection_count
-        projection_count += 1
-        return project_profiles(profile_indices)
 
     def cancel_during_first_evidence_comparison(residuals: Array) -> float:
         nonlocal comparison_count
@@ -1331,7 +1368,7 @@ def test_cancellation_during_first_evidence_comparison_stops_reconstruction() ->
         patch.object(
             engine,
             "project_profiles",
-            side_effect=record_projection,
+            side_effect=AssertionError("materialization rebuilt a child engine"),
         ),
         patch(
             "chemex.optimize.grouped_direct_trf.canonical_chi_square",
@@ -1358,7 +1395,6 @@ def test_cancellation_during_first_evidence_comparison_stops_reconstruction() ->
         )
 
     assert outcome.terminal is GroupedDirectTrfTerminal.CANCELLED
-    assert projection_count == 1
     assert comparison_count == 1
     aggregate_vector.assert_not_called()
     new_root_evaluator.assert_not_called()

--- a/tests/test_relaxation_feasibility.py
+++ b/tests/test_relaxation_feasibility.py
@@ -692,6 +692,11 @@ def test_component_projection_rejects_a_non_closed_root_feasibility_domain() -> 
             root,
             controlled_domain_groups=(frozenset(),),
         )
+    with pytest.raises(TypeError, match="init=False"):
+        dataclasses.replace(
+            root,
+            _projection_provenance=root._projection_provenance,
+        )
     with pytest.raises(
         FeasibleCoordinateConstructionError,
         match="closed root-chart subset",

--- a/tests/test_relaxation_feasibility.py
+++ b/tests/test_relaxation_feasibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -686,6 +687,11 @@ def test_component_projection_rejects_a_non_closed_root_feasibility_domain() -> 
     )
 
     assert root is not None
+    with pytest.raises(TypeError):
+        dataclasses.replace(
+            root,
+            controlled_domain_groups=(frozenset(),),
+        )
     with pytest.raises(
         FeasibleCoordinateConstructionError,
         match="closed root-chart subset",

--- a/tests/test_relaxation_feasibility.py
+++ b/tests/test_relaxation_feasibility.py
@@ -707,6 +707,23 @@ def test_component_projection_rejects_a_non_closed_root_feasibility_domain() -> 
             (0.0,),
             (maximum,),
         )
+    projected = root.project_component(
+        frame,
+        ("r2", "eta"),
+        (0.0, -maximum),
+        (maximum, maximum),
+    )
+    assert projected is not None
+    with pytest.raises(
+        FeasibleCoordinateConstructionError,
+        match="compiled root chart",
+    ):
+        projected.project_component(
+            frame,
+            ("r2", "eta"),
+            (0.0, -maximum),
+            (maximum, maximum),
+        )
 
 
 def test_collapsed_cross_rate_chart_has_singular_public_differential() -> None:

--- a/tests/test_relaxation_feasibility.py
+++ b/tests/test_relaxation_feasibility.py
@@ -667,6 +667,37 @@ def test_compiled_static_affine_floor_supersedes_nonnegative_rate_excess() -> No
     assert values["r2"] * values["r2a"] == pytest.approx(9.0)
 
 
+def test_component_projection_rejects_a_non_closed_root_feasibility_domain() -> None:
+    parameterization = _affine_parameterization()
+    frame = IndependentValueFrame(
+        "parameterization",
+        "program",
+        "occurrence",
+        0,
+        (("r2", 5.0), ("r1", 2.0), ("eta", 3.0)),
+    )
+    maximum = float(np.finfo(np.float64).max)
+    root = compile_feasible_coordinates(
+        parameterization,
+        frame,
+        ("r2", "eta"),
+        (0.0, -maximum),
+        (maximum, maximum),
+    )
+
+    assert root is not None
+    with pytest.raises(
+        FeasibleCoordinateConstructionError,
+        match="closed root-chart subset",
+    ):
+        root.project_component(
+            frame,
+            ("r2",),
+            (0.0,),
+            (maximum,),
+        )
+
+
 def test_collapsed_cross_rate_chart_has_singular_public_differential() -> None:
     parameterization = _affine_parameterization()
     frame = IndependentValueFrame(


### PR DESCRIPTION
Closes #719

## Summary

- reuse an exactly identical root feasibility chart instead of recompiling it
- project grouped-component charts from the sealed root chart after proving feasibility-domain closure
- validate supplied grouped decompositions without rebuilding every child
- preserve general recompilation for changed starts, GRID/DE, resampling, and other derivations

## Corrected STEP2 evidence

`CPMG_1HN_AP_0013` STEP2 has 150 profiles, 225 controlled coordinates, 600 PSD blocks, and 75 independent three-coordinate components.

Before:

- pre-minimizer construction: 88.00 s
- decomposition: 86.37 s
- child feasibility compiles: 75, taking 85.84 s

After:

- pre-minimizer construction: 2.14 s
- decomposition: 0.50 s
- child feasibility compiles: 0
- root feasibility compiles: 1

Projected charts match fresh legacy child compilation exactly, including identity and solver domain.

## Scientific qualification

The complete two-step example produces byte-identical fitted parameter and statistics files. STEP1 remains χ² 421.754 with 363 evaluations; STEP2 remains χ² 8944.92 with 1,757 evaluations. Covariance evidence is identical after excluding per-run occurrence/identity fields.

- focused grouped/feasibility/DE qualification: 86 passed
- expanded optimization/scientific matrix: 447 passed
- clean Python 3.13.13 worktree: 1,089 passed
- clean Python 3.14.5 worktree: 1,089 passed
- Ruff, format, ty, build, diff check: passed
- exact-head GitHub CI: passed
- independent architecture/performance, scientific/numerical, and specification/compatibility reviews: clean
- graph refreshed

Final reviewed head: `0f3ceaed4e571dcc56b26d62dda7b91ea21a3d6c`.

Ready for review; do not merge without maintainer approval.
