### PR TITLE
test: tolerate wrapped CLI error paths

### DIFF
--- a/tests/experiments/test_experiment_types.py
+++ b/tests/experiments/test_experiment_types.py
@@ -313,7 +313,8 @@ def test_malformed_dataset_cli_failure_has_no_traceback(
     output = capfd.readouterr()
     assert error_info.value.code == 1
     assert "Invalid data" in output.err
-    assert "malformed.dat" in output.err
+    # Rich may wrap long temporary paths; line breaks are presentation only.
+    assert "malformed.dat" in output.err.replace("\n", "")
     assert "Traceback" not in output.out + output.err
 
 


### PR DESCRIPTION
## Summary

Rich may wrap a long pytest temporary path across terminal lines when the malformed-dataset CLI test runs under xdist. This test-only correction normalizes captured diagnostic newlines before checking for the exact `malformed.dat` filename.

The test still proves:
- the CLI exits unsuccessfully with code 1;
- the diagnostic contains `Invalid data`;
- the exact malformed input filename is identified;
- no Python traceback is exposed.

Production rendering, scientific behavior, numerical tolerances, and test selection are unchanged. This PR is intentionally separate from the disposable xdist benchmark and contains no workflow or dependency changes.

## Validation

- Focused test: passed
- `tests/experiments/test_experiment_types.py`: 21 passed
- Full serial suite: 1170 passed in 300.03s
- Ruff check: passed
- Ruff format check: passed
- `git diff --check`: passed