### PR TITLE
docs: make uv the recommended ChemEx installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@
 ## Table of Contents
 
 - [ChemEx: NMR Chemical Exchange Analysis Tool](#chemex-nmr-chemical-exchange-analysis-tool)
-  - [Table of Contents](#table-of-contents)
-  - [About ChemEx](#about-chemex)
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
-    - [Quick Start with uv (Recommended)](#quick-start-with-uv-recommended)
-    - [Using pip with venv](#using-pip-with-venv)
-    - [Using pip (global)](#using-pip-global)
-    - [From source](#from-source)
-    - [Using conda](#using-conda)
-  - [Performance Optimization](#performance-optimization)
-  - [Contributing](#contributing)
-  - [Support and Documentation](#support-and-documentation)
-  - [License](#license)
+    - [Table of Contents](#table-of-contents)
+    - [About ChemEx](#about-chemex)
+    - [Prerequisites](#prerequisites)
+    - [Installation](#installation)
+        - [Recommended installation](#recommended-installation)
+        - [Try ChemEx without installing it](#try-chemex-without-installing-it)
+        - [Updating ChemEx](#updating-chemex)
+        - [Reproducible, version-pinned installation](#reproducible-version-pinned-installation)
+        - [Alternative: pip](#alternative-pip)
+        - [Conda packages](#conda-packages)
+    - [Contributing](#contributing)
+    - [Support and Documentation](#support-and-documentation)
+    - [License](#license)
+
 <!-- -   [Citing ChemEx](#citing-chemex) -->
 
 ## About ChemEx
@@ -26,81 +27,70 @@ ChemEx is an advanced, open-source software specifically designed for analyzing 
 
 ## Prerequisites
 
-ChemEx supports **Python 3.13 and 3.14**. Ensure one of these versions is
-installed on your system.
+ChemEx requires **Python 3.13 or later**. The recommended installer, uv, can
+download and manage a compatible Python interpreter when needed.
 
 ## Installation
 
-ChemEx offers several installation methods to suit your specific setup:
+[PyPI](https://pypi.org/project/chemex/) is the authoritative Python package
+distribution for ChemEx.
 
-### Quick Start with uv (Recommended)
+### Recommended installation
 
-[uv](https://docs.astral.sh/uv/) is a fast Python package and project manager. If you don't have it installed:
-
-```shell
-# macOS/Linux
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Windows
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-The fastest way to try ChemEx without installation:
+[uv](https://docs.astral.sh/uv/) installs ChemEx as an application in an
+isolated environment. On macOS, install uv with Homebrew:
 
 ```shell
-uvx chemex --help
+brew install uv
 ```
 
-Or install it as a tool:
+On Linux or Windows, follow Astral's current
+[uv installation instructions](https://docs.astral.sh/uv/getting-started/installation/).
+
+Then install ChemEx from PyPI and verify that it starts:
 
 ```shell
-uv tool install chemex
-chemex --help
+uv tool install --python 3.13 chemex
+chemex --version
 ```
 
-### Using pip with venv
+### Try ChemEx without installing it
 
-Create an isolated environment and install ChemEx:
+```shell
+uvx --python 3.13 chemex --help
+```
+
+### Updating ChemEx
+
+Update an unpinned tool installation with:
+
+```shell
+uv tool upgrade chemex
+```
+
+### Reproducible, version-pinned installation
+
+To install a specific release:
+
+```shell
+uv tool install --python 3.13 "chemex==2026.09.0"
+```
+
+### Alternative: pip
+
+If you need conventional Python tooling, use Python 3.13 or later to install
+ChemEx from PyPI inside a virtual environment:
 
 ```shell
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-pip install chemex
+python -m pip install chemex
 ```
 
-### Using pip (global)
+### Conda packages
 
-```shell
-pip install chemex
-```
-
-### From source
-
-```shell
-pip install git+https://github.com/gbouvignies/ChemEx.git
-```
-
-### Using conda
-
-If you prefer conda/mamba:
-
-```shell
-conda create -n chemex python=3.13
-conda activate chemex
-conda config --env --add channels conda-forge
-conda install chemex
-```
-
-## Performance Optimization
-
-ChemEx performance depends on the underlying numerical libraries (NumPy and SciPy). The default installation provides good performance for most users:
-
-- **pip** (PyPI wheels): Uses OpenBLAS on Linux/Windows, or Apple's Accelerate framework on macOS
-- **conda-forge**: Uses OpenBLAS as the BLAS/LAPACK backend
-- **Anaconda** (defaults channel): Uses Intel® MKL, which can provide better performance for some operations
-- **Intel® Distribution for Python**: Also uses Intel® MKL
-
-For most use cases, the default pip or conda-forge installation is sufficient. If you need maximum performance and are doing intensive numerical computations, consider using Anaconda's defaults channel or Intel's Python distribution.
+The historical conda-forge package is no longer maintained by the ChemEx
+project and may be outdated. Install the current PyPI release with uv or pip.
 
 ## Contributing
 

--- a/website/docs/welcome_to_chemex.md
+++ b/website/docs/welcome_to_chemex.md
@@ -11,91 +11,70 @@ ChemEx is a powerful tool for analyzing NMR experimental data to characterize ch
 
 ## Prerequisites
 
-Before installing ChemEx, ensure Python 3.13 (recommended) or later is installed on your system. It's recommended to create an isolated environment for a clean and conflict-free setup.
+ChemEx requires Python 3.13 or later. The recommended installer, uv, can
+download and manage a compatible Python interpreter when needed.
 
-## Installation Options {#installation}
+## Installation {#installation}
 
-ChemEx can be installed using various methods. Choose the one that best suits your workflow.
+[PyPI](https://pypi.org/project/chemex/) is the authoritative Python package
+distribution for ChemEx.
 
-### Quick Start with uv (Recommended)
+### Recommended installation
 
-[uv](https://docs.astral.sh/uv/) is a fast Python package and project manager written in Rust. It's significantly faster than pip and handles virtual environments automatically.
-
-**Installing uv:**
-
-```shell
-# macOS/Linux
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Windows
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-**Using ChemEx with uv:**
-
-The fastest way to try ChemEx without installation:
+[uv](https://docs.astral.sh/uv/) installs ChemEx as an application in an
+isolated environment. On macOS, install uv with Homebrew:
 
 ```shell
-uvx chemex --help
+brew install uv
 ```
 
-Or install it as a tool for repeated use:
+On Linux or Windows, follow Astral's current
+[uv installation instructions](https://docs.astral.sh/uv/getting-started/installation/).
+
+Then install ChemEx from PyPI and verify that it starts:
 
 ```shell
-uv tool install chemex
-chemex --help
+uv tool install --python 3.13 chemex
+chemex --version
 ```
 
-### Using pip with a Virtual Environment
+uv creates a dedicated environment for ChemEx and automatically downloads a
+Python 3.13 interpreter if a suitable interpreter is not already available.
 
-The standard Python approach for an isolated installation:
-
-1. **Create and activate a virtual environment:**
-
-   ```shell
-   python -m venv .venv
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-   ```
-
-2. **Install ChemEx using pip:**
-
-   ```shell
-   pip install chemex
-   ```
-
-### Using pip (global installation)
-
-For a system-wide installation:
+### Try ChemEx without installing it
 
 ```shell
-pip install chemex
+uvx --python 3.13 chemex --help
 ```
 
-### Using mamba or conda
+### Updating ChemEx
 
-If you prefer conda environments:
-
-1. **Create and activate a new environment:**
-
-   ```shell
-   conda create -n chemex python=3.13
-   conda activate chemex
-   ```
-
-2. **Install ChemEx via conda-forge channel:**
-
-   ```shell
-   conda install -c conda-forge chemex
-   ```
-
-   > **Tip**: For faster package management, consider using [mamba](https://mamba.readthedocs.io/) instead of conda: `mamba install -c conda-forge chemex`
-
-### Installing from GitHub
-
-To install the latest development version of ChemEx directly from GitHub, use the following command:
+Update an unpinned tool installation with:
 
 ```shell
-pip install git+https://github.com/gbouvignies/ChemEx.git
+uv tool upgrade chemex
 ```
 
-This method provides access to the latest features and updates that may not yet be included in the pip or conda-forge releases.
+### Reproducible, version-pinned installation
+
+To install a specific release:
+
+```shell
+uv tool install --python 3.13 "chemex==2026.09.0"
+```
+
+### Alternative: pip
+
+If you need conventional Python tooling, use Python 3.13 or later to install
+ChemEx from PyPI inside a virtual environment:
+
+```shell
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+python -m pip install chemex
+```
+
+### Conda packages
+
+The historical conda-forge package is no longer maintained by the ChemEx
+project and may be outdated. Install the current PyPI release with uv or pip.


### PR DESCRIPTION
## Summary

- make PyPI the authoritative ChemEx package distribution and `uv tool install --python 3.13 chemex` the recommended application install
- document `uvx --python 3.13 chemex --help`, `uv tool upgrade chemex`, and an explicit `chemex==2026.09.0` install
- retain only a virtual-environment-based pip fallback and a short factual conda-forge retirement note
- remove global pip, conda/mamba, GitHub-source installation promotion, and package-manager-specific BLAS/MKL performance advice
- leave packaging metadata and the release workflow unchanged because the current PyPI trusted-publishing path is working correctly

## Verification

- confirmed PyPI release `2026.9.0` matches GitHub release `2026.09.0` at `e1affb166b92ef8b28fc9c1701b8448d43dd3846`
- confirmed the release workflow build, PyPI publish, and signing jobs succeeded and PyPI records trusted-publishing provenance
- with uv 0.11.15 and isolated temporary tool/cache/Python directories, verified persistent install, `chemex --version`, `chemex --help`, ephemeral uvx execution, the pinned install, and the documented upgrade command
- verified uv downloaded and managed CPython 3.13.13 when no interpreter existed in the isolated Python directory
- ran `npm ci` and `npm run build` successfully with Node 26.8.1 (the project requires Node >=20)
- ran Prettier checks and `git diff --check`
- audited current installation references and final changed-file scope

No Python or scientific tests were run because this changes documentation only.

Frozen files under `website/versioned_docs/**`, `website/versioned_sidebars/**`, and `website/versions.json` were not changed.