### PR TITLE
Standardize the test suite on two pytest workers

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -86,7 +86,7 @@ jobs:
         run: uv sync --locked
 
       - name: Run tests
-        run: uv run pytest -q
+        run: uv run pytest -q -n 2
 
   package:
     name: Build and validate package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,10 @@ Run focused tests while developing. Before submitting a Python change, run the
 applicable repository checks:
 
 ```sh
+# Serial execution is useful for focused debugging.
 uv run pytest -q
+# The standard full-suite command matches CI.
+uv run pytest -q -n 2
 uv run ty check
 uv run ruff check .
 uv run ruff format --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ chemex = "chemex._entrypoint:main"
 [dependency-groups]
 dev = [
   "pytest>=8.4.2",
+  "pytest-xdist>=3.8.0,<4",
   # New Ruff minor releases require an explicit policy review.
   "ruff>=0.16.0,<0.17.0",
   "scipy-stubs>=1.18.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "scipy-stubs" },
     { name = "ty" },
@@ -61,6 +62,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-xdist", specifier = ">=3.8.0,<4" },
     { name = "ruff", specifier = ">=0.16.0,<0.17.0" },
     { name = "scipy-stubs", specifier = ">=1.18.0.1" },
     { name = "ty", specifier = ">=0.0.65" },
@@ -150,6 +152,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cb/53/1045ee878cb24281387079f8ee4f0ade1622c6aae1ed1fd91a53e4fa5b19/emcee-3.1.6.tar.gz", hash = "sha256:11af4daf6ab8f9ca69681e3c29054665db7bbd87fd4eb8e437d2c3a1248c637d", size = 2871117, upload-time = "2024-04-19T10:03:19.555Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/ef/2196b9bf88ffa1bde45853c72df021fbd07a8fa91a0f59a22d14a050dc04/emcee-3.1.6-py2.py3-none-any.whl", hash = "sha256:f2d63752023bdccf744461450e512a5b417ae7d28f18e12acd76a33de87580cb", size = 47351, upload-time = "2024-04-19T10:03:17.522Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -571,6 +582,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopt explicit fixed two-worker pytest-xdist execution for the complete Python test suite in CI on both Python 3.13 and 3.14.

- Add `pytest-xdist>=3.8.0,<4` as a development dependency; `uv.lock` resolves `pytest-xdist==3.8.0` and `execnet==2.1.2`.
- Change only the existing Python test-matrix command to `uv run pytest -q -n 2`.
- Keep serial `uv run pytest -q` available for debugging and document the explicit parallel command for the standard full suite.
- Preserve the complete test selection, both supported Python versions, default xdist load scheduling, and all scientific workloads/tolerances.
- No BLAS/OpenMP limits, markers, sharding, auto worker selection, production changes, or CEST/DE/CPMG changes.

The separate test-only Rich wrapping correction is already merged in PR #737. Disposable benchmark PR #735 remains closed and is not part of this change.

## Measurements

Local post-change validation:

- Serial: `1170 passed in 298.02s` pytest time (`298.43s` real).
- Two workers: `1170 passed in 203.89s` pytest time (`204.05s` real), about `1.46x` faster.
- `ty check`: passed.
- Ruff lint: passed.
- Ruff format check: passed.
- `git diff --check`: passed.

GitHub benchmark evidence on Linux, all runs passing with 1170 tests:

- Python 3.13, default threading: serial 794.01s; `-n 2` median 625.19/443.49/608.82s across three runs (runner variability observed).
- Python 3.14, default threading: serial 863.24s; `-n 2` median 524.49/589.39/383.19s across three runs (runner variability observed).
- The benchmark also compared `OPENBLAS_NUM_THREADS=1`; it showed no reliable benefit, so no thread limit is included here.

This PR is intentionally limited to the permanent dependency and test-runner policy change.