### PR TITLE
docs: improve website SEO metadata

### DIFF
--- a/website/docs/examples/index.mdx
+++ b/website/docs/examples/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_label: Examples
 sidebar_position: 4
+description: Explore representative ChemEx workflows for CPMG, CEST, D-CEST/cos-CEST, relaxation, diffusion, binding, and multi-experiment kinetic analysis.
 ---
 
 # Representative Examples

--- a/website/docs/experiments/cest/cest_13c.md
+++ b/website/docs/experiments/cest/cest_13c.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure in-phase ¹³C
 sidebar_position: 2
-description: '"cest_13c"'
+description: Analyze ¹³C CEST chemical exchange with ¹H composite decoupling and in-phase magnetization.
 ---
 
 # Pure in-phase ¹³C CEST

--- a/website/docs/experiments/cest/cest_15n.md
+++ b/website/docs/experiments/cest/cest_15n.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure in-phase ¹⁵N
 sidebar_position: 1
-description: '"cest_15n"'
+description: Analyze pure in-phase ¹⁵N CEST data with ¹H composite decoupling for chemical exchange.
 ---
 
 # Pure in-phase ¹⁵N CEST

--- a/website/docs/experiments/cest/cest_15n_cw.md
+++ b/website/docs/experiments/cest/cest_15n_cw.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: ¹⁵N with ¹H CW decoupling
 sidebar_position: 3
-description: '"cest_15n_cw"'
+description: Analyze ¹⁵N CEST chemical exchange with ¹H continuous-wave decoupling during the CEST block.
 ---
 
 # ¹⁵N CEST with ¹H CW decoupling

--- a/website/docs/experiments/cest/cest_15n_tr.md
+++ b/website/docs/experiments/cest/cest_15n_tr.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: ¹⁵N TROSY
 sidebar_position: 4
-description: '"cest_15n_tr"'
+description: Analyze ¹⁵N TROSY CEST data for chemical exchange during the CEST block.
 ---
 
 # ¹⁵N TROSY CEST

--- a/website/docs/experiments/cest/cest_1hn_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ap.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure anti-phase amide ¹H
 sidebar_position: 5
-description: '"cest_1hn_ap"'
+description: Analyze pure anti-phase amide ¹H CEST data for chemical exchange during the CEST block.
 ---
 
 # Pure anti-phase amide ¹H CEST

--- a/website/docs/experiments/cest/cest_1hn_ip_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ip_ap.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: In-phase/anti-phase amide ¹H
 sidebar_position: 6
-description: '"cest_1hn_ip_ap"'
+description: Analyze in-phase/anti-phase amide ¹H CEST data for chemical exchange during the CEST block.
 ---
 
 # In-phase/anti-phase amide ¹H CEST

--- a/website/docs/experiments/cest/cest_ch3_1h_ip_ap.md
+++ b/website/docs/experiments/cest/cest_ch3_1h_ip_ap.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: In-phase/anti-phase methyl ¹H
 sidebar_position: 7
-description: '"cest_ch3_1h_ip_ap"'
+description: Analyze in-phase/anti-phase methyl ¹H CEST data for ¹³CH₃- and ¹³CHD₂-labeled proteins.
 ---
 
 # In-phase/anti-phase methyl ¹H CEST

--- a/website/docs/experiments/cest/index.mdx
+++ b/website/docs/experiments/cest/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: CEST
 sidebar_position: 1
-description: CEST experiments
+description: ChemEx CEST experiments for analyzing chemical exchange in ¹³C, ¹⁵N, amide ¹H, and methyl groups.
 ---
 
 # CEST experiments

--- a/website/docs/experiments/cpmg/cpmg_13c_ip.md
+++ b/website/docs/experiments/cpmg/cpmg_13c_ip.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure in-phase ¹³C
 sidebar_position: 8
-description: '"cpmg_13c_ip"'
+description: Analyze pure in-phase ¹³C CPMG relaxation-dispersion data with high-power ¹H CW decoupling.
 ---
 
 # Pure in-phase ¹³C CPMG

--- a/website/docs/experiments/cpmg/cpmg_13co_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_13co_ap.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure anti-phase carbonyl ¹³C
 sidebar_position: 9
-description: '"cpmg_13co_ap"'
+description: Analyze pure anti-phase carbonyl ¹³C CPMG relaxation-dispersion data with optional C–C J-coupling refocusing.
 ---
 
 # Pure anti-phase carbonyl ¹³C CPMG

--- a/website/docs/experiments/cpmg/cpmg_15n_ip.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_ip.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure in-phase ¹⁵N
 sidebar_position: 1
-description: '"cpmg_15n_ip"'
+description: Analyze pure in-phase ¹⁵N CPMG relaxation-dispersion data with high-power ¹H CW decoupling.
 ---
 
 # Pure in-phase ¹⁵N CPMG

--- a/website/docs/experiments/cpmg/cpmg_15n_ip_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_ip_0013.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure in-phase ¹⁵N with [0013] phase cycle
 sidebar_position: 2
-description: '"cpmg_15n_ip_0013"'
+description: Analyze pure in-phase ¹⁵N CPMG relaxation-dispersion data with the [0013] phase cycle.
 ---
 
 # Pure in-phase ¹⁵N CPMG with [0013] phase cycle

--- a/website/docs/experiments/cpmg/cpmg_15n_tr.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_tr.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: ¹⁵N TROSY
 sidebar_position: 3
-description: '"cpmg_15n_tr"'
+description: Analyze ¹⁵N constant-time TROSY CPMG relaxation-dispersion data for millisecond-timescale exchange dynamics.
 ---
 
 # ¹⁵N TROSY CPMG

--- a/website/docs/experiments/cpmg/cpmg_15n_tr_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_15n_tr_0013.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: ¹⁵N TROSY with [0013] phase cycle
 sidebar_position: 4
-description: '"cpmg_15n_tr_0013"'
+description: Analyze ¹⁵N TROSY CPMG relaxation-dispersion data with the [0013] phase cycle for ΔD NH measurements.
 ---
 
 # ¹⁵N TROSY CPMG with [0013] phase cycle

--- a/website/docs/experiments/cpmg/cpmg_1hn_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_1hn_ap.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure anti-phase amide ¹H
 sidebar_position: 5
-description: '"cpmg_1hn_ap"'
+description: Analyze pure anti-phase amide ¹H CPMG relaxation-dispersion data with reduced intrinsic relaxation.
 ---
 
 # Pure anti-phase amide ¹H CPMG

--- a/website/docs/experiments/cpmg/cpmg_1hn_ap_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_1hn_ap_0013.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure anti-phase amide ¹H with [0013] phase cycle
 sidebar_position: 6
-description: '"cpmg_1hn_ap_0013"'
+description: Analyze pure anti-phase amide ¹H CPMG relaxation-dispersion data with the [0013] phase cycle.
 ---
 
 # Pure anti-phase amide ¹H CPMG with [0013] phase cycle

--- a/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Methyl ¹³C (“H-to-C”)
 sidebar_position: 10
-description: '"cpmg_ch3_13c_h2c"'
+description: Analyze methyl ¹³C CPMG relaxation-dispersion data from highly deuterated ¹³CH₃-labeled proteins with the “H-to-C” experiment.
 ---
 
 # Methyl ¹³C CPMG (“H-to-C”)

--- a/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c_0013.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_13c_h2c_0013.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Methyl ¹³C (“H-to-C”) with [0013] phase cycle
 sidebar_position: 17
-description: '"cpmg_ch3_13c_h2c_0013"'
+description: Analyze methyl ¹³C CPMG relaxation-dispersion data from highly deuterated ¹³CH₃-labeled proteins with the [0013] phase cycle.
 ---
 
 # Methyl ¹³C CPMG (“H-to-C”) with [0013] phase cycle

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_dq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_dq.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Methyl ¹H double quantum
 sidebar_position: 13
-description: '"cpmg_ch3_1h_dq"'
+description: Analyze methyl ¹H double-quantum CPMG relaxation-dispersion data from highly deuterated ¹³CH₃-labeled proteins.
 ---
 
 # Methyl ¹H double quantum CPMG

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_sq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_sq.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Methyl ¹H single quantum
 sidebar_position: 12
-description: '"cpmg_ch3_1h_sq"'
+description: Analyze methyl ¹H single-quantum CPMG relaxation-dispersion data from highly deuterated ¹³CH₃-labeled proteins.
 ---
 
 # Methyl ¹H single quantum CPMG

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_tq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_tq.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Methyl ¹H triple quantum
 sidebar_position: 14
-description: '"cpmg_ch3_1h_tq"'
+description: Analyze methyl ¹H triple-quantum CPMG relaxation-dispersion data from highly deuterated ¹³CH₃-labeled proteins.
 ---
 
 # Methyl ¹H triple quantum CPMG

--- a/website/docs/experiments/cpmg/cpmg_ch3_1h_tq_diff.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_1h_tq_diff.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Methyl ¹H triple quantum with gradients
 sidebar_position: 15
-description: '"cpmg_ch3_1h_tq_diff"'
+description: Analyze methyl ¹H triple-quantum CPMG data with pulsed-field gradients to measure diffusion constants of invisible states.
 ---
 
 # Methyl ¹H triple quantum CPMG with gradients

--- a/website/docs/experiments/cpmg/cpmg_ch3_mq.md
+++ b/website/docs/experiments/cpmg/cpmg_ch3_mq.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Methyl ¹³C–¹H multiple-quantum
 sidebar_position: 11
-description: '"cpmg_ch3_mq"'
+description: Analyze methyl ¹³C–¹H multiple-quantum CPMG data from highly deuterated ¹³CH₃-labeled proteins.
 ---
 
 # Methyl ¹³C–¹H multiple-quantum CPMG

--- a/website/docs/experiments/cpmg/cpmg_chd2_1h_ap.md
+++ b/website/docs/experiments/cpmg/cpmg_chd2_1h_ap.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure anti-phase methyl ¹H
 sidebar_position: 16
-description: '"cpmg_chd2_1h_ap"'
+description: Analyze pure anti-phase methyl ¹H CPMG relaxation-dispersion data from highly deuterated ¹³CHD₂-labeled proteins.
 ---
 
 # Pure anti-phase methyl ¹H CPMG

--- a/website/docs/experiments/cpmg/cpmg_hn_dq_zq.md
+++ b/website/docs/experiments/cpmg/cpmg_hn_dq_zq.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Amide ¹⁵N–¹H double-quantum/zero-quantum
 sidebar_position: 7
-description: '"cpmg_hn_dq_zq"'
+description: Analyze amide ¹⁵N–¹H double-quantum/zero-quantum CPMG relaxation-dispersion data.
 ---
 
 # Amide ¹⁵N–¹H double-quantum/zero-quantum CPMG

--- a/website/docs/experiments/dcest/coscest_1hn_ip_ap.md
+++ b/website/docs/experiments/dcest/coscest_1hn_ip_ap.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: In-phase/anti-phase amide ¹H cos-CEST
 sidebar_position: 3
-description: '"coscest_1hn_ip_ap"'
+description: Analyze in-phase/anti-phase amide ¹H cos-CEST chemical exchange data.
 ---
 
 # In-phase/anti-phase amide ¹H cos-CEST

--- a/website/docs/experiments/dcest/dcest_13c.md
+++ b/website/docs/experiments/dcest/dcest_13c.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure in-phase ¹³C D-CEST
 sidebar_position: 2
-description: '"dcest_13c"'
+description: Analyze pure in-phase ¹³C DANTE-CEST chemical exchange data with ¹H composite decoupling.
 ---
 
 # Pure in-phase ¹³C DANTE-CEST

--- a/website/docs/experiments/dcest/dcest_15n.md
+++ b/website/docs/experiments/dcest/dcest_15n.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pure in-phase ¹⁵N D-CEST
 sidebar_position: 1
-description: '"dcest_15n"'
+description: Analyze pure in-phase ¹⁵N DANTE-CEST chemical exchange data with ¹H composite decoupling.
 ---
 
 # Pure in-phase ¹⁵N DANTE-CEST

--- a/website/docs/experiments/dcest/index.mdx
+++ b/website/docs/experiments/dcest/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: D-CEST/cos-CEST
 sidebar_position: 2
-description: D-CEST/cos-CEST experiments
+description: ChemEx D-CEST and cos-CEST experiments for analyzing chemical exchange with in-phase and anti-phase magnetization.
 ---
 
 # D-CEST/cos-CEST experiments

--- a/website/docs/experiments/index.mdx
+++ b/website/docs/experiments/index.mdx
@@ -1,11 +1,12 @@
 ---
 sidebar_position: 3
+description: Explore ChemEx experiment modules for CPMG relaxation dispersion, CEST, D-CEST/cos-CEST, relaxation, and exchange-induced chemical-shift analysis.
 ---
 
 # Experiments
 
-This section contains information about the experiments that are available in
-ChemEx.
+Explore the ChemEx experiment modules for CPMG relaxation dispersion, CEST,
+D-CEST/cos-CEST, relaxation, and exchange-induced chemical-shift analysis.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/website/docs/experiments/relaxation/index.mdx
+++ b/website/docs/experiments/relaxation/index.mdx
@@ -1,10 +1,10 @@
 ---
 sidebar_label: Relaxation
 sidebar_position: 4
-description: Relaxation experiments
+description: ChemEx relaxation experiments for ¹⁵N T1 and amide ¹H–¹⁵N longitudinal two-spin-order measurements.
 ---
 
-# CPMG relaxation dispersion experiments
+# Relaxation experiments
 
 This section contains information about the relaxation experiments that are
 available in ChemEx.

--- a/website/docs/experiments/relaxation/relaxation_hznz.md
+++ b/website/docs/experiments/relaxation/relaxation_hznz.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Amide ¹H-¹⁵N longitudinal two-spin order relaxation
 sidebar_position: 2
-description: '"relaxation_hznz"'
+description: Analyze amide ¹H–¹⁵N longitudinal two-spin-order relaxation data.
 ---
 
 # Amide ¹H-¹⁵N longitudinal two-spin order relaxation

--- a/website/docs/experiments/relaxation/relaxation_nz.md
+++ b/website/docs/experiments/relaxation/relaxation_nz.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: ¹⁵N longitudinal relaxation
 sidebar_position: 1
-description: '"relaxation_nz"'
+description: Analyze ¹⁵N longitudinal (T1) relaxation data with ChemEx.
 ---
 
 # ¹⁵N longitudinal relaxation

--- a/website/docs/experiments/shift/index.mdx
+++ b/website/docs/experiments/shift/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Exchange-induced chemical shift experiments
 sidebar_position: 5
-description: Shift
+description: ChemEx experiments for measuring exchange-induced chemical-shift changes in ¹⁵N–¹H HSQC and HMQC data.
 ---
 
 # Exchange-induced chemical shift experiments

--- a/website/docs/experiments/shift/shift_15n_sqmq.md
+++ b/website/docs/experiments/shift/shift_15n_sqmq.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: ¹⁵N exchange induced shifts with ¹⁵N–¹H HSQC/HMQC
 sidebar_position: 1
-description: '"shift_15n_sqmq"'
+description: Analyze exchange-induced ¹⁵N chemical-shift changes in ¹⁵N–¹H HSQC and HMQC datasets.
 ---
 
 # ¹⁵N exchange induced shifts with ¹⁵N–¹H HSQC/HMQC

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 2
+sidebar_label: Overview
+title: 'ChemEx Overview: NMR Chemical Exchange Analysis'
+description: Learn how ChemEx uses numerical spin evolution to analyze biomolecular NMR chemical exchange, including CPMG, CEST, joint datasets, and multi-state kinetic models.
 ---
 
 # Overview

--- a/website/docs/user_guide/index.mdx
+++ b/website/docs/user_guide/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 lastmod: 2022-04-19T20:13:05.299Z
+description: Learn how to run ChemEx, prepare experiment and method files, fit NMR chemical exchange data, use kinetic models, and analyze results.
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/welcome_to_chemex.md
+++ b/website/docs/welcome_to_chemex.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Install ChemEx and learn the first steps for analyzing NMR chemical exchange data with CPMG relaxation dispersion and CEST experiments.
 ---
 
 # Welcome to ChemEx

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,7 +9,7 @@ const katex = require('rehype-katex');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
     title: 'ChemEx',
-    tagline: 'ChemEx is an analysis program for characterizing chemical exchange detected by NMR.',
+    tagline: 'Open-source Python software for analyzing NMR chemical exchange data.',
     url: 'https://gbouvignies.github.io',
     baseUrl: '/ChemEx/',
     onBrokenLinks: 'throw',
@@ -35,6 +35,11 @@ const config = {
                     editUrl: 'https://github.com/gbouvignies/chemex/tree/main/website/',
                     remarkPlugins: [math],
                     rehypePlugins: [katex],
+                },
+                blog: false,
+                sitemap: {
+                    ignorePatterns: ['/ChemEx/search'],
+                    lastmod: 'date',
                 },
                 theme: {
                     customCss: './src/css/custom.css',
@@ -87,6 +92,7 @@ const config = {
                     autoCollapseCategories: true,
                 },
             },
+            image: 'img/exchange_cest_cpmg_figure.png',
             footer: {
                 style: 'light',
                 links: [

--- a/website/src/components/HomepageFeatures/index.js
+++ b/website/src/components/HomepageFeatures/index.js
@@ -19,7 +19,7 @@ const FeatureList = [
         Svg: require('@site/static/img/combined_experiments.svg').default,
         description: (
             <>
-                Supporting diverse experiments and kinetic models, ChemEx allows joint analysis for high-precision exchange parameter extraction, making it essential for complex kinetics studies.
+                Analyze CPMG relaxation dispersion, CEST, D-CEST/cos-CEST, relaxation, and exchange-induced shift experiments, then combine datasets from multiple experiments with multi-state kinetic models.
             </>
         ),
     },

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -36,11 +36,10 @@ function HomepageHeader() {
 }
 
 export default function Home() {
-    const { siteConfig } = useDocusaurusContext();
     return (
         <Layout
-            title={`Hello from ${siteConfig.title}`}
-            description="Description will go into a meta tag in <head />">
+            title="NMR Chemical Exchange Analysis"
+            description="ChemEx is open-source software for analyzing NMR chemical exchange data, including CPMG relaxation dispersion, CEST, D-CEST/cos-CEST, and multi-state kinetic models.">
             <HomepageHeader />
             <main>
                 <HomepageFeatures />


### PR DESCRIPTION
## Summary

- Improve homepage, landing-page, and experiment-page SEO metadata.
- Add native Open Graph image and VCS-derived sitemap dates.
- Exclude the noindex search route and disable the unused default blog route.
- Preserve frozen documentation snapshots and release versioning behavior.

## Validation

- npm run build
- CHEMEX_DOCS_INCLUDE_CURRENT_VERSION=false npm run build
- git diff --check

Frozen documentation snapshots were not modified.