### PR TITLE
fix: restore tentative MCMC auto burn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- Native MCMC automatic burn-in once again uses a valid finite positive
+  tentative autocorrelation estimate from a short chain. Such runs publish
+  posterior products with explicit tentative-estimate and tentative-burn
+  warnings while withholding autocorrelation-derived ESS and MCSE; unavailable,
+  invalid, or chain-consuming automatic burn estimates remain fail-closed.
 - Native MCMC now uses isolated process workers for genuine CPU-parallel
   likelihood evaluation, while preserving seeded serial/parallel chain
   equivalence and native-library thread coordination.

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -1116,6 +1116,42 @@ def print_mcmc_unbounded_warning(parameters: list[str]) -> None:
     console.print()
 
 
+def print_mcmc_tentative_burn_warning(
+    sampled_steps: int,
+    recommended_min_steps: int | None,
+) -> None:
+    """Warn that automatic MCMC burn and autocorrelation evidence are tentative."""
+    console.print()
+    console.print(
+        "[yellow] -- WARNING: MCMC completed, but the chain is shorter than 50 "
+        "autocorrelation times; automatic burn-in and autocorrelation estimates "
+        "are tentative.",
+        soft_wrap=True,
+    )
+    if recommended_min_steps is not None:
+        console.print(
+            f"    {sampled_steps} sampled steps; at least {recommended_min_steps} "
+            "recommended for 50 autocorrelation times.",
+            soft_wrap=True,
+        )
+    console.print()
+
+
+def print_mcmc_incomplete_error(diagnostics_path: Path) -> None:
+    """Report a specific fail-closed MCMC outcome before the CLI boundary."""
+    error_console.print()
+    error_console.print(
+        "[red] -- ERROR: MCMC analysis is incomplete; posterior products were "
+        "withheld.",
+        soft_wrap=True,
+    )
+    error_console.print(
+        f"    See '{diagnostics_path}' for details.",
+        soft_wrap=True,
+    )
+    error_console.print()
+
+
 def print_model_error(name: str) -> None:
     """Display an error message for unavailable models.
 

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -14,7 +14,12 @@ from chemex.atomic import open_text_atomic, remove_paths_best_effort, write_text
 from chemex.configuration.method_plan import McmcRequest
 from chemex.configuration.methods import McmcSettings
 from chemex.containers.experiments import Experiments
-from chemex.messages import McmcProgressReporter, console
+from chemex.messages import (
+    McmcProgressReporter,
+    console,
+    print_mcmc_incomplete_error,
+    print_mcmc_tentative_burn_warning,
+)
 from chemex.optimize.native_deterministic import NativeDeterministicFit
 from chemex.optimize.native_mcmc import (
     EnsembleState,
@@ -454,6 +459,8 @@ def _write_diagnostics(
     lines.append("unbounded_parameters = []")
     if root_seed is not None:
         lines.append(f"root_seed = {root_seed}")
+    if result.burn_in_warning is not None:
+        lines.append(f"burn_in_warning = {_quote_toml_string(result.burn_in_warning)}")
     _extend_autocorrelation_diagnostics(lines, autocorrelation)
     _extend_timing_diagnostics(lines, timings)
     write_text_atomic(path / "diagnostics.toml", "\n".join(lines) + "\n")
@@ -781,6 +788,15 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
             engine="native MCMC",
             root_seed=root_seed,
         )
+        if analysis_result.burn_in_warning is not None:
+            autocorrelation = cast(
+                "McmcAutocorrelationReport",
+                analysis_result.autocorrelation_report,
+            )
+            print_mcmc_tentative_burn_warning(
+                analysis_result.raw_step_count,
+                autocorrelation.recommended_min_steps_50tau,
+            )
     except (Exception, KeyboardInterrupt) as error:
         raw_evidence = (
             analysis_result.evidence
@@ -890,6 +906,8 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
             analysis_result=analysis_result,
             timings=timings,
         )
+        if isinstance(error, NativeMcmcIncompleteError):
+            print_mcmc_incomplete_error(statistic_path / "diagnostics.toml")
         raise
     else:
         return analysis_result

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -4333,6 +4333,7 @@ class McmcAnalysisResult:
     retained_step_ordinals: tuple[int, ...]
     raw_chain: Array | None = field(default=None, repr=False, compare=False)
     raw_lnprob: Array | None = field(default=None, repr=False, compare=False)
+    burn_in_warning: str | None = None
     failure: McmcAnalysisFailure | None = None
     acceptance_summary: McmcAcceptanceSummary | None = None
     autocorrelation_report: McmcAutocorrelationReport | None = None
@@ -4360,6 +4361,15 @@ class McmcAnalysisResult:
         ):
             raise McmcConstructionError(
                 "Complete MCMC Analysis Result has inconsistent retained topology"
+            )
+        if self.burn_in_warning is not None and (
+            not complete
+            or self.autocorrelation_report is None
+            or self.autocorrelation_report.status
+            is not McmcAutocorrelationStatus.UNRELIABLE_SHORT_CHAIN
+        ):
+            raise McmcConstructionError(
+                "MCMC burn-in warning is inconsistent with autocorrelation evidence"
             )
 
     @property
@@ -4745,8 +4755,7 @@ def _resolve_product_mcmc_burn(
     raw_step_count: int,
     coordinate_count: int,
     autocorrelation_time: Array | None,
-    autocorrelation_time_reliable: bool,
-    autocorrelation_warning: str | None,
+    autocorrelation_warning: str | None = None,
 ) -> tuple[int | None, str | None]:
     if policy.burn != "auto":
         return int(policy.burn), None
@@ -4757,8 +4766,6 @@ def _resolve_product_mcmc_burn(
     max_tau = float(np.max(autocorrelation_time))
     if not math.isfinite(max_tau) or max_tau <= 0.0:
         return None, "autocorrelation time invalid"
-    if not autocorrelation_time_reliable:
-        return None, "the autocorrelation time estimate is unreliable"
     discarded_steps = math.ceil(2.0 * max_tau)
     if discarded_steps >= raw_step_count:
         return None, "the calculated discard does not leave a retained chain"
@@ -4812,7 +4819,6 @@ def derive_mcmc_analysis_result(
         raw_step_count=raw_chain.shape[0],
         coordinate_count=len(evidence.coordinate_ids),
         autocorrelation_time=burn_autocorrelation_time,
-        autocorrelation_time_reliable=autocorrelation_time is not None,
         autocorrelation_warning=autocorrelation_warning,
     )
     if burn_failure_reason is not None:
@@ -4839,6 +4845,14 @@ def derive_mcmc_analysis_result(
             ),
         )
     exact_discarded_steps = cast("int", discarded_steps)
+    burn_in_warning = (
+        "autocorrelation time estimate is unreliable; tentative automatic "
+        "burn-in was applied"
+        if policy.burn == "auto"
+        and autocorrelation_time is None
+        and tentative is not None
+        else None
+    )
     retained_chain = raw_chain[exact_discarded_steps :: policy.thin]
     retained_lnprob = raw_lnprob[exact_discarded_steps :: policy.thin]
     if retained_chain.shape[0] < 1:
@@ -4881,6 +4895,7 @@ def derive_mcmc_analysis_result(
         ),
         raw_chain=raw_chain,
         raw_lnprob=raw_lnprob,
+        burn_in_warning=burn_in_warning,
         failure=None,
         acceptance_summary=acceptance_summary,
         autocorrelation_report=autocorrelation_report,

--- a/src/chemex/optimize/statistics_plot.py
+++ b/src/chemex/optimize/statistics_plot.py
@@ -196,6 +196,8 @@ def _save_mcmc_summary_page(
         )
     if autocorrelation.warning is not None:
         lines.append(f"Autocorrelation warning: {autocorrelation.warning}")
+    if result.burn_in_warning is not None:
+        lines.append(f"Burn-in warning: {result.burn_in_warning}")
     lines.extend(["", "Posterior summaries:"])
     for name, summary in zip(parameter_names, result.summary, strict=True):
         lines.append(

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -858,6 +858,108 @@ def test_product_analysis_result_classifies_automatic_burn_failure(
     assert result.raw_chain.shape == (5, 8, 2)
 
 
+def test_product_auto_burn_uses_realistic_tentative_autocorrelation_time() -> None:
+    policy = native_mcmc._ProductMcmcInterpretationPolicy(
+        requested_steps=10_000,
+        burn="auto",
+        thin=1,
+    )
+    tentative_tau = np.array(
+        [
+            212.787,
+            193.166,
+            215.584,
+            224.983,
+            195.036,
+            201.503,
+            207.812,
+            230.222,
+            210.754,
+            247.529,
+            222.710,
+            224.156,
+            201.567,
+            228.543,
+            220.933,
+            215.228,
+            239.719,
+        ]
+    )
+
+    discarded_steps, failure = native_mcmc._resolve_product_mcmc_burn(
+        policy,
+        raw_step_count=10_000,
+        coordinate_count=17,
+        autocorrelation_time=tentative_tau,
+    )
+
+    assert discarded_steps == 496
+    assert failure is None
+
+
+def test_product_auto_burn_publishes_tentative_posterior_without_tau_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accepted, problem, parameterization, engine = _native_context()
+    request = McmcRequest(steps=5, walkers=8, seed=1234)
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=resolve_product_mcmc_policy(
+            dimension=2,
+            walkers=8,
+            steps=request.steps,
+            root_seed=1234,
+        ),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+    operation = execute_mcmc_evidence(accepted, plan)
+    assert operation.evidence is not None
+    tentative_tau = np.array([0.12, 0.124])
+    monkeypatch.setattr(
+        native_mcmc.emcee.autocorr,
+        "integrated_time",
+        lambda _chain, **_kwargs: (_ for _ in ()).throw(
+            native_mcmc.emcee.autocorr.AutocorrError(tentative_tau)
+        ),
+    )
+
+    result = derive_mcmc_analysis_result(
+        operation.evidence,
+        request,
+        _product_parameter_model(),
+    )
+
+    assert result.status is McmcAnalysisStatus.COMPLETE
+    assert result.failure is None
+    assert result.discarded_steps == 1
+    assert result.retained_step_count == 4
+    assert result.retained_sample_count == 32
+    assert result.burn_in_warning == (
+        "autocorrelation time estimate is unreliable; tentative automatic "
+        "burn-in was applied"
+    )
+    assert result.autocorrelation_report is not None
+    assert (
+        result.autocorrelation_report.status
+        is McmcAutocorrelationStatus.UNRELIABLE_SHORT_CHAIN
+    )
+    assert result.autocorrelation_report.values == pytest.approx(tentative_tau)
+    assert result.autocorrelation_report.sampled_steps_over_maximum == pytest.approx(
+        5.0 / 0.124
+    )
+    assert result.autocorrelation_report.minimum_effective_sample_size is None
+    assert all(
+        summary.effective_sample_size is None and summary.mcse_mean is None
+        for summary in result.summary
+    )
+
+
 @pytest.mark.parametrize(
     ("autocorrelation_outcome", "expected_status"),
     (

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import subprocess
 import sys
 import tomllib
@@ -443,8 +444,15 @@ def test_fit_plot_interruption_preserves_committed_results_and_propagates(
     assert "Plotting cancelled" not in rendered.out + rendered.err
 
 
-def _run_real_fit_cli(output: Path, method: Path, parameters: Path) -> None:
-    subprocess.run(  # noqa: S603 - fixed local CLI and repository-owned fixtures
+def _run_real_fit_cli(
+    output: Path,
+    method: Path,
+    parameters: Path,
+    *,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed local CLI and repository-owned fixtures
         [
             sys.executable,
             "-m",
@@ -466,8 +474,9 @@ def _run_real_fit_cli(output: Path, method: Path, parameters: Path) -> None:
             "1",
         ],
         cwd=ROOT,
-        check=True,
+        check=check,
         capture_output=True,
+        env=env,
         text=True,
         timeout=120,
     )
@@ -2497,7 +2506,12 @@ def test_valid_automatic_mcmc_burn_publishes_normal_posterior_outputs(
     assert diagnostics["status"] == "complete"
     assert diagnostics["discarded_steps"] == 2
     assert diagnostics["retained_steps"] == 3
+    assert diagnostics["autocorrelation_status"] == "reliable"
+    assert "burn_in_warning" not in diagnostics
     assert (statistics / "summary.toml").is_file()
+    summary = (statistics / "summary.toml").read_text(encoding="utf-8")
+    assert "effective_sample_size" in summary
+    assert "mcse_mean" in summary
     assert (statistics / "samples.tsv").is_file()
     assert (statistics / "correlations.tsv").is_file()
     assert (statistics / "plots.pdf").stat().st_size > 0
@@ -2518,11 +2532,6 @@ def test_valid_automatic_mcmc_burn_publishes_normal_posterior_outputs(
             "unavailable",
         ),
         (object(), "invalid", "unavailable"),
-        (
-            native_mcmc_module.emcee.autocorr.AutocorrError(np.array([1.0])),
-            "unreliable",
-            "unreliable_short_chain",
-        ),
         (np.array([1.0, 1.0]), "invalid shape", "invalid"),
         (np.array([np.nan]), "invalid", "unavailable"),
         (np.array([0.0]), "invalid", "unavailable"),
@@ -2533,7 +2542,6 @@ def test_valid_automatic_mcmc_burn_publishes_normal_posterior_outputs(
         "calculation-failure",
         "unexpected-calculation-failure",
         "malformed",
-        "unreliable",
         "wrong-shape",
         "non-finite",
         "zero",
@@ -2677,6 +2685,7 @@ def test_explicit_mcmc_burn_survives_autocorrelation_calculation_failure(
     assert diagnostics["requested_burn"] == 1
     assert diagnostics["autocorrelation_status"] == "unavailable"
     assert "RuntimeError" in diagnostics["autocorrelation_warning"]
+    assert "burn_in_warning" not in diagnostics
     assert (statistics / "summary.toml").is_file()
     assert (statistics / "samples.tsv").is_file()
     assert not (statistics / "raw_chain.tsv").exists()
@@ -2743,29 +2752,119 @@ def test_real_compact_mcmc_fit_is_wholly_native_and_writes_products(
     assert "complete" in rendered
 
 
-def test_short_compact_mcmc_form_fails_closed_through_real_chemex_cli(
+def test_tentative_automatic_mcmc_burn_publishes_complete_outputs_with_warning(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     output = tmp_path / "Output"
-    method = _statistics_method(tmp_path / "method.toml", '"MCMC" = 2')
+    method = _automatic_mcmc_method(tmp_path / "method.toml")
     parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    tentative_tau = np.array([0.124])
 
-    with pytest.raises(subprocess.CalledProcessError):
-        _run_real_fit_cli(output, method, parameters)
+    with patch.object(
+        native_mcmc_module.emcee.autocorr,
+        "integrated_time",
+        side_effect=native_mcmc_module.emcee.autocorr.AutocorrError(tentative_tau),
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
 
     statistics = output / "Statistics" / "MCMC"
     diagnostics = tomllib.loads(
         (statistics / "diagnostics.toml").read_text(encoding="utf-8")
     )
-    assert diagnostics["status"] == "incomplete"
-    assert diagnostics["engine"] == "native MCMC"
-    assert diagnostics["steps"] == 2
-    assert diagnostics["raw_evidence"] == "qualified_chain"
-    assert (statistics / "raw_chain.tsv").is_file()
-    assert not (statistics / "summary.toml").exists()
-    assert not (statistics / "samples.tsv").exists()
-    assert not (statistics / "correlations.tsv").exists()
-    assert not (statistics / "plots.pdf").exists()
+    assert diagnostics["status"] == "complete"
+    assert diagnostics["autocorrelation_status"] == "unreliable_short_chain"
+    assert diagnostics["autocorrelation_time_tentative"] == [pytest.approx(0.124)]
+    assert diagnostics["discarded_steps"] == 1
+    assert diagnostics["retained_steps"] == 4
+    assert diagnostics["retained_samples"] == 128
+    assert diagnostics["recommended_min_steps_50tau"] == 7
+    assert diagnostics["recommended_min_steps_100tau"] == 13
+    assert "tentative estimate" in diagnostics["autocorrelation_warning"]
+    assert "tentative automatic burn-in was applied" in diagnostics["burn_in_warning"]
+    assert "unreliable" in diagnostics["effective_sample_size_warning"]
+    assert (statistics / "summary.toml").is_file()
+    assert (statistics / "samples.tsv").is_file()
+    assert (statistics / "correlations.tsv").is_file()
+    assert (statistics / "plots.pdf").stat().st_size > 0
+    assert not (statistics / "raw_chain.tsv").exists()
+    summary = (statistics / "summary.toml").read_text(encoding="utf-8")
+    assert "effective_sample_size" not in summary
+    assert "mcse_mean" not in summary
+    rendered = capsys.readouterr().out
+    assert (
+        "MCMC completed, but the chain is shorter than 50 autocorrelation times"
+        in rendered
+    )
+    assert "automatic burn-in and autocorrelation estimates are tentative" in rendered
+    assert "5 sampled steps; at least 7 recommended" in rendered
+
+
+def test_incomplete_mcmc_reports_specific_error_before_entrypoint_boundary(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _automatic_mcmc_method(tmp_path / "method.toml")
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    (tmp_path / "sitecustomize.py").write_text(
+        """
+import chemex.optimize.native_mcmc as native_mcmc
+
+native_mcmc.emcee.autocorr.integrated_time = lambda *_args, **_kwargs: object()
+""".lstrip(),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(tmp_path), env.get("PYTHONPATH", "")))
+    )
+
+    completed = _run_real_fit_cli(
+        output,
+        method,
+        parameters,
+        check=False,
+        env=env,
+    )
+
+    rendered = " ".join((completed.stdout + completed.stderr).split())
+    assert completed.returncode == 1
+    assert "MCMC analysis is incomplete; posterior products were withheld" in rendered
+    assert "diagnostics.toml" in rendered
+    assert rendered.index("MCMC analysis is incomplete") < rendered.index(
+        "ChemEx encountered an unexpected error"
+    )
+    assert "Traceback (most recent call last)" not in rendered
+
+
+def test_short_automatic_mcmc_burn_succeeds_through_real_chemex_cli(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _automatic_mcmc_method(tmp_path / "method.toml")
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+
+    completed = _run_real_fit_cli(output, method, parameters)
+
+    rendered = " ".join((completed.stdout + completed.stderr).split())
+    assert (
+        "MCMC completed, but the chain is shorter than 50 autocorrelation times"
+        in rendered
+    )
+    assert "ChemEx encountered an unexpected error" not in rendered
+    statistics = output / "Statistics" / "MCMC"
+    diagnostics = tomllib.loads(
+        (statistics / "diagnostics.toml").read_text(encoding="utf-8")
+    )
+    assert diagnostics["status"] == "complete"
+    assert diagnostics["autocorrelation_status"] == "unreliable_short_chain"
+    assert (statistics / "summary.toml").is_file()
+    assert (statistics / "samples.tsv").is_file()
+    assert (statistics / "correlations.tsv").is_file()
+    assert (statistics / "plots.pdf").stat().st_size > 0
 
 
 def test_seeded_nested_mcmc_settings_run_through_real_chemex_cli(

--- a/website/docs/user_guide/fitting/method_files.md
+++ b/website/docs/user_guide/fitting/method_files.md
@@ -285,12 +285,17 @@ SEED = 680
 ```
 
 `STEPS` counts raw post-initialization ensemble iterations. Omitting `BURN`
-invokes ChemEx's automatic burn/convergence policy. If that policy cannot
-establish a defensible retained window, ChemEx preserves raw or partial chain
-evidence and diagnostics but publishes no authoritative posterior summary; it
-does not silently fall back to zero burn. A numeric `BURN` fixes the discard
-window but does not suppress convergence, autocorrelation, ESS, or MCSE
-diagnostics.
+invokes ChemEx's automatic burn policy, which discards
+`ceil(2 * max(autocorrelation time))` ensemble steps. A finite positive
+autocorrelation estimate from a chain shorter than emcee's recommended 50
+autocorrelation times is usable but tentative: ChemEx applies the tentative
+automatic burn, publishes posterior products with warnings, and withholds
+autocorrelation-derived ESS and MCSE. If no finite positive estimate is
+available, or the calculated burn leaves no retained samples, ChemEx preserves
+raw chain evidence and diagnostics but publishes no authoritative posterior
+summary; it does not silently fall back to zero burn. A numeric `BURN` fixes the
+discard window but does not suppress convergence or autocorrelation diagnostics;
+ESS and MCSE are reported only when the autocorrelation estimate is reliable.
 
 Walker topology, initialization, proposal policy, and parallel execution are
 ChemEx policy. Configure parallelism globally with `chemex fit --workers`; v2

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -298,9 +298,14 @@ retains only truthful completed sample/failure rows and atomically terminalizes
 the diagnostic as incomplete. MCMC diagnostics also
 include the direct emcee sampler engine, timing information, effective worker
 count and root seed, acceptance fractions, burn-in decisions, and
-autocorrelation estimates. Failed or interrupted MCMC suppresses every
-authoritative posterior product. If automatic burn selection cannot establish a
-retained window, `raw_chain.tsv` preserves the completed sampler chain as
+autocorrelation estimates. When a completed chain is shorter than emcee's
+recommended 50 autocorrelation times but supplies a finite positive tentative
+estimate, automatic burn uses that estimate and the normal posterior products
+are published. Diagnostics mark both the estimate and automatic burn as
+tentative, retain the 50τ and 100τ recommendations, and withhold τ-derived ESS
+and MCSE. Failed or interrupted MCMC suppresses every authoritative posterior
+product. If automatic burn has no finite positive estimate or would leave no
+retained samples, `raw_chain.tsv` preserves the completed sampler chain as
 diagnostic evidence while `diagnostics.toml` explicitly marks the analysis
 incomplete, distinguishes completed sampling from failed posterior retention,
 and retains acceptance, autocorrelation, and timing diagnostics. The raw chain


### PR DESCRIPTION
## Problem

Native MCMC changed the historical ChemEx behavior so that an emcee `AutocorrError` containing a valid finite positive tentative autocorrelation time caused automatic burn to fail completely. This conflated uncertainty in the autocorrelation-time estimate with invalidity of the underlying posterior samples.

A real 10,000-step CPMG chain completed successfully but was withheld solely because its length was about 40.4 times its maximum tentative autocorrelation time, below the conservative 50τ reliability criterion.

## Restored behavior

ChemEx again distinguishes reliable τ, valid but tentative τ, and unusable τ.

- Reliable finite positive τ uses `ceil(2 * max(tau))`, publishes posterior products normally, and reports τ-derived ESS and MCSE.
- Valid finite positive tentative τ uses the same automatic-burn calculation and publishes posterior summaries, retained samples, correlations, and plots with explicit tentative warnings and 50τ/100τ guidance. τ-derived ESS and MCSE remain withheld.
- Unavailable, malformed, non-finite, non-positive, dimensionally invalid, or chain-consuming τ still fails closed, preserves the qualified raw chain, and withholds posterior products.

## Historical compatibility

ChemEx `2026.06.1` already applied valid tentative τ values for automatic burn. Commits `bb88d976` and `31c0cea3` deliberately tightened the native-era policy. This PR restores the more appropriate scientific distinction without restoring lmfit-era architecture.

## Real evidence

Offline analysis of the existing authoritative 340,000-state CPMG raw chain found:

- max τ: `247.5286`
- N/max τ: `40.399`
- tentative automatic burn: `496`
- retained samples: `323136`
- 50τ recommendation: `12377`
- 100τ recommendation: `24753`

The evidence was derived from the existing `raw_chain.tsv` without resampling or likelihood recomputation. Retained coordinates, log densities, posterior quantiles, and the correlation matrix were finite; the correlation matrix was symmetric with unit diagonal.

## Scope

This PR does not change MCMC sampling, multicore execution, progress reporting, priors, parameter bounds, proposal or walker policy, explicit burn, thinning, likelihood evaluation, or deterministic fitting.

## Validation

- Focused native/product/CLI MCMC: `118 passed`
- Full tracked-files-only suite: `1232 passed`
- Scientific acceptance: `1 passed, 1231 deselected`
- Ruff: passed
- Formatting: `516 files already formatted`
- Type checking: passed
- `git diff --check`: passed
- Docusaurus production build: passed
