### PR TITLE
Use staged warm-start in CPMG HN DQ/ZQ example

### DIFF
--- a/examples/Experiments/CPMG_HN_DQ_ZQ/Methods/method.toml
+++ b/examples/Experiments/CPMG_HN_DQ_ZQ/Methods/method.toml
@@ -1,11 +1,21 @@
 FORMAT_VERSION = 2
 
 [STEP1]
-INCLUDE = ["Y10", "K25", "Q27", "W36", "S41", "E46", "S52", "A56"]
+INCLUDE = ["Y10", "K25", "Q27", "E33", "W36", "S41", "E46", "S52", "A56"]
+ROLES = [
+  { FIX = ["PB", "KEX_AB"] },
+]
 
 [STEP2]
-INCLUDE = "ALL"
+INCLUDE = ["Y10", "K25", "Q27", "E33", "W36", "S41", "E46", "S52", "A56"]
 ROLES_FROM = "STEP1"
+ROLES = [
+  { FIT = ["PB", "KEX_AB"] },
+]
+
+[STEP3]
+INCLUDE = "ALL"
+ROLES_FROM = "STEP2"
 ROLES = [
   { FIX = ["PB", "KEX_AB"] },
 ]

--- a/examples/Experiments/CPMG_HN_DQ_ZQ/Methods/method.toml
+++ b/examples/Experiments/CPMG_HN_DQ_ZQ/Methods/method.toml
@@ -1,7 +1,7 @@
 FORMAT_VERSION = 2
 
 [STEP1]
-INCLUDE = ["Y10", "K25", "Q27", "E33", "W36", "S41", "E46", "S52", "A56"]
+INCLUDE = ["Y10", "K25", "Q27", "W36", "S41", "E46", "S52", "A56"]
 
 [STEP2]
 INCLUDE = "ALL"


### PR DESCRIPTION
Closes #722

## Summary
- initialize local nuisance parameters on the original nine-residue STEP1 subset with PB/KEX_AB fixed
- release PB/KEX_AB in STEP2 for the selected-residue global fit
- keep STEP3 on all 192 profiles with PB/KEX_AB fixed

STEP1 is intended to estimate shared exchange parameters from an informative subset, but the original one-stage fit coupled those globals to weak local directions from crude defaults. The staged warm-start preserves the nine-residue selection and lets STEP2 converge normally under the unchanged native Direct-TRF policy.

## Validation
- clean `uv run ./run.sh` completed all three stages
- STEP1: 36 profiles, 1,122 evaluations, chi-square 1.53151e4
- STEP2: 36 profiles, 1,435 evaluations, chi-square 1.05773e4; no 114,000-request exhaustion
- STEP3: 192 profiles, 3,700 evaluations, chi-square 4.89247e4
- covariance available for all three stages
- all four plot sets produced for each stage
- 50 clean method-plan/configuration tests passed
- direct CPMG method parsing/selection check passed
- native Direct-TRF regression passed
- `git diff --check` passed
- production source code unchanged

The method file is the only repository change.