### PR TITLE
fix: allow zero diffusion gradient in CH3 TQ CPMG

### DIFF
--- a/src/chemex/experiments/catalog/cpmg_ch3_1h_tq_diff.py
+++ b/src/chemex/experiments/catalog/cpmg_ch3_1h_tq_diff.py
@@ -37,7 +37,7 @@ class CpmgCh31HTqDiffSettings(CpmgSettings):
     delta: float = Field(
         gt=0.0, description="Gradient pulse duration for diffusion encoding (seconds)"
     )
-    gradient: float = Field(gt=0.0, description="Gradient strength (G/cm)")
+    gradient: float = Field(ge=0.0, description="Gradient strength (G/cm)")
     tau: float = Field(
         default=500.0e-6,
         gt=0.0,

--- a/tests/experiments/test_cpmg_ch3_1h_tq_diff.py
+++ b/tests/experiments/test_cpmg_ch3_1h_tq_diff.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from chemex.experiments.catalog.cpmg_ch3_1h_tq_diff import (
+    CpmgCh31HTqDiffSettings,
+)
+
+
+def _settings_data(gradient: float) -> dict[str, object]:
+    return {
+        "name": "cpmg_ch3_1h_tq_diff",
+        "time_t2": 40.0e-3,
+        "carrier": 600.25,
+        "pw90": 10.5e-6,
+        "delta": 1.0e-3,
+        "gradient": gradient,
+    }
+
+
+@pytest.mark.parametrize("gradient", [0.0, 30.6e-2])
+def test_gradient_accepts_zero_and_positive_values(gradient: float) -> None:
+    settings = CpmgCh31HTqDiffSettings.model_validate(_settings_data(gradient))
+
+    assert settings.gradient == gradient
+
+
+def test_gradient_rejects_negative_values() -> None:
+    with pytest.raises(ValidationError):
+        CpmgCh31HTqDiffSettings.model_validate(_settings_data(-1.0))


### PR DESCRIPTION
## Summary
- allow the physically valid zero diffusion gradient
- continue rejecting negative gradient magnitudes
- add focused schema regression coverage

## Validation
- canonical CPMG_CH3_1H_TQ_DIFF example
- focused experiment/configuration tests
- Ruff, format, ty, and diff checks

Closes #720