### PR TITLE
Prevent tracebacks at the CLI boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,10 @@ tests together.
 
 ## Execution and data flow
 
-The installed `chemex` command calls `chemex.chemex:main`; `python -m chemex`
-uses the same function. `fit` and `simulate` follow this path:
+The installed `chemex` command and `python -m chemex` enter through
+`chemex._entrypoint:main`, which translates terminal failures and delegates to
+the exception-transparent `chemex.chemex:main`. `fit` and `simulate` then follow
+this path:
 
 1. `cli.py` parses paths, model selection, profile selection, output options,
    and fit execution settings.

--- a/docs/adr/0005-translate-exceptions-at-the-cli-boundary.md
+++ b/docs/adr/0005-translate-exceptions-at-the-cli-boundary.md
@@ -1,0 +1,52 @@
+---
+status: accepted
+---
+
+# Translate exceptions at the CLI boundary
+
+ChemEx will keep internal Python interfaces exception-transparent while one
+lightweight terminal boundary owns command-line failure translation.  The
+installed `chemex` command and `python -m chemex` share that boundary.  It
+covers application imports reached from the boundary as well as failures raised
+during command execution.
+
+`SystemExit` remains native so argparse and intentional command exits retain
+their established status and stream behavior.  A user interruption exits 130.
+Other ordinary failures exit non-zero.  Terminal diagnostics are concise,
+literal, written to stderr, and contain neither traceback nor chained exception
+details.  Rendering failure falls back to plain stderr without replacing the
+original exit status.
+
+Workflow layers may catch interruption temporarily to freeze scientifically
+valid partial state, serialize already committed values or qualified Evidence,
+write truthful incomplete status, and perform required cleanup.  Once
+interruption is recognized, finalization does not start further scientific
+calculation, sampling, replicates, Method Steps, or optional plotting.  The
+interruption remains distinguishable from ordinary failure and propagates to
+the terminal boundary after finalization.
+
+## Considered options
+
+- Catching failures in every command or scientific layer was rejected because
+  it duplicates presentation policy and risks converting failures into success.
+- Immediately re-raising every raw `KeyboardInterrupt` was rejected because it
+  can discard qualified Evidence and committed results before truthful
+  publication.
+- A new global exception hierarchy was rejected because existing workflow
+  terminals already distinguish interrupted operations from ordinary failure.
+- Leaving application imports outside the boundary was rejected because common
+  dependency and startup failures would still expose tracebacks.
+
+## Consequences
+
+Direct calls to `chemex.chemex.main()` and lower-level APIs continue to raise
+their original exceptions.  Workflow-specific incomplete exceptions may carry
+their existing normalized `terminal` value through orchestration.  Completed
+deterministic fits, qualified uncertainty Evidence, complete MCMC transitions,
+and completed resampling replicates survive a later interruption without being
+promoted to complete scientific conclusions.
+
+The boundary can only translate failures after Python has imported the ChemEx
+package and reached it.  Interpreter startup failures, an unavailable package,
+bootstrap syntax errors, native process crashes, and forced process termination
+remain outside this guarantee.

--- a/docs/adr/0005-translate-exceptions-at-the-cli-boundary.md
+++ b/docs/adr/0005-translate-exceptions-at-the-cli-boundary.md
@@ -14,8 +14,9 @@ during command execution.
 their established status and stream behavior.  A user interruption exits 130.
 Other ordinary failures exit non-zero.  Terminal diagnostics are concise,
 literal, written to stderr, and contain neither traceback nor chained exception
-details.  Rendering failure falls back to plain stderr without replacing the
-original exit status.
+details.  The boundary emits only boundary-owned diagnostics and never exposes
+arbitrary exception contents.  Rendering failure falls back to plain stderr
+without replacing the original exit status.
 
 Workflow layers may catch interruption temporarily to freeze scientifically
 valid partial state, serialize already committed values or qualified Evidence,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Homepage = "https://gbouvignies.github.io/ChemEx/"
 Repository = "https://github.com/gbouvignies/ChemEx"
 
 [project.scripts]
-chemex = "chemex.chemex:main"
+chemex = "chemex._entrypoint:main"
 
 [dependency-groups]
 dev = [

--- a/src/chemex/__main__.py
+++ b/src/chemex/__main__.py
@@ -1,6 +1,6 @@
-"""chemex.__main__: executed when the chemex directory is called as script."""
+"""Execute ChemEx through its terminal command-line boundary."""
 
-from chemex.chemex import main
+from chemex._entrypoint import main
 
 if __name__ == "__main__":
     main()

--- a/src/chemex/_entrypoint.py
+++ b/src/chemex/_entrypoint.py
@@ -6,22 +6,14 @@ import sys
 from collections.abc import Callable
 from contextlib import suppress
 from importlib import import_module
-from typing import cast
 
-type DiagnosticRenderer = Callable[[str, tuple[str, ...], bool], None]
+type DiagnosticRenderer = Callable[[str], None]
 
 _BASE_EXCEPTION_DICT = BaseException.__dict__["__dict__"]
 
 
-def _plain_diagnostic(
-    message: str,
-    notes: tuple[str, ...],
-    interrupted: bool,
-) -> None:
-    prefix = "" if interrupted else "ERROR: "
-    sys.stderr.write(f"{prefix}{message}\n")
-    for note in notes:
-        sys.stderr.write(f"NOTE: {note}\n")
+def _plain_diagnostic(message: str) -> None:
+    sys.stderr.write(f"{message}\n")
 
 
 def _instance_data(error: BaseException) -> dict[str, object]:
@@ -33,37 +25,9 @@ def _instance_data(error: BaseException) -> dict[str, object]:
     return data if type(data) is dict else {}
 
 
-def _audited_notes(error: BaseException) -> tuple[str, ...]:
-    notes = _instance_data(error).get("__notes__")
-    if type(notes) not in {list, tuple}:
-        return ()
-    trusted_notes = cast("list[object] | tuple[object, ...]", notes)
-    return tuple(
-        note
-        for note in trusted_notes
-        if type(note) is str and str.startswith(note, "ChemEx ")
-    )
-
-
 def _is_interrupted(error: Exception) -> bool:
     terminal = _instance_data(error).get("terminal")
     return isinstance(terminal, str) and str.__eq__(terminal, "interrupted") is True
-
-
-def _error_message(error: Exception) -> str:
-    try:
-        message = str(error)
-    except BaseException:  # noqa: BLE001 - diagnostics must be fail-safe
-        message = ""
-    if message:
-        return message
-    try:
-        name = type.__getattribute__(type(error), "__name__")
-    except BaseException:  # noqa: BLE001 - diagnostics must be fail-safe
-        name = "Exception"
-    if type(name) is not str or not name:
-        name = "Exception"
-    return f"{name} occurred without an error message."
 
 
 def _load_renderer() -> DiagnosticRenderer:
@@ -80,15 +44,12 @@ def _load_renderer() -> DiagnosticRenderer:
 def _render(
     renderer: DiagnosticRenderer,
     message: str,
-    notes: tuple[str, ...],
-    *,
-    interrupted: bool,
 ) -> None:
     try:
-        renderer(message, notes, interrupted)
+        renderer(message)
     except BaseException:  # noqa: BLE001 - diagnostics cannot replace exit semantics
         with suppress(BaseException):
-            _plain_diagnostic(message, notes, interrupted)
+            _plain_diagnostic(message)
 
 
 def main() -> None:
@@ -98,21 +59,17 @@ def main() -> None:
         renderer = _load_renderer()
         application = import_module("chemex.chemex")
         application.main()
-    except KeyboardInterrupt as error:
-        _render(
-            renderer,
-            "ChemEx interrupted.",
-            _audited_notes(error),
-            interrupted=True,
-        )
+    except KeyboardInterrupt:
+        _render(renderer, "ChemEx interrupted.")
         raise SystemExit(130) from None
     except Exception as error:  # noqa: BLE001 - terminal CLI translation seam
         interrupted = _is_interrupted(error)
-        message = "ChemEx interrupted." if interrupted else _error_message(error)
         _render(
             renderer,
-            message,
-            _audited_notes(error),
-            interrupted=interrupted,
+            (
+                "ChemEx interrupted."
+                if interrupted
+                else "ChemEx encountered an unexpected error."
+            ),
         )
         raise SystemExit(130 if interrupted else 1) from None

--- a/src/chemex/_entrypoint.py
+++ b/src/chemex/_entrypoint.py
@@ -1,0 +1,118 @@
+"""Lightweight terminal boundary shared by ChemEx command-line entry paths."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from contextlib import suppress
+from importlib import import_module
+from typing import cast
+
+type DiagnosticRenderer = Callable[[str, tuple[str, ...], bool], None]
+
+_BASE_EXCEPTION_DICT = BaseException.__dict__["__dict__"]
+
+
+def _plain_diagnostic(
+    message: str,
+    notes: tuple[str, ...],
+    interrupted: bool,
+) -> None:
+    prefix = "" if interrupted else "ERROR: "
+    sys.stderr.write(f"{prefix}{message}\n")
+    for note in notes:
+        sys.stderr.write(f"NOTE: {note}\n")
+
+
+def _instance_data(error: BaseException) -> dict[str, object]:
+    """Read built-in exception storage without invoking subclass descriptors."""
+    try:
+        data = _BASE_EXCEPTION_DICT.__get__(error, type(error))
+    except BaseException:  # noqa: BLE001 - diagnostics must be fail-safe
+        return {}
+    return data if type(data) is dict else {}
+
+
+def _audited_notes(error: BaseException) -> tuple[str, ...]:
+    notes = _instance_data(error).get("__notes__")
+    if type(notes) not in {list, tuple}:
+        return ()
+    trusted_notes = cast("list[object] | tuple[object, ...]", notes)
+    return tuple(
+        note
+        for note in trusted_notes
+        if type(note) is str and str.startswith(note, "ChemEx ")
+    )
+
+
+def _is_interrupted(error: Exception) -> bool:
+    terminal = _instance_data(error).get("terminal")
+    return isinstance(terminal, str) and str.__eq__(terminal, "interrupted") is True
+
+
+def _error_message(error: Exception) -> str:
+    try:
+        message = str(error)
+    except BaseException:  # noqa: BLE001 - diagnostics must be fail-safe
+        message = ""
+    if message:
+        return message
+    try:
+        name = type.__getattribute__(type(error), "__name__")
+    except BaseException:  # noqa: BLE001 - diagnostics must be fail-safe
+        name = "Exception"
+    if type(name) is not str or not name:
+        name = "Exception"
+    return f"{name} occurred without an error message."
+
+
+def _load_renderer() -> DiagnosticRenderer:
+    """Load optional application rendering without making it a failure source."""
+    try:
+        messages = import_module("chemex.messages")
+        renderer = messages.print_cli_diagnostic
+    except BaseException:  # noqa: BLE001 - renderer acquisition is optional
+        return _plain_diagnostic
+    else:
+        return renderer
+
+
+def _render(
+    renderer: DiagnosticRenderer,
+    message: str,
+    notes: tuple[str, ...],
+    *,
+    interrupted: bool,
+) -> None:
+    try:
+        renderer(message, notes, interrupted)
+    except BaseException:  # noqa: BLE001 - diagnostics cannot replace exit semantics
+        with suppress(BaseException):
+            _plain_diagnostic(message, notes, interrupted)
+
+
+def main() -> None:
+    """Run ChemEx and translate terminal failures without exposing tracebacks."""
+    renderer = _plain_diagnostic
+    try:
+        renderer = _load_renderer()
+        application = import_module("chemex.chemex")
+        application.main()
+    except KeyboardInterrupt as error:
+        _render(
+            renderer,
+            "ChemEx interrupted.",
+            _audited_notes(error),
+            interrupted=True,
+        )
+        raise SystemExit(130) from None
+    except Exception as error:  # noqa: BLE001 - terminal CLI translation seam
+        interrupted = _is_interrupted(error)
+        message = "ChemEx interrupted." if interrupted else _error_message(error)
+        _render(
+            renderer,
+            message,
+            _audited_notes(error),
+            interrupted=interrupted,
+        )
+        raise SystemExit(130 if interrupted else 1) from None

--- a/src/chemex/atomic.py
+++ b/src/chemex/atomic.py
@@ -33,13 +33,11 @@ def open_text_atomic(destination: Path) -> Iterator[TextIOWrapper]:
     except BaseException as error:
         try:
             temporary.unlink(missing_ok=True)
-        except BaseException as cleanup_error:  # noqa: BLE001 - preserve first failure
-            detail = str(cleanup_error) or type(cleanup_error).__name__
+        except BaseException:  # noqa: BLE001 - preserve first failure
             with suppress(BaseException):
                 BaseException.add_note(
                     error,
-                    "ChemEx could not remove incomplete temporary artifact "
-                    f"{temporary}: {detail}",
+                    "ChemEx could not remove an incomplete temporary artifact.",
                 )
         raise
 
@@ -53,22 +51,16 @@ def write_text_atomic(destination: Path, content: str) -> None:
 def remove_paths_best_effort(
     paths: Iterable[Path],
     error: BaseException,
-    *,
-    description: str,
 ) -> None:
     """Attempt every explicit removal without replacing the original failure."""
     for path in paths:
         try:
             path.unlink(missing_ok=True)
-        except BaseException as cleanup_error:  # noqa: BLE001 - cleanup is subordinate
-            try:
-                detail = str(cleanup_error) or type(cleanup_error).__name__
-            except BaseException:  # noqa: BLE001 - note rendering is best effort
-                detail = "unreportable cleanup failure"
+        except BaseException:  # noqa: BLE001 - cleanup is subordinate
             with suppress(BaseException):
                 BaseException.add_note(
                     error,
-                    f"ChemEx could not remove {description} {path.name}: {detail}",
+                    "ChemEx could not remove a stale artifact.",
                 )
 
 

--- a/src/chemex/atomic.py
+++ b/src/chemex/atomic.py
@@ -7,6 +7,9 @@ import errno
 import os
 import sys
 import tempfile
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager, suppress
+from io import TextIOWrapper
 from pathlib import Path
 
 _AT_FDCWD = -100
@@ -14,8 +17,9 @@ _RENAME_NOREPLACE = 1
 _RENAME_EXCL = 4
 
 
-def write_text_atomic(destination: Path, content: str) -> None:
-    """Replace one text file atomically from a same-directory temporary file."""
+@contextmanager
+def open_text_atomic(destination: Path) -> Iterator[TextIOWrapper]:
+    """Stream one text file and expose it only after a complete write."""
     descriptor, temporary_name = tempfile.mkstemp(
         dir=destination.parent,
         prefix=f".{destination.name}-",
@@ -24,11 +28,48 @@ def write_text_atomic(destination: Path, content: str) -> None:
     temporary = Path(temporary_name)
     try:
         with os.fdopen(descriptor, "w", encoding="utf-8") as output:
-            output.write(content)
+            yield output
         temporary.replace(destination)
-    except BaseException:
-        temporary.unlink(missing_ok=True)
+    except BaseException as error:
+        try:
+            temporary.unlink(missing_ok=True)
+        except BaseException as cleanup_error:  # noqa: BLE001 - preserve first failure
+            detail = str(cleanup_error) or type(cleanup_error).__name__
+            with suppress(BaseException):
+                BaseException.add_note(
+                    error,
+                    "ChemEx could not remove incomplete temporary artifact "
+                    f"{temporary}: {detail}",
+                )
         raise
+
+
+def write_text_atomic(destination: Path, content: str) -> None:
+    """Replace one text file atomically from a same-directory temporary file."""
+    with open_text_atomic(destination) as output:
+        output.write(content)
+
+
+def remove_paths_best_effort(
+    paths: Iterable[Path],
+    error: BaseException,
+    *,
+    description: str,
+) -> None:
+    """Attempt every explicit removal without replacing the original failure."""
+    for path in paths:
+        try:
+            path.unlink(missing_ok=True)
+        except BaseException as cleanup_error:  # noqa: BLE001 - cleanup is subordinate
+            try:
+                detail = str(cleanup_error) or type(cleanup_error).__name__
+            except BaseException:  # noqa: BLE001 - note rendering is best effort
+                detail = "unreportable cleanup failure"
+            with suppress(BaseException):
+                BaseException.add_note(
+                    error,
+                    f"ChemEx could not remove {description} {path.name}: {detail}",
+                )
 
 
 def publish_directory_noreplace(staging: Path, destination: Path) -> None:

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -97,10 +97,8 @@ def run_fit(
                 failure=error,
                 failure_stage="deterministic_fit",
             )
-        except (Exception, KeyboardInterrupt) as outcome_error:  # noqa: BLE001
-            error.add_note(
-                f"ChemEx could not publish the incomplete run outcome: {outcome_error}"
-            )
+        except (Exception, KeyboardInterrupt):  # noqa: BLE001
+            error.add_note("ChemEx could not publish the incomplete run outcome.")
         raise
 
 

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -18,7 +18,7 @@ from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
 from chemex.experiments.builder import build_experiments
 from chemex.messages import (
-    console,
+    error_console,
     print_logo,
     print_method_v1_deprecation_warning,
     print_no_data,
@@ -140,7 +140,7 @@ def _read_fit_methods(args: Namespace) -> MethodPlan:
     try:
         plan = read_method_plan(args.method)
     except MethodFormatError as error:
-        console.print(f"[red] -- ERROR: {error}")
+        error_console.print(f"[red] -- ERROR: {error}")
         sys.exit(1)
     if plan.format_origin is FormatOrigin.V1:
         print_method_v1_deprecation_warning()

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -14,7 +14,7 @@ Typical usage example:
   print_loading_experiments()
 """
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import replace
 from pathlib import Path
@@ -41,6 +41,21 @@ from chemex.optimize.progress import (
 )
 
 console = Console()
+error_console = Console(stderr=True)
+
+
+def print_cli_diagnostic(
+    message: str,
+    notes: Sequence[str],
+    interrupted: bool,
+) -> None:
+    """Render one literal terminal diagnostic to stderr."""
+    if interrupted:
+        error_console.print(Text(message, style="red"))
+    else:
+        error_console.print(Text(f"ERROR: {message}", style="red"))
+    for note in notes:
+        error_console.print(Text(f"NOTE: {note}", style="yellow"))
 
 
 class MinimizationProgressReporter:
@@ -750,8 +765,8 @@ def print_file_not_found(filename: Path) -> None:
         filename (Path): The path of the file that was not found.
 
     """
-    console.print()
-    console.print(f"[red]The file '{filename}' is empty or does not exist!")
+    error_console.print()
+    error_console.print(f"[red]The file '{filename}' is empty or does not exist!")
 
 
 def print_file_not_found_error(error: FileNotFoundError) -> None:
@@ -761,14 +776,14 @@ def print_file_not_found_error(error: FileNotFoundError) -> None:
         error (FileNotFoundError): The FileNotFoundError exception instance.
 
     """
-    console.print()
-    console.print(f"[red]Error: {error}")
+    error_console.print()
+    error_console.print(f"[red]Error: {error}")
 
 
 def print_dataset_error(filename: Path, explanation: str) -> None:
     """Display a concise error for invalid user-supplied dataset content."""
-    console.print()
-    console.print(f"[red]Error: Invalid data in '{filename}': {explanation}")
+    error_console.print()
+    error_console.print(f"[red]Error: Invalid data in '{filename}': {explanation}")
 
 
 def print_toml_error(filename: Path, error_message: Exception) -> None:
@@ -779,12 +794,12 @@ def print_toml_error(filename: Path, error_message: Exception) -> None:
         error_message (Exception): The exception instance with the error message.
 
     """
-    console.print()
-    console.print(Text.from_markup(f"[red]Error in the TOML file '{filename}'"))
-    console.print(
+    error_console.print()
+    error_console.print(Text.from_markup(f"[red]Error in the TOML file '{filename}'"))
+    error_console.print(
         Text.from_markup(f"[red]-> {error_message}\n"),
     )
-    console.print(
+    error_console.print(
         "Please check the website [link]https://toml.io[/]"
         " for a complete description of the TOML format.",
     )
@@ -797,12 +812,14 @@ def print_experiment_name_error(filename: Path) -> None:
         filename (Path): Path of the file with the missing experiment name.
 
     """
-    console.print()
-    console.print(f"[red]The experiment name is missing from the file '{filename}'\n")
-    console.print(
+    error_console.print()
+    error_console.print(
+        f"[red]The experiment name is missing from the file '{filename}'\n"
+    )
+    error_console.print(
         f"Please make sure that the 'name' field is provided in '{filename}':\n",
     )
-    console.print(
+    error_console.print(
         Syntax(EXPERIMENT_NAME, "toml"),
         "\nRun 'chemex info' to obtain the full list of the available experiments.",
     )
@@ -810,20 +827,20 @@ def print_experiment_name_error(filename: Path) -> None:
 
 def print_experiment_type_error(filename: Path, name: str) -> None:
     """Display an error when an input names an unknown Experiment Type."""
-    console.print()
-    console.print(
+    error_console.print()
+    error_console.print(
         f"[red]Unknown Experiment Type '{name}' in the file '{filename}'.[/]",
     )
-    console.print(
+    error_console.print(
         "Run 'chemex info' to obtain the full list of available experiments.",
     )
 
 
 def print_experiment_source_error(filename: Path | None, explanation: str) -> None:
     """Display an error for an invalid or stale opened Experiment source."""
-    console.print()
+    error_console.print()
     location = f" for '{filename}'" if filename is not None else ""
-    console.print(f"[red]Invalid Experiment source{location}: {explanation}")
+    error_console.print(f"[red]Invalid Experiment source{location}: {explanation}")
 
 
 def print_pydantic_parsing_error(filename: Path, error: ValidationError) -> None:
@@ -834,32 +851,25 @@ def print_pydantic_parsing_error(filename: Path, error: ValidationError) -> None
         error (ValidationError): Instance detailing parsing errors.
 
     """
-    console.print()
-    console.print(Text.from_markup(f"[red]Error(s) while parsing '{filename}'"))
+    error_console.print()
+    error_console.print(Text.from_markup(f"[red]Error(s) while parsing '{filename}'"))
     for err in error.errors():
         location = " -> ".join(str(loc) for loc in err["loc"])
-        console.print("  • ", location, ":", err["msg"], style="red")
+        error_console.print("  • ", location, ":", err["msg"], style="red")
 
 
 def print_calculation_stopped_error() -> None:
     """Inform the user that the calculation was manually stopped."""
-    console.print()
-    console.print("[red] -- Keyboard Interrupt: Calculation stopped --")
-    console.print()
-
-
-def print_plotting_canceled() -> None:
-    """Display a message indicating that the plotting process was cancelled."""
-    console.print()
-    console.print("[red] -- Keyboard Interrupt: Plotting cancelled --")
-    console.print()
+    error_console.print()
+    error_console.print("[red] -- Keyboard Interrupt: Calculation stopped --")
+    error_console.print()
 
 
 def print_value_error() -> None:
     """Inform the user that a ValueError occurred, stopping the calculation."""
-    console.print()
-    console.print("[red] -- Got a ValueError: Calculation stopped --")
-    console.print()
+    error_console.print()
+    error_console.print("[red] -- Got a ValueError: Calculation stopped --")
+    error_console.print()
 
 
 def print_warning_positive_jnh() -> None:
@@ -896,19 +906,19 @@ def print_error_grid_settings(entry: str, detail: str | None = None) -> None:
         detail (str | None): Optional explanation of the validation failure.
 
     """
-    console.print()
-    console.print("[red] -- ERROR: Error reading grid settings:")
-    console.print(Text(f'    "{entry}"', style="red"))
+    error_console.print()
+    error_console.print("[red] -- ERROR: Error reading grid settings:")
+    error_console.print(Text(f'    "{entry}"', style="red"))
     if detail is not None:
-        console.print(Text(f"    {detail}", style="red"))
-    console.print()
-    console.print(
+        error_console.print(Text(f"    {detail}", style="red"))
+    error_console.print()
+    error_console.print(
         "Please make sure that the grid settings are provided in the correct format",
     )
-    console.print(Text("    [PB] = lin(<min>, <max>, <nb of points>)"))
-    console.print(Text("    [PB] = log(<min>, <max>, <nb of points>)"))
-    console.print(Text("    [PB] = (<value1>, <value2>, ..., <valuen>)"))
-    console.print()
+    error_console.print(Text("    [PB] = lin(<min>, <max>, <nb of points>)"))
+    error_console.print(Text("    [PB] = log(<min>, <max>, <nb of points>)"))
+    error_console.print(Text("    [PB] = (<value1>, <value2>, ..., <valuen>)"))
+    error_console.print()
 
 
 def print_error_constraints(expression: str, detail: str | None = None) -> None:
@@ -919,11 +929,13 @@ def print_error_constraints(expression: str, detail: str | None = None) -> None:
         detail (str | None): Optional explanation of the validation failure.
 
     """
-    console.print()
-    console.print(f'[red] -- ERROR: Error reading constraints -> "{expression}" --')
+    error_console.print()
+    error_console.print(
+        f'[red] -- ERROR: Error reading constraints -> "{expression}" --'
+    )
     if detail is not None:
-        console.print(Text(f"    {detail}", style="red"))
-    console.print()
+        error_console.print(Text(f"    {detail}", style="red"))
+    error_console.print()
 
 
 def print_mcmc_no_vary_warning() -> None:
@@ -961,13 +973,13 @@ def print_model_error(name: str) -> None:
     """
     from chemex.models.factory import model_factory
 
-    console.print()
-    console.print(f"[red] -- ERROR: The model '{name}' is not available.")
-    console.print()
-    console.print("The available models are:")
+    error_console.print()
+    error_console.print(f"[red] -- ERROR: The model '{name}' is not available.")
+    error_console.print()
+    error_console.print("The available models are:")
     for model_name in sorted(model_factory.set):
-        console.print(f"    - '{model_name}'")
-    console.print()
+        error_console.print(f"    - '{model_name}'")
+    error_console.print()
 
 
 def print_model_suffix_error(
@@ -978,15 +990,15 @@ def print_model_suffix_error(
     """Display an error message for unsupported model suffixes."""
     suffixes = ", ".join(f"'.{suffix}'" for suffix in sorted(unknown_suffixes))
 
-    console.print()
-    console.print(
+    error_console.print()
+    error_console.print(
         f"[red] -- ERROR: The model '{name}' uses unsupported suffixes: {suffixes}.",
     )
-    console.print()
-    console.print("The supported model suffixes are:")
+    error_console.print()
+    error_console.print("The supported model suffixes are:")
     for suffix in supported_suffixes:
-        console.print(f"    - '.{suffix}'")
-    console.print()
+        error_console.print(f"    - '.{suffix}'")
+    error_console.print()
 
 
 def print_not_implemented_noise_method_warning(
@@ -1118,12 +1130,12 @@ def print_method_error(filename: Path, section: str, options: set[int | str]) ->
         options (set[int | str]): Set of options or methods that are incorrect.
 
     """
-    console.print()
-    console.print(
+    error_console.print()
+    error_console.print(
         f"[red] -- ERROR: Error reading section '[{section}]' of '{filename}' --",
     )
     for option in options:
-        console.print(
+        error_console.print(
             METHOD_ERROR_MESSAGES.get(str(option), print_wrong_option(str(option))),
         )
-    console.print()
+    error_console.print()

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -14,7 +14,7 @@ Typical usage example:
   print_loading_experiments()
 """
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import replace
 from pathlib import Path
@@ -44,18 +44,9 @@ console = Console()
 error_console = Console(stderr=True)
 
 
-def print_cli_diagnostic(
-    message: str,
-    notes: Sequence[str],
-    interrupted: bool,
-) -> None:
+def print_cli_diagnostic(message: str) -> None:
     """Render one literal terminal diagnostic to stderr."""
-    if interrupted:
-        error_console.print(Text(message, style="red"))
-    else:
-        error_console.print(Text(f"ERROR: {message}", style="red"))
-    for note in notes:
-        error_console.print(Text(f"NOTE: {note}", style="yellow"))
+    error_console.print(Text(message, style="red"))
 
 
 class MinimizationProgressReporter:

--- a/src/chemex/models/model.py
+++ b/src/chemex/models/model.py
@@ -31,7 +31,7 @@ class ModelSpec:
 
         if name not in model_factory.set:
             print_model_error(name)
-            sys.exit()
+            sys.exit(1)
         return name
 
     @staticmethod
@@ -43,7 +43,7 @@ class ModelSpec:
                 unknown_suffixes,
                 SUPPORTED_MODEL_EXTENSIONS,
             )
-            sys.exit()
+            sys.exit(1)
         return set(extensions)
 
     @classmethod

--- a/src/chemex/optimize/deterministic_uncertainty.py
+++ b/src/chemex/optimize/deterministic_uncertainty.py
@@ -26,13 +26,14 @@ from chemex.optimize.uncertainty import (
     ParameterUnit,
     ResidualVarianceScaling,
     RootAnchoredBlockCovarianceEvidence,
+    RootAnchoredBlockCovarianceOperation,
     UncertaintyConstructionError,
     UncertaintyEvidence,
     UncertaintyPolicy,
     UncertaintyUnavailableKind,
     compile_constraint_linearization_capabilities,
-    derive_root_anchored_block_covariance,
     derive_uncertainty_evidence,
+    execute_root_anchored_block_covariance,
 )
 from chemex.parameters.parameterization import (
     ActiveParameterization,
@@ -130,7 +131,7 @@ class DeterministicUncertainty:
         repr=False,
         compare=False,
     )
-    block_evidence: RootAnchoredBlockCovarianceEvidence | None = field(
+    block_operation: RootAnchoredBlockCovarianceOperation | None = field(
         default=None,
         repr=False,
         compare=False,
@@ -151,7 +152,7 @@ class DeterministicUncertainty:
         self._validate_interpretation_state()
 
     def _validate_evidence_lineage(self) -> None:
-        if self.block_evidence is not None and self.root_evidence is None:
+        if self.block_operation is not None and self.root_evidence is None:
             raise UncertaintyConstructionError(
                 "Block uncertainty Evidence requires root Evidence"
             )
@@ -164,9 +165,9 @@ class DeterministicUncertainty:
                 raise UncertaintyConstructionError(
                     "Root Evidence does not belong to this deterministic uncertainty"
                 )
-        if self.block_evidence is not None:
-            block = self.block_evidence
-            if block.source_bundle is not self.root_evidence:
+        if self.block_operation is not None:
+            operation = self.block_operation
+            if operation.source_bundle is not self.root_evidence:
                 raise UncertaintyConstructionError(
                     "Block Evidence does not belong to this deterministic uncertainty"
                 )
@@ -176,7 +177,7 @@ class DeterministicUncertainty:
             if (
                 self.completeness is not InterpretationCompleteness.COMPLETE
                 or self.root_evidence is not None
-                or self.block_evidence is not None
+                or self.block_operation is not None
                 or self.incomplete_terminal is not None
                 or any(
                     item.reportable
@@ -205,6 +206,14 @@ class DeterministicUncertainty:
             raise UncertaintyConstructionError(
                 "Complete evaluated uncertainty requires root Evidence"
             )
+        if self.block_operation is not None:
+            complete_blocks = self.block_operation.complete_evidence is not None
+            if (
+                self.completeness is InterpretationCompleteness.COMPLETE
+            ) != complete_blocks:
+                raise UncertaintyConstructionError(
+                    "Block operation and uncertainty completeness disagree"
+                )
         if any(
             not item.reportable and item.unavailable_kind is None
             for item in self.parameters
@@ -227,10 +236,27 @@ class DeterministicUncertainty:
             and self.root_evidence.covariance is not None
             and self.root_evidence.covariance.boundary_warning
         )
-        block_warning = self.block_evidence is not None and any(
-            block.boundary_warning for block in self.block_evidence.blocks
+        block_warning = self.block_operation is not None and any(
+            block.boundary_warning for block in self.block_operation.completed_blocks
         )
         return root_warning or block_warning
+
+    @property
+    def block_evidence(self) -> RootAnchoredBlockCovarianceEvidence | None:
+        """Return complete block Evidence when the full partition exists."""
+        return (
+            None
+            if self.block_operation is None
+            else self.block_operation.complete_evidence
+        )
+
+    @property
+    def derivation_interrupted(self) -> bool:
+        """Whether uncertainty execution was interrupted, independently of science."""
+        return self.incomplete_terminal is OperationTerminal.INTERRUPTED or (
+            self.block_operation is not None
+            and self.block_operation.terminal is OperationTerminal.INTERRUPTED
+        )
 
     @property
     def root_covariance_available(self) -> bool:
@@ -248,8 +274,9 @@ class DeterministicUncertainty:
     @property
     def block_covariance_available(self) -> bool:
         """Whether any root-anchored recovery block has covariance."""
-        return self.block_evidence is not None and any(
-            block.covariance is not None for block in self.block_evidence.blocks
+        return self.block_operation is not None and any(
+            block.covariance is not None
+            for block in self.block_operation.completed_blocks
         )
 
 
@@ -450,7 +477,7 @@ def _constrained_boundary_warning_ids(
 
 def _interpret_evidence(
     evidence: UncertaintyEvidence,
-    block_evidence: RootAnchoredBlockCovarianceEvidence | None,
+    block_operation: RootAnchoredBlockCovarianceOperation | None,
     inputs: _ResolvedUncertaintyInputs,
 ) -> tuple[ParameterUncertaintyConclusion, ...]:
     standard_errors: dict[str, float] = {}
@@ -509,13 +536,13 @@ def _interpret_evidence(
         )
         for param_id in inputs.unsupported_constrained_ids
     )
-    if block_evidence is not None:
-        block_controlled_warning_ids = block_evidence.simple_bound_warning_ids
+    if block_operation is not None:
+        block_controlled_warning_ids = block_operation.simple_bound_warning_ids
         block_constrained_warning_ids = _constrained_boundary_warning_ids(
-            block_evidence.source_bundle,
+            block_operation.source_bundle,
             block_controlled_warning_ids,
         )
-        for block in block_evidence.blocks:
+        for block in block_operation.completed_blocks:
             recovered_ids: set[str] = set()
             for entry in (*block.marginal_errors, *block.constrained_marginal_errors):
                 if entry.value is not None:
@@ -614,7 +641,7 @@ def derive_deterministic_uncertainty(
             incomplete_terminal=OperationTerminal.INTERRUPTED,
         )
     try:
-        block_evidence = derive_root_anchored_block_covariance(
+        block_operation = execute_root_anchored_block_covariance(
             root_evidence,
             facts.basis.partition_proof,
         )
@@ -628,12 +655,18 @@ def derive_deterministic_uncertainty(
             root_evidence,
             incomplete_terminal=OperationTerminal.INTERRUPTED,
         )
+    complete = block_operation is None or block_operation.complete_evidence is not None
     return DeterministicUncertainty(
-        facts.accepted,
-        inputs.policy,
-        InterpretationCompleteness.COMPLETE,
-        DerivationDisposition.EVALUATED,
-        _interpret_evidence(root_evidence, block_evidence, inputs),
-        root_evidence,
-        block_evidence,
+        accepted_anchor=facts.accepted,
+        policy=inputs.policy,
+        completeness=(
+            InterpretationCompleteness.COMPLETE
+            if complete
+            else InterpretationCompleteness.INCOMPLETE
+        ),
+        disposition=DerivationDisposition.EVALUATED,
+        parameters=_interpret_evidence(root_evidence, block_operation, inputs),
+        root_evidence=root_evidence,
+        block_operation=block_operation,
+        incomplete_terminal=(None if complete else OperationTerminal.INTERRUPTED),
     )

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -9,7 +9,6 @@ from scipy import stats
 from chemex.containers.experiments import Experiments
 from chemex.messages import (
     print_making_plots,
-    print_plotting_canceled,
     print_writing_results,
 )
 from chemex.optimize.deterministic_uncertainty import (
@@ -24,6 +23,7 @@ from chemex.parameters.parameterization import (
     SealedParameterModel,
 )
 from chemex.printers.native_reporting import (
+    write_block_recovery,
     write_block_uncertainty,
     write_json,
     write_uncertainty,
@@ -108,12 +108,17 @@ def _write_files(
         deterministic_uncertainty=deterministic_uncertainty,
     )
     experiments.write(path)
-    _write_statistics(
-        experiments,
-        path=path,
-        residuals=residuals,
-        nvarys=nvarys,
+    uncertainty_interrupted = (
+        deterministic_uncertainty is not None
+        and deterministic_uncertainty.derivation_interrupted
     )
+    if not uncertainty_interrupted:
+        _write_statistics(
+            experiments,
+            path=path,
+            residuals=residuals,
+            nvarys=nvarys,
+        )
     if (
         deterministic_uncertainty is not None
         and deterministic_uncertainty.root_evidence is not None
@@ -124,6 +129,10 @@ def _write_files(
         write_block_uncertainty(
             statistics_path,
             deterministic_uncertainty.block_evidence,
+        )
+        write_block_recovery(
+            statistics_path,
+            deterministic_uncertainty.block_operation,
         )
     if deterministic_uncertainty is not None and (
         deterministic_uncertainty.disposition is DerivationDisposition.WITHHELD
@@ -181,11 +190,7 @@ def _write_plots(experiments: Experiments, path: Path) -> None:
 
     path_ = path / "Plots"
     path_.mkdir(parents=True, exist_ok=True)
-    try:
-        experiments.plot(path=path_)
-    except KeyboardInterrupt:
-        print_plotting_canceled()
-        raise
+    experiments.plot(path=path_)
 
 
 def _write_simulation_plots(experiments: Experiments, path: Path) -> None:
@@ -194,10 +199,7 @@ def _write_simulation_plots(experiments: Experiments, path: Path) -> None:
 
     path_ = path / "Plots"
     path_.mkdir(parents=True, exist_ok=True)
-    try:
-        experiments.plot_simulation(path=path_)
-    except KeyboardInterrupt:
-        print_plotting_canceled()
+    experiments.plot_simulation(path=path_)
 
 
 def execute_post_fit(
@@ -224,7 +226,11 @@ def execute_post_fit(
         parameterization=parameterization,
         fitted_ids=fitted_ids,
     )
-    if plot:
+    uncertainty_interrupted = (
+        deterministic_uncertainty is not None
+        and deterministic_uncertainty.derivation_interrupted
+    )
+    if plot and not uncertainty_interrupted:
         _write_plots(experiments, path)
 
 

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -807,7 +807,6 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
             remove_paths_best_effort(
                 (statistic_path / name for name in _MCMC_ARTIFACT_NAMES),
                 error,
-                description="interrupted MCMC artifact",
             )
             published_evidence: McmcEvidence | None = None
             published_capture: RawMcmcCapture | None = None
@@ -819,11 +818,9 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
                         fit.parameter_model,
                     )
                     published_evidence = raw_evidence
-                except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
-                    detail = str(publication_error) or type(publication_error).__name__
+                except (Exception, KeyboardInterrupt):  # noqa: BLE001
                     error.add_note(
-                        "ChemEx could not finish interrupted qualified MCMC chain: "
-                        f"{detail}"
+                        "ChemEx could not publish an interrupted qualified MCMC chain."
                     )
             elif raw_capture is not None:
                 try:
@@ -834,11 +831,9 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
                         fit.problem.controlled_ids,
                     )
                     published_capture = raw_capture
-                except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
-                    detail = str(publication_error) or type(publication_error).__name__
+                except (Exception, KeyboardInterrupt):  # noqa: BLE001
                     error.add_note(
-                        "ChemEx could not finish interrupted MCMC execution capture: "
-                        f"{detail}"
+                        "ChemEx could not publish interrupted MCMC execution capture."
                     )
             try:
                 _write_native_mcmc_state_diagnostics(
@@ -855,11 +850,8 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
                     analysis_result=analysis_result,
                     timings=timings,
                 )
-            except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
-                detail = str(publication_error) or type(publication_error).__name__
-                error.add_note(
-                    f"ChemEx could not finish interrupted MCMC diagnostics: {detail}"
-                )
+            except (Exception, KeyboardInterrupt):  # noqa: BLE001
+                error.add_note("ChemEx could not publish interrupted MCMC diagnostics.")
             raise
         _clear_mcmc_artifacts(statistic_path)
         if raw_evidence is not None:

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -10,19 +10,23 @@ from typing import Literal, cast
 
 import numpy as np
 
+from chemex.atomic import open_text_atomic, remove_paths_best_effort, write_text_atomic
 from chemex.configuration.method_plan import McmcRequest
 from chemex.configuration.methods import McmcSettings
 from chemex.containers.experiments import Experiments
 from chemex.optimize.native_deterministic import NativeDeterministicFit
 from chemex.optimize.native_mcmc import (
+    EnsembleState,
     McmcAcceptanceSummary,
     McmcAnalysisFailureCategory,
     McmcAnalysisResult,
     McmcAnalysisStatus,
     McmcAutocorrelationReport,
     McmcEvidence,
+    McmcOperation,
     McmcOperationTerminal,
     McmcPlan,
+    RawMcmcCapture,
     derive_mcmc_analysis_result,
     execute_mcmc_evidence,
     product_mcmc_invalid_bound_ids,
@@ -59,6 +63,16 @@ _TIMING_KEYS = (
     "output_plots_seconds",
     "output_total_seconds",
     "total_seconds",
+)
+
+_MCMC_ARTIFACT_NAMES = (
+    "summary.toml",
+    "samples.tsv",
+    "correlations.tsv",
+    "diagnostics.toml",
+    "plots.pdf",
+    "raw_chain.tsv",
+    "raw_capture.tsv",
 )
 
 
@@ -334,9 +348,18 @@ def _write_raw_chain_evidence(
     parameter_model: SealedParameterModel,
 ) -> None:
     parameter_names = _format_parameter_ids(evidence.coordinate_ids, parameter_model)
-    with (path / "raw_chain.tsv").open("w", encoding="utf-8") as fileout:
+    _write_raw_states(path / "raw_chain.tsv", evidence.states[1:], parameter_names)
+
+
+def _write_raw_states(
+    destination: Path,
+    states: tuple[EnsembleState, ...],
+    parameter_names: tuple[str, ...],
+) -> None:
+    """Write already-selected complete ensemble states atomically."""
+    with open_text_atomic(destination) as fileout:
         fileout.write("\t".join(("step", "walker", *parameter_names, "lnprob")) + "\n")
-        for state in evidence.states[1:]:
+        for state in states:
             for walker, (position, lnprob) in enumerate(
                 zip(state.positions, state.log_densities, strict=True),
             ):
@@ -345,6 +368,16 @@ def _write_raw_chain_evidence(
                     f"{state.ordinal}\t{walker}\t{values}\t"
                     f"{_format_toml_float(lnprob)}\n"
                 )
+
+
+def _write_raw_capture(
+    capture: RawMcmcCapture,
+    path: Path,
+    parameter_model: SealedParameterModel,
+    parameter_ids: tuple[str, ...],
+) -> None:
+    parameter_names = _format_parameter_ids(parameter_ids, parameter_model)
+    _write_raw_states(path / "raw_capture.tsv", capture.states, parameter_names)
 
 
 def _extend_acceptance_diagnostics(
@@ -422,7 +455,7 @@ def _write_diagnostics(
         lines.append(f"root_seed = {root_seed}")
     _extend_autocorrelation_diagnostics(lines, autocorrelation)
     _extend_timing_diagnostics(lines, timings)
-    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_text_atomic(path / "diagnostics.toml", "\n".join(lines) + "\n")
 
 
 def write_mcmc_outputs(
@@ -478,14 +511,7 @@ def write_mcmc_outputs(
 
 
 def _clear_mcmc_artifacts(path: Path) -> None:
-    for name in (
-        "summary.toml",
-        "samples.tsv",
-        "correlations.tsv",
-        "diagnostics.toml",
-        "plots.pdf",
-        "raw_chain.tsv",
-    ):
+    for name in _MCMC_ARTIFACT_NAMES:
         (path / name).unlink(missing_ok=True)
 
 
@@ -500,6 +526,7 @@ def _write_native_mcmc_state_diagnostics(
     completed_steps: int | None = None,
     failure: BaseException | None = None,
     raw_evidence: McmcEvidence | None = None,
+    raw_capture: RawMcmcCapture | None = None,
     analysis_result: McmcAnalysisResult | None = None,
     timings: Mapping[str, float] | None = None,
 ) -> None:
@@ -529,32 +556,58 @@ def _write_native_mcmc_state_diagnostics(
             )
         )
     if raw_evidence is not None:
-        if analysis_result is None:
-            raise RuntimeError(
-                "Diagnostic MCMC Evidence has no authoritative Analysis Result"
-            )
-        raw_steps = analysis_result.raw_step_count
-        raw_samples = analysis_result.raw_sample_count
+        raw_steps = (
+            raw_evidence.completed_transition_count
+            if analysis_result is None
+            else analysis_result.raw_step_count
+        )
+        raw_samples = (
+            raw_steps * raw_evidence.plan.policy.walkers
+            if analysis_result is None
+            else analysis_result.raw_sample_count
+        )
         lines.extend(
             (
                 (
                     "sampling_terminal = "
                     f"{_quote_toml_string(raw_evidence.terminal.value)}"
                 ),
-                'posterior_retention = "failed"',
                 'posterior_summary = "withheld"',
-                'raw_evidence = "diagnostic_chain"',
+                'raw_evidence = "qualified_chain"',
                 'raw_chain_file = "raw_chain.tsv"',
                 f"raw_steps = {raw_steps}",
                 f"raw_samples = {raw_samples}",
                 f"emcee_version = {_quote_toml_string(_package_version('emcee'))}",
-                'convergence_diagnostic = "integrated_autocorrelation_time"',
-                'rhat = "not computed: emcee ensemble walkers are not independent chains"',
             )
         )
-        if analysis_result.acceptance_summary is not None:
+        if terminal == "interrupted":
+            lines.extend(
+                (
+                    'posterior_retention = "withheld"',
+                    'burn_validity = "withheld"',
+                    'convergence = "withheld"',
+                    'correlations = "withheld"',
+                )
+            )
+        else:
+            lines.extend(
+                (
+                    'posterior_retention = "failed"',
+                    'convergence_diagnostic = "integrated_autocorrelation_time"',
+                    'rhat = "not computed: emcee ensemble walkers are not independent chains"',
+                )
+            )
+        if (
+            terminal != "interrupted"
+            and analysis_result is not None
+            and analysis_result.acceptance_summary is not None
+        ):
             _extend_acceptance_diagnostics(lines, analysis_result.acceptance_summary)
-        if analysis_result.autocorrelation_report is not None:
+        if (
+            terminal != "interrupted"
+            and analysis_result is not None
+            and analysis_result.autocorrelation_report is not None
+        ):
             lines.append(
                 "autocorrelation_status = "
                 f"{_quote_toml_string(analysis_result.autocorrelation_report.status)}"
@@ -563,12 +616,35 @@ def _write_native_mcmc_state_diagnostics(
                 lines,
                 analysis_result.autocorrelation_report,
             )
+    elif raw_capture is not None:
+        lines.extend(
+            (
+                (
+                    "sampling_terminal = "
+                    f"{_quote_toml_string(raw_capture.terminal.value)}"
+                ),
+                'posterior_retention = "withheld"',
+                'posterior_summary = "withheld"',
+                'burn_validity = "withheld"',
+                'convergence = "withheld"',
+                'correlations = "withheld"',
+                'acceptance_fraction = "withheld"',
+                'raw_evidence = "execution_capture_unqualified"',
+                'raw_capture_file = "raw_capture.tsv"',
+                f"captured_states = {raw_capture.complete_state_count}",
+                (
+                    "completed_transitions = "
+                    f"{max(0, raw_capture.complete_state_count - 1)}"
+                ),
+                f"emcee_version = {_quote_toml_string(_package_version('emcee'))}",
+            )
+        )
     if timings is not None:
         _extend_timing_diagnostics(lines, timings)
-    (path / "diagnostics.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_text_atomic(path / "diagnostics.toml", "\n".join(lines) + "\n")
 
 
-def run_native_mcmc(
+def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
     experiments: Experiments,
     fit: NativeDeterministicFit,
     request: McmcRequest,
@@ -620,6 +696,7 @@ def run_native_mcmc(
 
     timings: dict[str, float] = {}
     completed_steps = 0
+    mcmc_operation: McmcOperation | None = None
     mcmc_evidence: McmcEvidence | None = None
     analysis_result: McmcAnalysisResult | None = None
     try:
@@ -641,7 +718,7 @@ def run_native_mcmc(
             ),
         )
         phase_start = perf_counter()
-        operation = execute_mcmc_evidence(
+        mcmc_operation = execute_mcmc_evidence(
             fit.accepted,
             plan,
             execution=ExecutionSettings(
@@ -649,27 +726,29 @@ def run_native_mcmc(
                 native_threads=effective.native_threads,
             ),
         )
-        mcmc_evidence = operation.evidence
+        mcmc_evidence = mcmc_operation.evidence
         timings["sampling_seconds"] = perf_counter() - phase_start
-        completed_steps = (
-            0
-            if operation.evidence is None
-            else operation.evidence.completed_transition_count
-        )
+        completed_steps = max(0, mcmc_operation.complete_state_count - 1)
         if (
-            operation.terminal is not McmcOperationTerminal.COMPLETED
-            or operation.evidence is None
+            mcmc_operation.terminal is not McmcOperationTerminal.COMPLETED
+            or mcmc_operation.evidence is None
         ):
             error = NativeMcmcIncompleteError(
-                f"Native MCMC {operation.terminal.value}: {operation.failure_message}",
-                terminal=operation.terminal.value,
+                "Native MCMC "
+                f"{mcmc_operation.terminal.value}: "
+                f"{mcmc_operation.failure_message}",
+                terminal=mcmc_operation.terminal.value,
                 completed_steps=completed_steps,
+                preserve_raw_evidence=(
+                    mcmc_operation.terminal is McmcOperationTerminal.INTERRUPTED
+                    and mcmc_operation.evidence is not None
+                ),
             )
             raise error
         phase_start = perf_counter()
         try:
             analysis_result = derive_mcmc_analysis_result(
-                operation.evidence,
+                mcmc_operation.evidence,
                 request,
                 fit.parameter_model,
             )
@@ -687,7 +766,6 @@ def run_native_mcmc(
             root_seed=root_seed,
         )
     except (Exception, KeyboardInterrupt) as error:
-        _clear_mcmc_artifacts(statistic_path)
         raw_evidence = (
             analysis_result.evidence
             if analysis_result is not None
@@ -695,12 +773,15 @@ def run_native_mcmc(
             and analysis_result.failure is not None
             and analysis_result.failure.preserve_raw_evidence
             else mcmc_evidence
-            if isinstance(error, NativeMcmcIncompleteError)
-            and error.preserve_raw_evidence
+            if (
+                isinstance(error, KeyboardInterrupt)
+                or (
+                    isinstance(error, NativeMcmcIncompleteError)
+                    and error.preserve_raw_evidence
+                )
+            )
             else None
         )
-        if raw_evidence is not None:
-            _write_raw_chain_evidence(raw_evidence, statistic_path, fit.parameter_model)
         terminal = (
             error.terminal
             if isinstance(error, NativeMcmcIncompleteError)
@@ -713,6 +794,80 @@ def run_native_mcmc(
             if isinstance(error, NativeMcmcIncompleteError)
             else completed_steps
         )
+        raw_capture = (
+            mcmc_operation.raw_capture
+            if terminal == "interrupted"
+            and raw_evidence is None
+            and mcmc_operation is not None
+            and mcmc_operation.raw_capture is not None
+            and mcmc_operation.raw_capture.complete_state_count > 0
+            else None
+        )
+        if terminal == "interrupted":
+            remove_paths_best_effort(
+                (statistic_path / name for name in _MCMC_ARTIFACT_NAMES),
+                error,
+                description="interrupted MCMC artifact",
+            )
+            published_evidence: McmcEvidence | None = None
+            published_capture: RawMcmcCapture | None = None
+            if raw_evidence is not None:
+                try:
+                    _write_raw_chain_evidence(
+                        raw_evidence,
+                        statistic_path,
+                        fit.parameter_model,
+                    )
+                    published_evidence = raw_evidence
+                except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
+                    detail = str(publication_error) or type(publication_error).__name__
+                    error.add_note(
+                        "ChemEx could not finish interrupted qualified MCMC chain: "
+                        f"{detail}"
+                    )
+            elif raw_capture is not None:
+                try:
+                    _write_raw_capture(
+                        raw_capture,
+                        statistic_path,
+                        fit.parameter_model,
+                        fit.problem.controlled_ids,
+                    )
+                    published_capture = raw_capture
+                except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
+                    detail = str(publication_error) or type(publication_error).__name__
+                    error.add_note(
+                        "ChemEx could not finish interrupted MCMC execution capture: "
+                        f"{detail}"
+                    )
+            try:
+                _write_native_mcmc_state_diagnostics(
+                    statistic_path,
+                    settings=effective,
+                    root_seed=root_seed,
+                    parameter_ids=fit.problem.controlled_ids,
+                    status="incomplete",
+                    terminal=terminal,
+                    completed_steps=failure_completed_steps,
+                    failure=error,
+                    raw_evidence=published_evidence,
+                    raw_capture=published_capture,
+                    analysis_result=analysis_result,
+                    timings=timings,
+                )
+            except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
+                detail = str(publication_error) or type(publication_error).__name__
+                error.add_note(
+                    f"ChemEx could not finish interrupted MCMC diagnostics: {detail}"
+                )
+            raise
+        _clear_mcmc_artifacts(statistic_path)
+        if raw_evidence is not None:
+            _write_raw_chain_evidence(
+                raw_evidence,
+                statistic_path,
+                fit.parameter_model,
+            )
         _write_native_mcmc_state_diagnostics(
             statistic_path,
             settings=effective,
@@ -723,6 +878,7 @@ def run_native_mcmc(
             completed_steps=failure_completed_steps,
             failure=error,
             raw_evidence=raw_evidence,
+            raw_capture=None,
             analysis_result=analysis_result,
             timings=timings,
         )

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -91,10 +91,7 @@ def _propagate_uncertainty_interruption(
     error = KeyboardInterrupt("Native deterministic uncertainty derivation interrupted")
     mark_failure_stage(error, "uncertainty")
     if finalization_error is not None:
-        detail = str(finalization_error) or type(finalization_error).__name__
-        error.add_note(
-            f"ChemEx could not finish interrupted uncertainty output: {detail}"
-        )
+        error.add_note("ChemEx could not publish interrupted uncertainty output.")
         raise error from finalization_error
     raise error
 

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from functools import reduce
 from operator import and_
 from pathlib import Path
+from typing import Never
 
 import numpy as np
 
@@ -82,6 +83,20 @@ from chemex.runtime.environment import RuntimeEnvironment
 # The finalized #573/#664 policy uses 2000 * (nvars + 1), with numerical
 # Jacobian requests counted in the same total objective-request ceiling.
 _TRF_OBJECTIVE_REQUESTS_PER_DIMENSION = 2000
+
+
+def _propagate_uncertainty_interruption(
+    finalization_error: BaseException | None = None,
+) -> Never:
+    error = KeyboardInterrupt("Native deterministic uncertainty derivation interrupted")
+    mark_failure_stage(error, "uncertainty")
+    if finalization_error is not None:
+        detail = str(finalization_error) or type(finalization_error).__name__
+        error.add_note(
+            f"ChemEx could not finish interrupted uncertainty output: {detail}"
+        )
+        raise error from finalization_error
+    raise error
 
 
 @dataclass(frozen=True, slots=True)
@@ -510,9 +525,12 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
         parameter_model,
         deterministic_uncertainty,
     )
+    uncertainty_interrupted = deterministic_uncertainty.derivation_interrupted
     try:
         _materialize_evaluation(experiments, result)
     except (Exception, KeyboardInterrupt) as error:
+        if uncertainty_interrupted:
+            _propagate_uncertainty_interruption(error)
         mark_failure_stage(error, "output")
         raise
     variable_count = len(problem.controlled_ids)
@@ -539,8 +557,12 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
                 fitted_ids=problem.controlled_ids,
             )
         except (Exception, KeyboardInterrupt) as error:
+            if uncertainty_interrupted:
+                _propagate_uncertainty_interruption(error)
             mark_failure_stage(error, "output")
             raise
+        if uncertainty_interrupted:
+            _propagate_uncertainty_interruption()
         return fit
 
     try:
@@ -557,6 +579,10 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
             fitted_ids=problem.controlled_ids,
         )
     except (Exception, KeyboardInterrupt) as error:
+        if uncertainty_interrupted:
+            _propagate_uncertainty_interruption(error)
         mark_failure_stage(error, "output")
         raise
+    if uncertainty_interrupted:
+        _propagate_uncertainty_interruption()
     return fit

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -2437,13 +2437,21 @@ class McmcOperation:
             raise McmcConstructionError(
                 "Non-completed MCMC operation requires typed failure evidence"
             )
-        if (
-            self.raw_capture is None
-            or self.validation is None
-            or self.backend_transition_evidence is None
-        ):
+        if self.raw_capture is None or self.backend_transition_evidence is None:
             raise McmcConstructionError(
                 "Every MCMC operation requires raw and backend diagnostic evidence"
+            )
+        if self.validation is None:
+            if (
+                self.evidence is not None
+                or self.terminal is not McmcOperationTerminal.INTERRUPTED
+            ):
+                raise McmcConstructionError(
+                    "Only interrupted MCMC may retain unqualified raw capture"
+                )
+        elif self.validation.primary_evidence is not self.evidence:
+            raise McmcConstructionError(
+                "MCMC operation Evidence differs from fresh validation"
             )
         if (
             self.backend_transition_evidence.kind
@@ -2466,7 +2474,6 @@ class McmcOperation:
 
     def _content_identity(self) -> str:
         capture = cast("RawMcmcCapture", self.raw_capture)
-        validation = cast("McmcChainValidation", self.validation)
         backend = cast(
             "BackendTransitionEvidence",
             self.backend_transition_evidence,
@@ -2479,7 +2486,7 @@ class McmcOperation:
                 self.failure_category,
                 self.failure_message,
                 capture.identity,
-                validation.identity,
+                None if self.validation is None else self.validation.identity,
                 backend.identity,
             ),
         )
@@ -2497,8 +2504,8 @@ class McmcOperation:
     def validate_integrity(self) -> None:
         capture = cast("RawMcmcCapture", self.raw_capture)
         capture.validate_integrity()
-        validation = cast("McmcChainValidation", self.validation)
-        validation.validate_integrity()
+        if self.validation is not None:
+            self.validation.validate_integrity()
         backend = cast(
             "BackendTransitionEvidence",
             self.backend_transition_evidence,
@@ -2533,7 +2540,7 @@ def _mint_mcmc_operation(
     failure_category: str | None,
     failure_message: str,
     raw_capture: RawMcmcCapture,
-    validation: McmcChainValidation,
+    validation: McmcChainValidation | None,
     backend_transition_evidence: BackendTransitionEvidence,
 ) -> McmcOperation:
     return McmcOperation(
@@ -3694,6 +3701,10 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     stage = McmcExecutionStage.BEFORE_INITIALIZATION
     initialization_outcome = McmcInitializationOutcome.NOT_STARTED
     execution_settings = ExecutionSettings() if execution is None else execution
+    raw_capture: RawMcmcCapture | None = None
+    validation: McmcChainValidation | None = None
+    backend_transition_evidence: BackendTransitionEvidence | None = None
+    evidence: McmcEvidence | None = None
 
     def checkpoint(next_stage: McmcExecutionStage) -> None:
         nonlocal stage
@@ -3794,12 +3805,12 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
         validation = validate_raw_mcmc_capture(plan, raw_capture)
         if not validation.is_complete or validation.primary_evidence is None:
             raise McmcExecutionError("fresh MCMC validation did not complete")
+        evidence = validation.primary_evidence
         checkpoint(McmcExecutionStage.BEFORE_FINAL_ASSEMBLY)
         backend_transition_evidence = _mint_observed_backend_transition_evidence(
             backend_observation,
             raw_capture,
         )
-        evidence = validation.primary_evidence
         object.__setattr__(
             evidence,
             "backend_transition_evidence",
@@ -3833,29 +3844,43 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
         message = str(error)
         if initialization_outcome is McmcInitializationOutcome.NOT_STARTED:
             initialization_outcome = McmcInitializationOutcome.FAILED
-    raw_capture = _mint_raw_capture(
-        plan,
-        terminal,
-        tuple(states),
-        log_density.objective_request_count,
-        log_density.evaluation_request_count,
-        stage,
-        initialization_outcome,
-        backend_observation,
-        category,
-    )
-    backend_transition_evidence = _mint_observed_backend_transition_evidence(
-        backend_observation,
-        raw_capture,
-    )
-    validation = validate_raw_mcmc_capture(
-        plan,
-        raw_capture,
-        backend_transition_evidence=backend_transition_evidence,
-    )
+    if raw_capture is None or terminal is not McmcOperationTerminal.INTERRUPTED:
+        raw_capture = _mint_raw_capture(
+            plan,
+            terminal,
+            tuple(states),
+            log_density.objective_request_count,
+            log_density.evaluation_request_count,
+            stage,
+            initialization_outcome,
+            backend_observation,
+            category,
+        )
+        backend_transition_evidence = None
+        validation = None
+        evidence = None
+    if backend_transition_evidence is None:
+        backend_transition_evidence = _mint_observed_backend_transition_evidence(
+            backend_observation,
+            raw_capture,
+        )
+        if evidence is not None:
+            object.__setattr__(
+                evidence,
+                "backend_transition_evidence",
+                backend_transition_evidence,
+            )
+            evidence.validate_integrity()
+    if terminal is not McmcOperationTerminal.INTERRUPTED:
+        validation = validate_raw_mcmc_capture(
+            plan,
+            raw_capture,
+            backend_transition_evidence=backend_transition_evidence,
+        )
+        evidence = validation.primary_evidence
     return _mint_mcmc_operation(
         terminal,
-        validation.primary_evidence,
+        evidence,
         category,
         message,
         raw_capture,

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -9,7 +9,7 @@ from typing import cast
 
 import numpy as np
 
-from chemex.atomic import write_text_atomic
+from chemex.atomic import open_text_atomic, remove_paths_best_effort, write_text_atomic
 from chemex.configuration.method_plan import ResamplingKind, ResamplingRequest
 from chemex.containers.experiments import Experiments
 from chemex.messages import print_running_statistics
@@ -24,6 +24,7 @@ from chemex.optimize.native_resampling import (
     ResamplingAnalysisStatus,
     ResamplingAnalysisSummary,
     ResamplingDatasetManifest,
+    ResamplingEvidence,
     ResamplingOperation,
     ResamplingPlan,
     ResamplingScheme,
@@ -47,6 +48,10 @@ class _ResamplingMethod:
 
 class NativeResamplingIncompleteError(RuntimeError):
     """Raised after truthful incomplete native statistics have been published."""
+
+    def __init__(self, message: str, *, terminal: str = "failed") -> None:
+        super().__init__(message)
+        self.terminal = terminal
 
 
 def _resampling_result_and_samples(
@@ -258,7 +263,7 @@ def _write_native_failures(path: Path, outcomes: Sequence[ReplicateOutcome]) -> 
     failed = tuple(outcome for outcome in outcomes if outcome.failure is not None)
     if not failed:
         return
-    with (path / "failures.tsv").open("w", encoding="utf-8") as output:
+    with open_text_atomic(path / "failures.tsv") as output:
         output.write("ordinal\tdisposition\tcategory\tmessage\n")
         for outcome in failed:
             failure = outcome.failure
@@ -271,6 +276,49 @@ def _write_native_failures(path: Path, outcomes: Sequence[ReplicateOutcome]) -> 
             )
 
 
+def _write_native_samples(
+    path: Path,
+    parameter_names: tuple[str, ...],
+    samples: Sequence[ResamplingAnalysisSample],
+) -> None:
+    with open_text_atomic(path / "samples.tsv") as output:
+        output.write("\t".join((*parameter_names, "chisqr")) + "\n")
+        for sample in samples:
+            output.write(
+                "\t".join(
+                    _format_tsv_float(value)
+                    for value in (*sample.values, float(sample.chi_square))
+                )
+                + "\n"
+            )
+
+
+def _disposition_counts(
+    source: ResamplingEvidence | ResamplingAnalysisResult | None = None,
+    *,
+    unstarted: int = 0,
+) -> tuple[tuple[str, int], ...]:
+    """Map authoritative dispositions to their diagnostic representation."""
+    if source is None:
+        return (
+            ("completed_samples", 0),
+            ("failed_samples", 0),
+            ("cancelled_samples", 0),
+            ("interrupted_samples", 0),
+            ("unstarted_samples", unstarted),
+        )
+    return tuple(
+        (name, source.disposition_count(disposition))
+        for name, disposition in (
+            ("completed_samples", ReplicateDisposition.SUCCEEDED),
+            ("failed_samples", ReplicateDisposition.FAILED),
+            ("cancelled_samples", ReplicateDisposition.CANCELLED),
+            ("interrupted_samples", ReplicateDisposition.INTERRUPTED),
+            ("unstarted_samples", ReplicateDisposition.NOT_STARTED),
+        )
+    )
+
+
 def _write_native_state_diagnostics(
     path: Path,
     *,
@@ -279,11 +327,7 @@ def _write_native_state_diagnostics(
     parameter_ids: tuple[str, ...],
     root_seed: int,
     status: str,
-    successful_samples: int | None = None,
-    failed_samples: int | None = None,
-    cancelled_samples: int | None = None,
-    interrupted_samples: int | None = None,
-    unstarted_samples: int | None = None,
+    sample_counts: Sequence[tuple[str, int]] = (),
     terminal: str | None = None,
     failure: BaseException | None = None,
 ) -> None:
@@ -299,16 +343,7 @@ def _write_native_state_diagnostics(
     ]
     if terminal is not None:
         lines.append(f"terminal = {_quote_toml_string(terminal)}")
-    sample_counts = (
-        ("completed_samples", successful_samples),
-        ("failed_samples", failed_samples),
-        ("cancelled_samples", cancelled_samples),
-        ("interrupted_samples", interrupted_samples),
-        ("unstarted_samples", unstarted_samples),
-    )
-    lines.extend(
-        f"{name} = {count}" for name, count in sample_counts if count is not None
-    )
+    lines.extend(f"{name} = {count}" for name, count in sample_counts)
     if status == "incomplete":
         if (path / "samples.tsv").is_file():
             lines.append('samples_file = "samples.tsv"')
@@ -337,19 +372,7 @@ def _clear_native_statistics_artifacts(path: Path) -> None:
         (path / name).unlink(missing_ok=True)
 
 
-def _remove_failed_publication_artifacts(
-    path: Path,
-    names: Sequence[str],
-    failure: BaseException,
-) -> None:
-    for name in names:
-        try:
-            (path / name).unlink(missing_ok=True)
-        except (Exception, KeyboardInterrupt) as cleanup_error:  # noqa: BLE001
-            failure.add_note(f"ChemEx could not remove {name}: {cleanup_error}")
-
-
-def _run_native_resampling_method(
+def _run_native_resampling_method(  # noqa: C901 - closed execution/publication lifecycle
     experiments: Experiments,
     path: Path,
     method: _ResamplingMethod,
@@ -409,26 +432,36 @@ def _run_native_resampling_method(
         )
     except (Exception, KeyboardInterrupt) as error:
         terminal = "interrupted" if isinstance(error, KeyboardInterrupt) else "failed"
-        _write_native_state_diagnostics(
-            statistic_path,
-            method=method,
-            workers=worker_count,
-            parameter_ids=parameter_ids,
-            root_seed=root_seed,
-            status="incomplete",
-            successful_samples=0,
-            failed_samples=0,
-            cancelled_samples=0,
-            interrupted_samples=0,
-            unstarted_samples=method.iterations,
-            terminal=terminal,
-            failure=error,
-        )
+        try:
+            _write_native_state_diagnostics(
+                statistic_path,
+                method=method,
+                workers=worker_count,
+                parameter_ids=parameter_ids,
+                root_seed=root_seed,
+                status="incomplete",
+                sample_counts=_disposition_counts(unstarted=method.iterations),
+                terminal=terminal,
+                failure=error,
+            )
+        except (Exception, KeyboardInterrupt) as diagnostics_error:
+            if terminal != "interrupted":
+                raise
+            detail = str(diagnostics_error) or type(diagnostics_error).__name__
+            error.add_note(
+                f"ChemEx could not publish interrupted resampling diagnostics: {detail}"
+            )
+            remove_paths_best_effort(
+                (statistic_path / "diagnostics.toml",),
+                error,
+                description="resampling artifact",
+            )
         raise
     evidence = operation.evidence
     if evidence is None:
         error = NativeResamplingIncompleteError(
-            f"Native {method.message} produced no replicate evidence"
+            f"Native {method.message} produced no replicate evidence",
+            terminal=operation.terminal.value,
         )
         _write_native_state_diagnostics(
             statistic_path,
@@ -437,11 +470,7 @@ def _run_native_resampling_method(
             parameter_ids=parameter_ids,
             root_seed=root_seed,
             status="incomplete",
-            successful_samples=0,
-            failed_samples=0,
-            cancelled_samples=0,
-            interrupted_samples=0,
-            unstarted_samples=method.iterations,
+            sample_counts=_disposition_counts(unstarted=method.iterations),
             terminal=operation.terminal.value,
             failure=error,
         )
@@ -464,15 +493,7 @@ def _run_native_resampling_method(
         samples = np.asarray(sample_rows, dtype=float).reshape(
             (len(sample_rows), len(parameter_ids))
         )
-        with (statistic_path / "samples.tsv").open("w", encoding="utf-8") as output:
-            output.write("\t".join((*parameter_names, "chisqr")) + "\n")
-            for values, chisqr in zip(sample_rows, chisqr_rows, strict=True):
-                output.write(
-                    "\t".join(
-                        _format_tsv_float(value) for value in (*values, float(chisqr))
-                    )
-                    + "\n"
-                )
+        _write_native_samples(statistic_path, parameter_names, analysis_samples)
         samples_published = True
         if not complete:
             _write_native_failures(statistic_path, evidence.outcomes)
@@ -485,21 +506,7 @@ def _run_native_resampling_method(
                 parameter_ids=parameter_ids,
                 root_seed=root_seed,
                 status="incomplete",
-                successful_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.SUCCEEDED
-                ),
-                failed_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.FAILED
-                ),
-                cancelled_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.CANCELLED
-                ),
-                interrupted_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.INTERRUPTED
-                ),
-                unstarted_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.NOT_STARTED
-                ),
+                sample_counts=_disposition_counts(disposition_source),
                 terminal=operation.terminal.value,
             )
         else:
@@ -548,13 +555,53 @@ def _run_native_resampling_method(
             artifacts_to_remove.append("samples.tsv")
         if not failures_published:
             artifacts_to_remove.append("failures.tsv")
-        _remove_failed_publication_artifacts(
-            statistic_path,
-            artifacts_to_remove,
+        remove_paths_best_effort(
+            (statistic_path / name for name in artifacts_to_remove),
             error,
+            description="resampling artifact",
         )
-        terminal = "interrupted" if isinstance(error, KeyboardInterrupt) else "failed"
+        terminal = (
+            "interrupted"
+            if operational_interruption or isinstance(error, KeyboardInterrupt)
+            else "failed"
+        )
         disposition_source = evidence if result is None else result
+        if terminal == "interrupted" and not samples_published:
+            try:
+                diagnostic_samples = derive_resampling_diagnostic_samples(
+                    operation,
+                    fit.accepted,
+                )
+                _write_native_samples(
+                    statistic_path,
+                    parameter_names,
+                    diagnostic_samples,
+                )
+                samples_published = True
+            except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
+                detail = str(publication_error) or type(publication_error).__name__
+                error.add_note(
+                    f"ChemEx could not finish interrupted resampling samples: {detail}"
+                )
+                remove_paths_best_effort(
+                    (statistic_path / "samples.tsv",),
+                    error,
+                    description="resampling artifact",
+                )
+        if terminal == "interrupted" and not failures_published:
+            try:
+                _write_native_failures(statistic_path, evidence.outcomes)
+                failures_published = True
+            except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
+                detail = str(publication_error) or type(publication_error).__name__
+                error.add_note(
+                    f"ChemEx could not finish interrupted resampling failures: {detail}"
+                )
+                remove_paths_best_effort(
+                    (statistic_path / "failures.tsv",),
+                    error,
+                    description="resampling artifact",
+                )
         try:
             _write_native_state_diagnostics(
                 statistic_path,
@@ -563,21 +610,7 @@ def _run_native_resampling_method(
                 parameter_ids=parameter_ids,
                 root_seed=root_seed,
                 status="incomplete",
-                successful_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.SUCCEEDED
-                ),
-                failed_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.FAILED
-                ),
-                cancelled_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.CANCELLED
-                ),
-                interrupted_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.INTERRUPTED
-                ),
-                unstarted_samples=disposition_source.disposition_count(
-                    ReplicateDisposition.NOT_STARTED
-                ),
+                sample_counts=_disposition_counts(disposition_source),
                 terminal=terminal,
                 failure=error,
             )
@@ -586,18 +619,33 @@ def _run_native_resampling_method(
                 "ChemEx could not publish incomplete resampling diagnostics: "
                 f"{diagnostics_error}"
             )
-            _remove_failed_publication_artifacts(
-                statistic_path,
-                ("diagnostics.toml",),
+            remove_paths_best_effort(
+                (statistic_path / "diagnostics.toml",),
                 error,
+                description="resampling artifact",
             )
+        if operational_interruption and not isinstance(error, KeyboardInterrupt):
+            interrupted_error = NativeResamplingIncompleteError(
+                f"Native {method.message} completed {evidence.successful_count} of "
+                f"{method.iterations} requested replicates",
+                terminal="interrupted",
+            )
+            detail = str(error) or type(error).__name__
+            interrupted_error.add_note(
+                f"ChemEx could not finish interrupted resampling output: {detail}"
+            )
+            for note in getattr(error, "__notes__", ()):
+                if isinstance(note, str) and note.startswith("ChemEx "):
+                    interrupted_error.add_note(note)
+            raise interrupted_error from error
         raise
     if operational_interruption or (
         result is not None and result.status is ResamplingAnalysisStatus.INCOMPLETE
     ):
         raise NativeResamplingIncompleteError(
             f"Native {method.message} completed {evidence.successful_count} of "
-            f"{method.iterations} requested replicates"
+            f"{method.iterations} requested replicates",
+            terminal="interrupted" if operational_interruption else "failed",
         )
 
 

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -444,17 +444,15 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 terminal=terminal,
                 failure=error,
             )
-        except (Exception, KeyboardInterrupt) as diagnostics_error:
+        except (Exception, KeyboardInterrupt):
             if terminal != "interrupted":
                 raise
-            detail = str(diagnostics_error) or type(diagnostics_error).__name__
             error.add_note(
-                f"ChemEx could not publish interrupted resampling diagnostics: {detail}"
+                "ChemEx could not publish interrupted resampling diagnostics."
             )
             remove_paths_best_effort(
                 (statistic_path / "diagnostics.toml",),
                 error,
-                description="resampling artifact",
             )
         raise
     evidence = operation.evidence
@@ -558,7 +556,6 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
         remove_paths_best_effort(
             (statistic_path / name for name in artifacts_to_remove),
             error,
-            description="resampling artifact",
         )
         terminal = (
             "interrupted"
@@ -578,29 +575,25 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                     diagnostic_samples,
                 )
                 samples_published = True
-            except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
-                detail = str(publication_error) or type(publication_error).__name__
+            except (Exception, KeyboardInterrupt):  # noqa: BLE001
                 error.add_note(
-                    f"ChemEx could not finish interrupted resampling samples: {detail}"
+                    "ChemEx could not publish interrupted resampling samples."
                 )
                 remove_paths_best_effort(
                     (statistic_path / "samples.tsv",),
                     error,
-                    description="resampling artifact",
                 )
         if terminal == "interrupted" and not failures_published:
             try:
                 _write_native_failures(statistic_path, evidence.outcomes)
                 failures_published = True
-            except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
-                detail = str(publication_error) or type(publication_error).__name__
+            except (Exception, KeyboardInterrupt):  # noqa: BLE001
                 error.add_note(
-                    f"ChemEx could not finish interrupted resampling failures: {detail}"
+                    "ChemEx could not publish interrupted resampling failures."
                 )
                 remove_paths_best_effort(
                     (statistic_path / "failures.tsv",),
                     error,
-                    description="resampling artifact",
                 )
         try:
             _write_native_state_diagnostics(
@@ -614,15 +607,13 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 terminal=terminal,
                 failure=error,
             )
-        except (Exception, KeyboardInterrupt) as diagnostics_error:  # noqa: BLE001
+        except (Exception, KeyboardInterrupt):  # noqa: BLE001
             error.add_note(
-                "ChemEx could not publish incomplete resampling diagnostics: "
-                f"{diagnostics_error}"
+                "ChemEx could not publish incomplete resampling diagnostics."
             )
             remove_paths_best_effort(
                 (statistic_path / "diagnostics.toml",),
                 error,
-                description="resampling artifact",
             )
         if operational_interruption and not isinstance(error, KeyboardInterrupt):
             interrupted_error = NativeResamplingIncompleteError(
@@ -630,13 +621,9 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 f"{method.iterations} requested replicates",
                 terminal="interrupted",
             )
-            detail = str(error) or type(error).__name__
             interrupted_error.add_note(
-                f"ChemEx could not finish interrupted resampling output: {detail}"
+                "ChemEx could not publish interrupted resampling output."
             )
-            for note in getattr(error, "__notes__", ()):
-                if isinstance(note, str) and note.startswith("ChemEx "):
-                    interrupted_error.add_note(note)
             raise interrupted_error from error
         raise
     if operational_interruption or (

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -2788,6 +2788,20 @@ class RootAnchoredBlockCovariance:
     claims: tuple[ClaimAssessment, ...]
     failure: EvidenceFailure | None = None
     constrained_failure: EvidenceFailure | None = None
+    _source_bundle: UncertaintyEvidence | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
+    _source_partition_proof: FitPartitionProof | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        metadata={"record": False},
+        kw_only=True,
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -2985,6 +2999,12 @@ class RootAnchoredBlockCovarianceEvidence:
         )
         if block_scopes != proof_scopes:
             raise ValueError("Root-anchored blocks differ from the partition proof")
+        if any(
+            block._source_bundle is not source
+            or block._source_partition_proof is not proof
+            for block in self.blocks
+        ):
+            raise ValueError("Root-anchored blocks have foreign source context")
         object.__setattr__(
             self,
             "identity",
@@ -3048,6 +3068,167 @@ class RootAnchoredBlockCovarianceEvidence:
         )
 
 
+def _validated_root_block_scopes(
+    evidence: UncertaintyEvidence,
+    partition_proof: FitPartitionProof,
+) -> tuple[tuple[tuple[str, ...], tuple[int, ...]], ...]:
+    jacobian = evidence.residual_jacobian
+    if (
+        jacobian is None
+        or partition_proof.root_plan_identity != evidence.source_engine.plan.identity
+        or partition_proof.constraint_program_identity
+        != evidence.source_parameterization.program.fingerprint
+        or partition_proof.controlled_ids != jacobian.controlled_ids
+    ):
+        raise ValueError("Block covariance requires the exact root partition proof")
+    root_bounds = {
+        param_id: (float(lower).hex(), float(upper).hex())
+        for param_id, lower, upper in zip(
+            evidence.source_problem.controlled_ids,
+            evidence.source_problem.lower_bounds,
+            evidence.source_problem.upper_bounds,
+            strict=True,
+        )
+    }
+    if any(
+        bounds
+        != tuple((param_id, *root_bounds[param_id]) for param_id in controlled_ids)
+        for _component_id, controlled_ids, _profiles, bounds in (
+            partition_proof.component_records
+        )
+    ):
+        raise ValueError("Block covariance partition bounds differ from the root")
+    return tuple(
+        (controlled_ids, profile_indices)
+        for _component_id, controlled_ids, profile_indices, _bounds in (
+            partition_proof.component_records
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class RootAnchoredBlockCovarianceOperation:
+    """Terminal lifecycle record for one root-anchored block recovery."""
+
+    source_bundle: UncertaintyEvidence = field(repr=False, compare=False)
+    source_partition_proof: FitPartitionProof = field(repr=False, compare=False)
+    terminal: OperationTerminal
+    completed_blocks: tuple[RootAnchoredBlockCovariance, ...]
+    complete_evidence: RootAnchoredBlockCovarianceEvidence | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        source = self.source_bundle
+        proof = self.source_partition_proof
+        if self.terminal not in {
+            OperationTerminal.COMPLETED,
+            OperationTerminal.INTERRUPTED,
+        }:
+            raise ValueError("Block covariance operation has an invalid terminal")
+        planned_scopes = _validated_root_block_scopes(source, proof)
+        completed = tuple(self.completed_blocks)
+        completed_scopes = tuple(
+            (block.controlled_ids, block.root_profile_indices) for block in completed
+        )
+        if completed_scopes != planned_scopes[: len(completed)]:
+            raise ValueError(
+                "Completed block covariance must be an exact partition prefix"
+            )
+        if any(
+            block._source_bundle is not source
+            or block._source_partition_proof is not proof
+            for block in completed
+        ):
+            raise ValueError("Completed block covariance has foreign source context")
+        object.__setattr__(self, "completed_blocks", completed)
+        full_partition = len(completed) == len(planned_scopes)
+        if self.terminal is OperationTerminal.COMPLETED and not full_partition:
+            raise ValueError("Completed block covariance operation lacks blocks")
+        if full_partition:
+            complete = self.complete_evidence
+            if (
+                complete is None
+                or complete.source_bundle is not source
+                or complete.source_partition_proof is not proof
+                or complete.blocks != completed
+            ):
+                raise ValueError(
+                    "Full block covariance operation requires its complete Evidence"
+                )
+        elif self.complete_evidence is not None:
+            raise ValueError("Partial block covariance operation has complete Evidence")
+
+    @property
+    def simple_bound_warning_ids(self) -> frozenset[str]:
+        source = self.source_bundle
+        standard_errors = {
+            entry.param_id: entry.value
+            for block in self.completed_blocks
+            for entry in block.marginal_errors
+        }
+        return _simple_bound_warning_ids(
+            source.source_problem.controlled_ids,
+            source.accepted_anchor.vector,
+            source.source_problem.lower_bounds,
+            source.source_problem.upper_bounds,
+            standard_errors,
+        )
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize lifecycle facts without claiming a complete partition."""
+        source = self.source_bundle
+        proof = self.source_partition_proof
+        jacobian = cast("ResidualJacobianEvidence", source.residual_jacobian)
+        records = []
+        for index, (
+            component_id,
+            controlled_ids,
+            profile_indices,
+            _bounds,
+        ) in enumerate(proof.component_records):
+            completed = index < len(self.completed_blocks)
+            records.append(
+                {
+                    "partition_index": index,
+                    "component_identity": component_id,
+                    "controlled_ids": list(controlled_ids),
+                    "root_profile_indices": list(profile_indices),
+                    "disposition": "completed" if completed else "not_completed",
+                    "evidence": (
+                        _record_value(self.completed_blocks[index])
+                        if completed
+                        else None
+                    ),
+                }
+            )
+        return {
+            "artifact_type": "native_root_anchored_block_covariance_operation",
+            "schema_version": _SCHEMA_VERSION,
+            "terminal": self.terminal.value,
+            "accepted_result_identity": source.accepted_result_identity,
+            "accepted_occurrence_identity": source.accepted_occurrence_identity,
+            "source_jacobian_identity": jacobian.identity,
+            "source_constraint_jacobian_identity": (
+                None
+                if source.constraint_jacobian is None
+                else source.constraint_jacobian.identity
+            ),
+            "partition_proof_identity": proof.identity,
+            "policy_identity": source.policy_identity,
+            "completed_block_count": len(self.completed_blocks),
+            "planned_block_count": len(proof.component_records),
+            "complete_evidence_identity": (
+                None
+                if self.complete_evidence is None
+                else self.complete_evidence.identity
+            ),
+            "blocks": records,
+        }
+
+
 def _failed_block_claims(
     category: str,
     *,
@@ -3096,9 +3277,36 @@ def _partition_coordinate_indices(
     return tuple(tuple(root_order[param_id] for param_id in scope) for scope in scopes)
 
 
-def derive_root_anchored_block_covariance(  # noqa: C901
+def _assemble_root_anchored_block_covariance_evidence(
     evidence: UncertaintyEvidence,
     partition_proof: FitPartitionProof,
+    blocks: Sequence[RootAnchoredBlockCovariance],
+) -> RootAnchoredBlockCovarianceEvidence:
+    """Assemble complete block Evidence without further scientific work."""
+    jacobian = evidence.residual_jacobian
+    if jacobian is None:
+        raise ValueError("Block covariance Evidence requires the root Jacobian")
+    return RootAnchoredBlockCovarianceEvidence(
+        evidence.accepted_result_identity,
+        evidence.accepted_occurrence_identity,
+        jacobian.identity,
+        (
+            None
+            if evidence.constraint_jacobian is None
+            else evidence.constraint_jacobian.identity
+        ),
+        partition_proof.identity,
+        evidence.policy_identity,
+        tuple(blocks),
+        evidence,
+        partition_proof,
+    )
+
+
+def _derive_root_anchored_block_covariance_complete(  # noqa: C901
+    evidence: UncertaintyEvidence,
+    partition_proof: FitPartitionProof,
+    completed_blocks: list[RootAnchoredBlockCovariance],
 ) -> RootAnchoredBlockCovarianceEvidence | None:
     """Derive independent full-rank blocks when the joint root is unavailable."""
     jacobian = evidence.residual_jacobian
@@ -3112,36 +3320,7 @@ def derive_root_anchored_block_covariance(  # noqa: C901
         is not ResidualVarianceScaling.ABSOLUTE_OBSERVATION_UNCERTAINTIES
     ):
         return None
-    if (
-        partition_proof.root_plan_identity != evidence.source_engine.plan.identity
-        or partition_proof.constraint_program_identity
-        != evidence.source_parameterization.program.fingerprint
-        or partition_proof.controlled_ids != jacobian.controlled_ids
-    ):
-        raise ValueError("Block covariance requires the exact root partition proof")
-    root_bounds = {
-        param_id: (float(lower).hex(), float(upper).hex())
-        for param_id, lower, upper in zip(
-            evidence.source_problem.controlled_ids,
-            evidence.source_problem.lower_bounds,
-            evidence.source_problem.upper_bounds,
-            strict=True,
-        )
-    }
-    if any(
-        bounds
-        != tuple((param_id, *root_bounds[param_id]) for param_id in controlled_ids)
-        for _component_id, controlled_ids, _profiles, bounds in (
-            partition_proof.component_records
-        )
-    ):
-        raise ValueError("Block covariance partition bounds differ from the root")
-    scopes = tuple(
-        (controlled_ids, profile_indices)
-        for _component_id, controlled_ids, profile_indices, _bounds in (
-            partition_proof.component_records
-        )
-    )
+    scopes = _validated_root_block_scopes(evidence, partition_proof)
     if len(scopes) < 2:
         return None
     coordinate_indices = _partition_coordinate_indices(
@@ -3161,7 +3340,7 @@ def derive_root_anchored_block_covariance(  # noqa: C901
     if row_offset != jacobian.residual_count:
         raise ValueError("Root residual rows do not match the evaluation profile plan")
     constraint_jacobian = evidence.constraint_jacobian
-    blocks: list[RootAnchoredBlockCovariance] = []
+    blocks = completed_blocks
     for (scope, profile_indices), indices in zip(
         scopes,
         coordinate_indices,
@@ -3343,19 +3522,68 @@ def derive_root_anchored_block_covariance(  # noqa: C901
                 claims,
                 failure,
                 constrained_failure,
+                _source_bundle=evidence,
+                _source_partition_proof=partition_proof,
             )
         )
-    return RootAnchoredBlockCovarianceEvidence(
-        evidence.accepted_result_identity,
-        evidence.accepted_occurrence_identity,
-        jacobian.identity,
-        None if constraint_jacobian is None else constraint_jacobian.identity,
-        partition_proof.identity,
-        evidence.policy_identity,
-        tuple(blocks),
+    return _assemble_root_anchored_block_covariance_evidence(
         evidence,
         partition_proof,
+        blocks,
     )
+
+
+def execute_root_anchored_block_covariance(
+    evidence: UncertaintyEvidence,
+    partition_proof: FitPartitionProof,
+) -> RootAnchoredBlockCovarianceOperation | None:
+    """Recover complete blocks while freezing a truthful interrupted prefix."""
+    completed_blocks: list[RootAnchoredBlockCovariance] = []
+    try:
+        complete = _derive_root_anchored_block_covariance_complete(
+            evidence,
+            partition_proof,
+            completed_blocks,
+        )
+    except KeyboardInterrupt:
+        complete = (
+            _assemble_root_anchored_block_covariance_evidence(
+                evidence,
+                partition_proof,
+                completed_blocks,
+            )
+            if len(completed_blocks) == len(partition_proof.component_records)
+            else None
+        )
+        return RootAnchoredBlockCovarianceOperation(
+            evidence,
+            partition_proof,
+            OperationTerminal.INTERRUPTED,
+            tuple(completed_blocks),
+            complete,
+        )
+    if complete is None:
+        return None
+    return RootAnchoredBlockCovarianceOperation(
+        evidence,
+        partition_proof,
+        OperationTerminal.COMPLETED,
+        complete.blocks,
+        complete,
+    )
+
+
+def derive_root_anchored_block_covariance(
+    evidence: UncertaintyEvidence,
+    partition_proof: FitPartitionProof,
+) -> RootAnchoredBlockCovarianceEvidence | None:
+    """Compatibility view returning only complete block Evidence."""
+    operation = execute_root_anchored_block_covariance(evidence, partition_proof)
+    if operation is None:
+        return None
+    if operation.terminal is OperationTerminal.INTERRUPTED:
+        raise KeyboardInterrupt("Root-anchored block covariance interrupted")
+    return operation.complete_evidence
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/chemex/printers/native_reporting.py
+++ b/src/chemex/printers/native_reporting.py
@@ -6,8 +6,11 @@ import json
 from pathlib import Path
 from typing import cast
 
+from chemex.atomic import write_text_atomic
 from chemex.optimize.uncertainty import (
+    OperationTerminal,
     RootAnchoredBlockCovarianceEvidence,
+    RootAnchoredBlockCovarianceOperation,
     UncertaintyEvidence,
 )
 from chemex.printers.parameters import uncertainty_unavailable_reason
@@ -15,7 +18,8 @@ from chemex.printers.parameters import uncertainty_unavailable_reason
 
 def write_json(path: Path, record: object) -> None:
     """Write one deterministic, strict JSON evidence artifact."""
-    path.write_text(
+    write_text_atomic(
+        path,
         json.dumps(
             record,
             allow_nan=False,
@@ -24,7 +28,6 @@ def write_json(path: Path, record: object) -> None:
             sort_keys=True,
         )
         + "\n",
-        encoding="utf-8",
     )
 
 
@@ -102,3 +105,15 @@ def write_block_uncertainty(
             else uncertainty_unavailable_reason(block.unavailable_kind)
         )
     write_json(covariance_path / "blocks.json", record)
+
+
+def write_block_recovery(
+    path: Path,
+    operation: RootAnchoredBlockCovarianceOperation | None,
+) -> None:
+    """Write interrupted block-recovery lifecycle without weakening Evidence."""
+    if operation is None or operation.terminal is not OperationTerminal.INTERRUPTED:
+        return
+    covariance_path = path / "Covariance"
+    covariance_path.mkdir(exist_ok=True)
+    write_json(covariance_path / "block_recovery.json", operation.to_record())

--- a/tests/experiments/test_experiment_types.py
+++ b/tests/experiments/test_experiment_types.py
@@ -312,8 +312,8 @@ def test_malformed_dataset_cli_failure_has_no_traceback(
 
     output = capfd.readouterr()
     assert error_info.value.code == 1
-    assert "Invalid data" in output.out
-    assert "malformed.dat" in output.out
+    assert "Invalid data" in output.err
+    assert "malformed.dat" in output.err
     assert "Traceback" not in output.out + output.err
 
 

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -70,11 +70,7 @@ def test_atomic_cleanup_failure_is_noted_without_replacing_original_error(
     assert destination.read_text(encoding="utf-8") == "previous complete artifact\n"
     assert tuple(tmp_path.glob(".artifact.tsv-*"))
     assert error_info.value.__notes__ == [
-        next(
-            note
-            for note in error_info.value.__notes__
-            if note.startswith("ChemEx ") and "unlink refused" in note
-        )
+        "ChemEx could not remove an incomplete temporary artifact."
     ]
 
 
@@ -97,15 +93,9 @@ def test_best_effort_removal_attempts_every_path_and_preserves_original_error(
     monkeypatch.setattr(Path, "unlink", fail_first_cleanup)
     interruption = KeyboardInterrupt()
 
-    remove_paths_best_effort(paths, interruption, description="test artifact")
+    remove_paths_best_effort(paths, interruption)
 
     assert attempted == list(paths)
     assert paths[0].is_file()
     assert all(not path.exists() for path in paths[1:])
-    assert interruption.__notes__ == [
-        next(
-            note
-            for note in interruption.__notes__
-            if note.startswith("ChemEx ") and "stale cleanup refused" in note
-        )
-    ]
+    assert interruption.__notes__ == ["ChemEx could not remove a stale artifact."]

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chemex.atomic import open_text_atomic, remove_paths_best_effort
+
+
+def test_streaming_atomic_write_never_exposes_a_truncated_final_file(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "artifact.tsv"
+    destination.write_text("previous complete artifact\n", encoding="utf-8")
+
+    with pytest.raises(KeyboardInterrupt), open_text_atomic(destination) as output:
+        output.write("header\n")
+        output.write("first complete row\n")
+        raise KeyboardInterrupt
+
+    assert destination.read_text(encoding="utf-8") == "previous complete artifact\n"
+    assert not tuple(tmp_path.glob(".artifact.tsv-*"))
+
+
+def test_atomic_replace_failure_preserves_previous_complete_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "artifact.tsv"
+    destination.write_text("previous complete artifact\n", encoding="utf-8")
+    original_replace = Path.replace
+
+    def fail_destination_replace(source: Path, target: Path) -> Path:
+        if target == destination:
+            raise OSError("replace refused")
+        return original_replace(source, target)
+
+    monkeypatch.setattr(Path, "replace", fail_destination_replace)
+    with (
+        pytest.raises(OSError, match="replace refused"),
+        open_text_atomic(destination) as output,
+    ):
+        output.write("complete new artifact\n")
+
+    assert destination.read_text(encoding="utf-8") == "previous complete artifact\n"
+    assert not tuple(tmp_path.glob(".artifact.tsv-*"))
+
+
+def test_atomic_cleanup_failure_is_noted_without_replacing_original_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "artifact.tsv"
+    destination.write_text("previous complete artifact\n", encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def refuse_temporary_cleanup(path: Path, *, missing_ok: bool = False) -> None:
+        if path.name.startswith(".artifact.tsv-"):
+            raise OSError("unlink refused")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", refuse_temporary_cleanup)
+    with (
+        pytest.raises(KeyboardInterrupt) as error_info,
+        open_text_atomic(destination) as output,
+    ):
+        output.write("new partial artifact\n")
+        raise KeyboardInterrupt
+
+    assert destination.read_text(encoding="utf-8") == "previous complete artifact\n"
+    assert tuple(tmp_path.glob(".artifact.tsv-*"))
+    assert error_info.value.__notes__ == [
+        next(
+            note
+            for note in error_info.value.__notes__
+            if note.startswith("ChemEx ") and "unlink refused" in note
+        )
+    ]
+
+
+def test_best_effort_removal_attempts_every_path_and_preserves_original_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = tuple(tmp_path / f"artifact-{index}.tsv" for index in range(3))
+    for path in paths:
+        path.write_text("stale complete artifact\n", encoding="utf-8")
+    original_unlink = Path.unlink
+    attempted: list[Path] = []
+
+    def fail_first_cleanup(path: Path, *, missing_ok: bool = False) -> None:
+        attempted.append(path)
+        if path == paths[0]:
+            raise OSError("stale cleanup refused")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_first_cleanup)
+    interruption = KeyboardInterrupt()
+
+    remove_paths_best_effort(paths, interruption, description="test artifact")
+
+    assert attempted == list(paths)
+    assert paths[0].is_file()
+    assert all(not path.exists() for path in paths[1:])
+    assert interruption.__notes__ == [
+        next(
+            note
+            for note in interruption.__notes__
+            if note.startswith("ChemEx ") and "stale cleanup refused" in note
+        )
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,22 @@ def test_fit_cli_does_not_emit_v1_deprecation_warning_for_v2(
     assert "Method format v1 is deprecated" not in capsys.readouterr().out
 
 
+def test_fit_cli_reports_method_errors_on_stderr(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    method = tmp_path / "invalid.toml"
+    method.write_text("[STEP\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as error_info:
+        _read_fit_methods(_fit_args(method))
+
+    output = capsys.readouterr()
+    assert error_info.value.code == 1
+    assert "Error in the TOML file" in output.err
+    assert "Traceback (most recent call last)" not in output.out + output.err
+
+
 def test_fit_parser_defaults_execution_arguments_to_auto() -> None:
     args = build_parser().parse_args(
         [

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import tomllib
+from collections.abc import Sequence
+from configparser import Error as ConfigParserError
+from pathlib import Path
+
+import pytest
+
+from chemex import chemex as application_module
+
+TRACEBACK_HEADER = "Traceback (most recent call last)"
+ROOT = Path(__file__).parent.parent
+EXAMPLE = ROOT / "examples/Experiments/RELAXATION_HZNZ"
+EXPERIMENT = EXAMPLE / "Experiments/800mhz.toml"
+PARAMETERS = EXAMPLE / "Parameters/parameters.toml"
+
+
+def _entry_commands() -> tuple[tuple[str, ...], ...]:
+    return (
+        (str(Path(sys.executable).with_name("chemex")),),
+        (sys.executable, "-m", "chemex"),
+    )
+
+
+def _run(
+    command: Sequence[str],
+    *arguments: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed local test entry paths
+        (*command, *arguments),
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _run_bootstrap(
+    failure_source: str,
+    *,
+    setup_source: str = "",
+    messages_source: str = "",
+) -> subprocess.CompletedProcess[str]:
+    failure = textwrap.indent(textwrap.dedent(failure_source).strip(), "    ")
+    source = f"""
+import sys
+import types
+{textwrap.dedent(setup_source)}
+{textwrap.dedent(messages_source)}
+application = types.ModuleType("chemex.chemex")
+
+def fail():
+{failure}
+
+application.main = fail
+sys.modules["chemex.chemex"] = application
+
+from chemex._entrypoint import main
+main()
+"""
+    return _run((sys.executable, "-c"), source)
+
+
+def _assert_bootstrap_result(
+    completed: subprocess.CompletedProcess[str],
+    status: int,
+    message: str,
+    *,
+    absent: Sequence[str] = (),
+) -> None:
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == status
+    assert completed.stdout == ""
+    assert message in completed.stderr
+    assert all(item not in combined for item in absent)
+    assert TRACEBACK_HEADER not in combined
+
+
+def _application_import_failure_env(
+    tmp_path: Path,
+    failure_source: str,
+) -> dict[str, str]:
+    (tmp_path / "sitecustomize.py").write_text(
+        f"""
+import importlib.abc
+import sys
+
+
+class BlockApplicationImport(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "chemex.chemex":
+            raise {failure_source}
+        return None
+
+
+sys.meta_path.insert(0, BlockApplicationImport())
+""".lstrip(),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(tmp_path), env.get("PYTHONPATH", "")))
+    )
+    return env
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+def test_cli_entrypoints_translate_application_import_failure(
+    command: tuple[str, ...],
+    tmp_path: Path,
+) -> None:
+    env = _application_import_failure_env(
+        tmp_path,
+        "ImportError('application import failed')",
+    )
+
+    completed = _run(command, env=env)
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert completed.stdout == ""
+    assert "application import failed" in completed.stderr
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+@pytest.mark.parametrize(
+    ("argument", "status", "stream", "message"),
+    (
+        ("--help", 0, "stdout", "usage:"),
+        ("--version", 0, "stdout", "chemex"),
+        (
+            "--not-a-real-option",
+            2,
+            "stderr",
+            "unrecognized arguments: --not-a-real-option",
+        ),
+    ),
+)
+def test_cli_entrypoints_preserve_argparse_behavior(
+    command: tuple[str, ...],
+    argument: str,
+    status: int,
+    stream: str,
+    message: str,
+) -> None:
+    completed = _run(command, argument)
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == status
+    assert message in getattr(completed, stream).lower()
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+@pytest.mark.parametrize("model", ("missing-model", "2st.unsupported"))
+def test_cli_entrypoints_report_invalid_model_as_unsuccessful_error(
+    command: tuple[str, ...],
+    model: str,
+) -> None:
+    completed = _run(
+        command,
+        "simulate",
+        "-e",
+        str(EXPERIMENT),
+        "-p",
+        str(PARAMETERS),
+        "-d",
+        model,
+        "--plot",
+        "nothing",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert "ERROR:" in completed.stderr
+    assert model in completed.stderr
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+def test_cli_entrypoints_preserve_no_selected_profiles_success(
+    command: tuple[str, ...],
+) -> None:
+    completed = _run(
+        command,
+        "simulate",
+        "-e",
+        str(EXPERIMENT),
+        "-p",
+        str(PARAMETERS),
+        "--include",
+        "DOES-NOT-EXIST",
+        "--plot",
+        "nothing",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 0
+    assert "No data to fit" in completed.stdout
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+def test_cli_entrypoints_translate_uncaught_runtime_failure(
+    command: tuple[str, ...],
+) -> None:
+    completed = _run(
+        command,
+        "plot_param",
+        "-p",
+        str(ROOT / "pyproject.toml"),
+        "-n",
+        "BAD",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert "ERROR:" in completed.stderr
+    assert "parsing errors" in completed.stderr
+    assert TRACEBACK_HEADER not in combined
+
+
+def test_programmatic_main_retains_ordinary_exception_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["chemex", "plot_param", "-p", "pyproject.toml", "-n", "BAD"],
+    )
+
+    with pytest.raises(ConfigParserError):
+        application_module.main()
+
+
+@pytest.mark.parametrize(
+    ("failure_source", "expected_status", "expected_message"),
+    [
+        ("raise KeyboardInterrupt", 130, "ChemEx interrupted."),
+        (
+            "error = RuntimeError('stop'); error.terminal = 'interrupted'; raise error",
+            130,
+            "ChemEx interrupted.",
+        ),
+        ("raise RuntimeError('ordinary failure')", 1, "ordinary failure"),
+        ("raise RuntimeError('[bold]literal[/]')", 1, "[bold]literal[/]"),
+        ("raise RuntimeError", 1, "RuntimeError occurred without an error message."),
+    ],
+)
+def test_cli_bootstrap_translates_terminal_failures(
+    failure_source: str,
+    expected_status: int,
+    expected_message: str,
+) -> None:
+    completed = _run_bootstrap(failure_source)
+
+    _assert_bootstrap_result(completed, expected_status, expected_message)
+
+
+def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
+    completed = _run_bootstrap(
+        """
+        error = RuntimeError("publication failed")
+        error.add_note("ChemEx retained the accepted fit")
+        error.add_note("")
+        error.add_note("third-party internal detail")
+        raise error
+        """
+    )
+
+    _assert_bootstrap_result(
+        completed,
+        1,
+        "ERROR: publication failed",
+        absent=("third-party internal detail",),
+    )
+    assert "ERROR: publication failed" in completed.stderr
+    assert "NOTE: ChemEx retained the accepted fit" in completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("failure_source", "setup_source", "expected_status", "message", "absent"),
+    (
+        pytest.param(
+            "error = RuntimeError('application failed'); "
+            "error.__notes__ = None; raise error",
+            "",
+            1,
+            "application failed",
+            (),
+            id="notes-none",
+        ),
+        pytest.param(
+            "error = RuntimeError('application failed'); "
+            "error.__notes__ = object(); raise error",
+            "",
+            1,
+            "application failed",
+            (),
+            id="notes-non-sequence",
+        ),
+        pytest.param(
+            """
+            HostileNote = type('HostileNote', (), {
+                '__str__': lambda self: (_ for _ in ()).throw(
+                    RuntimeError('note stringification leaked')
+                )
+            })
+            error = RuntimeError('application failed')
+            error.__notes__ = [HostileNote(), 'ChemEx retained valid work']
+            raise error
+            """,
+            "",
+            1,
+            "NOTE: ChemEx retained valid work",
+            ("note stringification leaked",),
+            id="hostile-note",
+        ),
+        pytest.param(
+            """
+            class HostileError(RuntimeError):
+                def __str__(self):
+                    raise RuntimeError("stringification leaked")
+            raise HostileError()
+            """,
+            "",
+            1,
+            "HostileError occurred without an error message.",
+            ("stringification leaked",),
+            id="hostile-message",
+        ),
+        pytest.param(
+            """
+            class HostileTerminalError(RuntimeError):
+                @property
+                def terminal(self):
+                    raise RuntimeError("terminal property leaked")
+            raise HostileTerminalError("ordinary failure")
+            """,
+            "",
+            1,
+            "ordinary failure",
+            ("terminal property leaked",),
+            id="hostile-terminal-property",
+        ),
+        pytest.param(
+            """
+            error = RuntimeError("typed interruption")
+            error.terminal = Terminal.INTERRUPTED
+            raise error
+            """,
+            """
+            from enum import StrEnum
+            class Terminal(StrEnum):
+                INTERRUPTED = "interrupted"
+            """,
+            130,
+            "ChemEx interrupted.",
+            (),
+            id="strenum-terminal",
+        ),
+    ),
+)
+def test_cli_bootstrap_handles_hostile_exception_metadata(
+    failure_source: str,
+    setup_source: str,
+    expected_status: int,
+    message: str,
+    absent: tuple[str, ...],
+) -> None:
+    completed = _run_bootstrap(failure_source, setup_source=setup_source)
+
+    _assert_bootstrap_result(
+        completed,
+        expected_status,
+        message,
+        absent=absent,
+    )
+
+
+@pytest.mark.parametrize(
+    ("phase", "renderer_failure"),
+    (
+        *(
+            ("acquisition", failure)
+            for failure in (
+                "ImportError('renderer unavailable')",
+                "SystemExit(71)",
+                "KeyboardInterrupt()",
+            )
+        ),
+        *(
+            ("execution", failure)
+            for failure in (
+                "RuntimeError('renderer failed')",
+                "SystemExit(77)",
+                "KeyboardInterrupt()",
+            )
+        ),
+    ),
+)
+def test_cli_bootstrap_renderer_failures_use_plain_stderr(
+    phase: str,
+    renderer_failure: str,
+) -> None:
+    messages_source = (
+        f"""
+        class BrokenMessages(types.ModuleType):
+            def __getattribute__(self, name):
+                if name == "print_cli_diagnostic":
+                    raise {renderer_failure}
+                return super().__getattribute__(name)
+        sys.modules["chemex.messages"] = BrokenMessages("chemex.messages")
+        """
+        if phase == "acquisition"
+        else f"""
+        messages = types.ModuleType("chemex.messages")
+        def broken_renderer(*args, **kwargs):
+            raise {renderer_failure}
+        messages.print_cli_diagnostic = broken_renderer
+        sys.modules["chemex.messages"] = messages
+        """
+    )
+    completed = _run_bootstrap(
+        "raise RuntimeError('application failed')",
+        messages_source=messages_source,
+    )
+
+    _assert_bootstrap_result(
+        completed,
+        1,
+        "application failed",
+        absent=("renderer unavailable", "renderer failed"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("import_failure", "expected_status"),
+    (("SyntaxError('broken application')", 1), ("SystemExit(23)", 23)),
+)
+def test_cli_bootstrap_handles_protected_application_import_baseexceptions(
+    import_failure: str,
+    expected_status: int,
+    tmp_path: Path,
+) -> None:
+    env = _application_import_failure_env(tmp_path, import_failure)
+
+    completed = _run((sys.executable, "-m", "chemex"), env=env)
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == expected_status
+    if expected_status == 1:
+        assert "broken application" in completed.stderr
+    assert TRACEBACK_HEADER not in combined
+
+
+def test_real_fit_interruption_flows_through_run_info_and_shared_bootstrap(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sitecustomize.py").write_text(
+        """
+import chemex.optimize.direct_trf as direct_trf
+
+original = direct_trf.least_squares
+calls = 0
+
+def interrupt_third_fit(*args, **kwargs):
+    global calls
+    calls += 1
+    if calls == 3:
+        raise KeyboardInterrupt
+    return original(*args, **kwargs)
+
+direct_trf.least_squares = interrupt_third_fit
+""".lstrip(),
+        encoding="utf-8",
+    )
+    method = tmp_path / "method.toml"
+    method.write_text(
+        '[STEP1]\nFIX = ["PB", "KEX_AB"]\n\n[STEP2]\nFIX = ["PB", "KEX_AB"]\n',
+        encoding="utf-8",
+    )
+    output = tmp_path / "Output"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(tmp_path), env.get("PYTHONPATH", "")))
+    )
+
+    completed = _run(
+        (sys.executable, "-m", "chemex"),
+        "fit",
+        "-e",
+        str(EXPERIMENT),
+        "-p",
+        str(PARAMETERS),
+        "-m",
+        str(method),
+        "-o",
+        str(output),
+        "-d",
+        "2st",
+        "--include",
+        "G2N-HN",
+        "H3N-HN",
+        "--plot",
+        "nothing",
+        "--workers",
+        "1",
+        env=env,
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 130
+    assert completed.stderr.count("ChemEx interrupted.") == 1
+    assert TRACEBACK_HEADER not in combined
+    assert (output / "STEP1" / "Parameters" / "fitted.toml").is_file()
+    assert not (output / "STEP2" / "Parameters" / "fitted.toml").exists()
+    outcome = tomllib.loads(
+        (output / "run_info" / "outcome.toml").read_text(encoding="utf-8")
+    )
+    assert outcome["status"] == "incomplete"
+    assert outcome["terminal"] == "interrupted"
+    assert outcome["latest_committed_revision"] == 1

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -14,6 +14,9 @@ import pytest
 from chemex import chemex as application_module
 
 TRACEBACK_HEADER = "Traceback (most recent call last)"
+SECRET_CANARY = "SECRET_CANARY"  # noqa: S105 - security regression canary
+UNEXPECTED_MESSAGE = "ChemEx encountered an unexpected error."
+INTERRUPTED_MESSAGE = "ChemEx interrupted."
 ROOT = Path(__file__).parent.parent
 EXAMPLE = ROOT / "examples/Experiments/RELAXATION_HZNZ"
 EXPERIMENT = EXAMPLE / "Experiments/800mhz.toml"
@@ -77,7 +80,7 @@ def _assert_bootstrap_result(
     combined = completed.stdout + completed.stderr
     assert completed.returncode == status
     assert completed.stdout == ""
-    assert message in completed.stderr
+    assert completed.stderr == f"{message}\n"
     assert all(item not in combined for item in absent)
     assert TRACEBACK_HEADER not in combined
 
@@ -117,16 +120,17 @@ def test_cli_entrypoints_translate_application_import_failure(
 ) -> None:
     env = _application_import_failure_env(
         tmp_path,
-        "ImportError('application import failed')",
+        f"ImportError('{SECRET_CANARY}')",
     )
 
     completed = _run(command, env=env)
 
-    combined = completed.stdout + completed.stderr
-    assert completed.returncode == 1
-    assert completed.stdout == ""
-    assert "application import failed" in completed.stderr
-    assert TRACEBACK_HEADER not in combined
+    _assert_bootstrap_result(
+        completed,
+        1,
+        UNEXPECTED_MESSAGE,
+        absent=(SECRET_CANARY,),
+    )
 
 
 @pytest.mark.parametrize("command", _entry_commands())
@@ -222,8 +226,8 @@ def test_cli_entrypoints_translate_uncaught_runtime_failure(
 
     combined = completed.stdout + completed.stderr
     assert completed.returncode == 1
-    assert "ERROR:" in completed.stderr
-    assert "parsing errors" in completed.stderr
+    assert completed.stderr == f"{UNEXPECTED_MESSAGE}\n"
+    assert "parsing errors" not in combined
     assert TRACEBACK_HEADER not in combined
 
 
@@ -243,15 +247,22 @@ def test_programmatic_main_retains_ordinary_exception_semantics(
 @pytest.mark.parametrize(
     ("failure_source", "expected_status", "expected_message"),
     [
-        ("raise KeyboardInterrupt", 130, "ChemEx interrupted."),
+        ("raise KeyboardInterrupt", 130, INTERRUPTED_MESSAGE),
         (
-            "error = RuntimeError('stop'); error.terminal = 'interrupted'; raise error",
+            "; ".join(
+                (
+                    f"error = RuntimeError('{SECRET_CANARY}')",
+                    f"error.add_note('ChemEx {SECRET_CANARY}')",
+                    "error.terminal = 'interrupted'",
+                    "raise error",
+                )
+            ),
             130,
-            "ChemEx interrupted.",
+            INTERRUPTED_MESSAGE,
         ),
-        ("raise RuntimeError('ordinary failure')", 1, "ordinary failure"),
-        ("raise RuntimeError('[bold]literal[/]')", 1, "[bold]literal[/]"),
-        ("raise RuntimeError", 1, "RuntimeError occurred without an error message."),
+        (f"raise RuntimeError('{SECRET_CANARY}')", 1, UNEXPECTED_MESSAGE),
+        ("raise RuntimeError('[bold]literal[/]')", 1, UNEXPECTED_MESSAGE),
+        ("raise RuntimeError", 1, UNEXPECTED_MESSAGE),
     ],
 )
 def test_cli_bootstrap_translates_terminal_failures(
@@ -261,16 +272,20 @@ def test_cli_bootstrap_translates_terminal_failures(
 ) -> None:
     completed = _run_bootstrap(failure_source)
 
-    _assert_bootstrap_result(completed, expected_status, expected_message)
+    _assert_bootstrap_result(
+        completed,
+        expected_status,
+        expected_message,
+        absent=(SECRET_CANARY,),
+    )
 
 
-def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
+def test_cli_bootstrap_ignores_all_exception_notes() -> None:
     completed = _run_bootstrap(
-        """
-        error = RuntimeError("publication failed")
-        error.add_note("ChemEx retained the accepted fit")
-        error.add_note("")
-        error.add_note("third-party internal detail")
+        f"""
+        error = RuntimeError("{SECRET_CANARY}")
+        error.add_note("ChemEx {SECRET_CANARY}")
+        error.add_note("third-party {SECRET_CANARY}")
         raise error
         """
     )
@@ -278,11 +293,9 @@ def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
     _assert_bootstrap_result(
         completed,
         1,
-        "ERROR: publication failed",
-        absent=("third-party internal detail",),
+        UNEXPECTED_MESSAGE,
+        absent=(SECRET_CANARY, "NOTE:"),
     )
-    assert "ERROR: publication failed" in completed.stderr
-    assert "NOTE: ChemEx retained the accepted fit" in completed.stderr
 
 
 @pytest.mark.parametrize(
@@ -293,7 +306,7 @@ def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
             "error.__notes__ = None; raise error",
             "",
             1,
-            "application failed",
+            UNEXPECTED_MESSAGE,
             (),
             id="notes-none",
         ),
@@ -302,7 +315,7 @@ def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
             "error.__notes__ = object(); raise error",
             "",
             1,
-            "application failed",
+            UNEXPECTED_MESSAGE,
             (),
             id="notes-non-sequence",
         ),
@@ -313,14 +326,14 @@ def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
                     RuntimeError('note stringification leaked')
                 )
             })
-            error = RuntimeError('application failed')
-            error.__notes__ = [HostileNote(), 'ChemEx retained valid work']
+            error = RuntimeError('SECRET_CANARY')
+            error.__notes__ = [HostileNote(), 'ChemEx SECRET_CANARY']
             raise error
             """,
             "",
             1,
-            "NOTE: ChemEx retained valid work",
-            ("note stringification leaked",),
+            UNEXPECTED_MESSAGE,
+            ("note stringification leaked", SECRET_CANARY),
             id="hostile-note",
         ),
         pytest.param(
@@ -328,12 +341,12 @@ def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
             class HostileError(RuntimeError):
                 def __str__(self):
                     raise RuntimeError("stringification leaked")
-            raise HostileError()
+            raise HostileError("SECRET_CANARY")
             """,
             "",
             1,
-            "HostileError occurred without an error message.",
-            ("stringification leaked",),
+            UNEXPECTED_MESSAGE,
+            ("stringification leaked", SECRET_CANARY),
             id="hostile-message",
         ),
         pytest.param(
@@ -342,17 +355,18 @@ def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
                 @property
                 def terminal(self):
                     raise RuntimeError("terminal property leaked")
-            raise HostileTerminalError("ordinary failure")
+            raise HostileTerminalError("SECRET_CANARY")
             """,
             "",
             1,
-            "ordinary failure",
-            ("terminal property leaked",),
+            UNEXPECTED_MESSAGE,
+            ("terminal property leaked", SECRET_CANARY),
             id="hostile-terminal-property",
         ),
         pytest.param(
             """
-            error = RuntimeError("typed interruption")
+            error = RuntimeError("SECRET_CANARY")
+            error.add_note("ChemEx SECRET_CANARY")
             error.terminal = Terminal.INTERRUPTED
             raise error
             """,
@@ -362,8 +376,8 @@ def test_cli_bootstrap_renders_only_audited_chemex_notes() -> None:
                 INTERRUPTED = "interrupted"
             """,
             130,
-            "ChemEx interrupted.",
-            (),
+            INTERRUPTED_MESSAGE,
+            (SECRET_CANARY,),
             id="strenum-terminal",
         ),
     ),
@@ -406,9 +420,19 @@ def test_cli_bootstrap_handles_hostile_exception_metadata(
         ),
     ),
 )
+@pytest.mark.parametrize(
+    ("failure_source", "expected_status", "expected_message"),
+    (
+        (f"raise RuntimeError('{SECRET_CANARY}')", 1, UNEXPECTED_MESSAGE),
+        ("raise KeyboardInterrupt", 130, INTERRUPTED_MESSAGE),
+    ),
+)
 def test_cli_bootstrap_renderer_failures_use_plain_stderr(
     phase: str,
     renderer_failure: str,
+    failure_source: str,
+    expected_status: int,
+    expected_message: str,
 ) -> None:
     messages_source = (
         f"""
@@ -429,21 +453,21 @@ def test_cli_bootstrap_renderer_failures_use_plain_stderr(
         """
     )
     completed = _run_bootstrap(
-        "raise RuntimeError('application failed')",
+        failure_source,
         messages_source=messages_source,
     )
 
     _assert_bootstrap_result(
         completed,
-        1,
-        "application failed",
-        absent=("renderer unavailable", "renderer failed"),
+        expected_status,
+        expected_message,
+        absent=("renderer unavailable", "renderer failed", SECRET_CANARY),
     )
 
 
 @pytest.mark.parametrize(
     ("import_failure", "expected_status"),
-    (("SyntaxError('broken application')", 1), ("SystemExit(23)", 23)),
+    ((f"SyntaxError('{SECRET_CANARY}')", 1), ("SystemExit(23)", 23)),
 )
 def test_cli_bootstrap_handles_protected_application_import_baseexceptions(
     import_failure: str,
@@ -454,11 +478,16 @@ def test_cli_bootstrap_handles_protected_application_import_baseexceptions(
 
     completed = _run((sys.executable, "-m", "chemex"), env=env)
 
-    combined = completed.stdout + completed.stderr
-    assert completed.returncode == expected_status
     if expected_status == 1:
-        assert "broken application" in completed.stderr
-    assert TRACEBACK_HEADER not in combined
+        _assert_bootstrap_result(
+            completed,
+            1,
+            UNEXPECTED_MESSAGE,
+            absent=(SECRET_CANARY,),
+        )
+    else:
+        assert completed.returncode == expected_status
+        assert completed.stdout == completed.stderr == ""
 
 
 def test_real_fit_interruption_flows_through_run_info_and_shared_bootstrap(

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -974,7 +974,9 @@ def test_seeded_native_chain_recovers_known_truncated_normal_posterior() -> None
     assert samples.std(ddof=1) == pytest.approx(distribution.std(), abs=0.025)
 
 
-def test_interruption_preserves_only_a_contiguous_complete_state_prefix() -> None:
+def test_interruption_preserves_unqualified_complete_state_prefix_without_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     accepted, problem, parameterization, engine = _native_context()
     plan = McmcPlan.for_accepted(
         accepted,
@@ -992,6 +994,15 @@ def test_interruption_preserves_only_a_contiguous_complete_state_prefix() -> Non
         if state.ordinal == 2:
             raise KeyboardInterrupt
 
+    def forbid_fresh_validation(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("interrupted execution must not freshly validate raw capture")
+
+    monkeypatch.setattr(
+        native_mcmc,
+        "validate_raw_mcmc_capture",
+        forbid_fresh_validation,
+    )
+
     operation = execute_mcmc_evidence(
         accepted,
         plan,
@@ -1000,15 +1011,51 @@ def test_interruption_preserves_only_a_contiguous_complete_state_prefix() -> Non
 
     assert operation.terminal is McmcOperationTerminal.INTERRUPTED
     assert operation.failure_category == "interrupted"
+    assert operation.evidence is None
+    assert operation.validation is None
+    assert operation.raw_capture is not None
+    assert tuple(state.ordinal for state in operation.raw_capture.states) == (0, 1, 2)
+    assert operation.raw_capture.objective_request_count == plan.policy.walkers * 3
+
+
+def test_interruption_after_qualification_preserves_complete_chain_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accepted, plan = _plan_context()
+    original = native_mcmc.validate_raw_mcmc_capture
+    validation_calls = 0
+
+    def count_validation(*args: object, **kwargs: object):
+        nonlocal validation_calls
+        validation_calls += 1
+        return original(*args, **kwargs)
+
+    def interrupt_before_final_assembly(
+        stage: McmcExecutionStage,
+        _count: int,
+    ) -> None:
+        if stage is McmcExecutionStage.BEFORE_FINAL_ASSEMBLY:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        native_mcmc,
+        "validate_raw_mcmc_capture",
+        count_validation,
+    )
+    operation = execute_mcmc_evidence(
+        accepted,
+        plan,
+        checkpoint_observer=interrupt_before_final_assembly,
+    )
+
+    assert validation_calls == 1
+    assert operation.terminal is McmcOperationTerminal.INTERRUPTED
     assert operation.evidence is not None
-    evidence = operation.evidence
-    assert evidence.lifecycle is McmcEvidenceLifecycle.PARTIAL
-    assert tuple(state.ordinal for state in evidence.states) == (0, 1, 2)
-    assert evidence.completed_transition_count == 2
-    assert evidence.objective_request_count == plan.policy.walkers * 3
-    retained = derive_retained_sample_view(evidence)
-    assert retained.selected_state_ordinals == ()
-    assert not retained.is_complete
+    assert operation.evidence.lifecycle is McmcEvidenceLifecycle.COMPLETED
+    assert operation.validation is not None
+    assert operation.validation.is_complete
+    assert operation.raw_capture is not None
+    assert operation.raw_capture.terminal is McmcOperationTerminal.COMPLETED
 
 
 def test_primary_chain_evidence_round_trips_and_rejects_tampering() -> None:

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -1870,10 +1870,9 @@ def test_interrupted_uncertainty_publication_failure_preserves_interruption(
             session=AnalysisSession.create(),
         )
 
-    assert any(
-        note.startswith("ChemEx ") and "evidence write failed" in note
-        for note in error_info.value.__notes__
-    )
+    assert error_info.value.__notes__ == [
+        "ChemEx could not publish interrupted uncertainty output."
+    ]
     assert _read_outcome(output)["terminal"] == "interrupted"
 
 
@@ -2894,10 +2893,9 @@ def test_interrupted_mcmc_publication_failure_preserves_interruption(
         )
 
     assert error_info.value.terminal == "interrupted"
-    assert any(
-        note.startswith("ChemEx ") and "raw capture write failed" in note
-        for note in error_info.value.__notes__
-    )
+    assert error_info.value.__notes__ == [
+        "ChemEx could not publish interrupted MCMC execution capture."
+    ]
     assert _read_outcome(output)["terminal"] == "interrupted"
 
 
@@ -3324,10 +3322,9 @@ def test_interrupted_resampling_publication_failure_preserves_interruption(
         run(_fit_arguments(output, method), session=AnalysisSession.create())
 
     assert error_info.value.terminal == "interrupted"
-    assert any(
-        note.startswith("ChemEx ") and "failure manifest write failed" in note
-        for note in error_info.value.__notes__
-    )
+    assert error_info.value.__notes__ == [
+        "ChemEx could not publish interrupted resampling output."
+    ]
     statistics = output / "Statistics" / "MonteCarlo"
     assert (statistics / "samples.tsv").is_file()
     assert _read_outcome(output)["terminal"] == "interrupted"

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -197,7 +197,7 @@ def _fit_arguments(
     )
 
 
-def _simulation_arguments(output: Path):
+def _simulation_arguments(output: Path, *, plot_level: str = "nothing"):
     return build_parser().parse_args(
         [
             "simulate",
@@ -210,7 +210,7 @@ def _simulation_arguments(output: Path):
             "--include",
             "G2N-HN",
             "--plot",
-            "nothing",
+            plot_level,
         ]
     )
 
@@ -392,6 +392,50 @@ def test_real_simulation_uses_native_values_and_preserves_back_calculation(
     assert (output / "Parameters" / "constrained.toml").is_file()
 
 
+def test_simulation_plot_interruption_preserves_written_results_and_propagates(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "Output"
+
+    with (
+        patch.object(Experiments, "plot_simulation", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run(
+            _simulation_arguments(output, plot_level="normal"),
+            session=AnalysisSession.create(),
+        )
+
+    assert (output / "Data" / "800mhz.dat").is_file()
+    assert (output / "Parameters" / "fixed.toml").is_file()
+    rendered = capsys.readouterr()
+    assert "Plotting cancelled" not in rendered.out + rendered.err
+
+
+def test_fit_plot_interruption_preserves_committed_results_and_propagates(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "Output"
+    session = AnalysisSession.create()
+
+    with (
+        patch.object(Experiments, "plot", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run(
+            _fit_arguments(output, plot_level="normal"),
+            session=session,
+        )
+
+    assert session.analysis_values.snapshot().revision == 1
+    assert (output / "Parameters" / "fitted.toml").is_file()
+    assert _read_outcome(output)["terminal"] == "interrupted"
+    rendered = capsys.readouterr()
+    assert "Plotting cancelled" not in rendered.out + rendered.err
+
+
 def _run_real_fit_cli(output: Path, method: Path, parameters: Path) -> None:
     subprocess.run(  # noqa: S603 - fixed local CLI and repository-owned fixtures
         [
@@ -425,6 +469,20 @@ def _run_real_fit_cli(output: Path, method: Path, parameters: Path) -> None:
 def _read_outcome(output: Path) -> dict[str, object]:
     return tomllib.loads(
         (output / "run_info" / "outcome.toml").read_text(encoding="utf-8")
+    )
+
+
+def _assert_interrupted_mcmc_artifacts(
+    statistics: Path,
+    *,
+    raw_capture: bool,
+    raw_chain: bool,
+) -> None:
+    assert (statistics / "raw_capture.tsv").is_file() is raw_capture
+    assert (statistics / "raw_chain.tsv").is_file() is raw_chain
+    assert all(
+        not (statistics / name).exists()
+        for name in ("summary.toml", "samples.tsv", "correlations.tsv", "plots.pdf")
     )
 
 
@@ -1547,6 +1605,7 @@ G2N-H = [2.3, 2.18, 5.0]
             encoding="utf-8"
         )
     )
+    assert not (output / "Statistics" / "Covariance" / "block_recovery.json").exists()
     assert len(blocks["partition_proof_identity"]) == 64
     assert all(block["scope_reportable"] for block in blocks["blocks"])
     claim_sets = [
@@ -1625,6 +1684,8 @@ def test_interrupted_block_fallback_preserves_committed_root_evidence(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text("[STEP1]\n\n[STEP2]\n", encoding="utf-8")
     session = AnalysisSession.create()
     original_svd = uncertainty_module.svd
 
@@ -1638,24 +1699,182 @@ def test_interrupted_block_fallback_preserves_committed_root_evidence(
         patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_svd),
         patch.object(
             deterministic_uncertainty_module,
-            "derive_root_anchored_block_covariance",
+            "execute_root_anchored_block_covariance",
             side_effect=KeyboardInterrupt,
         ),
+        pytest.raises(KeyboardInterrupt, match="uncertainty derivation interrupted"),
     ):
         run(
-            _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
+            _fit_arguments(
+                output,
+                method,
+                include=("G2N-HN", "H3N-HN"),
+            ),
             session=session,
         )
 
     assert session.analysis_values.snapshot().revision == 1
-    covariance_path = output / "Statistics" / "Covariance"
+    covariance_path = output / "STEP1" / "Statistics" / "Covariance"
     assert (covariance_path / "evidence.json").is_file()
     assert not (covariance_path / "blocks.json").exists()
     status = json.loads((covariance_path / "status.json").read_text(encoding="utf-8"))
     assert status["status"] == "incomplete"
     assert status["terminal"] == "interrupted"
     assert status["reason"] == "derivation interrupted/cancelled"
-    assert (output / "Parameters" / "fitted.toml").is_file()
+    assert (output / "STEP1" / "Parameters" / "fitted.toml").is_file()
+    assert not (output / "STEP1" / "statistics.toml").exists()
+    assert not (output / "STEP2").exists()
+    outcome = _read_outcome(output)
+    assert outcome["terminal"] == "interrupted"
+    assert outcome["failure_stage"] == "uncertainty"
+
+
+def test_later_block_interruption_publishes_exact_prefix_and_stops_plan(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        '[DEFAULT]\nFIX = ["PB", "KEX_AB"]\n\n[STEP1]\n\n[STEP2]\n',
+        encoding="utf-8",
+    )
+    original_svd = uncertainty_module.svd
+    block_calls = 0
+
+    def interrupt_second_block(*args, **kwargs):
+        nonlocal block_calls
+        is_block = np.asarray(args[0]).shape[1] == 1
+        if is_block:
+            block_calls += 1
+        if is_block and block_calls == 2:
+            raise KeyboardInterrupt
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        if not is_block or block_calls == 1:
+            singular[-1] = 0.0
+        return left, singular, right
+
+    with (
+        patch("chemex.optimize.uncertainty.svd", side_effect=interrupt_second_block),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run(
+            _fit_arguments(output, method, include=("G2N-HN", "H3N-HN")),
+            session=AnalysisSession.create(),
+        )
+
+    covariance = output / "DEFAULT" / "Statistics" / "Covariance"
+    recovery = json.loads(
+        (covariance / "block_recovery.json").read_text(encoding="utf-8")
+    )
+    assert recovery["terminal"] == "interrupted"
+    assert recovery["completed_block_count"] == 1
+    assert recovery["planned_block_count"] == 2
+    assert [item["disposition"] for item in recovery["blocks"]] == [
+        "completed",
+        "not_completed",
+    ]
+    assert not (covariance / "blocks.json").exists()
+    assert not (output / "DEFAULT" / "statistics.toml").exists()
+    assert not (output / "STEP1").exists()
+    assert not (output / "STEP2").exists()
+    assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_full_block_prefix_interruption_publishes_complete_science_but_stops_plan(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = tmp_path / "method.toml"
+    method.write_text(
+        '[DEFAULT]\nFIX = ["PB", "KEX_AB"]\n\n[STEP1]\n\n[STEP2]\n',
+        encoding="utf-8",
+    )
+    original_svd = uncertainty_module.svd
+    original_bundle = uncertainty_module.RootAnchoredBlockCovarianceEvidence
+    root_seen = False
+    bundle_calls = 0
+
+    def rank_deficient_root(*args, **kwargs):
+        nonlocal root_seen
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        if not root_seen and np.asarray(args[0]).shape[1] == 2:
+            root_seen = True
+            singular[-1] = 0.0
+        return left, singular, right
+
+    def interrupt_initial_bundle_assembly(*args, **kwargs):
+        nonlocal bundle_calls
+        bundle_calls += 1
+        if bundle_calls == 1:
+            raise KeyboardInterrupt
+        return original_bundle(*args, **kwargs)
+
+    with (
+        patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_root),
+        patch.object(
+            uncertainty_module,
+            "RootAnchoredBlockCovarianceEvidence",
+            side_effect=interrupt_initial_bundle_assembly,
+        ),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run(
+            _fit_arguments(output, method, include=("G2N-HN", "H3N-HN")),
+            session=AnalysisSession.create(),
+        )
+
+    covariance = output / "DEFAULT" / "Statistics" / "Covariance"
+    recovery = json.loads(
+        (covariance / "block_recovery.json").read_text(encoding="utf-8")
+    )
+    blocks = json.loads((covariance / "blocks.json").read_text(encoding="utf-8"))
+    assert recovery["terminal"] == "interrupted"
+    assert recovery["completed_block_count"] == recovery["planned_block_count"] == 2
+    assert recovery["complete_evidence_identity"] == blocks["identity"]
+    assert not (covariance / "status.json").exists()
+    assert not (output / "DEFAULT" / "statistics.toml").exists()
+    assert not (output / "STEP1").exists()
+    assert not (output / "STEP2").exists()
+    assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_interrupted_uncertainty_publication_failure_preserves_interruption(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    original_svd = uncertainty_module.svd
+
+    def rank_deficient_svd(*args, **kwargs):
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        singular[-1] = 0.0
+        return left, singular, right
+
+    with (
+        patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_svd),
+        patch.object(
+            deterministic_uncertainty_module,
+            "execute_root_anchored_block_covariance",
+            side_effect=KeyboardInterrupt,
+        ),
+        patch(
+            "chemex.optimize.helper.write_uncertainty",
+            side_effect=RuntimeError("evidence write failed"),
+        ),
+        pytest.raises(KeyboardInterrupt) as error_info,
+    ):
+        run(
+            _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
+            session=AnalysisSession.create(),
+        )
+
+    assert any(
+        note.startswith("ChemEx ") and "evidence write failed" in note
+        for note in error_info.value.__notes__
+    )
+    assert _read_outcome(output)["terminal"] == "interrupted"
 
 
 def test_shared_parameter_coupling_is_not_split_into_covariance_blocks(
@@ -1851,9 +2070,12 @@ def test_interrupted_covariance_keeps_committed_fit_and_invalidates_stale_eviden
     assert (output / "Statistics" / "Covariance" / "evidence.json").is_file()
 
     session = AnalysisSession.create()
-    with patch(
-        "chemex.optimize.deterministic_uncertainty.derive_uncertainty_evidence",
-        side_effect=KeyboardInterrupt,
+    with (
+        patch(
+            "chemex.optimize.deterministic_uncertainty.derive_uncertainty_evidence",
+            side_effect=KeyboardInterrupt,
+        ),
+        pytest.raises(KeyboardInterrupt, match="uncertainty derivation interrupted"),
     ):
         run(_fit_arguments(output), session=session)
 
@@ -1875,6 +2097,10 @@ def test_interrupted_covariance_keeps_committed_fit_and_invalidates_stale_eviden
         "status": "incomplete",
         "terminal": "interrupted",
     }
+    assert not (output / "statistics.toml").exists()
+    outcome = _read_outcome(output)
+    assert outcome["terminal"] == "interrupted"
+    assert outcome["failure_stage"] == "uncertainty"
 
 
 def test_uncertainty_exception_does_not_roll_back_the_committed_fit(
@@ -2172,7 +2398,7 @@ def test_automatic_mcmc_burn_failure_preserves_only_incomplete_raw_evidence(
     assert diagnostics["sampling_terminal"] == "completed"
     assert diagnostics["posterior_retention"] == "failed"
     assert diagnostics["posterior_summary"] == "withheld"
-    assert diagnostics["raw_evidence"] == "diagnostic_chain"
+    assert diagnostics["raw_evidence"] == "qualified_chain"
     assert diagnostics["raw_chain_file"] == "raw_chain.tsv"
     assert diagnostics["raw_steps"] == 5
     assert diagnostics["raw_samples"] == 160
@@ -2321,7 +2547,7 @@ def test_short_compact_mcmc_form_fails_closed_through_real_chemex_cli(
     assert diagnostics["status"] == "incomplete"
     assert diagnostics["engine"] == "native MCMC"
     assert diagnostics["steps"] == 2
-    assert diagnostics["raw_evidence"] == "diagnostic_chain"
+    assert diagnostics["raw_evidence"] == "qualified_chain"
     assert (statistics / "raw_chain.tsv").is_file()
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "samples.tsv").exists()
@@ -2482,10 +2708,196 @@ def test_interrupted_native_mcmc_publishes_only_incomplete_diagnostics(
     assert diagnostics["status"] == "incomplete"
     assert diagnostics["terminal"] == "interrupted"
     assert diagnostics["completed_steps"] == 0
-    assert not (statistics / "summary.toml").exists()
-    assert not (statistics / "samples.tsv").exists()
-    assert not (statistics / "correlations.tsv").exists()
-    assert not (statistics / "plots.pdf").exists()
+    assert diagnostics["raw_evidence"] == "execution_capture_unqualified"
+    assert diagnostics["captured_states"] == 1
+    assert diagnostics["completed_transitions"] == 0
+    _assert_interrupted_mcmc_artifacts(
+        statistics,
+        raw_capture=True,
+        raw_chain=False,
+    )
+    assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_interrupted_native_mcmc_publishes_unqualified_raw_capture(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+
+    def interrupt_after_second_transition(accepted, plan, *, execution):
+        def observe(state):
+            if state.ordinal == 2:
+                raise KeyboardInterrupt
+
+        return native_mcmc_module.execute_mcmc_evidence(
+            accepted,
+            plan,
+            execution=execution,
+            state_observer=observe,
+        )
+
+    with (
+        patch.object(
+            mcmc_module,
+            "execute_mcmc_evidence",
+            side_effect=interrupt_after_second_transition,
+        ),
+        pytest.raises(NativeMcmcIncompleteError, match="interrupted") as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    assert error_info.value.terminal == "interrupted"
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "incomplete"
+    assert diagnostics["terminal"] == "interrupted"
+    assert diagnostics["sampling_terminal"] == "interrupted"
+    assert diagnostics["completed_steps"] == 2
+    assert diagnostics["raw_evidence"] == "execution_capture_unqualified"
+    assert diagnostics["posterior_summary"] == "withheld"
+    assert diagnostics["captured_states"] == 3
+    assert diagnostics["completed_transitions"] == 2
+    raw_lines = (
+        (statistics / "raw_capture.tsv").read_text(encoding="utf-8").splitlines()
+    )
+    assert len(raw_lines) == 13
+    _assert_interrupted_mcmc_artifacts(
+        statistics,
+        raw_capture=True,
+        raw_chain=False,
+    )
+    assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_interruption_after_mcmc_qualification_publishes_only_qualified_chain(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+
+    with (
+        patch.object(
+            mcmc_module,
+            "derive_mcmc_analysis_result",
+            side_effect=KeyboardInterrupt,
+        ),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["terminal"] == "interrupted"
+    assert diagnostics["raw_evidence"] == "qualified_chain"
+    assert diagnostics["posterior_retention"] == "withheld"
+    assert diagnostics["convergence"] == "withheld"
+    _assert_interrupted_mcmc_artifacts(
+        statistics,
+        raw_capture=False,
+        raw_chain=True,
+    )
+    assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+@pytest.mark.parametrize(
+    "publication_name",
+    (
+        "_write_summary",
+        "_write_samples",
+        "_write_correlations",
+        "write_mcmc_plots",
+        "_write_diagnostics",
+    ),
+)
+def test_each_mcmc_publication_interruption_retains_only_qualified_chain(
+    tmp_path: Path,
+    publication_name: str,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+
+    with (
+        patch.object(
+            mcmc_module,
+            publication_name,
+            side_effect=KeyboardInterrupt,
+        ),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["terminal"] == "interrupted"
+    assert diagnostics["raw_evidence"] == "qualified_chain"
+    _assert_interrupted_mcmc_artifacts(
+        statistics,
+        raw_capture=False,
+        raw_chain=True,
+    )
+
+
+def test_interrupted_mcmc_publication_failure_preserves_interruption(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+
+    def interrupt_after_second_transition(accepted, plan, *, execution):
+        def observe(state):
+            if state.ordinal == 2:
+                raise KeyboardInterrupt
+
+        return native_mcmc_module.execute_mcmc_evidence(
+            accepted,
+            plan,
+            execution=execution,
+            state_observer=observe,
+        )
+
+    with (
+        patch.object(
+            mcmc_module,
+            "execute_mcmc_evidence",
+            side_effect=interrupt_after_second_transition,
+        ),
+        patch.object(
+            mcmc_module,
+            "_write_raw_capture",
+            side_effect=RuntimeError("raw capture write failed"),
+        ),
+        pytest.raises(NativeMcmcIncompleteError) as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    assert error_info.value.terminal == "interrupted"
+    assert any(
+        note.startswith("ChemEx ") and "raw capture write failed" in note
+        for note in error_info.value.__notes__
+    )
     assert _read_outcome(output)["terminal"] == "interrupted"
 
 
@@ -2845,10 +3257,18 @@ def test_interrupted_native_statistics_report_truthful_disposition_counts(
             "chemex.optimize.native_resampling.generate_resampling_draw",
             side_effect=interrupt_second_draw,
         ),
-        pytest.raises(NativeResamplingIncompleteError, match="1 of 3"),
+        patch.object(
+            resampling_module,
+            "derive_resampling_analysis_result",
+            side_effect=AssertionError(
+                "interrupted resampling must not derive statistical summaries"
+            ),
+        ),
+        pytest.raises(NativeResamplingIncompleteError, match="1 of 3") as error_info,
     ):
         run(_fit_arguments(output, method), session=session)
 
+    assert error_info.value.terminal == "interrupted"
     statistics = output / "Statistics" / "MonteCarlo"
     diagnostics = tomllib.loads(
         (statistics / "diagnostics.toml").read_text(encoding="utf-8")
@@ -2874,6 +3294,73 @@ def test_interrupted_native_statistics_report_truthful_disposition_counts(
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()
+    assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_interrupted_resampling_publication_failure_preserves_interruption(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 3')
+    real_generate = native_resampling_module.generate_resampling_draw
+
+    def interrupt_second_draw(dataset, request):
+        if request.ordinal == 1:
+            raise KeyboardInterrupt
+        return real_generate(dataset, request)
+
+    with (
+        patch(
+            "chemex.optimize.native_resampling.generate_resampling_draw",
+            side_effect=interrupt_second_draw,
+        ),
+        patch.object(
+            resampling_module,
+            "_write_native_failures",
+            side_effect=RuntimeError("failure manifest write failed"),
+        ),
+        pytest.raises(NativeResamplingIncompleteError) as error_info,
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    assert error_info.value.terminal == "interrupted"
+    assert any(
+        note.startswith("ChemEx ") and "failure manifest write failed" in note
+        for note in error_info.value.__notes__
+    )
+    statistics = output / "Statistics" / "MonteCarlo"
+    assert (statistics / "samples.tsv").is_file()
+    assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_ctrl_c_after_resampling_operation_preserves_validated_sample_values(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 3')
+
+    with (
+        patch.object(
+            resampling_module,
+            "_resampling_result_and_samples",
+            side_effect=KeyboardInterrupt,
+        ),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    statistics = output / "Statistics" / "MonteCarlo"
+    sample_lines = (statistics / "samples.tsv").read_text(encoding="utf-8").splitlines()
+    assert len(sample_lines) == 4
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["terminal"] == "interrupted"
+    assert diagnostics["completed_samples"] == 3
+    assert not (statistics / "summary.toml").exists()
+    assert not (statistics / "correlations.tsv").exists()
+    assert not (statistics / "plots.pdf").exists()
+    assert _read_outcome(output)["terminal"] == "interrupted"
 
 
 def test_native_statistics_setup_failure_publishes_incomplete_diagnostics(

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -123,7 +123,9 @@ def _analytic_pa_kba(kab: float, kba: float) -> float:
     return kab / (kab + kba) ** 2
 
 
-def _accepted_relaxation_fit() -> tuple[
+def _accepted_relaxation_fit(
+    spin_systems: tuple[str, ...] = ("G2N-HN",),
+) -> tuple[
     AnalysisSession,
     ActiveParameterization,
     EvaluationEngine,
@@ -135,7 +137,7 @@ def _accepted_relaxation_fit() -> tuple[
     experiments = build_experiments(
         [EXPERIMENT],
         Selection(
-            include=[SpinSystem.from_name("G2N-HN")],
+            include=[SpinSystem.from_name(name) for name in spin_systems],
             exclude=None,
         ),
         session=session,
@@ -292,7 +294,7 @@ def test_block_interruption_retains_root_evidence_and_conclusions() -> None:
     _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit()
 
     with patch(
-        "chemex.optimize.deterministic_uncertainty.derive_root_anchored_block_covariance",
+        "chemex.optimize.deterministic_uncertainty.execute_root_anchored_block_covariance",
         side_effect=KeyboardInterrupt,
     ):
         uncertainty = _derive_product_uncertainty(
@@ -310,6 +312,180 @@ def test_block_interruption_retains_root_evidence_and_conclusions() -> None:
     controlled = uncertainty.parameter(problem.controlled_ids[0])
     assert controlled is not None
     assert controlled.reportable
+
+
+def test_block_operation_retains_exact_completed_prefix_after_interruption() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit(
+        ("G2N-HN", "H3N-HN")
+    )
+    original_svd = uncertainty_module.svd
+    call_count = 0
+
+    def interrupt_second_block(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 3:
+            raise KeyboardInterrupt
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        if call_count in {1, 2}:
+            singular[-1] = 0.0
+        return left, singular, right
+
+    with patch(
+        "chemex.optimize.uncertainty.svd",
+        side_effect=interrupt_second_block,
+    ):
+        uncertainty = _derive_product_uncertainty(
+            accepted,
+            problem,
+            parameterization,
+            engine,
+        )
+
+    operation = uncertainty.block_operation
+    assert operation is not None
+    assert operation.terminal is OperationTerminal.INTERRUPTED
+    assert len(operation.completed_blocks) == 1
+    assert operation.completed_blocks[0].failure is not None
+    assert operation.completed_blocks[0].failure.category == "rank_deficient"
+    assert operation.complete_evidence is None
+    assert uncertainty.completeness is InterpretationCompleteness.INCOMPLETE
+    assert uncertainty.incomplete_terminal is OperationTerminal.INTERRUPTED
+
+
+def test_full_block_prefix_interruption_retains_complete_uncertainty() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit(
+        ("G2N-HN", "H3N-HN")
+    )
+    original_svd = uncertainty_module.svd
+    original_bundle = uncertainty_module.RootAnchoredBlockCovarianceEvidence
+    bundle_attempts = 0
+    svd_calls = 0
+
+    def rank_deficient_root(*args, **kwargs):
+        nonlocal svd_calls
+        svd_calls += 1
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        if svd_calls == 1:
+            singular[-1] = 0.0
+        return left, singular, right
+
+    def interrupt_first_bundle(*args, **kwargs):
+        nonlocal bundle_attempts
+        bundle_attempts += 1
+        if bundle_attempts == 1:
+            raise KeyboardInterrupt
+        return original_bundle(*args, **kwargs)
+
+    with (
+        patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_root),
+        patch.object(
+            uncertainty_module,
+            "RootAnchoredBlockCovarianceEvidence",
+            side_effect=interrupt_first_bundle,
+        ),
+    ):
+        uncertainty = _derive_product_uncertainty(
+            accepted,
+            problem,
+            parameterization,
+            engine,
+        )
+
+    operation = uncertainty.block_operation
+    assert operation is not None
+    assert operation.terminal is OperationTerminal.INTERRUPTED
+    assert (
+        len(operation.completed_blocks)
+        == len(operation.source_partition_proof.component_records)
+        == 2
+    )
+    assert operation.complete_evidence is not None
+    assert uncertainty.completeness is InterpretationCompleteness.COMPLETE
+    assert uncertainty.incomplete_terminal is None
+    assert uncertainty.derivation_interrupted
+
+
+def test_block_operation_rejects_reordered_complete_blocks() -> None:
+    _session, parameterization, engine, problem, accepted = _accepted_relaxation_fit(
+        ("G2N-HN", "H3N-HN")
+    )
+    original_svd = uncertainty_module.svd
+    call_count = 0
+
+    def rank_deficient_root(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        if call_count == 1:
+            singular[-1] = 0.0
+        return left, singular, right
+
+    with patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_root):
+        uncertainty = _derive_product_uncertainty(
+            accepted,
+            problem,
+            parameterization,
+            engine,
+        )
+
+    operation = uncertainty.block_operation
+    assert operation is not None
+    with pytest.raises(ValueError, match="exact partition prefix"):
+        dataclasses.replace(
+            operation,
+            completed_blocks=tuple(reversed(operation.completed_blocks)),
+        )
+    first, second = operation.completed_blocks
+    with pytest.raises(ValueError, match="exact partition prefix"):
+        dataclasses.replace(operation, completed_blocks=(first, first))
+    with pytest.raises(ValueError, match="exact partition prefix"):
+        dataclasses.replace(operation, completed_blocks=(second,))
+    foreign_proof = dataclasses.replace(
+        operation.source_partition_proof,
+        root_plan_identity="foreign-root-plan",
+    )
+    with pytest.raises(ValueError, match="exact root partition proof"):
+        dataclasses.replace(operation, source_partition_proof=foreign_proof)
+    with pytest.raises(ValueError, match="marginal scope"):
+        dataclasses.replace(first, marginal_errors=())
+    foreign_source = dataclasses.replace(operation.source_bundle)
+    with pytest.raises(ValueError, match="foreign source context"):
+        dataclasses.replace(operation, source_bundle=foreign_source)
+    equivalent_foreign_proof = dataclasses.replace(operation.source_partition_proof)
+    with pytest.raises(ValueError, match="foreign source context"):
+        dataclasses.replace(
+            operation,
+            source_partition_proof=equivalent_foreign_proof,
+        )
+    with pytest.raises(ValueError, match="exact partition prefix"):
+        dataclasses.replace(
+            operation,
+            completed_blocks=(
+                dataclasses.replace(
+                    first,
+                    root_profile_indices=second.root_profile_indices,
+                ),
+                second,
+            ),
+        )
+    detached = dataclasses.replace(
+        first,
+        _source_bundle=None,
+        _source_partition_proof=None,
+    )
+    with pytest.raises(ValueError, match="foreign source context"):
+        dataclasses.replace(
+            operation,
+            completed_blocks=(detached, *operation.completed_blocks[1:]),
+        )
+    complete = operation.complete_evidence
+    assert complete is not None
+    with pytest.raises(ValueError, match="foreign source context"):
+        dataclasses.replace(complete, source_bundle=foreign_source)
 
 
 def _accepted_step1_profile_fit(


### PR DESCRIPTION
## Summary

- Translate uncaught CLI failures into concise stderr diagnostics instead of Python tracebacks.
- Make Ctrl-C stop further scientific computation, preserve completed scientifically valid work where possible, propagate interruption, and exit with status 130.
- Preserve deterministic uncertainty root Evidence and validated partial or complete block recovery.
- Keep unqualified MCMC execution capture distinct from qualified chain Evidence.
- Preserve completed validated resampling replicates without claiming complete statistics.
- Publish interrupted artifacts atomically and fail closed when finalization fails.
- Keep programmatic APIs exception-transparent.
- Leave successful numerical behavior and normal artifact schemas unchanged.

## Architecture

ADR-0005 records the single terminal bootstrap and exception-transparent internal API contract.

## Validation

- 1,164 tests passed
- `uv run ty check` passed
- `uv run ruff check .` passed
- `uv run ruff format --check .` passed
- `git diff --check` passed

Invariant: stop new scientific work → preserve truthful completed work → bounded atomic finalization → propagate interruption → exit 130 without traceback.