### PR TITLE
Report relaxation-PSD boundary uncertainty explicitly

### DIFF
--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -2909,6 +2909,8 @@ class RootAnchoredBlockCovariance:
                 "non_positive_nominal_residual_degrees_of_freedom",
             }:
                 return UncertaintyUnavailableKind.INSUFFICIENT_INFORMATION
+            if self.failure.category == "active_relaxation_feasibility_boundary":
+                return UncertaintyUnavailableKind.BOUNDARY_LIMITED
             if self.failure.stage == "residual_linearization":
                 return UncertaintyUnavailableKind.JACOBIAN_UNAVAILABLE
             return UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE

--- a/src/chemex/printers/parameters.py
+++ b/src/chemex/printers/parameters.py
@@ -53,7 +53,9 @@ class ParameterUncertaintyView:
 _UNAVAILABLE_REASON_TEXT = {
     UncertaintyUnavailableKind.RANK_DEFICIENT: "rank deficient",
     UncertaintyUnavailableKind.INSUFFICIENT_INFORMATION: "insufficient information",
-    UncertaintyUnavailableKind.BOUNDARY_LIMITED: "boundary limited",
+    UncertaintyUnavailableKind.BOUNDARY_LIMITED: (
+        "boundary limited (active relaxation-PSD boundary)"
+    ),
     UncertaintyUnavailableKind.NORMALIZATION_INVALID: "normalization invalid",
     UncertaintyUnavailableKind.JACOBIAN_UNAVAILABLE: "Jacobian unavailable",
     UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE: (
@@ -92,6 +94,8 @@ def _controlled_unavailability_kind(
         "non_positive_nominal_residual_degrees_of_freedom",
     }:
         return UncertaintyUnavailableKind.INSUFFICIENT_INFORMATION
+    if "active_relaxation_feasibility_boundary" in categories:
+        return UncertaintyUnavailableKind.BOUNDARY_LIMITED
     covariance = evidence.covariance
     if covariance is not None:
         claims = {item.name: item.state.value for item in covariance.claims}

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -40,12 +40,16 @@ from chemex.optimize.direct_trf import (
     execute_direct_trf,
 )
 from chemex.optimize.uncertainty import (
+    ClaimAssessment,
     ClaimState,
+    EvidenceFailure,
     FunctionAnalyticPartialCapability,
     FunctionFiniteDifferenceCapability,
     OperationTerminal,
     ParameterUnit,
     ResidualVarianceScaling,
+    RootAnchoredBlockCovariance,
+    ScalarEvidenceEntry,
     UncertaintyPolicy,
     compile_constraint_linearization_capabilities,
     derive_uncertainty_evidence,
@@ -81,7 +85,9 @@ def test_uncertainty_unavailability_vocabulary_is_exhaustive_and_truthful() -> N
         UncertaintyUnavailableKind.INSUFFICIENT_INFORMATION: (
             "insufficient information"
         ),
-        UncertaintyUnavailableKind.BOUNDARY_LIMITED: "boundary limited",
+        UncertaintyUnavailableKind.BOUNDARY_LIMITED: (
+            "boundary limited (active relaxation-PSD boundary)"
+        ),
         UncertaintyUnavailableKind.NORMALIZATION_INVALID: "normalization invalid",
         UncertaintyUnavailableKind.JACOBIAN_UNAVAILABLE: "Jacobian unavailable",
         UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE: (
@@ -1686,6 +1692,45 @@ def test_invalid_relaxation_anchor_has_no_public_uncertainty_stencil() -> None:
     assert any(
         failure.category == "active_relaxation_feasibility_boundary"
         for failure in evidence.failures
+    )
+    view = parameter_uncertainty_view(evidence)
+    expected_reason = "boundary limited (active relaxation-PSD boundary)"
+    assert view.unavailable_reason(controlled_id) == expected_reason
+    assert (
+        native_deterministic_module._uncertainty_progress_status(
+            evidence,
+            None,
+            view,
+            problem.controlled_ids,
+        )
+        == f"uncertainty unavailable: {expected_reason}"
+    )
+
+
+def test_active_relaxation_boundary_classifies_root_block_as_boundary_limited() -> None:
+    failure = EvidenceFailure(
+        "residual_linearization",
+        "active_relaxation_feasibility_boundary",
+        "active relaxation boundary",
+        "test-source",
+    )
+    block = RootAnchoredBlockCovariance(
+        controlled_ids=("__CONTROLLED",),
+        root_profile_indices=(0,),
+        rank=0,
+        jacobian_condition=None,
+        covariance=None,
+        factor=None,
+        marginal_errors=(ScalarEvidenceEntry("__CONTROLLED", None, "UNAVAILABLE"),),
+        correlations=(),
+        constrained_marginal_errors=(),
+        claims=(ClaimAssessment("USABLE_LOCAL_COVARIANCE", ClaimState.VIOLATED),),
+        failure=failure,
+    )
+
+    assert block.unavailable_kind is UncertaintyUnavailableKind.BOUNDARY_LIMITED
+    assert uncertainty_unavailable_reason(block.unavailable_kind) == (
+        "boundary limited (active relaxation-PSD boundary)"
     )
 
 


### PR DESCRIPTION
## Summary

- classify `active_relaxation_feasibility_boundary` as `BOUNDARY_LIMITED` for controlled uncertainty reporting
- classify the same failure as `BOUNDARY_LIMITED` for root-anchored block covariance reporting
- render `boundary limited (active relaxation-PSD boundary)`
- preserve genuine residual-linearization failures as `JACOBIAN_UNAVAILABLE`

This is based on issue #726. It changes classification and user-facing wording only; covariance mathematics, Jacobian construction/fallback, PSD detection/tolerances, feasibility coordinates, and optimizer behavior are unchanged.

## Validation

- `uv run pytest -q tests/test_native_uncertainty.py::test_invalid_relaxation_anchor_has_no_public_uncertainty_stencil tests/test_native_uncertainty.py::test_active_relaxation_boundary_classifies_root_block_as_boundary_limited tests/test_native_uncertainty.py::test_failed_accepted_point_fallback_reports_jacobian_unavailable tests/test_native_uncertainty.py::test_uncertainty_unavailability_vocabulary_is_exhaustive_and_truthful tests/test_native_production_fitting.py::test_shared_parameter_coupling_is_not_split_into_covariance_blocks tests/test_native_production_fitting.py::test_boundary_warning_fit_reports_uncertainty_without_changing_central_values tests/test_native_binding_uncertainty.py::test_full_binding_step2_reports_boundary_warning_with_retained_jacobian`
- `uvx ruff check src/chemex/optimize/uncertainty.py src/chemex/printers/parameters.py tests/test_native_uncertainty.py`
- `uvx ruff format --check src/chemex/optimize/uncertainty.py src/chemex/printers/parameters.py tests/test_native_uncertainty.py`
- `git diff --check`
