### PR TITLE
Constrain CEST 1H B-state transverse relaxation

### DIFF
--- a/examples/Experiments/CEST_1HN_IP_AP/Methods/method.toml
+++ b/examples/Experiments/CEST_1HN_IP_AP/Methods/method.toml
@@ -4,6 +4,7 @@ FORMAT_VERSION = 2
 ROLES = [
   { FIX = ["KEX_AB", "R1_A"] },
   { FIT = ["CS_A"] },
+  { CONSTRAIN = ["[R2_B] = [R2_A]"] },
 ]
 
 [2_FIT_R1]

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -466,7 +466,7 @@ def test_cest_1hn_ip_ap_commits_psd_transverse_relaxation_block(
     final_statistics = tomllib.loads(
         (output / "2_FIT_R1" / "statistics.toml").read_text(encoding="utf-8")
     )
-    assert final_statistics["chi-square"] == pytest.approx(52.4331, rel=2.0e-5)
+    assert final_statistics["chi-square"] == pytest.approx(52.7997, rel=2.0e-5)
 
 
 def test_complete_cest_1hn_ip_ap_shipped_selection_finishes_both_steps(
@@ -488,8 +488,8 @@ def test_complete_cest_1hn_ip_ap_shipped_selection_finishes_both_steps(
     second = tomllib.loads(
         (output / "2_FIT_R1" / "statistics.toml").read_text(encoding="utf-8")
     )
-    assert first["chi-square"] == pytest.approx(11938.9, rel=2.0e-5)
-    assert second["chi-square"] == pytest.approx(3877.57, rel=2.0e-5)
+    assert first["chi-square"] == pytest.approx(12417.8, rel=2.0e-5)
+    assert second["chi-square"] == pytest.approx(4805.51, rel=2.0e-5)
 
 
 def test_cpmg_15n_tr_nested_antiphase_rate_remains_feasible(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- constrain `R2_B` to `R2_A` in the shipped `CEST_1HN_IP_AP` method
- update the two shipped-example regression expectations to the parsimonious model

This keeps the example focused on robust `DW_AB` extraction while avoiding poorly identified nuisance B-state transverse-relaxation freedom. It is based on issue #724 and the focused M0/M1/M2 sensitivity study; the rationale is scientific parsimony and `DW_AB` robustness, not covariance behavior.

## Validation

- `uv run pytest -q tests/configuration/test_method_plan.py -k 'v1_and_v2_normalize_to_the_same_ordered_role_semantics or v1_and_v2_validate_same_group_companion_constraints or constraint_equations_compile_to_typed_ast_and_render_canonically'`
- `uv run pytest -q tests/test_native_production_fitting.py::test_cest_1hn_ip_ap_commits_psd_transverse_relaxation_block tests/test_native_production_fitting.py::test_complete_cest_1hn_ip_ap_shipped_selection_finishes_both_steps`
- `git diff --check`

The full method-plan file was also attempted; one unrelated pre-existing scan-count failure remains because generated `examples/**/Output/run_info/inputs/Methods` artifacts are present in this checkout.
