### PR TITLE
fix: restore native MCMC multicore execution and progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 - Direct Python callers of `calculate_kij_3st_eyring` must use its linear-model
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
+### Fixed
+- Native MCMC now uses isolated process workers for genuine CPU-parallel
+  likelihood evaluation, while preserving seeded serial/parallel chain
+  equivalence and native-library thread coordination.
+- Native MCMC capture qualification no longer serially re-evaluates every stored
+  walker state through the same authoritative evaluator. Structural, content,
+  bounds, transition-mask, and evidence-lineage checks remain fail-closed.
+
 ## [2026.09.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 - Native MCMC capture qualification no longer serially re-evaluates every stored
   walker state through the same authoritative evaluator. Structural, content,
   bounds, transition-mask, and evidence-lineage checks remain fail-closed.
+- Native MCMC sampling now reports transition progress interactively and concise
+  start/completion status in non-interactive output.
 
 ## [2026.09.0] - 2026-09-02
 

--- a/src/chemex/evaluation/native.py
+++ b/src/chemex/evaluation/native.py
@@ -1685,6 +1685,58 @@ class EvaluationEngine:
             ),
         )
 
+    def worker_context(self) -> NativeEvaluationWorkerContext:
+        """Copy the narrow executable recipe needed by an isolated process."""
+        return NativeEvaluationWorkerContext(
+            self.plan,
+            self.compatibility_identity,
+            tuple(deepcopy(template) for template in self._templates),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NativeEvaluationWorkerContext:
+    """Serializable native plan and trusted kernels for one process evaluator."""
+
+    plan: EvaluationPlan
+    compatibility_identity: str
+    _templates: tuple[_NativeKernelCapability, ...] = field(
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        if len(self._templates) != len(
+            self.plan.profiles
+        ) or self.compatibility_identity != _compatibility_identity(self.plan):
+            raise ValueError("Native worker context differs from its evaluation plan")
+
+    def new_evaluator(
+        self,
+        parameterization: ActiveParameterization,
+    ) -> BoundEvaluator:
+        """Build one process-owned evaluator from copied trusted kernels."""
+        if (
+            self.plan.parameterization_identity != parameterization.evaluator_identity
+            or self.plan.constraint_program_identity
+            != parameterization.program.fingerprint
+            or self.plan.resolved_ids != parameterization.scope_ids
+        ):
+            raise ValueError(
+                "Native worker context belongs to another parameterization"
+            )
+        return BoundEvaluator(
+            self.plan,
+            parameterization,
+            self.compatibility_identity,
+            _Workspace(
+                tuple(
+                    _ProfileWorkspace(deepcopy(template))
+                    for template in self._templates
+                )
+            ),
+        )
+
 
 class BoundEvaluator:
     """One non-reentrant evaluator with private reusable ChemEx workspaces."""

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -26,6 +26,16 @@ from rich.console import Console
 from rich.live import Live
 from rich.padding import Padding
 from rich.panel import Panel
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from rich.progress import Progress as RichProgress
 from rich.rule import Rule
 from rich.syntax import Syntax
 from rich.table import Table
@@ -34,6 +44,9 @@ from rich.text import Text
 from chemex import __version__
 from chemex.optimize.progress import (
     FitProgressContext,
+    McmcProgressEvent,
+    McmcProgressObserver,
+    McmcProgressPhase,
     ProgressEvent,
     ProgressPhase,
     ProgressRateLimiter,
@@ -306,6 +319,154 @@ class MinimizationProgressReporter:
     def _disable(self) -> None:
         self._enabled = False
         self._stop_live()
+
+
+class McmcProgressReporter:
+    """Report completed ensemble transitions without affecting sampling."""
+
+    def __init__(
+        self,
+        output_console: Console,
+        *,
+        requested_steps: int,
+        interactive: bool,
+        observer: McmcProgressObserver | None = None,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        self._console = output_console
+        self._requested_steps = requested_steps
+        self._interactive = interactive
+        self._observer = observer
+        self._clock = clock
+        self._started_at: float | None = None
+        self._completed_steps = 0
+        self._progress: RichProgress | None = None
+        self._task_id: TaskID | None = None
+        self._finished = False
+        self._enabled = True
+
+    def start(self) -> None:
+        """Start one sampling progress scope at zero completed transitions."""
+        if self._started_at is not None or self._finished:
+            return
+        self._started_at = self._clock()
+        try:
+            if self._interactive:
+                self._progress = RichProgress(
+                    TextColumn("  • MCMC sampling"),
+                    BarColumn(),
+                    TaskProgressColumn(),
+                    MofNCompleteColumn(),
+                    TimeElapsedColumn(),
+                    TimeRemainingColumn(),
+                    console=self._console,
+                    transient=True,
+                    auto_refresh=False,
+                )
+                self._progress.start()
+                self._task_id = self._progress.add_task(
+                    "MCMC sampling",
+                    total=self._requested_steps,
+                    completed=0,
+                )
+            else:
+                self._console.print(f"  • MCMC sampling 0/{self._requested_steps}...")
+            self._emit(McmcProgressPhase.STARTED)
+        except KeyboardInterrupt:
+            self._stop()
+            raise
+        except Exception:  # noqa: BLE001 - reporting is non-scientific
+            self._disable()
+
+    def observe(self, completed_steps: int) -> None:
+        """Advance to one atomically completed ensemble-transition count."""
+        if not self._enabled or self._finished:
+            return
+        if self._started_at is None:
+            self.start()
+        if (
+            completed_steps <= self._completed_steps
+            or completed_steps > self._requested_steps
+        ):
+            return
+        self._completed_steps = completed_steps
+        try:
+            if self._progress is not None and self._task_id is not None:
+                self._progress.update(
+                    self._task_id,
+                    completed=self._completed_steps,
+                    refresh=True,
+                )
+            self._emit(McmcProgressPhase.ADVANCED)
+        except KeyboardInterrupt:
+            self._stop()
+            raise
+        except Exception:  # noqa: BLE001 - reporting is non-scientific
+            self._disable()
+
+    def finish(self, terminal_status: str) -> None:
+        """Close rendering and persist one concise terminal status line."""
+        if self._finished:
+            return
+        self._finished = True
+        try:
+            self._emit(McmcProgressPhase.TERMINATED, terminal_status)
+        except KeyboardInterrupt:
+            self._stop()
+            raise
+        except Exception:  # noqa: BLE001 - reporting is non-scientific
+            self._enabled = False
+        self._stop()
+        if not self._enabled:
+            return
+        try:
+            style = "blue" if terminal_status == "completed" else "yellow"
+            self._console.print(
+                Text.from_markup(
+                    "  • MCMC sampling "
+                    f"{self._completed_steps}/{self._requested_steps} -> "
+                    f"[{style}]{terminal_status}[/] ({self._elapsed():.1f} s)"
+                )
+            )
+        except KeyboardInterrupt:
+            raise
+        except Exception:  # noqa: BLE001 - reporting is non-scientific
+            self._enabled = False
+
+    def _emit(
+        self,
+        phase: McmcProgressPhase,
+        terminal_status: str | None = None,
+    ) -> None:
+        if self._observer is not None:
+            self._observer(
+                McmcProgressEvent(
+                    phase,
+                    self._completed_steps,
+                    self._requested_steps,
+                    self._elapsed(),
+                    terminal_status,
+                )
+            )
+
+    def _elapsed(self) -> float:
+        return (
+            0.0
+            if self._started_at is None
+            else max(0.0, self._clock() - self._started_at)
+        )
+
+    def _stop(self) -> None:
+        if self._progress is None:
+            return
+        progress, self._progress = self._progress, None
+        self._task_id = None
+        with suppress(Exception):
+            progress.stop()
+
+    def _disable(self) -> None:
+        self._enabled = False
+        self._stop()
 
 
 class UncertaintyProgressReporter:

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -14,6 +14,7 @@ from chemex.atomic import open_text_atomic, remove_paths_best_effort, write_text
 from chemex.configuration.method_plan import McmcRequest
 from chemex.configuration.methods import McmcSettings
 from chemex.containers.experiments import Experiments
+from chemex.messages import McmcProgressReporter, console
 from chemex.optimize.native_deterministic import NativeDeterministicFit
 from chemex.optimize.native_mcmc import (
     EnsembleState,
@@ -718,14 +719,29 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
             ),
         )
         phase_start = perf_counter()
-        mcmc_operation = execute_mcmc_evidence(
-            fit.accepted,
-            plan,
-            execution=ExecutionSettings(
-                workers=effective.workers,
-                native_threads=effective.native_threads,
-            ),
+        progress = McmcProgressReporter(
+            console,
+            requested_steps=effective.steps,
+            interactive=console.is_terminal,
         )
+        progress.start()
+        try:
+            mcmc_operation = execute_mcmc_evidence(
+                fit.accepted,
+                plan,
+                state_observer=lambda state: progress.observe(state.ordinal),
+                execution=ExecutionSettings(
+                    workers=effective.workers,
+                    native_threads=effective.native_threads,
+                ),
+            )
+        except BaseException as error:
+            progress.finish(
+                "interrupted" if isinstance(error, KeyboardInterrupt) else "failed"
+            )
+            raise
+        else:
+            progress.finish(mcmc_operation.terminal.value)
         mcmc_evidence = mcmc_operation.evidence
         timings["sampling_seconds"] = perf_counter() - phase_start
         completed_steps = max(0, mcmc_operation.complete_state_count - 1)

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import multiprocessing
 import secrets
 import warnings
-from collections.abc import Callable, Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from enum import StrEnum
-from threading import Lock, RLock, local
+from threading import RLock
 from typing import Literal, SupportsIndex, cast
 from weakref import WeakKeyDictionary
 
@@ -21,10 +21,10 @@ import numpy as np
 
 from chemex.configuration.method_plan import McmcRequest
 from chemex.evaluation.native import (
-    BoundEvaluator,
     EvaluationEngine,
     EvaluationFailure,
     EvaluationFrame,
+    NativeEvaluationWorkerContext,
 )
 from chemex.optimize.direct_trf import (
     AcceptedFitResult,
@@ -36,6 +36,10 @@ from chemex.optimize.direct_trf import (
 from chemex.optimize.uncertainty import ParameterUnit
 from chemex.parameters.parameterization import (
     ActiveParameterization,
+    ConstraintProgram,
+    IndependentValueFrame,
+    ParameterRole,
+    ScientificFunctionBinder,
     SealedParameterModel,
 )
 from chemex.runtime import ExecutionSettings
@@ -126,6 +130,8 @@ class McmcExecutionStage(StrEnum):
     BEFORE_TRANSITION = "before_transition"
     DURING_TRANSITION = "during_transition"
     AFTER_COMPLETE_STATE = "after_complete_state"
+    CAPTURE_VALIDATION = "fresh_validation"
+    # Compatibility alias for the stable serialized evidence token.
     FRESH_VALIDATION = "fresh_validation"
     BEFORE_FINAL_ASSEMBLY = "before_final_assembly"
 
@@ -1900,7 +1906,7 @@ class McmcEvidence:
     def __post_init__(self) -> None:  # noqa: C901 - complete evidence invariant
         if self._occurrence_witness is None:
             raise McmcConstructionError(
-                "Primary MCMC evidence must come from fresh native validation"
+                "Primary MCMC evidence must come from capture validation"
             )
         if not self.backend_execution_occurrence_identity:
             raise McmcConstructionError(
@@ -2123,13 +2129,14 @@ class McmcEvidence:
         if raw_capture is None:
             raise McmcConstructionError(
                 "Primary MCMC evidence reconstruction requires its raw capture and "
-                "fresh validation"
+                "capture validation"
             )
         validation = validate_raw_mcmc_capture(plan, raw_capture)
         expected = validation.primary_evidence
         if expected is None or record != expected.to_record():
             raise McmcConstructionError(
-                "Stored MCMC evidence identity differs from fresh canonical validation"
+                "Stored MCMC evidence identity differs from canonical capture "
+                "validation"
             )
         return expected
 
@@ -2159,19 +2166,18 @@ def _mint_primary_evidence(
 
 @dataclass(frozen=True, slots=True)
 class McmcValidationFailure:
-    """One typed fresh-validation failure for a state/walker observation."""
+    """One typed capture-validation failure for a state/walker observation."""
 
     state_ordinal: int
     walker_ordinal: int
     category: str
     message: str
-    backend_log_density: float | None = None
-    authoritative_log_density: float | None = None
+    captured_log_density: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class McmcChainValidation:
-    """Fresh-workspace validation and any qualified primary-chain result."""
+    """Structural capture validation and any qualified primary-chain result."""
 
     raw_capture_identity: str
     validated_states: tuple[EnsembleState, ...]
@@ -2196,11 +2202,8 @@ class McmcChainValidation:
                         item.category,
                         item.message,
                         None
-                        if item.backend_log_density is None
-                        else float(item.backend_log_density).hex(),
-                        None
-                        if item.authoritative_log_density is None
-                        else float(item.authoritative_log_density).hex(),
+                        if item.captured_log_density is None
+                        else float(item.captured_log_density).hex(),
                     )
                     for item in self.failures
                 ),
@@ -2232,40 +2235,18 @@ class McmcChainValidation:
         )
 
 
-def _fresh_authoritative_log_density(
-    plan: McmcPlan,
-    evaluator: BoundEvaluator,
-    position: tuple[float, ...],
-) -> float:
-    """Re-derive one stored state through a validation-only evaluator."""
-    candidate = np.asarray(position, dtype=np.float64)
-    if (
-        candidate.shape != (plan.policy.dimension,)
-        or not np.all(np.isfinite(candidate))
-        or np.any(candidate <= np.asarray(plan.lower_bounds))
-        or np.any(candidate >= np.asarray(plan.upper_bounds))
-    ):
-        raise McmcExecutionError("stored MCMC state is outside its frozen bounds")
-    lifecycle = plan.source_problem.lifecycle_frame(
-        candidate,
-        plan.parameterization,
-    )
-    frame = EvaluationFrame.from_lifecycle_frame(plan.parameterization, lifecycle)
-    outcome = evaluator.evaluate(frame)
-    if isinstance(outcome, EvaluationFailure):
-        raise McmcExecutionError(
-            f"fresh MCMC validation failed: {outcome.category}: {outcome.message}"
-        )
-    return -0.5 * canonical_chi_square(outcome.residuals)
-
-
 def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
     plan: McmcPlan,
     raw_capture: RawMcmcCapture,
     *,
     backend_transition_evidence: BackendTransitionEvidence | None = None,
 ) -> McmcChainValidation:
-    """Freshly validate raw backend observations before minting evidence."""
+    """Validate capture structure and lineage before minting primary evidence.
+
+    Log densities are produced by the authoritative native evaluator during
+    sampling. Replaying every stored point through that same implementation
+    would test repeatability, not an independent scientific authority.
+    """
     expected_state_count = plan.policy.total_steps + 1
     try:
         plan.validate_integrity()
@@ -2293,9 +2274,54 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
             expected_state_count,
             None,
         )
-    evaluator = plan.source_engine.new_evaluator()
+    if (
+        raw_capture.policy_identity != plan.policy.identity
+        or raw_capture.root_seed != plan.policy.root_seed
+        or raw_capture.walkers != plan.policy.walkers
+        or raw_capture.dimension != plan.policy.dimension
+        or raw_capture.total_steps != plan.policy.total_steps
+    ):
+        return McmcChainValidation(
+            raw_capture.identity,
+            (),
+            (
+                McmcValidationFailure(
+                    0,
+                    0,
+                    "capture_topology_mismatch",
+                    "raw MCMC capture metadata differs from its frozen topology",
+                ),
+            ),
+            expected_state_count,
+            None,
+        )
+    if (
+        raw_capture.objective_request_count > plan.policy.objective_request_budget
+        or raw_capture.evaluation_request_count > raw_capture.objective_request_count
+        or (
+            raw_capture.terminal is McmcOperationTerminal.COMPLETED
+            and raw_capture.objective_request_count
+            != plan.policy.objective_request_budget
+        )
+    ):
+        return McmcChainValidation(
+            raw_capture.identity,
+            (),
+            (
+                McmcValidationFailure(
+                    0,
+                    0,
+                    "request_accounting_mismatch",
+                    "raw MCMC request accounting differs from its frozen budget",
+                ),
+            ),
+            expected_state_count,
+            None,
+        )
     validated: list[EnsembleState] = []
     failures: list[McmcValidationFailure] = []
+    lower = np.asarray(plan.lower_bounds, dtype=np.float64)
+    upper = np.asarray(plan.upper_bounds, dtype=np.float64)
     for state in raw_capture.states:
         if (
             len(state.positions) != plan.policy.walkers
@@ -2323,46 +2349,36 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
                 )
             )
             break
-        authoritative: list[float] = []
-        for walker, (position, backend) in enumerate(
-            zip(state.positions, state.log_densities, strict=True)
-        ):
-            try:
-                value = _fresh_authoritative_log_density(plan, evaluator, position)
-            except Exception as error:  # noqa: BLE001 - typed validation evidence
-                failures.append(
-                    McmcValidationFailure(
-                        state.ordinal,
-                        walker,
-                        "fresh_native_evaluation_failed",
-                        f"{type(error).__name__}: {error}",
-                        backend,
-                    )
+        positions = np.asarray(state.positions, dtype=np.float64)
+        outside = np.any((positions <= lower) | (positions >= upper), axis=1)
+        if np.any(outside):
+            walker = int(np.flatnonzero(outside)[0])
+            failures.append(
+                McmcValidationFailure(
+                    state.ordinal,
+                    walker,
+                    "state_outside_frozen_bounds",
+                    "raw MCMC state is outside its frozen bounds",
+                    state.log_densities[walker],
                 )
-                break
-            authoritative.append(value)
-            if backend != value:
-                failures.append(
-                    McmcValidationFailure(
-                        state.ordinal,
-                        walker,
-                        "backend_log_density_mismatch",
-                        "backend log density differs from fresh native evaluation",
-                        backend,
-                        value,
-                    )
-                )
-                break
+            )
         if failures:
             break
-        validated.append(
-            EnsembleState(
-                state.ordinal,
-                state.positions,
-                tuple(authoritative),
+        validated.append(state)
+    primary: McmcEvidence | None = None
+    if (
+        not failures
+        and raw_capture.terminal is McmcOperationTerminal.COMPLETED
+        and len(validated) != expected_state_count
+    ):
+        failures.append(
+            McmcValidationFailure(
+                len(validated),
+                0,
+                "incomplete_completed_capture",
+                "completed raw MCMC capture does not contain its frozen topology",
             )
         )
-    primary: McmcEvidence | None = None
     complete = (
         raw_capture.terminal is McmcOperationTerminal.COMPLETED
         and not failures
@@ -2383,15 +2399,6 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
             McmcEvidenceLifecycle.PARTIAL,
             tuple(validated),
             backend_transition_evidence,
-        )
-    elif not failures and raw_capture.terminal is McmcOperationTerminal.COMPLETED:
-        failures.append(
-            McmcValidationFailure(
-                len(validated),
-                0,
-                "incomplete_completed_capture",
-                "completed raw MCMC capture does not contain its frozen topology",
-            )
         )
     return McmcChainValidation(
         raw_capture.identity,
@@ -2451,7 +2458,7 @@ class McmcOperation:
                 )
         elif self.validation.primary_evidence is not self.evidence:
             raise McmcConstructionError(
-                "MCMC operation Evidence differs from fresh validation"
+                "MCMC operation Evidence differs from capture validation"
             )
         if (
             self.backend_transition_evidence.kind
@@ -3593,60 +3600,312 @@ def summarize_posterior_evidence(
     )
 
 
-class _LogDensityEvaluator:
-    def __init__(self, plan: McmcPlan) -> None:
-        self.plan = plan
-        self._worker_state = local()
-        self._count_lock = Lock()
-        self.objective_request_count = 0
-        self.evaluation_request_count = 0
+@dataclass(frozen=True, slots=True)
+class _ParameterizationWorkerSpec:
+    program: ConstraintProgram
+    binder_model_name: str
+    binder_functions: tuple[tuple[str, Callable[..., object]], ...]
+    occurrence_identity: str
+    source_revision: int
+    roles: tuple[tuple[str, ParameterRole], ...]
+    identity: str
+    evaluator_identity: str
 
-    def _evaluator(self) -> BoundEvaluator:
-        evaluator = getattr(self._worker_state, "evaluator", None)
-        if evaluator is None:
-            evaluator = self.plan.source_engine.new_evaluator()
-            self._worker_state.evaluator = evaluator
-        return cast("BoundEvaluator", evaluator)
+    @classmethod
+    def from_parameterization(
+        cls,
+        parameterization: ActiveParameterization,
+    ) -> _ParameterizationWorkerSpec:
+        return cls(
+            parameterization.program,
+            parameterization.binder.model_name,
+            parameterization.binder.worker_bindings(),
+            parameterization.occurrence_identity,
+            parameterization.source_revision,
+            tuple(
+                (param_id, parameterization.role(param_id))
+                for param_id in parameterization.scope_ids
+            ),
+            parameterization.identity,
+            parameterization.evaluator_identity,
+        )
 
-    def __call__(self, vector: Array) -> float:
-        with self._count_lock:
-            if (
-                self.objective_request_count
-                >= self.plan.policy.objective_request_budget
-            ):
-                raise McmcExecutionError("MCMC objective-request budget exhausted")
-            self.objective_request_count += 1
+    def build(self) -> ActiveParameterization:
+        parameterization = ActiveParameterization(
+            self.program,
+            ScientificFunctionBinder(
+                self.binder_model_name,
+                dict(self.binder_functions),
+            ),
+            self.occurrence_identity,
+            self.source_revision,
+            self.roles,
+        )
+        if (
+            parameterization.identity != self.identity
+            or parameterization.evaluator_identity != self.evaluator_identity
+        ):
+            raise McmcExecutionError(
+                "MCMC worker reconstructed a foreign parameterization"
+            )
+        return parameterization
+
+
+@dataclass(frozen=True, slots=True)
+class _McmcWorkerContext:
+    """Serializable native recipe for one isolated process-local evaluator."""
+
+    independent_items: tuple[tuple[str, float], ...]
+    controlled_ids: tuple[str, ...]
+    parameterization: _ParameterizationWorkerSpec
+    evaluator: NativeEvaluationWorkerContext
+    lower_bounds: tuple[float, ...]
+    upper_bounds: tuple[float, ...]
+    dimension: int
+
+    @classmethod
+    def from_plan(cls, plan: McmcPlan) -> _McmcWorkerContext:
+        return cls(
+            plan.source_problem.independent_items,
+            plan.source_problem.controlled_ids,
+            _ParameterizationWorkerSpec.from_parameterization(plan.parameterization),
+            plan.source_engine.worker_context(),
+            plan.lower_bounds,
+            plan.upper_bounds,
+            plan.policy.dimension,
+        )
+
+    def build(self) -> ActiveParameterization:
+        parameterization = self.parameterization.build()
+        if self.evaluator.plan.parameterization_identity != (
+            parameterization.evaluator_identity
+        ):
+            raise McmcExecutionError(
+                "MCMC worker evaluator belongs to a foreign parameterization"
+            )
+        return parameterization
+
+
+@dataclass(frozen=True, slots=True)
+class _LogDensityResult:
+    value: float
+    evaluated: bool
+
+
+class _LogDensityKernelFailure(McmcExecutionError):
+    def __init__(self, message: str, *, evaluated: bool) -> None:
+        super().__init__(message)
+        self.evaluated = evaluated
+
+
+class _LogDensityKernel:
+    """One native evaluator owned exclusively by its calling process."""
+
+    def __init__(self, context: _McmcWorkerContext) -> None:
+        self._context = context
+        self._parameterization = context.build()
+        self._base_frame = IndependentValueFrame(
+            self._parameterization.identity,
+            self._parameterization.program.fingerprint,
+            self._parameterization.occurrence_identity,
+            self._parameterization.source_revision,
+            context.independent_items,
+        )
+        self._evaluator = context.evaluator.new_evaluator(self._parameterization)
+
+    def evaluate(self, vector: Array) -> _LogDensityResult:
         candidate = np.asarray(vector, dtype=np.float64)
         if (
-            candidate.shape != (self.plan.policy.dimension,)
+            candidate.shape != (self._context.dimension,)
             or not np.all(np.isfinite(candidate))
-            or np.any(candidate <= np.asarray(self.plan.lower_bounds))
-            or np.any(candidate >= np.asarray(self.plan.upper_bounds))
+            or np.any(candidate <= np.asarray(self._context.lower_bounds))
+            or np.any(candidate >= np.asarray(self._context.upper_bounds))
         ):
-            return -np.inf
+            return _LogDensityResult(-np.inf, False)
         try:
-            lifecycle = self.plan.source_problem.lifecycle_frame(
-                candidate,
-                self.plan.parameterization,
+            lifecycle = self._base_frame.with_updates(
+                dict(zip(self._context.controlled_ids, candidate, strict=True))
             )
             frame = EvaluationFrame.from_lifecycle_frame(
-                self.plan.parameterization,
+                self._parameterization,
                 lifecycle,
             )
         except Exception as error:
-            raise McmcExecutionError(
-                f"MCMC candidate frame failed: {type(error).__name__}: {error}"
+            raise _LogDensityKernelFailure(
+                f"MCMC candidate frame failed: {type(error).__name__}: {error}",
+                evaluated=False,
             ) from error
-        outcome = self._evaluator().evaluate(frame)
-        with self._count_lock:
-            self.evaluation_request_count += 1
+        try:
+            outcome = self._evaluator.evaluate(frame)
+        except Exception as error:
+            raise _LogDensityKernelFailure(
+                f"MCMC native evaluation raised: {type(error).__name__}: {error}",
+                evaluated=True,
+            ) from error
         if isinstance(outcome, EvaluationFailure):
             if outcome.validity == "INVALID_TRIAL":
-                return -np.inf
-            raise McmcExecutionError(
-                f"MCMC native evaluation failed: {outcome.category}: {outcome.message}"
+                return _LogDensityResult(-np.inf, True)
+            raise _LogDensityKernelFailure(
+                f"MCMC native evaluation failed: {outcome.category}: {outcome.message}",
+                evaluated=True,
             )
-        return -0.5 * canonical_chi_square(outcome.residuals)
+        return _LogDensityResult(
+            -0.5 * canonical_chi_square(outcome.residuals),
+            True,
+        )
+
+
+class _LogDensityAccounting:
+    """Parent-process accounting for the fixed objective-request budget."""
+
+    def __init__(self, objective_request_budget: int) -> None:
+        self._budget = objective_request_budget
+        self.objective_request_count = 0
+        self.evaluation_request_count = 0
+
+    def reserve(self, count: int) -> None:
+        if self.objective_request_count + count > self._budget:
+            raise McmcExecutionError("MCMC objective-request budget exhausted")
+        self.objective_request_count += count
+
+    def record_evaluations(self, count: int) -> None:
+        self.evaluation_request_count += count
+
+
+class _SerialLogDensityEvaluator:
+    def __init__(
+        self,
+        context: _McmcWorkerContext,
+        accounting: _LogDensityAccounting,
+    ) -> None:
+        self._kernel = _LogDensityKernel(context)
+        self._accounting = accounting
+
+    def __call__(self, vector: Array) -> float:
+        self._accounting.reserve(1)
+        try:
+            result = self._kernel.evaluate(vector)
+        except _LogDensityKernelFailure as error:
+            self._accounting.record_evaluations(int(error.evaluated))
+            raise
+        self._accounting.record_evaluations(int(result.evaluated))
+        return result.value
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessLogDensityReceipt:
+    result: _LogDensityResult | None
+    evaluated: bool = False
+    failure_category: str | None = None
+    failure_message: str = ""
+
+
+_PROCESS_LOG_DENSITY_KERNEL: _LogDensityKernel | None = None
+_PROCESS_LOG_DENSITY_INITIALIZATION_FAILURE: tuple[str, str] | None = None
+
+
+def _initialize_mcmc_process_worker(context: _McmcWorkerContext) -> None:
+    global _PROCESS_LOG_DENSITY_INITIALIZATION_FAILURE
+    global _PROCESS_LOG_DENSITY_KERNEL
+    try:
+        _PROCESS_LOG_DENSITY_KERNEL = _LogDensityKernel(context)
+        _PROCESS_LOG_DENSITY_INITIALIZATION_FAILURE = None
+    except Exception as error:  # noqa: BLE001 - return typed initializer failure
+        _PROCESS_LOG_DENSITY_KERNEL = None
+        _PROCESS_LOG_DENSITY_INITIALIZATION_FAILURE = (
+            type(error).__name__,
+            str(error),
+        )
+
+
+def _process_log_density(vector: Array) -> _ProcessLogDensityReceipt:
+    kernel = _PROCESS_LOG_DENSITY_KERNEL
+    if kernel is None:
+        category, message = _PROCESS_LOG_DENSITY_INITIALIZATION_FAILURE or (
+            "McmcExecutionError",
+            "MCMC worker was not initialized",
+        )
+        return _ProcessLogDensityReceipt(
+            None,
+            False,
+            category,
+            message,
+        )
+    try:
+        result = kernel.evaluate(vector)
+    except _LogDensityKernelFailure as error:
+        return _ProcessLogDensityReceipt(
+            None,
+            error.evaluated,
+            "McmcExecutionError",
+            str(error),
+        )
+    except Exception as error:  # noqa: BLE001 - return typed worker failure
+        return _ProcessLogDensityReceipt(
+            None,
+            False,
+            type(error).__name__,
+            str(error),
+        )
+    return _ProcessLogDensityReceipt(result, result.evaluated)
+
+
+class _McmcProcessPool:
+    """Ordered emcee map backed by isolated spawned native evaluators."""
+
+    def __init__(
+        self,
+        context: _McmcWorkerContext,
+        accounting: _LogDensityAccounting,
+        *,
+        workers: int,
+    ) -> None:
+        process_context = multiprocessing.get_context("spawn")
+        self._pool = process_context.Pool(
+            processes=workers,
+            initializer=_initialize_mcmc_process_worker,
+            initargs=(context,),
+        )
+        self._accounting = accounting
+
+    def __enter__(self) -> _McmcProcessPool:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: object,
+    ) -> bool:
+        if exc_type is None:
+            self._pool.close()
+        else:
+            self._pool.terminate()
+        self._pool.join()
+        return False
+
+    def map(
+        self,
+        function: Callable[[Array], _ProcessLogDensityReceipt],
+        vectors: Iterable[Array],
+    ) -> list[float]:
+        exact_vectors = tuple(vectors)
+        self._accounting.reserve(len(exact_vectors))
+        try:
+            receipts = self._pool.map(function, exact_vectors, chunksize=1)
+        except BaseException:
+            self._pool.terminate()
+            raise
+        self._accounting.record_evaluations(
+            sum(receipt.evaluated for receipt in receipts)
+        )
+        for receipt in receipts:
+            if receipt.result is None:
+                raise McmcExecutionError(
+                    "MCMC worker failed: "
+                    f"{receipt.failure_category}: {receipt.failure_message}"
+                )
+        return [receipt.result.value for receipt in receipts if receipt.result]
 
 
 class _RecordingStretchMove(emcee.moves.StretchMove):
@@ -3692,7 +3951,8 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     """Execute one fixed run while preserving only complete ensemble states."""
     plan.validate_integrity(accepted)
     signal = CancellationToken() if cancellation is None else cancellation
-    log_density = _LogDensityEvaluator(plan)
+    worker_context = _McmcWorkerContext.from_plan(plan)
+    accounting = _LogDensityAccounting(plan.policy.objective_request_budget)
     backend_observation = _mint_backend_execution_observation(
         plan,
         backend_implementation_identity="emcee-stretch-backend-v1",
@@ -3725,17 +3985,28 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
             )
             pool = (
                 stack.enter_context(
-                    ThreadPoolExecutor(max_workers=execution_settings.workers)
+                    _McmcProcessPool(
+                        worker_context,
+                        accounting,
+                        workers=execution_settings.workers,
+                    )
                 )
                 if execution_settings.is_parallel
                 else None
             )
+            log_density = (
+                _SerialLogDensityEvaluator(worker_context, accounting)
+                if pool is None
+                else _process_log_density
+            )
             checkpoint(McmcExecutionStage.BEFORE_INITIALIZATION)
             initial = np.asarray(plan.initial_ensemble, dtype=np.float64)
-            initial_values: list[float] = []
-            for row in initial:
-                checkpoint(McmcExecutionStage.INITIALIZING)
-                initial_values.append(log_density(row))
+            checkpoint(McmcExecutionStage.INITIALIZING)
+            initial_values = (
+                [log_density(row) for row in initial]
+                if pool is None
+                else pool.map(_process_log_density, initial)
+            )
             initial_log_density = np.asarray(initial_values, dtype=np.float64)
             if not np.all(np.isfinite(initial_log_density)):
                 raise McmcExecutionError(
@@ -3787,24 +4058,24 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
                 if state_observer is not None:
                     state_observer(state)
                 checkpoint(McmcExecutionStage.AFTER_COMPLETE_STATE)
-        if log_density.objective_request_count != plan.policy.objective_request_budget:
+        if accounting.objective_request_count != plan.policy.objective_request_budget:
             raise McmcExecutionError(
                 "MCMC backend request count differs from the frozen budget"
             )
-        checkpoint(McmcExecutionStage.FRESH_VALIDATION)
+        checkpoint(McmcExecutionStage.CAPTURE_VALIDATION)
         raw_capture = _mint_raw_capture(
             plan,
             McmcOperationTerminal.COMPLETED,
             tuple(states),
-            log_density.objective_request_count,
-            log_density.evaluation_request_count,
+            accounting.objective_request_count,
+            accounting.evaluation_request_count,
             stage,
             initialization_outcome,
             backend_observation,
         )
         validation = validate_raw_mcmc_capture(plan, raw_capture)
         if not validation.is_complete or validation.primary_evidence is None:
-            raise McmcExecutionError("fresh MCMC validation did not complete")
+            raise McmcExecutionError("MCMC capture validation did not complete")
         evidence = validation.primary_evidence
         checkpoint(McmcExecutionStage.BEFORE_FINAL_ASSEMBLY)
         backend_transition_evidence = _mint_observed_backend_transition_evidence(
@@ -3849,8 +4120,8 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
             plan,
             terminal,
             tuple(states),
-            log_density.objective_request_count,
-            log_density.evaluation_request_count,
+            accounting.objective_request_count,
+            accounting.evaluation_request_count,
             stage,
             initialization_outcome,
             backend_observation,

--- a/src/chemex/optimize/progress.py
+++ b/src/chemex/optimize/progress.py
@@ -65,6 +65,28 @@ class FitProgressContext:
 type ContextualProgressObserver = Callable[[FitProgressContext, ProgressEvent], None]
 
 
+class McmcProgressPhase(StrEnum):
+    """Lifecycle phase for one visible MCMC sampling operation."""
+
+    STARTED = "started"
+    ADVANCED = "advanced"
+    TERMINATED = "terminated"
+
+
+@dataclass(frozen=True, slots=True)
+class McmcProgressEvent:
+    """Semantic progress for completed ensemble transitions."""
+
+    phase: McmcProgressPhase
+    completed_steps: int
+    requested_steps: int
+    elapsed_seconds: float
+    terminal_status: str | None = None
+
+
+type McmcProgressObserver = Callable[[McmcProgressEvent], None]
+
+
 @dataclass(frozen=True, slots=True)
 class ProgressUpdate:
     """One progress event selected for user-visible reporting."""
@@ -128,6 +150,9 @@ class ProgressRateLimiter:
 __all__ = [
     "ContextualProgressObserver",
     "FitProgressContext",
+    "McmcProgressEvent",
+    "McmcProgressObserver",
+    "McmcProgressPhase",
     "ProgressEvent",
     "ProgressPhase",
     "ProgressObserver",

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -561,6 +561,11 @@ class ScientificFunctionBinder:
                     function_id=function_id,
                 )
 
+    def worker_bindings(self) -> tuple[tuple[str, Callable[..., object]], ...]:
+        """Return the validated callable bindings needed by an isolated worker."""
+        self.validate_implementations()
+        return tuple(self._functions.items())
+
     @classmethod
     def for_model(cls, model_name: str) -> ScientificFunctionBinder:
         functions: dict[str, Callable[..., object]] = {

--- a/tests/test_mcmc_progress.py
+++ b/tests/test_mcmc_progress.py
@@ -1,0 +1,103 @@
+"""Semantic reporting tests for native MCMC sampling progress."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from chemex.messages import McmcProgressReporter
+from chemex.optimize.progress import McmcProgressEvent, McmcProgressPhase
+
+
+def test_mcmc_progress_tracks_complete_ensemble_transitions() -> None:
+    output = StringIO()
+    events: list[McmcProgressEvent] = []
+    reporter = McmcProgressReporter(
+        Console(file=output, force_terminal=False),
+        requested_steps=3,
+        interactive=False,
+        observer=events.append,
+    )
+
+    reporter.start()
+    reporter.observe(1)
+    reporter.observe(2)
+    reporter.observe(3)
+    reporter.finish("completed")
+
+    assert [event.phase for event in events] == [
+        McmcProgressPhase.STARTED,
+        McmcProgressPhase.ADVANCED,
+        McmcProgressPhase.ADVANCED,
+        McmcProgressPhase.ADVANCED,
+        McmcProgressPhase.TERMINATED,
+    ]
+    assert [event.completed_steps for event in events] == [0, 1, 2, 3, 3]
+    assert all(event.requested_steps == 3 for event in events)
+    assert events[-1].terminal_status == "completed"
+    rendered = output.getvalue()
+    assert "MCMC sampling 0/3" in rendered
+    assert "MCMC sampling 3/3" in rendered
+    assert "complete" in rendered
+
+
+@pytest.mark.parametrize("terminal", ["interrupted", "failed"])
+def test_mcmc_progress_closes_partial_operations(terminal: str) -> None:
+    output = StringIO()
+    events: list[McmcProgressEvent] = []
+    reporter = McmcProgressReporter(
+        Console(file=output, force_terminal=False),
+        requested_steps=4,
+        interactive=False,
+        observer=events.append,
+    )
+
+    reporter.start()
+    reporter.observe(1)
+    reporter.finish(terminal)
+    reporter.observe(2)
+
+    assert events[-1].phase is McmcProgressPhase.TERMINATED
+    assert events[-1].completed_steps == 1
+    assert events[-1].terminal_status == terminal
+    assert f"1/4 -> {terminal}" in output.getvalue()
+
+
+def test_mcmc_progress_ignores_duplicate_or_out_of_range_steps() -> None:
+    events: list[McmcProgressEvent] = []
+    reporter = McmcProgressReporter(
+        Console(file=StringIO(), force_terminal=False),
+        requested_steps=2,
+        interactive=False,
+        observer=events.append,
+    )
+
+    reporter.start()
+    reporter.observe(1)
+    reporter.observe(1)
+    reporter.observe(3)
+    reporter.finish("interrupted")
+
+    assert [event.completed_steps for event in events] == [0, 1, 1]
+
+
+def test_mcmc_progress_observer_failure_cannot_escape_into_sampling() -> None:
+    def fail_reporting(_event: McmcProgressEvent) -> None:
+        raise RuntimeError("terminal reporter failed")
+
+    output = StringIO()
+    reporter = McmcProgressReporter(
+        Console(file=output, force_terminal=False),
+        requested_steps=2,
+        interactive=False,
+        observer=fail_reporting,
+    )
+
+    reporter.start()
+    reporter.observe(1)
+    reporter.finish("completed")
+
+    assert "MCMC sampling 0/2" in output.getvalue()
+    assert "1/2" not in output.getvalue()

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import multiprocessing
+import os
 import pickle
-import threading
-import time
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
@@ -81,6 +81,7 @@ from chemex.parameters.spin_system import SpinSystem
 from chemex.parameters.values import AnalysisValuesSnapshot
 from chemex.printers.data import Printer
 from chemex.runtime import ExecutionSettings
+from chemex.runtime.execution import NATIVE_THREAD_ENV_VARS
 from chemex.typing import Array
 
 
@@ -106,7 +107,43 @@ class _LinearSpectrometer:
 class _LinearPulseSequence:
     settings = _KernelSettings()
 
+    def __init__(
+        self,
+        evaluation_observer: Any | None = None,
+        evaluation_barrier: Any | None = None,
+        fail_outside_pid: int | None = None,
+    ) -> None:
+        self._evaluation_observer = evaluation_observer
+        self._evaluation_barrier = evaluation_barrier
+        self._fail_outside_pid = fail_outside_pid
+        self._source_pid = os.getpid()
+        self._barrier_used = False
+
+    def __deepcopy__(self, _memo: dict[int, object]) -> _LinearPulseSequence:
+        return type(self)(
+            self._evaluation_observer,
+            self._evaluation_barrier,
+            self._fail_outside_pid,
+        )
+
     def calculate(self, spectrometer: _LinearSpectrometer, data: Data) -> Array:
+        if (
+            self._evaluation_barrier is not None
+            and os.getpid() != self._source_pid
+            and not self._barrier_used
+        ):
+            self._barrier_used = True
+            self._evaluation_barrier.wait(timeout=10.0)
+        if self._evaluation_observer is not None:
+            self._evaluation_observer.append(
+                (
+                    os.getpid(),
+                    id(self),
+                    tuple(os.environ.get(name) for name in NATIVE_THREAD_ENV_VARS),
+                )
+            )
+        if self._fail_outside_pid is not None and os.getpid() != self._fail_outside_pid:
+            raise RuntimeError("worker kernel failure")
         return spectrometer.values["a"] + spectrometer.values["b"] * np.asarray(
             data.metadata,
             dtype=np.float64,
@@ -117,7 +154,11 @@ class _LinearPulseSequence:
 
 
 def _native_context(
-    *, fit_b: bool = True
+    *,
+    fit_b: bool = True,
+    evaluation_observer: Any | None = None,
+    evaluation_barrier: Any | None = None,
+    fail_outside_pid: int | None = None,
 ) -> tuple[
     AcceptedFitResult,
     OptimizationProblem,
@@ -163,7 +204,14 @@ def _native_context(
     profile = Profile(
         data,
         cast("Spectrometer", _LinearSpectrometer()),
-        cast("PulseSequence", _LinearPulseSequence()),
+        cast(
+            "PulseSequence",
+            _LinearPulseSequence(
+                evaluation_observer,
+                evaluation_barrier,
+                fail_outside_pid,
+            ),
+        ),
         {"a": "A", "b": "B"},
         cast("Printer", None),
         is_scaled=False,
@@ -287,46 +335,242 @@ def _same_semantics_foreign_occurrence(
     )
 
 
-def test_seeded_native_mcmc_workers_execute_in_parallel_without_changing_chain(
+def test_seeded_native_mcmc_workers_execute_in_processes_without_changing_chain() -> (
+    None
+):
+    context = multiprocessing.get_context("spawn")
+    with context.Manager() as manager:
+        two_worker_observations = manager.list()
+        accepted, plan = _plan_context(
+            evaluation_observer=two_worker_observations,
+            evaluation_barrier=manager.Barrier(2),
+        )
+        two_worker_observations[:] = []
+
+        parallel = execute_mcmc_evidence(
+            accepted,
+            plan,
+            execution=ExecutionSettings(workers=2),
+        )
+        parallel_observations = set(two_worker_observations)
+
+        four_worker_observations_proxy = manager.list()
+        four_worker_accepted, four_worker_plan = _plan_context(
+            evaluation_observer=four_worker_observations_proxy,
+            evaluation_barrier=manager.Barrier(4),
+        )
+        four_worker_observations_proxy[:] = []
+        four_worker = execute_mcmc_evidence(
+            four_worker_accepted,
+            four_worker_plan,
+            execution=ExecutionSettings(workers=4),
+        )
+        four_worker_observations = set(four_worker_observations_proxy)
+
+        serial_observations_proxy = manager.list()
+        serial_accepted, serial_plan = _plan_context(
+            evaluation_observer=serial_observations_proxy,
+        )
+        serial_observations_proxy[:] = []
+        serial = execute_mcmc_evidence(
+            serial_accepted,
+            serial_plan,
+            execution=ExecutionSettings(workers=1),
+        )
+        serial_observations = set(serial_observations_proxy)
+
+    parallel_pids = {pid for pid, _evaluator, _environment in parallel_observations}
+    serial_pids = {pid for pid, _evaluator, _environment in serial_observations}
+    four_worker_pids = {
+        pid for pid, _evaluator, _environment in four_worker_observations
+    }
+
+    assert parallel.terminal is McmcOperationTerminal.COMPLETED
+    assert four_worker.terminal is McmcOperationTerminal.COMPLETED
+    assert serial.terminal is McmcOperationTerminal.COMPLETED
+    assert parallel.evidence is not None
+    assert four_worker.evidence is not None
+    assert serial.evidence is not None
+    assert len(parallel_pids) == 2
+    assert len(four_worker_pids) == 4
+    assert os.getpid() not in parallel_pids
+    assert os.getpid() not in four_worker_pids
+    assert serial_pids == {os.getpid()}
+    assert (parallel_pids | four_worker_pids).isdisjoint(
+        child.pid for child in multiprocessing.active_children()
+    )
+    assert {environment for _pid, _evaluator, environment in parallel_observations} == {
+        tuple("1" for _name in NATIVE_THREAD_ENV_VARS)
+    }
+    assert all(
+        len(
+            {
+                evaluator
+                for observed_pid, evaluator, _environment in parallel_observations
+                if observed_pid == pid
+            }
+        )
+        == 1
+        for pid in parallel_pids
+    )
+    assert parallel.evidence.states == serial.evidence.states
+    assert four_worker.evidence.states == serial.evidence.states
+    assert parallel.evidence.identity == serial.evidence.identity
+    assert four_worker.evidence.identity == serial.evidence.identity
+    assert parallel.backend_transition_evidence is not None
+    assert four_worker.backend_transition_evidence is not None
+    assert serial.backend_transition_evidence is not None
+    serial_masks = tuple(
+        transition.accepted
+        for transition in serial.backend_transition_evidence.transitions
+    )
+    assert (
+        tuple(
+            transition.accepted
+            for transition in parallel.backend_transition_evidence.transitions
+        )
+        == serial_masks
+    )
+    assert (
+        tuple(
+            transition.accepted
+            for transition in four_worker.backend_transition_evidence.transitions
+        )
+        == serial_masks
+    )
+    assert parallel.raw_capture is not None
+    assert four_worker.raw_capture is not None
+    assert serial.raw_capture is not None
+    assert parallel.raw_capture.objective_request_count == (
+        serial.raw_capture.objective_request_count
+    )
+    assert parallel.raw_capture.evaluation_request_count == (
+        serial.raw_capture.evaluation_request_count
+    )
+    assert four_worker.raw_capture.objective_request_count == (
+        serial.raw_capture.objective_request_count
+    )
+    assert four_worker.raw_capture.evaluation_request_count == (
+        serial.raw_capture.evaluation_request_count
+    )
+    parallel_diagnostics = derive_mcmc_diagnostics(parallel.evidence)
+    four_worker_diagnostics = derive_mcmc_diagnostics(four_worker.evidence)
+    serial_diagnostics = derive_mcmc_diagnostics(serial.evidence)
+    assert parallel_diagnostics.accepted_counts == serial_diagnostics.accepted_counts
+    assert four_worker_diagnostics.accepted_counts == (
+        serial_diagnostics.accepted_counts
+    )
+    assert parallel_diagnostics.acceptance_fractions == (
+        serial_diagnostics.acceptance_fractions
+    )
+    assert four_worker_diagnostics.acceptance_fractions == (
+        serial_diagnostics.acceptance_fractions
+    )
+    assert parallel_diagnostics.mean_acceptance_fraction == (
+        serial_diagnostics.mean_acceptance_fraction
+    )
+    assert four_worker_diagnostics.mean_acceptance_fraction == (
+        serial_diagnostics.mean_acceptance_fraction
+    )
+
+
+def test_parallel_worker_failure_enters_typed_failed_lifecycle() -> None:
+    context = multiprocessing.get_context("spawn")
+    with context.Manager() as manager:
+        evaluation_observations = manager.list()
+        accepted, plan = _plan_context(
+            evaluation_observer=evaluation_observations,
+            fail_outside_pid=os.getpid(),
+        )
+
+        operation = execute_mcmc_evidence(
+            accepted,
+            plan,
+            execution=ExecutionSettings(workers=2),
+        )
+        worker_pids = {pid for pid, _evaluator, _environment in evaluation_observations}
+
+    assert operation.terminal is McmcOperationTerminal.FAILED
+    assert operation.failure_category == "McmcExecutionError"
+    assert "MCMC worker failed: McmcExecutionError" in (operation.failure_message)
+    assert "kernel_exception: worker kernel failure" in operation.failure_message
+    assert operation.raw_capture is not None
+    assert operation.raw_capture.complete_state_count == 0
+    assert operation.raw_capture.objective_request_count == plan.policy.walkers
+    assert operation.raw_capture.evaluation_request_count == plan.policy.walkers
+    assert operation.evidence is None
+    assert worker_pids
+    assert worker_pids.isdisjoint(
+        child.pid for child in multiprocessing.active_children()
+    )
+
+
+def test_parallel_worker_initialization_failure_is_typed_and_does_not_hang(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     accepted, plan = _plan_context()
-    main_thread = threading.get_ident()
-    worker_threads: set[int] = set()
-    worker_lock = threading.Lock()
-    original_calculate = _LinearPulseSequence.calculate
+    original = native_mcmc._McmcWorkerContext.from_plan
 
-    def record_worker(
-        pulse_sequence: _LinearPulseSequence,
-        spectrometer: _LinearSpectrometer,
-        data: Data,
-    ) -> Array:
-        thread_id = threading.get_ident()
-        if thread_id != main_thread:
-            with worker_lock:
-                worker_threads.add(thread_id)
-            time.sleep(0.002)
-        return original_calculate(pulse_sequence, spectrometer, data)
+    def invalid_worker_context(source_plan: McmcPlan) -> Any:
+        context = original(source_plan)
+        return dataclasses.replace(
+            context,
+            parameterization=dataclasses.replace(
+                context.parameterization,
+                identity="foreign-parameterization",
+            ),
+        )
 
-    monkeypatch.setattr(_LinearPulseSequence, "calculate", record_worker)
+    monkeypatch.setattr(
+        native_mcmc._McmcWorkerContext,
+        "from_plan",
+        staticmethod(invalid_worker_context),
+    )
+    children_before = {child.pid for child in multiprocessing.active_children()}
 
-    parallel = execute_mcmc_evidence(
+    operation = execute_mcmc_evidence(
         accepted,
         plan,
         execution=ExecutionSettings(workers=2),
     )
-    serial = execute_mcmc_evidence(
-        accepted,
-        plan,
-        execution=ExecutionSettings(workers=1),
-    )
 
-    assert parallel.terminal is McmcOperationTerminal.COMPLETED
-    assert serial.terminal is McmcOperationTerminal.COMPLETED
-    assert parallel.evidence is not None
-    assert serial.evidence is not None
-    assert len(worker_threads) == 2
-    assert parallel.evidence.states == serial.evidence.states
+    assert operation.terminal is McmcOperationTerminal.FAILED
+    assert operation.failure_category == "McmcExecutionError"
+    assert "MCMC worker failed: McmcExecutionError" in operation.failure_message
+    assert "foreign parameterization" in operation.failure_message
+    assert operation.raw_capture is not None
+    assert operation.raw_capture.complete_state_count == 0
+    assert operation.raw_capture.objective_request_count == plan.policy.walkers
+    assert operation.raw_capture.evaluation_request_count == 0
+    assert {child.pid for child in multiprocessing.active_children()} == children_before
+
+
+def test_parallel_keyboard_interrupt_terminates_and_joins_workers() -> None:
+    context = multiprocessing.get_context("spawn")
+    with context.Manager() as manager:
+        evaluation_observations = manager.list()
+        accepted, plan = _plan_context(
+            evaluation_observer=evaluation_observations,
+        )
+
+        def interrupt_after_first_transition(state: EnsembleState) -> None:
+            if state.ordinal == 1:
+                raise KeyboardInterrupt
+
+        operation = execute_mcmc_evidence(
+            accepted,
+            plan,
+            state_observer=interrupt_after_first_transition,
+            execution=ExecutionSettings(workers=2),
+        )
+        worker_pids = {pid for pid, _evaluator, _environment in evaluation_observations}
+
+    assert operation.terminal is McmcOperationTerminal.INTERRUPTED
+    assert operation.complete_state_count == 2
+    assert worker_pids
+    assert worker_pids.isdisjoint(
+        child.pid for child in multiprocessing.active_children()
+    )
 
 
 def test_expert_policy_only_overrides_predeclared_topology() -> None:
@@ -994,13 +1238,13 @@ def test_interruption_preserves_unqualified_complete_state_prefix_without_valida
         if state.ordinal == 2:
             raise KeyboardInterrupt
 
-    def forbid_fresh_validation(*_args: object, **_kwargs: object) -> None:
-        pytest.fail("interrupted execution must not freshly validate raw capture")
+    def forbid_capture_qualification(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("interrupted execution must not qualify an incomplete capture")
 
     monkeypatch.setattr(
         native_mcmc,
         "validate_raw_mcmc_capture",
-        forbid_fresh_validation,
+        forbid_capture_qualification,
     )
 
     operation = execute_mcmc_evidence(
@@ -1120,7 +1364,7 @@ def test_execution_rejects_same_semantics_from_foreign_accepted_occurrence() -> 
         execute_mcmc_evidence(foreign, plan)
 
 
-def test_fresh_validation_rejects_tampered_backend_log_density() -> None:
+def test_capture_integrity_rejects_tampered_captured_log_density() -> None:
     accepted, problem, parameterization, engine = _native_context()
     plan = McmcPlan.for_accepted(
         accepted,
@@ -1147,38 +1391,187 @@ def test_fresh_validation_rejects_tampered_backend_log_density() -> None:
         )
 
 
-def test_fresh_validator_rejects_backend_originated_log_density_mismatch(
+def _copy_raw_capture(
+    source: native_mcmc.RawMcmcCapture,
+    **changes: Any,
+) -> native_mcmc.RawMcmcCapture:
+    values = {
+        "plan_identity": source.plan_identity,
+        "policy_identity": source.policy_identity,
+        "root_seed": source.root_seed,
+        "walkers": source.walkers,
+        "dimension": source.dimension,
+        "total_steps": source.total_steps,
+        "backend_execution_occurrence_identity": (
+            source.backend_execution_occurrence_identity
+        ),
+        "terminal": source.terminal,
+        "states": source.states,
+        "objective_request_count": source.objective_request_count,
+        "evaluation_request_count": source.evaluation_request_count,
+        "stage": source.stage,
+        "initialization_outcome": source.initialization_outcome,
+        "failure_category": source.failure_category,
+    }
+    values.update(changes)
+    return native_mcmc.RawMcmcCapture(
+        **values,
+        _occurrence_witness=native_mcmc._mint_mcmc_evidence_witness("raw-capture"),
+    )
+
+
+@pytest.mark.parametrize("field", ["walkers", "dimension", "total_steps"])
+def test_capture_qualification_rejects_frozen_topology_metadata_mutation(
+    field: str,
+) -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.raw_capture is not None
+    source = operation.raw_capture
+    corrupted = _copy_raw_capture(
+        source,
+        **{field: cast("int", getattr(source, field)) + 1},
+    )
+
+    validation = validate_raw_mcmc_capture(plan, corrupted)
+
+    assert not validation.is_complete
+    assert validation.primary_evidence is None
+    assert validation.failures[0].category == "capture_topology_mismatch"
+
+
+@pytest.mark.parametrize("accounting", ["objective", "evaluation"])
+def test_capture_qualification_rejects_request_accounting_mutation(
+    accounting: str,
+) -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.raw_capture is not None
+    source = operation.raw_capture
+    changes = (
+        {"objective_request_count": source.objective_request_count - 1}
+        if accounting == "objective"
+        else {"evaluation_request_count": source.objective_request_count + 1}
+    )
+    corrupted = _copy_raw_capture(source, **changes)
+
+    validation = validate_raw_mcmc_capture(plan, corrupted)
+
+    assert not validation.is_complete
+    assert validation.primary_evidence is None
+    assert validation.failures[0].category == "request_accounting_mismatch"
+
+
+@pytest.mark.parametrize("corruption", ["bounds", "dimension"])
+def test_capture_qualification_rejects_validly_encoded_state_corruption(
+    corruption: str,
+) -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.raw_capture is not None
+    source = operation.raw_capture
+    state = source.states[1]
+    positions = [list(row) for row in state.positions]
+    if corruption == "bounds":
+        positions[0][0] = plan.upper_bounds[0]
+        expected_category = "state_outside_frozen_bounds"
+    else:
+        positions = [row[:-1] for row in positions]
+        expected_category = "state_topology_mismatch"
+    corrupted_state = EnsembleState(
+        state.ordinal,
+        tuple(tuple(row) for row in positions),
+        state.log_densities,
+    )
+    corrupted = _copy_raw_capture(
+        source,
+        states=(source.states[0], corrupted_state, *source.states[2:]),
+    )
+
+    validation = validate_raw_mcmc_capture(plan, corrupted)
+
+    assert not validation.is_complete
+    assert validation.primary_evidence is None
+    assert validation.failures[0].category == expected_category
+
+
+def test_capture_qualification_rejects_missing_completed_state() -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.raw_capture is not None
+    corrupted = _copy_raw_capture(
+        operation.raw_capture,
+        states=operation.raw_capture.states[:-1],
+    )
+
+    validation = validate_raw_mcmc_capture(plan, corrupted)
+
+    assert not validation.is_complete
+    assert validation.primary_evidence is None
+    assert validation.failures[0].category == "incomplete_completed_capture"
+
+
+@pytest.mark.parametrize("corruption", ["reordered", "invalid_ordinal"])
+def test_raw_capture_construction_rejects_noncanonical_state_order(
+    corruption: str,
+) -> None:
+    accepted, plan = _plan_context()
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.raw_capture is not None
+    states = list(operation.raw_capture.states)
+    if corruption == "reordered":
+        states[1], states[2] = states[2], states[1]
+    else:
+        state = states[1]
+        states[1] = EnsembleState(
+            state.ordinal + 1,
+            state.positions,
+            state.log_densities,
+        )
+
+    with pytest.raises(McmcConstructionError, match="contiguous"):
+        _copy_raw_capture(operation.raw_capture, states=tuple(states))
+
+
+def test_execution_qualification_does_not_repeat_chain_likelihoods(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     accepted, plan = _plan_context()
-    original = native_mcmc._ensemble_state
+    original_calculate = _LinearPulseSequence.calculate
+    calculation_count = 0
 
-    def wrong_backend_density(
-        ordinal: int,
-        positions: Array,
-        log_densities: Array,
-    ) -> EnsembleState:
-        state = original(ordinal, positions, log_densities)
-        if ordinal != 0:
-            return state
-        return EnsembleState(
-            state.ordinal,
-            state.positions,
-            (state.log_densities[0] + 1.0, *state.log_densities[1:]),
-        )
+    def count_calculation(
+        pulse_sequence: _LinearPulseSequence,
+        spectrometer: _LinearSpectrometer,
+        data: Data,
+    ) -> Array:
+        nonlocal calculation_count
+        calculation_count += 1
+        return original_calculate(pulse_sequence, spectrometer, data)
 
-    monkeypatch.setattr(native_mcmc, "_ensemble_state", wrong_backend_density)
+    monkeypatch.setattr(_LinearPulseSequence, "calculate", count_calculation)
 
     operation = execute_mcmc_evidence(accepted, plan)
 
-    assert operation.terminal is McmcOperationTerminal.FAILED
-    assert operation.evidence is None
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.raw_capture is not None
+    assert calculation_count == operation.raw_capture.evaluation_request_count
+    assert operation.evidence is not None
     assert operation.validation is not None
-    assert operation.validation.failures[0].category == "backend_log_density_mismatch"
+    assert operation.validation.is_complete
 
 
-def _plan_context() -> tuple[AcceptedFitResult, McmcPlan]:
-    accepted, problem, parameterization, engine = _native_context()
+def _plan_context(
+    *,
+    evaluation_observer: Any | None = None,
+    evaluation_barrier: Any | None = None,
+    fail_outside_pid: int | None = None,
+) -> tuple[AcceptedFitResult, McmcPlan]:
+    accepted, problem, parameterization, engine = _native_context(
+        evaluation_observer=evaluation_observer,
+        evaluation_barrier=evaluation_barrier,
+        fail_outside_pid=fail_outside_pid,
+    )
     return accepted, McmcPlan.for_accepted(
         accepted,
         source_problem=problem,

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -112,11 +112,13 @@ class _LinearPulseSequence:
         evaluation_observer: Any | None = None,
         evaluation_barrier: Any | None = None,
         fail_outside_pid: int | None = None,
+        *,
+        source_pid: int | None = None,
     ) -> None:
         self._evaluation_observer = evaluation_observer
         self._evaluation_barrier = evaluation_barrier
         self._fail_outside_pid = fail_outside_pid
-        self._source_pid = os.getpid()
+        self._source_pid = os.getpid() if source_pid is None else source_pid
         self._barrier_used = False
 
     def __deepcopy__(self, _memo: dict[int, object]) -> _LinearPulseSequence:
@@ -124,6 +126,7 @@ class _LinearPulseSequence:
             self._evaluation_observer,
             self._evaluation_barrier,
             self._fail_outside_pid,
+            source_pid=self._source_pid,
         )
 
     def calculate(self, spectrometer: _LinearSpectrometer, data: Data) -> Array:
@@ -151,6 +154,20 @@ class _LinearPulseSequence:
 
     def is_reference(self, metadata: Array) -> Array:
         return metadata < 0.0
+
+
+def test_linear_pulse_sequence_deepcopy_preserves_source_process_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pid = os.getpid()
+    pulse_sequence = _LinearPulseSequence()
+    pulse_sequence._barrier_used = True
+    monkeypatch.setattr(os, "getpid", lambda: source_pid + 1)
+
+    worker_copy = deepcopy(pulse_sequence)
+
+    assert worker_copy._source_pid == source_pid
+    assert not worker_copy._barrier_used
 
 
 def _native_context(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -2684,6 +2684,7 @@ def test_explicit_mcmc_burn_survives_autocorrelation_calculation_failure(
 
 def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     output = tmp_path / "Output"
     method = _statistics_method(tmp_path / "method.toml", '"MCMC" = 2')
@@ -2735,6 +2736,11 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     assert "half_credible_interval_68_width" not in fitted
     plan = native_sampler.call_args.args[1]
     assert plan.coordinate_units[0][1] is ParameterUnit.UNSPECIFIED
+    rendered = capsys.readouterr().out
+    assert "MCMC sampling" in rendered
+    assert "0/2" in rendered
+    assert "2/2" in rendered
+    assert "complete" in rendered
 
 
 def test_short_compact_mcmc_form_fails_closed_through_real_chemex_cli(
@@ -2999,8 +3005,16 @@ def test_interrupted_native_mcmc_publishes_unqualified_raw_capture(
     method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
     parameters = _bounded_parameters(tmp_path / "parameters.toml")
 
-    def interrupt_after_second_transition(accepted, plan, *, execution):
+    def interrupt_after_second_transition(
+        accepted,
+        plan,
+        *,
+        execution,
+        state_observer=None,
+    ):
         def observe(state):
+            if state_observer is not None:
+                state_observer(state)
             if state.ordinal == 2:
                 raise KeyboardInterrupt
 
@@ -3136,8 +3150,16 @@ def test_interrupted_mcmc_publication_failure_preserves_interruption(
     method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
     parameters = _bounded_parameters(tmp_path / "parameters.toml")
 
-    def interrupt_after_second_transition(accepted, plan, *, execution):
+    def interrupt_after_second_transition(
+        accepted,
+        plan,
+        *,
+        execution,
+        state_observer=None,
+    ):
         def observe(state):
+            if state_observer is not None:
+                state_observer(state)
             if state.ordinal == 2:
                 raise KeyboardInterrupt
 

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -2409,7 +2409,7 @@ def _cpmg_15n_ip_mcmc_arguments(output: Path, method: Path) -> Namespace:
             "--plot",
             "nothing",
             "--workers",
-            "1",
+            "2",
         ]
     )
 
@@ -2890,7 +2890,7 @@ def test_explicitly_unbounded_native_mcmc_fails_closed_after_central_fit(
     assert outcome["failure_stage"] == "statistics"
 
 
-def test_standard_cpmg_15n_ip_parameters_run_native_mcmc_transitions(
+def test_standard_cpmg_15n_ip_parameters_run_parallel_native_mcmc_transitions(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -2916,6 +2916,7 @@ def test_standard_cpmg_15n_ip_parameters_run_native_mcmc_transitions(
         (statistics / "diagnostics.toml").read_text(encoding="utf-8")
     )
     assert diagnostics["status"] == "complete"
+    assert diagnostics["workers"] == 2
     assert diagnostics["walkers"] == 34
     assert diagnostics["steps"] == 2
     assert diagnostics["retained_steps"] == 2

--- a/website/docs/user_guide/fitting/chemex_fit.md
+++ b/website/docs/user_guide/fitting/chemex_fit.md
@@ -24,7 +24,7 @@ The table below lists the available options for `chemex fit`. Each option links 
 | [`-d`](kinetic_models.md) or [`--model`](kinetic_models.md) | Specify the kinetic model for fitting (optional, default: `2st`). |
 | [`-o`](outputs.mdx) or [`--output`](outputs.mdx) | Set the output directory (optional, default: `./Output`). |
 | `--plot {nothing, normal, all}` | Select the plotting level (optional, default: `normal`). |
-| [`--workers N\|auto`](multicore_execution.md) | Set the number of ChemEx worker processes for fit statistics (optional, default: `auto`). |
+| [`--workers N\|auto`](multicore_execution.md) | Set the number of ChemEx worker slots for fit statistics (optional, default: `auto`). |
 | [`--native-threads N\|auto`](multicore_execution.md) | Set native numerical-library threads per worker (optional, default: `auto`). |
 | `--include` | Define residues to include in the fit (optional). |
 | `--exclude` | Define residues to exclude from the fit (optional). |
@@ -64,7 +64,7 @@ Output files are saved in the directory specified by `-o`. By default, plots ill
 For uncertainty analyses, ChemEx can use multiple CPU cores during the statistics
 phase. The default `--workers auto` setting chooses a conservative worker count,
 and `--native-threads auto` avoids oversubscribing native numerical-library
-threads when worker processes are used. See
+threads when parallel worker pools are used. See
 [Multicore Execution](multicore_execution.md) for tuning guidance.
 
 :::tip

--- a/website/docs/user_guide/fitting/multicore_execution.md
+++ b/website/docs/user_guide/fitting/multicore_execution.md
@@ -109,6 +109,12 @@ Do not expect every fit to scale linearly. Parallel execution helps most when
 each likelihood evaluation or refit is expensive enough to dominate process-pool
 overhead. Very short MCMC runs or small bootstrap jobs may show little speedup.
 
+Interactive MCMC runs show completed ensemble transitions against the requested
+step count, together with elapsed time and an estimated time remaining. One
+completed transition advances the display by one step, independent of the
+number of walkers. Redirected or otherwise non-interactive output reports a
+concise start and terminal line instead of printing one line per step.
+
 ## Diagnostics
 
 Statistics diagnostics record the effective worker count. MCMC diagnostics also

--- a/website/docs/user_guide/fitting/multicore_execution.md
+++ b/website/docs/user_guide/fitting/multicore_execution.md
@@ -35,8 +35,10 @@ simulation runs, plotting, and output writing are not controlled by
 `--workers`.
 
 Workers are active only while the parallel statistics task is running. Native
-MC, BS, BSN, and MCMC use worker threads with isolated native evaluators. The
-earlier deterministic fit and later output-writing phase remain serial.
+MCMC uses worker processes with one isolated native evaluator per process, so
+CPU-bound likelihood calculations can execute on separate CPU cores. Native MC,
+BS, and BSN use worker threads with isolated native evaluators. The earlier
+deterministic fit and later output-writing phase remain serial.
 
 ## Command-Line Controls
 
@@ -68,8 +70,9 @@ Controls native numerical library threads, such as BLAS or OpenMP threads.
 
 The default, `--native-threads auto`, leaves native thread settings untouched for
 serial runs. When ChemEx starts multiple workers, it sets native numerical
-threads to 1 inside the worker-pool context. This avoids oversubscription, where
-each ChemEx worker also starts many BLAS or OpenMP threads.
+threads to 1 before starting the worker pool; MCMC worker processes inherit that
+setting. This avoids oversubscription, where each ChemEx worker also starts many
+BLAS or OpenMP threads.
 
 Most users should keep the default. Use an explicit value only when you are
 benchmarking a specific machine:
@@ -111,6 +114,12 @@ overhead. Very short MCMC runs or small bootstrap jobs may show little speedup.
 Statistics diagnostics record the effective worker count. MCMC diagnostics also
 record the direct emcee sampler engine, timing information, acceptance
 fractions, and autocorrelation diagnostics.
+
+`sampling_seconds` covers sampler execution, worker-pool startup and shutdown,
+and structural capture qualification. Posterior selection, summary, and output
+timings are recorded separately. Capture qualification checks topology, content
+identities, bounds, and evidence lineage; it does not re-evaluate every stored
+likelihood after the authoritative native sampler has already evaluated it.
 
 Look at `Statistics/MCMC/diagnostics.toml` after a run to confirm the effective
 settings:


### PR DESCRIPTION
## Summary

Native MCMC had regressed from process workers to `ThreadPoolExecutor`, which did not provide useful CPU parallelism for ChemEx's CPU-bound likelihood work. Sampling progress had also disappeared, and capture qualification replayed the complete stored chain through the scientific evaluator, approximately doubling likelihood work for long runs.

This change:

- restores spawned process workers for genuine CPU-parallel likelihood evaluation when `--workers` is greater than one;
- reconstructs one isolated native evaluator per worker from the existing authoritative parameterization and bindings;
- keeps the single-worker path direct and serial;
- treats sampled native log densities as authoritative evidence and removes complete-chain numerical replay;
- retains fail-closed structural, immutable-content, bounds, topology, request-accounting, transition-mask, identity, and lineage qualification;
- restores interactive progress, advancing once per completed ensemble transition;
- coordinates native numerical threads before spawning to avoid process-level oversubscription.

Serial and parallel execution preserve canonical walker/state ordering and produce identical scientific chains, acceptance evidence, accounting, and evidence identities for a fixed root seed.

## Compatibility and scope

MCMC priors, walker count and proposal policy, burn-in/convergence policy, parameter bounds, and deterministic fitting are unchanged. The finite standard-parameter bounds merged in #751 are inherited from `main`; none of that implementation is duplicated here. MC, BS, and BSN execution are outside this change.

## Performance

Audited representative 200-step CPMG benchmark:

| Workers | Sampling time | Speedup |
| ---: | ---: | ---: |
| 1 | ~20.65 s | 1.00x |
| 2 | ~12.61 s | ~1.64x |
| 4 | ~8.99 s | ~2.30x |

## Validation

- Focused native/product MCMC, process/spawn lifecycle, progress, seeded serial/parallel equivalence, and evidence-integrity tests: `115 passed, 99 deselected`
- Full tracked-tree suite: `1228 passed`
- Ruff: passed
- Formatting check: passed (`516 files already formatted`)
- Type checking: passed
- `git diff --check`: passed
- Docusaurus production build: passed

The full suite was run from an isolated tracked-files-only checkout so local untracked reproduction files did not affect shipped-example fixture counts.

The Linux/xdist CI failure was traced to the test rendezvous fixture and fixed without production changes.