### PR TITLE
docs: let uv select a compatible Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ ChemEx is an advanced, open-source software specifically designed for analyzing 
 
 ## Prerequisites
 
-ChemEx requires **Python 3.13 or later**. The recommended installer, uv, can
-download and manage a compatible Python interpreter when needed.
+ChemEx requires **Python 3.13 or later**. When a requested ChemEx release needs
+a newer Python, uv can use a compatible installed interpreter or download a
+managed one when automatic Python downloads are enabled (the default).
 
 ## Installation
 
@@ -50,14 +51,17 @@ On Linux or Windows, follow Astral's current
 Then install ChemEx from PyPI and verify that it starts:
 
 ```shell
-uv tool install --python 3.13 chemex
+uv tool install chemex@latest
 chemex --version
 ```
+
+Requesting `@latest` prevents uv from selecting an older ChemEx release to match
+an outdated Python interpreter.
 
 ### Try ChemEx without installing it
 
 ```shell
-uvx --python 3.13 chemex --help
+uvx chemex@latest --help
 ```
 
 ### Updating ChemEx
@@ -73,7 +77,7 @@ uv tool upgrade chemex
 To install a specific release:
 
 ```shell
-uv tool install --python 3.13 "chemex==2026.09.0"
+uv tool install "chemex==2026.09.0"
 ```
 
 ### Alternative: pip

--- a/website/docs/welcome_to_chemex.md
+++ b/website/docs/welcome_to_chemex.md
@@ -11,8 +11,9 @@ ChemEx is a powerful tool for analyzing NMR experimental data to characterize ch
 
 ## Prerequisites
 
-ChemEx requires Python 3.13 or later. The recommended installer, uv, can
-download and manage a compatible Python interpreter when needed.
+ChemEx requires Python 3.13 or later. When a requested ChemEx release needs a
+newer Python, uv can use a compatible installed interpreter or download a
+managed one when automatic Python downloads are enabled (the default).
 
 ## Installation {#installation}
 
@@ -34,17 +35,17 @@ On Linux or Windows, follow Astral's current
 Then install ChemEx from PyPI and verify that it starts:
 
 ```shell
-uv tool install --python 3.13 chemex
+uv tool install chemex@latest
 chemex --version
 ```
 
-uv creates a dedicated environment for ChemEx and automatically downloads a
-Python 3.13 interpreter if a suitable interpreter is not already available.
+Requesting `@latest` prevents uv from selecting an older ChemEx release to match
+an outdated Python interpreter.
 
 ### Try ChemEx without installing it
 
 ```shell
-uvx --python 3.13 chemex --help
+uvx chemex@latest --help
 ```
 
 ### Updating ChemEx
@@ -60,7 +61,7 @@ uv tool upgrade chemex
 To install a specific release:
 
 ```shell
-uv tool install --python 3.13 "chemex==2026.09.0"
+uv tool install "chemex==2026.09.0"
 ```
 
 ### Alternative: pip


### PR DESCRIPTION
## Summary

- remove the explicit Python 3.13 pin from the recommended uv commands so uv can select any compatible interpreter allowed by ChemEx
- request chemex@latest for installation and one-off execution so uv does not resolve an older ChemEx release around an outdated interpreter
- keep the unpinned upgrade and exact-version installation workflows

## Why

In an isolated environment with only Python 3.9 available, bare uv tool install chemex resolved ChemEx 2022.3.5 instead of selecting the current release and obtaining a newer Python. Requesting chemex@latest selected ChemEx 2026.9.0 and, with automatic Python downloads enabled, downloaded a compatible managed Python 3.13.13. An explicit --python 3.13 pin is unnecessary because the package metadata already declares Python >=3.13 and ChemEx also supports later compatible versions.

## Validation

- reproduced bare and @latest resolution with uv 0.11.15 in isolated temporary tool, cache, bin, and Python directories
- verified uv tool install chemex@latest
- verified uvx chemex@latest --help
- verified uv tool upgrade chemex
- verified uv tool install chemex==2026.09.0 without a Python pin
- verified automatic-download behavior, including the expected failure when downloads are set to manual and no compatible interpreter is installed
- npm run build in website
- git diff --check

## Scope

Only README.md and website/docs/welcome_to_chemex.md are changed. Frozen website/versioned_docs documentation is untouched.