### PR TITLE
feat: improve CLI failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   `3st_eyring` name remains a compatibility name for the linear topology.
 
 ### Changed
+- ChemEx now presents known failures and user interruptions once at the CLI
+  boundary, reports verified diagnostic paths when available, and exits with
+  status 130 for Ctrl-C. Unexpected internal exceptions remain concise and
+  private by default; the new global `--debug` option restores their natural
+  Python tracebacks and chained causes for diagnosis.
 - Standard independent spin, relaxation, chemical-shift, coupling, kinetic,
   binding, oligomerization, and equilibrium parameters now have finite broad
   default safety domains. Scalar parameter-file values inherit these bounds,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,3 +46,18 @@ The complete interpreted uncertainty associated with one accepted deterministic
 fit, including its Evidence and predetermined availability, completeness, and
 reportability.
 _Avoid_: Product Uncertainty, Uncertainty Result, publication artifacts
+
+**Known ChemEx Failure**:
+A termination that ChemEx deliberately classifies with trusted information
+intended for concise user presentation.
+_Avoid_: Any exception raised while ChemEx is running
+
+**Unexpected Internal Failure**:
+An unclassified failure for which ChemEx cannot responsibly provide a known
+user or scientific explanation.
+_Avoid_: Known ChemEx Failure, validation failure
+
+**User Interruption**:
+A user-requested stop whose scientifically valid committed state or Evidence may
+be finalized before termination.
+_Avoid_: Failed analysis, cancellation

--- a/docs/adr/0005-translate-exceptions-at-the-cli-boundary.md
+++ b/docs/adr/0005-translate-exceptions-at-the-cli-boundary.md
@@ -11,12 +11,28 @@ covers application imports reached from the boundary as well as failures raised
 during command execution.
 
 `SystemExit` remains native so argparse and intentional command exits retain
-their established status and stream behavior.  A user interruption exits 130.
-Other ordinary failures exit non-zero.  Terminal diagnostics are concise,
-literal, written to stderr, and contain neither traceback nor chained exception
-details.  The boundary emits only boundary-owned diagnostics and never exposes
-arbitrary exception contents.  Rendering failure falls back to plain stderr
-without replacing the original exit status.
+their established status and stream behavior. The boundary applies exactly
+three terminal policies: a known ChemEx failure is rendered concisely and exits
+1, a user interruption is rendered without a traceback and exits 130, and an
+unexpected internal failure is reported as such and exits 1. User-input,
+scientific, numerical, operational, and internal categories are useful for
+reasoning about failures, but do not form a parallel exception framework.
+
+A small `ChemExError` marker identifies only failures whose structured
+information ChemEx deliberately produced and intends to present to users.
+Scientific and domain layers raise typed failures without Rich rendering or
+process exits. The console entry point owns final error presentation and process
+translation. Intermediate orchestration may add narrow operation context and
+verified publication paths without introducing a generic context dictionary or
+artifact registry.
+
+Default diagnostics for unexpected internal failures never expose arbitrary
+exception contents, notes, causes, or tracebacks. They explicitly direct the
+user to rerun with the global `--debug` option. In debug mode an unexpected
+exception is not translated: its natural traceback, type, message, notes, and
+cause or context chain remain visible. Known ChemEx failures and interruptions
+retain their normal semantic classification in debug mode. Rendering failure
+falls back to plain stderr without replacing the original exit status.
 
 Workflow layers may catch interruption temporarily to freeze scientifically
 valid partial state, serialize already committed values or qualified Evidence,
@@ -24,7 +40,10 @@ write truthful incomplete status, and perform required cleanup.  Once
 interruption is recognized, finalization does not start further scientific
 calculation, sampling, replicates, Method Steps, or optional plotting.  The
 interruption remains distinguishable from ordinary failure and propagates to
-the terminal boundary after finalization.
+the terminal boundary after finalization. The final diagnostic includes a stage
+or artifact path only when orchestration knows the stage or the artifact was
+successfully published; directory existence alone is not evidence of
+publication.
 
 ## Considered options
 
@@ -33,16 +52,23 @@ the terminal boundary after finalization.
 - Immediately re-raising every raw `KeyboardInterrupt` was rejected because it
   can discard qualified Evidence and committed results before truthful
   publication.
-- A new global exception hierarchy was rejected because existing workflow
-  terminals already distinguish interrupted operations from ordinary failure.
+- A category-shaped global exception hierarchy was rejected because the CLI
+  needs only one safe-to-present marker. Existing domain-specific failures keep
+  their useful types, while unclassified exceptions remain unexpected.
+- Always exposing tracebacks was rejected because ordinary CLI use must not
+  disclose arbitrary exception contents. Permanently suppressing tracebacks was
+  also rejected because it prevents useful bug reports; explicit `--debug`
+  provides the diagnostic path without changing the safe default.
 - Leaving application imports outside the boundary was rejected because common
   dependency and startup failures would still expose tracebacks.
 
 ## Consequences
 
 Direct calls to `chemex.chemex.main()` and lower-level APIs continue to raise
-their original exceptions.  Workflow-specific incomplete exceptions may carry
-their existing normalized `terminal` value through orchestration.  Completed
+their original exceptions. Expected domain failures no longer exit the process
+or render terminal errors below the console entry point. Workflow-specific
+incomplete exceptions may carry their existing normalized `terminal` value and
+verified publication paths through orchestration. Completed
 deterministic fits, qualified uncertainty Evidence, complete MCMC transitions,
 and completed resampling replicates survive a later interruption without being
 promoted to complete scientific conclusions.

--- a/src/chemex/_entrypoint.py
+++ b/src/chemex/_entrypoint.py
@@ -6,8 +6,17 @@ import sys
 from collections.abc import Callable
 from contextlib import suppress
 from importlib import import_module
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from chemex.exceptions import ChemExError
 
 type DiagnosticRenderer = Callable[[str], None]
+
+_UNEXPECTED_MESSAGE = (
+    "ChemEx encountered an unexpected internal error.\n"
+    "Rerun with --debug to show the traceback and chained causes."
+)
 
 _BASE_EXCEPTION_DICT = BaseException.__dict__["__dict__"]
 
@@ -28,6 +37,15 @@ def _instance_data(error: BaseException) -> dict[str, object]:
 def _is_interrupted(error: Exception) -> bool:
     terminal = _instance_data(error).get("terminal")
     return isinstance(terminal, str) and str.__eq__(terminal, "interrupted") is True
+
+
+def _known_failure_message(error: Exception) -> str:
+    try:
+        terminal = import_module("chemex.terminal")
+        message = terminal.format_known_failure(cast("ChemExError", error))
+    except BaseException:  # noqa: BLE001 - diagnostics must remain fail-safe
+        return "ChemEx could not complete the requested operation."
+    return message or "ChemEx could not complete the requested operation."
 
 
 def _load_renderer() -> DiagnosticRenderer:
@@ -53,23 +71,38 @@ def _render(
 
 
 def main() -> None:
-    """Run ChemEx and translate terminal failures without exposing tracebacks."""
+    """Run ChemEx and apply the three terminal failure policies."""
     renderer = _plain_diagnostic
+    chemex_error_type: type[Exception] | None = None
+    debug = "--debug" in sys.argv[1:]
     try:
         renderer = _load_renderer()
+        exceptions = import_module("chemex.exceptions")
+        chemex_error_type = exceptions.ChemExError
         application = import_module("chemex.chemex")
         application.main()
-    except KeyboardInterrupt:
-        _render(renderer, "ChemEx interrupted.")
+    except KeyboardInterrupt as error:
+        try:
+            terminal = import_module("chemex.terminal")
+            message = terminal.format_interruption(error)
+        except BaseException:  # noqa: BLE001 - diagnostics must remain fail-safe
+            message = "ChemEx interrupted."
+        _render(renderer, message)
         raise SystemExit(130) from None
-    except Exception as error:  # noqa: BLE001 - terminal CLI translation seam
-        interrupted = _is_interrupted(error)
-        _render(
-            renderer,
-            (
-                "ChemEx interrupted."
-                if interrupted
-                else "ChemEx encountered an unexpected error."
-            ),
-        )
-        raise SystemExit(130 if interrupted else 1) from None
+    except Exception as error:
+        known = chemex_error_type is not None and isinstance(error, chemex_error_type)
+        if known and _is_interrupted(error):
+            try:
+                terminal = import_module("chemex.terminal")
+                message = terminal.format_interruption(error)
+            except BaseException:  # noqa: BLE001 - diagnostics must remain fail-safe
+                message = "ChemEx interrupted."
+            _render(renderer, message)
+            raise SystemExit(130) from None
+        if known:
+            _render(renderer, _known_failure_message(error))
+            raise SystemExit(1) from None
+        if debug:
+            raise
+        _render(renderer, _UNEXPECTED_MESSAGE)
+        raise SystemExit(1) from None

--- a/src/chemex/_entrypoint.py
+++ b/src/chemex/_entrypoint.py
@@ -39,6 +39,15 @@ def _is_interrupted(error: Exception) -> bool:
     return isinstance(terminal, str) and str.__eq__(terminal, "interrupted") is True
 
 
+def _debug_requested(arguments: list[str]) -> bool:
+    """Recognize explicit debug opt-in without scanning past end-of-options."""
+    try:
+        end_of_options = arguments.index("--")
+    except ValueError:
+        return "--debug" in arguments
+    return "--debug" in arguments[:end_of_options]
+
+
 def _known_failure_message(error: Exception) -> str:
     try:
         terminal = import_module("chemex.terminal")
@@ -74,7 +83,7 @@ def main() -> None:
     """Run ChemEx and apply the three terminal failure policies."""
     renderer = _plain_diagnostic
     chemex_error_type: type[Exception] | None = None
-    debug = "--debug" in sys.argv[1:]
+    debug = _debug_requested(sys.argv[1:])
     try:
         renderer = _load_renderer()
         exceptions = import_module("chemex.exceptions")

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -135,6 +135,7 @@ def run_fit(
         except ArtifactPublicationError as finalization_error:
             if _is_interrupted_failure(error):
                 _copy_verified_paths(error, finalization_error)
+                object.__setattr__(finalization_error, "terminal", "interrupted")
                 if run_info.restart_revision > 0:
                     object.__setattr__(
                         finalization_error,

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -4,21 +4,21 @@ import os
 import sys
 from argparse import Namespace
 from collections.abc import Sequence
+from pathlib import Path
 
 from chemex.cli import build_parser
 from chemex.configuration.method_input import prepare_method_plan
 from chemex.configuration.method_plan import (
     FormatOrigin,
-    MethodFormatError,
     MethodPlan,
     StepPlan,
 )
 from chemex.configuration.methods import Method, Methods, Selection, read_method_plan
-from chemex.configuration.parameters import read_defaults
+from chemex.configuration.parameters import ParameterConfigurationError, read_defaults
 from chemex.containers.experiments import Experiments
+from chemex.exceptions import ArtifactPublicationError, ChemExError
 from chemex.experiments.builder import build_experiments
 from chemex.messages import (
-    error_console,
     print_logo,
     print_method_v1_deprecation_warning,
     print_no_data,
@@ -30,6 +30,10 @@ from chemex.messages import (
 from chemex.optimize.fitting import invalidate_planned_outputs
 from chemex.optimize.helper import execute_simulation
 from chemex.optimize.method_plan_execution import execute_method_plan
+from chemex.parameters.parameterization import (
+    IncompleteParameterDependenciesError,
+)
+from chemex.parameters.sealed import InvalidConfigurationError
 from chemex.run_info import (
     InputFile,
     capture_input_files,
@@ -41,6 +45,29 @@ from chemex.runtime import (
     ExecutionSettings,
     ensure_plugins_registered,
 )
+
+_VERIFIED_PATH_ATTRIBUTES = (
+    "diagnostics_path",
+    "evidence_path",
+    "samples_path",
+    "failures_path",
+    "restart_path",
+    "outcome_path",
+)
+
+
+def _is_interrupted_failure(error: BaseException) -> bool:
+    return isinstance(error, KeyboardInterrupt) or (
+        isinstance(error, ChemExError)
+        and error.__dict__.get("terminal") == "interrupted"
+    )
+
+
+def _copy_verified_paths(source: BaseException, target: BaseException) -> None:
+    for name in _VERIFIED_PATH_ATTRIBUTES:
+        value = getattr(source, name, None)
+        if isinstance(value, Path):
+            object.__setattr__(target, name, value)
 
 
 def run_fit(
@@ -90,6 +117,7 @@ def run_fit(
         )
         run_info.write_outcome("complete", session.analysis_values.snapshot())
     except (Exception, KeyboardInterrupt) as error:
+        mark_failure_stage(error, "deterministic_fit")
         try:
             run_info.write_outcome(
                 "incomplete",
@@ -97,8 +125,32 @@ def run_fit(
                 failure=error,
                 failure_stage="deterministic_fit",
             )
-        except (Exception, KeyboardInterrupt):  # noqa: BLE001
-            error.add_note("ChemEx could not publish the incomplete run outcome.")
+            object.__setattr__(error, "outcome_path", run_info.path / "outcome.toml")
+            if run_info.restart_revision > 0:
+                object.__setattr__(
+                    error,
+                    "restart_path",
+                    run_info.path / "restart.toml",
+                )
+        except ArtifactPublicationError as finalization_error:
+            if _is_interrupted_failure(error):
+                _copy_verified_paths(error, finalization_error)
+                if run_info.restart_revision > 0:
+                    object.__setattr__(
+                        finalization_error,
+                        "restart_path",
+                        run_info.path / "restart.toml",
+                    )
+                raise
+            error.add_note(
+                "ChemEx could not publish the incomplete run outcome: "
+                f"{type(finalization_error).__name__}: {finalization_error}"
+            )
+        except (Exception, KeyboardInterrupt) as finalization_error:  # noqa: BLE001
+            error.add_note(
+                "ChemEx could not publish the incomplete run outcome: "
+                f"{type(finalization_error).__name__}: {finalization_error}"
+            )
         raise
 
 
@@ -121,25 +173,25 @@ def run_sim(
         parameterization.frame_from_snapshot(snapshot)
     )
 
-    execute_simulation(
-        experiments,
-        path,
-        parameter_values=resolved_values,
-        parameter_model=parameter_model,
-        parameterization=parameterization,
-        plot=plot,
-    )
+    try:
+        execute_simulation(
+            experiments,
+            path,
+            parameter_values=resolved_values,
+            parameter_model=parameter_model,
+            parameterization=parameterization,
+            plot=plot,
+        )
+    except (Exception, KeyboardInterrupt) as error:
+        mark_failure_stage(error, "simulation")
+        raise
 
 
 def _read_fit_methods(args: Namespace) -> MethodPlan:
     if args.method is None:
         return MethodPlan(FormatOrigin.V1, (StepPlan(""),))
     print_reading_methods()
-    try:
-        plan = read_method_plan(args.method)
-    except MethodFormatError as error:
-        error_console.print(f"[red] -- ERROR: {error}")
-        sys.exit(1)
+    plan = read_method_plan(args.method)
     if plan.format_origin is FormatOrigin.V1:
         print_method_v1_deprecation_warning()
     return plan
@@ -189,6 +241,17 @@ def run(
         msg = "Native parameter initialization failed"
         if construction_error is None:
             raise RuntimeError(msg)
+        if isinstance(
+            construction_error,
+            (
+                IncompleteParameterDependenciesError,
+                InvalidConfigurationError,
+            ),
+        ):
+            raise ParameterConfigurationError(
+                tuple(args.parameters),
+                str(construction_error),
+            ) from construction_error
         raise RuntimeError(f"{msg}: {construction_error}") from construction_error
 
     if args.commands == "simulate":

--- a/src/chemex/cli.py
+++ b/src/chemex/cli.py
@@ -1,6 +1,6 @@
 """The parsing module contains the code for the parsing of command-line arguments."""
 
-from argparse import ArgumentParser, ArgumentTypeError
+from argparse import SUPPRESS, ArgumentParser, ArgumentTypeError
 from pathlib import Path
 
 from chemex import __version__
@@ -22,6 +22,19 @@ def _execution_count(value: str) -> ExecutionCount:
         msg = "must be 'auto' or a non-negative integer"
         raise ArgumentTypeError(msg)
     return parsed
+
+
+def _add_debug_argument(
+    parser: ArgumentParser,
+    *,
+    inherit_default: bool = False,
+) -> None:
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=SUPPRESS if inherit_default else False,
+        help="Show tracebacks and chained causes for unexpected internal errors",
+    )
 
 
 def _add_fit_execution_arguments(parser: ArgumentParser) -> None:
@@ -61,6 +74,8 @@ def build_parser() -> ArgumentParser:
 
     parser = ArgumentParser(description=description, prog="chemex")
 
+    _add_debug_argument(parser)
+
     parser.set_defaults(func=lambda _: parser.print_usage())
     parser.set_defaults(analysis_command=False)
 
@@ -74,6 +89,8 @@ def build_parser() -> ArgumentParser:
 
     # parser for the positional argument "fit"
     fit_parser = subparsers.add_parser("fit", help="Start a fit")
+
+    _add_debug_argument(fit_parser, inherit_default=True)
 
     fit_parser.set_defaults(analysis_command=True)
 
@@ -154,6 +171,8 @@ def build_parser() -> ArgumentParser:
     # parser for the positional argument "simulate"
     simulate_parser = subparsers.add_parser("simulate", help="Start a simulation")
 
+    _add_debug_argument(simulate_parser, inherit_default=True)
+
     simulate_parser.set_defaults(analysis_command=True)
 
     simulate_parser.add_argument(
@@ -225,6 +244,8 @@ def build_parser() -> ArgumentParser:
         help="Plot CEST profiles for dip picking",
     )
 
+    _add_debug_argument(pick_cest_parser, inherit_default=True)
+
     pick_cest_parser.set_defaults(func=pick_cest)
 
     pick_cest_parser.add_argument(
@@ -251,6 +272,8 @@ def build_parser() -> ArgumentParser:
         "plot_param",
         help="Plot one selected parameter from a 'parameters.fit' file",
     )
+
+    _add_debug_argument(plot_param_parser, inherit_default=True)
 
     plot_param_parser.set_defaults(func=plot_param)
 

--- a/src/chemex/configuration/method_plan.py
+++ b/src/chemex/configuration/method_plan.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal
 
+from chemex.exceptions import ChemExError
 from chemex.parameters.spin_system import SpinSystem
 
 if TYPE_CHECKING:
@@ -30,7 +31,7 @@ class SourceRef:
     end: int | None = None
 
 
-class MethodFormatError(ValueError):
+class MethodFormatError(ChemExError, ValueError):
     def __init__(self, message: str, source: SourceRef) -> None:
         super().__init__(message)
         self.message = message
@@ -43,6 +44,16 @@ class MethodFormatError(ValueError):
         if self.source.start is not None and self.source.end is not None:
             location += f" characters {self.source.start}:{self.source.end}"
         return f"{location}: {self.message}"
+
+
+def validate_step_name(filename: Path, name: str) -> None:
+    """Reject Method Step names that could escape an analysis output root."""
+    path = Path(name)
+    if path.is_absolute() or ".." in path.parts:
+        raise MethodFormatError(
+            "Method Step names must remain inside the output directory",
+            SourceRef(filename, name, "<step>"),
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/chemex/configuration/method_v1.py
+++ b/src/chemex/configuration/method_v1.py
@@ -24,6 +24,7 @@ from chemex.configuration.method_plan import (
     StatisticsPlan,
     StepPlan,
     profile_selection,
+    validate_step_name,
 )
 
 
@@ -80,6 +81,7 @@ def adapt_v1(raw_steps: list[tuple[Path, str, dict[str, Any]]]) -> MethodPlan:
     previous: str | None = None
     previous_selection = ProfileSelection()
     for filename, name, settings in raw_steps:
+        validate_step_name(filename, name)
         normalized = {str(key).lower(): value for key, value in settings.items()}
         selection = (
             profile_selection(

--- a/src/chemex/configuration/method_v2.py
+++ b/src/chemex/configuration/method_v2.py
@@ -28,6 +28,7 @@ from chemex.configuration.method_plan import (
     StatisticsPlan,
     StepPlan,
     profile_selection,
+    validate_step_name,
 )
 
 
@@ -290,6 +291,7 @@ def _step(
     settings: dict[str, Any],
     earlier: set[str],
 ) -> StepPlan:
+    validate_step_name(filename, name)
     if any(str(key).lower() == "fitmethod" for key in settings):
         raise MethodFormatError(
             "V2 has no FITMETHOD; omit it because TRF is implicit",

--- a/src/chemex/configuration/methods.py
+++ b/src/chemex/configuration/methods.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -22,7 +21,6 @@ from chemex.configuration.method_plan import MethodFormatError, MethodPlan, Sour
 from chemex.configuration.method_v1 import adapt_v1
 from chemex.configuration.method_v2 import adapt_v2
 from chemex.configuration.utils import key_to_lower
-from chemex.messages import print_method_error
 from chemex.parameters.spin_system import SpinSystem
 from chemex.toml import read_toml
 
@@ -251,8 +249,11 @@ def read_methods(filenames: Iterable[Path]) -> Methods:
             try:
                 method = Method(**settings)
             except ValidationError as error:
-                options = {option for err in error.errors() for option in err["loc"]}
-                print_method_error(filename, section, options)
-                sys.exit(1)
+                first = error.errors()[0]
+                field = " -> ".join(str(item) for item in first["loc"])
+                raise MethodFormatError(
+                    str(first["msg"]),
+                    SourceRef(filename, str(section), field or "<section>"),
+                ) from error
             methods[section] = method
     return methods

--- a/src/chemex/configuration/parameters.py
+++ b/src/chemex/configuration/parameters.py
@@ -6,9 +6,10 @@ from pathlib import Path
 from typing import Annotated
 
 from annotated_types import Len
-from pydantic import AfterValidator, BeforeValidator, RootModel
+from pydantic import AfterValidator, BeforeValidator, RootModel, ValidationError
 
 from chemex.configuration.utils import ensure_list
+from chemex.exceptions import ChemExError
 from chemex.parameters.name import ParamName
 from chemex.toml import read_toml_multi
 
@@ -19,12 +20,25 @@ def rename_section(section_name: str) -> str:
     return f"{section_name},nuc->"
 
 
-ValuesType = Annotated[list[float], Len(max_length=4), BeforeValidator(ensure_list)]
+ValuesType = Annotated[
+    list[float],
+    Len(min_length=1, max_length=4),
+    BeforeValidator(ensure_list),
+]
 LowerCaseString = Annotated[str, BeforeValidator(str.lower)]
 ValuesDictType = dict[LowerCaseString, ValuesType]
 SectionType = Annotated[LowerCaseString, AfterValidator(rename_section)]
 ParamsConfigType = dict[SectionType, ValuesDictType]
 ParamsConfigModel = RootModel[ParamsConfigType]
+
+
+class ParameterConfigurationError(ChemExError, ValueError):
+    """User parameter defaults do not satisfy the parameter-file schema."""
+
+    def __init__(self, filenames: tuple[Path, ...], explanation: str) -> None:
+        super().__init__(explanation)
+        self.filenames = filenames
+        self.explanation = explanation
 
 
 @dataclass(frozen=True)
@@ -50,6 +64,15 @@ def build_default_list(params_config: ParamsConfigModel) -> DefaultListType:
 
 
 def read_defaults(filenames: Iterable[Path]) -> DefaultListType:
-    config = read_toml_multi(filenames)
-    param_config = ParamsConfigModel.model_validate(config)
+    sources = tuple(filenames)
+    config = read_toml_multi(sources)
+    try:
+        param_config = ParamsConfigModel.model_validate(config)
+    except ValidationError as error:
+        first = error.errors()[0]
+        location = " -> ".join(str(item) for item in first["loc"])
+        explanation = str(first["msg"])
+        if location:
+            explanation = f"{location}: {explanation}"
+        raise ParameterConfigurationError(sources, explanation) from error
     return build_default_list(param_config)

--- a/src/chemex/exceptions.py
+++ b/src/chemex/exceptions.py
@@ -1,0 +1,26 @@
+"""Semantic exceptions shared below ChemEx's terminal presentation boundary."""
+
+from pathlib import Path
+
+
+class ChemExError(Exception):
+    """Known ChemEx failure safe for concise terminal presentation."""
+
+
+class InputFileReadError(ChemExError, OSError):
+    """A known user input could not be captured from a concrete path."""
+
+    def __init__(self, path: Path, error: OSError) -> None:
+        OSError.__init__(self, *error.args)
+        self.path = path
+        self.error = error
+
+
+class ArtifactPublicationError(ChemExError, OSError):
+    """A named ChemEx artifact could not be published at a concrete path."""
+
+    def __init__(self, operation: str, path: Path, error: OSError) -> None:
+        OSError.__init__(self, *error.args)
+        self.operation = operation
+        self.path = path
+        self.error = error

--- a/src/chemex/experiments/builder.py
+++ b/src/chemex/experiments/builder.py
@@ -2,70 +2,26 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-from typing import NoReturn
 
 from rich.live import Live
 
 from chemex.configuration.methods import Selection
-from chemex.containers.dataset import DatasetLoadError
 from chemex.containers.experiment import (
     NoDuplicateNoiseNotice,
     UnsupportedNoiseMethodNotice,
 )
 from chemex.containers.experiments import Experiments
 from chemex.experiments import experiment_types
-from chemex.experiments.experiment_types import (
-    ExperimentBuildError,
-    ExperimentConfigurationError,
-    ExperimentDataError,
-    ExperimentFileError,
-    ExperimentNameError,
-    ExperimentNotice,
-    ExperimentTomlError,
-    InvalidExperimentSourceError,
-    UnknownExperimentTypeError,
-)
+from chemex.experiments.experiment_types import ExperimentNotice
 from chemex.messages import (
     console,
     get_reading_exp_text,
-    print_dataset_error,
-    print_experiment_name_error,
-    print_experiment_source_error,
-    print_experiment_type_error,
-    print_file_not_found,
-    print_file_not_found_error,
     print_loading_experiments,
     print_no_duplicate_warning,
     print_not_implemented_noise_method_warning,
-    print_pydantic_parsing_error,
-    print_toml_error,
 )
 from chemex.runtime import AnalysisSession
-
-
-def _exit_after_build_error(error: ExperimentBuildError) -> NoReturn:
-    if isinstance(error, ExperimentFileError):
-        print_file_not_found(error.filename)
-    elif isinstance(error, ExperimentTomlError):
-        print_toml_error(error.filename, error.error)
-    elif isinstance(error, ExperimentNameError):
-        print_experiment_name_error(error.filename)
-    elif isinstance(error, UnknownExperimentTypeError):
-        print_experiment_type_error(error.filename, error.experiment_type_name)
-    elif isinstance(error, InvalidExperimentSourceError):
-        print_experiment_source_error(error.filename, error.explanation)
-    elif isinstance(error, ExperimentConfigurationError):
-        print_pydantic_parsing_error(error.filename, error.error)
-    elif isinstance(error, ExperimentDataError):
-        if isinstance(error.error, DatasetLoadError):
-            print_dataset_error(error.error.filename, error.error.explanation)
-        else:
-            print_file_not_found_error(error.error)
-    else:
-        raise error
-    sys.exit(1)
 
 
 def _print_notice(notice: ExperimentNotice) -> None:
@@ -94,25 +50,18 @@ def build_experiments(
     experiments = Experiments()
 
     for filename in filenames:
-        try:
-            source = experiment_types.open(filename)
-        except ExperimentBuildError as error:
-            _exit_after_build_error(error)
+        source = experiment_types.open(filename)
 
         with Live(
             get_reading_exp_text(filename, source.experiment_type_name),
             console=console,
         ) as live:
-            try:
-                result = experiment_types.build(
-                    source,
-                    selection=selection,
-                    model=session.model.spec,
-                    parameters=session.parameter_factory,
-                )
-            except ExperimentBuildError as error:
-                live.stop()
-                _exit_after_build_error(error)
+            result = experiment_types.build(
+                source,
+                selection=selection,
+                model=session.model.spec,
+                parameters=session.parameter_factory,
+            )
 
             live.update(
                 get_reading_exp_text(

--- a/src/chemex/experiments/experiment_types.py
+++ b/src/chemex/experiments/experiment_types.py
@@ -33,6 +33,7 @@ from chemex.containers.dataset import (
 )
 from chemex.containers.experiment import Experiment, NoiseEstimateNotice
 from chemex.containers.profile import Filterer, Profile, PulseSequence
+from chemex.exceptions import ChemExError
 from chemex.filterers import (
     CestExperimentSettings,
     CestFilterer,
@@ -222,12 +223,14 @@ class ExperimentBuildResult:
 type ExperimentNotice = NoiseEstimateNotice
 
 
-class ExperimentBuildError(Exception):
+class ExperimentBuildError(ChemExError):
     """Base class for expected Experiment construction failures."""
 
 
 @dataclass(eq=False)
-class InvalidExperimentSourceError(ExperimentBuildError):
+class InvalidExperimentSourceError(RuntimeError):
+    """An impossible, forged, or stale programmatic source handle."""
+
     filename: Path | None
     explanation: str
 
@@ -238,7 +241,7 @@ class InvalidExperimentSourceError(ExperimentBuildError):
 @dataclass(eq=False)
 class ExperimentFileError(ExperimentBuildError):
     filename: Path
-    error: FileNotFoundError
+    error: OSError
 
     def __post_init__(self) -> None:
         super().__init__(str(self.error))
@@ -247,7 +250,7 @@ class ExperimentFileError(ExperimentBuildError):
 @dataclass(eq=False)
 class ExperimentTomlError(ExperimentBuildError):
     filename: Path
-    error: tomllib.TOMLDecodeError | TypeError
+    error: UnicodeDecodeError | tomllib.TOMLDecodeError
 
     def __post_init__(self) -> None:
         super().__init__(str(self.error))
@@ -284,7 +287,7 @@ class ExperimentConfigurationError(ExperimentBuildError):
 @dataclass(eq=False)
 class ExperimentDataError(ExperimentBuildError):
     filename: Path
-    error: FileNotFoundError | DatasetLoadError
+    error: OSError | DatasetLoadError
 
     def __post_init__(self) -> None:
         super().__init__(str(self.error))
@@ -517,9 +520,9 @@ def open(filename: Path) -> ExperimentSource:
     """Read an Experiment input once and identify its Experiment Type."""
     try:
         raw_config = load_toml(filename)
-    except FileNotFoundError as error:
+    except OSError as error:
         raise ExperimentFileError(filename, error) from error
-    except (tomllib.TOMLDecodeError, TypeError) as error:
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
         raise ExperimentTomlError(filename, error) from error
 
     try:
@@ -586,7 +589,7 @@ def _build[ConfigT: GenericConfig](
 
     try:
         dataset = experiment_type_.support.load_dataset(source.filename.parent, config)
-    except (FileNotFoundError, DatasetLoadError) as error:
+    except (OSError, DatasetLoadError) as error:
         raise ExperimentDataError(source.filename, error) from error
     selected_dataset = _apply_selection(dataset, selection)
 

--- a/src/chemex/messages.py
+++ b/src/chemex/messages.py
@@ -20,7 +20,6 @@ from dataclasses import replace
 from pathlib import Path
 from time import monotonic
 
-from pydantic import ValidationError
 from rich import box
 from rich.console import Console
 from rich.live import Live
@@ -37,7 +36,6 @@ from rich.progress import (
 )
 from rich.progress import Progress as RichProgress
 from rich.rule import Rule
-from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 
@@ -59,7 +57,7 @@ error_console = Console(stderr=True)
 
 def print_cli_diagnostic(message: str) -> None:
     """Render one literal terminal diagnostic to stderr."""
-    error_console.print(Text(message, style="red"))
+    error_console.print(Text(message, style="red"), soft_wrap=True)
 
 
 class MinimizationProgressReporter:
@@ -681,13 +679,6 @@ LOGO = r"""
 """
 """ASCII art logo of the ChemEx software."""
 
-EXPERIMENT_NAME = """
-[experiment]
-name = "experiment_name"
-...
-"""
-"""Template for the experiment name in configuration files."""
-
 
 def print_logo() -> None:
     """Print the ChemEx software logo with version information."""
@@ -910,120 +901,6 @@ def print_plot_filename(filename: Path, *, extra: bool = True) -> None:
     console.print(Text.from_markup(text))
 
 
-def print_file_not_found(filename: Path) -> None:
-    """Inform the user that a specified file was not found.
-
-    Args:
-        filename (Path): The path of the file that was not found.
-
-    """
-    error_console.print()
-    error_console.print(f"[red]The file '{filename}' is empty or does not exist!")
-
-
-def print_file_not_found_error(error: FileNotFoundError) -> None:
-    """Display the file not found error message.
-
-    Args:
-        error (FileNotFoundError): The FileNotFoundError exception instance.
-
-    """
-    error_console.print()
-    error_console.print(f"[red]Error: {error}")
-
-
-def print_dataset_error(filename: Path, explanation: str) -> None:
-    """Display a concise error for invalid user-supplied dataset content."""
-    error_console.print()
-    error_console.print(f"[red]Error: Invalid data in '{filename}': {explanation}")
-
-
-def print_toml_error(filename: Path, error_message: Exception) -> None:
-    """Display an error related to TOML file parsing.
-
-    Args:
-        filename (Path): Path of the TOML file.
-        error_message (Exception): The exception instance with the error message.
-
-    """
-    error_console.print()
-    error_console.print(Text.from_markup(f"[red]Error in the TOML file '{filename}'"))
-    error_console.print(
-        Text.from_markup(f"[red]-> {error_message}\n"),
-    )
-    error_console.print(
-        "Please check the website [link]https://toml.io[/]"
-        " for a complete description of the TOML format.",
-    )
-
-
-def print_experiment_name_error(filename: Path) -> None:
-    """Display an error message when the experiment name is missing from a file.
-
-    Args:
-        filename (Path): Path of the file with the missing experiment name.
-
-    """
-    error_console.print()
-    error_console.print(
-        f"[red]The experiment name is missing from the file '{filename}'\n"
-    )
-    error_console.print(
-        f"Please make sure that the 'name' field is provided in '{filename}':\n",
-    )
-    error_console.print(
-        Syntax(EXPERIMENT_NAME, "toml"),
-        "\nRun 'chemex info' to obtain the full list of the available experiments.",
-    )
-
-
-def print_experiment_type_error(filename: Path, name: str) -> None:
-    """Display an error when an input names an unknown Experiment Type."""
-    error_console.print()
-    error_console.print(
-        f"[red]Unknown Experiment Type '{name}' in the file '{filename}'.[/]",
-    )
-    error_console.print(
-        "Run 'chemex info' to obtain the full list of available experiments.",
-    )
-
-
-def print_experiment_source_error(filename: Path | None, explanation: str) -> None:
-    """Display an error for an invalid or stale opened Experiment source."""
-    error_console.print()
-    location = f" for '{filename}'" if filename is not None else ""
-    error_console.print(f"[red]Invalid Experiment source{location}: {explanation}")
-
-
-def print_pydantic_parsing_error(filename: Path, error: ValidationError) -> None:
-    """Display errors encountered while parsing a file using Pydantic.
-
-    Args:
-        filename (Path): Path of the file being parsed.
-        error (ValidationError): Instance detailing parsing errors.
-
-    """
-    error_console.print()
-    error_console.print(Text.from_markup(f"[red]Error(s) while parsing '{filename}'"))
-    for err in error.errors():
-        location = " -> ".join(str(loc) for loc in err["loc"])
-        error_console.print("  • ", location, ":", err["msg"], style="red")
-
-
-def print_calculation_stopped_error() -> None:
-    """Inform the user that the calculation was manually stopped."""
-    error_console.print()
-    error_console.print("[red] -- Keyboard Interrupt: Calculation stopped --")
-    error_console.print()
-
-
-def print_value_error() -> None:
-    """Inform the user that a ValueError occurred, stopping the calculation."""
-    error_console.print()
-    error_console.print("[red] -- Got a ValueError: Calculation stopped --")
-    error_console.print()
-
-
 def print_warning_positive_jnh() -> None:
     """Warn about positive 1J(NH) coupling values."""
     console.print()
@@ -1048,46 +925,6 @@ def print_warning_negative_jch() -> None:
         " experiments.",
     )
     console.print()
-
-
-def print_error_grid_settings(entry: str, detail: str | None = None) -> None:
-    """Display an error related to grid settings.
-
-    Args:
-        entry (str): The problematic entry in the grid settings.
-        detail (str | None): Optional explanation of the validation failure.
-
-    """
-    error_console.print()
-    error_console.print("[red] -- ERROR: Error reading grid settings:")
-    error_console.print(Text(f'    "{entry}"', style="red"))
-    if detail is not None:
-        error_console.print(Text(f"    {detail}", style="red"))
-    error_console.print()
-    error_console.print(
-        "Please make sure that the grid settings are provided in the correct format",
-    )
-    error_console.print(Text("    [PB] = lin(<min>, <max>, <nb of points>)"))
-    error_console.print(Text("    [PB] = log(<min>, <max>, <nb of points>)"))
-    error_console.print(Text("    [PB] = (<value1>, <value2>, ..., <valuen>)"))
-    error_console.print()
-
-
-def print_error_constraints(expression: str, detail: str | None = None) -> None:
-    """Display an error message for issues with constraint expressions.
-
-    Args:
-        expression (str): The problematic constraint expression.
-        detail (str | None): Optional explanation of the validation failure.
-
-    """
-    error_console.print()
-    error_console.print(
-        f'[red] -- ERROR: Error reading constraints -> "{expression}" --'
-    )
-    if detail is not None:
-        error_console.print(Text(f"    {detail}", style="red"))
-    error_console.print()
 
 
 def print_mcmc_no_vary_warning() -> None:
@@ -1135,58 +972,6 @@ def print_mcmc_tentative_burn_warning(
             soft_wrap=True,
         )
     console.print()
-
-
-def print_mcmc_incomplete_error(diagnostics_path: Path) -> None:
-    """Report a specific fail-closed MCMC outcome before the CLI boundary."""
-    error_console.print()
-    error_console.print(
-        "[red] -- ERROR: MCMC analysis is incomplete; posterior products were "
-        "withheld.",
-        soft_wrap=True,
-    )
-    error_console.print(
-        f"    See '{diagnostics_path}' for details.",
-        soft_wrap=True,
-    )
-    error_console.print()
-
-
-def print_model_error(name: str) -> None:
-    """Display an error message for unavailable models.
-
-    Args:
-        name (str): The name of the model that is not available.
-
-    """
-    from chemex.models.factory import model_factory
-
-    error_console.print()
-    error_console.print(f"[red] -- ERROR: The model '{name}' is not available.")
-    error_console.print()
-    error_console.print("The available models are:")
-    for model_name in sorted(model_factory.set):
-        error_console.print(f"    - '{model_name}'")
-    error_console.print()
-
-
-def print_model_suffix_error(
-    name: str,
-    unknown_suffixes: set[str],
-    supported_suffixes: tuple[str, ...],
-) -> None:
-    """Display an error message for unsupported model suffixes."""
-    suffixes = ", ".join(f"'.{suffix}'" for suffix in sorted(unknown_suffixes))
-
-    error_console.print()
-    error_console.print(
-        f"[red] -- ERROR: The model '{name}' uses unsupported suffixes: {suffixes}.",
-    )
-    error_console.print()
-    error_console.print("The supported model suffixes are:")
-    for suffix in supported_suffixes:
-        error_console.print(f"    - '.{suffix}'")
-    error_console.print()
 
 
 def print_not_implemented_noise_method_warning(
@@ -1307,23 +1092,3 @@ def print_wrong_option(option: str) -> str:
         "[/] "
         "for a complete list of valid options."
     )
-
-
-def print_method_error(filename: Path, section: str, options: set[int | str]) -> None:
-    """Display errors for invalid methods or options in a specific section of a file.
-
-    Args:
-        filename (Path): The file containing the error.
-        section (str): The section of the file with the erroneous method or option.
-        options (set[int | str]): Set of options or methods that are incorrect.
-
-    """
-    error_console.print()
-    error_console.print(
-        f"[red] -- ERROR: Error reading section '[{section}]' of '{filename}' --",
-    )
-    for option in options:
-        error_console.print(
-            METHOD_ERROR_MESSAGES.get(str(option), print_wrong_option(str(option))),
-        )
-    error_console.print()

--- a/src/chemex/models/model.py
+++ b/src/chemex/models/model.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass, field
 from string import ascii_lowercase
 
-from chemex.messages import print_model_error, print_model_suffix_error
+from chemex.exceptions import ChemExError
 
 SUPPORTED_MODEL_EXTENSIONS = ("mf", "rs", "tc")
+
+
+class ModelSelectionError(ChemExError, ValueError):
+    """The requested kinetics model or extension is not supported."""
+
+    def __init__(
+        self,
+        name: str,
+        explanation: str,
+        *,
+        available: tuple[str, ...],
+    ) -> None:
+        super().__init__(explanation)
+        self.name = name
+        self.explanation = explanation
+        self.available = available
 
 
 @dataclass(frozen=True, order=True)
@@ -30,20 +45,23 @@ class ModelSpec:
         from chemex.models.factory import model_factory
 
         if name not in model_factory.set:
-            print_model_error(name)
-            sys.exit(1)
+            raise ModelSelectionError(
+                name,
+                f"The model {name!r} is not available.",
+                available=tuple(sorted(model_factory.set)),
+            )
         return name
 
     @staticmethod
     def validate_extensions(name: str, extensions: list[str]) -> set[str]:
         unknown_suffixes = set(extensions) - set(SUPPORTED_MODEL_EXTENSIONS)
         if unknown_suffixes:
-            print_model_suffix_error(
+            suffixes = ", ".join(f".{suffix}" for suffix in sorted(unknown_suffixes))
+            raise ModelSelectionError(
                 name,
-                unknown_suffixes,
-                SUPPORTED_MODEL_EXTENSIONS,
+                f"The model {name!r} uses unsupported suffixes: {suffixes}.",
+                available=tuple(f".{suffix}" for suffix in SUPPORTED_MODEL_EXTENSIONS),
             )
-            sys.exit(1)
         return set(extensions)
 
     @classmethod

--- a/src/chemex/optimize/fitting.py
+++ b/src/chemex/optimize/fitting.py
@@ -7,6 +7,7 @@ from chemex.configuration.method_input import prepare_method_plan
 from chemex.configuration.method_plan import MethodPlan
 from chemex.configuration.methods import Methods
 from chemex.containers.experiments import Experiments
+from chemex.exceptions import ArtifactPublicationError
 from chemex.optimize.method_plan_execution import execute_method_plan
 from chemex.run_info import RunInfo
 from chemex.runtime import AnalysisSession
@@ -41,10 +42,17 @@ def invalidate_planned_outputs(plan: MethodPlan, path: Path) -> None:
     for step_root in step_roots:
         for name in _CHEMEX_RESULT_PATHS:
             result_path = step_root / name
-            if result_path.is_symlink() or result_path.is_file():
-                result_path.unlink()
-            elif result_path.is_dir():
-                shutil.rmtree(result_path)
+            try:
+                if result_path.is_symlink() or result_path.is_file():
+                    result_path.unlink()
+                elif result_path.is_dir():
+                    shutil.rmtree(result_path)
+            except OSError as error:
+                raise ArtifactPublicationError(
+                    "invalidate planned analysis output",
+                    result_path,
+                    error,
+                ) from error
 
 
 def run_methods(

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy import stats
 
 from chemex.containers.experiments import Experiments
+from chemex.exceptions import ArtifactPublicationError
 from chemex.messages import (
     print_making_plots,
     print_writing_results,
@@ -245,15 +246,30 @@ def execute_simulation(
 ) -> None:
     validate_relaxation_state(parameterization, parameter_values)
     experiments.prepare_for_simulation(parameter_values)
-    _write_simulation_files(
-        experiments,
-        path,
-        parameter_model=parameter_model,
-        parameter_values=parameter_values,
-        parameterization=parameterization,
-    )
-    if plot:
-        _write_simulation_plots(experiments, path)
+    try:
+        _write_simulation_files(
+            experiments,
+            path,
+            parameter_model=parameter_model,
+            parameter_values=parameter_values,
+            parameterization=parameterization,
+        )
+        if plot:
+            _write_simulation_plots(experiments, path)
+    except OSError as error:
+        filename = error.filename
+        destination = Path(filename) if isinstance(filename, str) else path
+        failure = ArtifactPublicationError(
+            "publish simulation output",
+            destination,
+            error,
+        )
+        object.__setattr__(failure, "failure_stage", "output")
+        raise failure from error
+    except (Exception, KeyboardInterrupt) as error:
+        if getattr(error, "failure_stage", None) is None:
+            object.__setattr__(error, "failure_stage", "output")
+        raise
 
 
 def print_header(

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -14,10 +14,10 @@ from chemex.atomic import open_text_atomic, remove_paths_best_effort, write_text
 from chemex.configuration.method_plan import McmcRequest
 from chemex.configuration.methods import McmcSettings
 from chemex.containers.experiments import Experiments
+from chemex.exceptions import ArtifactPublicationError, ChemExError
 from chemex.messages import (
     McmcProgressReporter,
     console,
-    print_mcmc_incomplete_error,
     print_mcmc_tentative_burn_warning,
 )
 from chemex.optimize.native_deterministic import NativeDeterministicFit
@@ -82,7 +82,7 @@ _MCMC_ARTIFACT_NAMES = (
 )
 
 
-class NativeMcmcIncompleteError(RuntimeError):
+class NativeMcmcIncompleteError(ChemExError, RuntimeError):
     """Raised when native product MCMC cannot publish a complete chain."""
 
     def __init__(
@@ -95,6 +95,8 @@ class NativeMcmcIncompleteError(RuntimeError):
         autocorrelation_time: Array | None = None,
         autocorrelation_time_reliable: bool = False,
         autocorrelation_warning: str | None = None,
+        diagnostics_path: Path | None = None,
+        evidence_path: Path | None = None,
     ) -> None:
         super().__init__(message)
         self.terminal = terminal
@@ -103,6 +105,38 @@ class NativeMcmcIncompleteError(RuntimeError):
         self.autocorrelation_time = autocorrelation_time
         self.autocorrelation_time_reliable = autocorrelation_time_reliable
         self.autocorrelation_warning = autocorrelation_warning
+        self.diagnostics_path = diagnostics_path
+        self.evidence_path = evidence_path
+
+
+class McmcConfigurationError(ChemExError, ValueError):
+    """A trusted MCMC request cannot be executed as configured."""
+
+    def __init__(
+        self,
+        explanation: str,
+        *,
+        diagnostics_path: Path | None = None,
+    ) -> None:
+        super().__init__(explanation)
+        self.explanation = explanation
+        self.diagnostics_path = diagnostics_path
+
+
+def _mcmc_publication_error(
+    operation: str,
+    path: Path,
+    error: OSError,
+    *,
+    preserved_from: BaseException | None = None,
+) -> ArtifactPublicationError:
+    failure = ArtifactPublicationError(operation, path, error)
+    if preserved_from is not None:
+        for name in ("evidence_path", "diagnostics_path"):
+            value = getattr(preserved_from, name, None)
+            if isinstance(value, Path):
+                object.__setattr__(failure, name, value)
+    return failure
 
 
 def _compatibility_error_from_result(
@@ -148,7 +182,7 @@ def resolve_mcmc_request(
             f"MCMC requires at least {min_walkers} walkers for {nvarys} fitted "
             f"parameters"
         )
-        raise ValueError(msg)
+        raise McmcConfigurationError(msg)
 
     workers = request.workers or (execution.workers if execution is not None else 1)
     native_threads = execution.native_threads if execution is not None else None
@@ -479,27 +513,62 @@ def write_mcmc_outputs(
     timings = {} if timings is None else timings
     output_start = perf_counter()
     path_mcmc = path / "Statistics" / "MCMC"
-    path_mcmc.mkdir(parents=True, exist_ok=True)
+    try:
+        path_mcmc.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise ArtifactPublicationError(
+            "prepare MCMC output",
+            path_mcmc,
+            error,
+        ) from error
 
     phase_start = perf_counter()
-    _write_summary(result, path_mcmc, parameter_model)
+    try:
+        _write_summary(result, path_mcmc, parameter_model)
+    except OSError as error:
+        raise ArtifactPublicationError(
+            "publish MCMC summary",
+            path_mcmc / "summary.toml",
+            error,
+        ) from error
     timings["output_summary_seconds"] = perf_counter() - phase_start
 
     phase_start = perf_counter()
-    _write_samples(result, path_mcmc, parameter_model)
+    try:
+        _write_samples(result, path_mcmc, parameter_model)
+    except OSError as error:
+        raise ArtifactPublicationError(
+            "publish MCMC samples",
+            path_mcmc / "samples.tsv",
+            error,
+        ) from error
     timings["output_samples_seconds"] = perf_counter() - phase_start
 
     phase_start = perf_counter()
-    _write_correlations(result, path_mcmc, parameter_model)
+    try:
+        _write_correlations(result, path_mcmc, parameter_model)
+    except OSError as error:
+        raise ArtifactPublicationError(
+            "publish MCMC correlations",
+            path_mcmc / "correlations.tsv",
+            error,
+        ) from error
     timings["output_correlations_seconds"] = perf_counter() - phase_start
 
     phase_start = perf_counter()
-    write_mcmc_plots(
-        result,
-        settings,
-        path_mcmc,
-        parameter_names=_format_parameter_ids(result.var_names, parameter_model),
-    )
+    try:
+        write_mcmc_plots(
+            result,
+            settings,
+            path_mcmc,
+            parameter_names=_format_parameter_ids(result.var_names, parameter_model),
+        )
+    except OSError as error:
+        raise ArtifactPublicationError(
+            "publish MCMC plots",
+            path_mcmc / "plots.pdf",
+            error,
+        ) from error
     timings["output_plots_seconds"] = perf_counter() - phase_start
     timings["output_total_seconds"] = perf_counter() - output_start
     if "sampling_seconds" in timings and "result_processing_seconds" in timings:
@@ -508,14 +577,21 @@ def write_mcmc_outputs(
             + timings["result_processing_seconds"]
             + timings["output_total_seconds"]
         )
-    _write_diagnostics(
-        result,
-        settings,
-        path_mcmc,
-        timings,
-        engine=engine,
-        root_seed=root_seed,
-    )
+    try:
+        _write_diagnostics(
+            result,
+            settings,
+            path_mcmc,
+            timings,
+            engine=engine,
+            root_seed=root_seed,
+        )
+    except OSError as error:
+        raise ArtifactPublicationError(
+            "publish MCMC diagnostics",
+            path_mcmc / "diagnostics.toml",
+            error,
+        ) from error
 
 
 def _clear_mcmc_artifacts(path: Path) -> None:
@@ -671,35 +747,52 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
     if seed_recorder is not None:
         seed_recorder(root_seed)
     statistic_path = path / "Statistics" / "MCMC"
-    statistic_path.mkdir(parents=True, exist_ok=True)
-    _clear_mcmc_artifacts(statistic_path)
-    _write_native_mcmc_state_diagnostics(
-        statistic_path,
-        settings=effective,
-        root_seed=root_seed,
-        parameter_ids=fit.problem.controlled_ids,
-        status="running",
-    )
+    try:
+        statistic_path.mkdir(parents=True, exist_ok=True)
+        _clear_mcmc_artifacts(statistic_path)
+        _write_native_mcmc_state_diagnostics(
+            statistic_path,
+            settings=effective,
+            root_seed=root_seed,
+            parameter_ids=fit.problem.controlled_ids,
+            status="running",
+        )
+    except OSError as error:
+        filename = error.filename
+        destination = Path(filename) if isinstance(filename, str) else statistic_path
+        raise ArtifactPublicationError(
+            "prepare MCMC diagnostics",
+            destination,
+            error,
+        ) from error
     invalid_bound_ids = product_mcmc_invalid_bound_ids(fit.problem)
     if invalid_bound_ids:
         parameter_names = _format_parameter_ids(
             invalid_bound_ids,
             fit.parameter_model,
         )
-        error = ValueError(
+        error = McmcConfigurationError(
             "Native MCMC requires finite lower and upper bounds with lower < upper "
-            f"for every fitted parameter; affected: {', '.join(parameter_names)}"
+            f"for every fitted parameter; affected: {', '.join(parameter_names)}",
+            diagnostics_path=statistic_path / "diagnostics.toml",
         )
-        _write_native_mcmc_state_diagnostics(
-            statistic_path,
-            settings=effective,
-            root_seed=root_seed,
-            parameter_ids=fit.problem.controlled_ids,
-            status="incomplete",
-            terminal="failed",
-            completed_steps=0,
-            failure=error,
-        )
+        try:
+            _write_native_mcmc_state_diagnostics(
+                statistic_path,
+                settings=effective,
+                root_seed=root_seed,
+                parameter_ids=fit.problem.controlled_ids,
+                status="incomplete",
+                terminal="failed",
+                completed_steps=0,
+                failure=error,
+            )
+        except OSError as publication_error:
+            raise ArtifactPublicationError(
+                "publish incomplete MCMC diagnostics",
+                statistic_path / "diagnostics.toml",
+                publication_error,
+            ) from publication_error
         raise error
 
     timings: dict[str, float] = {}
@@ -752,6 +845,11 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
         mcmc_evidence = mcmc_operation.evidence
         timings["sampling_seconds"] = perf_counter() - phase_start
         completed_steps = max(0, mcmc_operation.complete_state_count - 1)
+        if mcmc_operation.terminal is McmcOperationTerminal.FAILED:
+            failure = mcmc_operation.failure
+            if failure is None:
+                raise RuntimeError("Failed MCMC operation lost its original exception")
+            raise failure
         if (
             mcmc_operation.terminal is not McmcOperationTerminal.COMPLETED
             or mcmc_operation.evidence is None
@@ -850,6 +948,18 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
                         fit.parameter_model,
                     )
                     published_evidence = raw_evidence
+                    object.__setattr__(
+                        error,
+                        "evidence_path",
+                        statistic_path / "raw_chain.tsv",
+                    )
+                except OSError as publication_error:
+                    raise _mcmc_publication_error(
+                        "publish interrupted MCMC evidence",
+                        statistic_path / "raw_chain.tsv",
+                        publication_error,
+                        preserved_from=error,
+                    ) from publication_error
                 except (Exception, KeyboardInterrupt):  # noqa: BLE001
                     error.add_note(
                         "ChemEx could not publish an interrupted qualified MCMC chain."
@@ -863,6 +973,18 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
                         fit.problem.controlled_ids,
                     )
                     published_capture = raw_capture
+                    object.__setattr__(
+                        error,
+                        "evidence_path",
+                        statistic_path / "raw_capture.tsv",
+                    )
+                except OSError as publication_error:
+                    raise _mcmc_publication_error(
+                        "publish interrupted MCMC execution capture",
+                        statistic_path / "raw_capture.tsv",
+                        publication_error,
+                        preserved_from=error,
+                    ) from publication_error
                 except (Exception, KeyboardInterrupt):  # noqa: BLE001
                     error.add_note(
                         "ChemEx could not publish interrupted MCMC execution capture."
@@ -882,32 +1004,86 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
                     analysis_result=analysis_result,
                     timings=timings,
                 )
+                object.__setattr__(
+                    error,
+                    "diagnostics_path",
+                    statistic_path / "diagnostics.toml",
+                )
+            except OSError as publication_error:
+                raise _mcmc_publication_error(
+                    "publish interrupted MCMC diagnostics",
+                    statistic_path / "diagnostics.toml",
+                    publication_error,
+                    preserved_from=error,
+                ) from publication_error
             except (Exception, KeyboardInterrupt):  # noqa: BLE001
                 error.add_note("ChemEx could not publish interrupted MCMC diagnostics.")
             raise
-        _clear_mcmc_artifacts(statistic_path)
-        if raw_evidence is not None:
-            _write_raw_chain_evidence(
-                raw_evidence,
+        publication_operation = "publish incomplete MCMC diagnostics"
+        publication_path = statistic_path / "diagnostics.toml"
+        try:
+            _clear_mcmc_artifacts(statistic_path)
+            if raw_evidence is not None:
+                publication_operation = "publish incomplete MCMC evidence"
+                publication_path = statistic_path / "raw_chain.tsv"
+                _write_raw_chain_evidence(
+                    raw_evidence,
+                    statistic_path,
+                    fit.parameter_model,
+                )
+                if isinstance(error, NativeMcmcIncompleteError):
+                    error.evidence_path = publication_path
+            publication_operation = "publish incomplete MCMC diagnostics"
+            publication_path = statistic_path / "diagnostics.toml"
+            _write_native_mcmc_state_diagnostics(
                 statistic_path,
-                fit.parameter_model,
+                settings=effective,
+                root_seed=root_seed,
+                parameter_ids=fit.problem.controlled_ids,
+                status="incomplete",
+                terminal=terminal,
+                completed_steps=failure_completed_steps,
+                failure=error,
+                raw_evidence=raw_evidence,
+                raw_capture=None,
+                analysis_result=analysis_result,
+                timings=timings,
             )
-        _write_native_mcmc_state_diagnostics(
-            statistic_path,
-            settings=effective,
-            root_seed=root_seed,
-            parameter_ids=fit.problem.controlled_ids,
-            status="incomplete",
-            terminal=terminal,
-            completed_steps=failure_completed_steps,
-            failure=error,
-            raw_evidence=raw_evidence,
-            raw_capture=None,
-            analysis_result=analysis_result,
-            timings=timings,
-        )
-        if isinstance(error, NativeMcmcIncompleteError):
-            print_mcmc_incomplete_error(statistic_path / "diagnostics.toml")
+        except OSError as publication_error:
+            if isinstance(error, NativeMcmcIncompleteError):
+                remove_paths_best_effort(
+                    (statistic_path / "diagnostics.toml",),
+                    error,
+                )
+                raise _mcmc_publication_error(
+                    publication_operation,
+                    publication_path,
+                    publication_error,
+                    preserved_from=error,
+                ) from publication_error
+            error.add_note(
+                "ChemEx could not publish incomplete MCMC diagnostics: "
+                f"{type(publication_error).__name__}: {publication_error}"
+            )
+            remove_paths_best_effort(
+                (statistic_path / "diagnostics.toml",),
+                error,
+            )
+            raise error from publication_error
+        except KeyboardInterrupt:
+            raise
+        except Exception as publication_error:
+            error.add_note(
+                "ChemEx could not publish incomplete MCMC diagnostics: "
+                f"{type(publication_error).__name__}: {publication_error}"
+            )
+            raise error from publication_error
+        if isinstance(error, (ArtifactPublicationError, NativeMcmcIncompleteError)):
+            object.__setattr__(
+                error,
+                "diagnostics_path",
+                statistic_path / "diagnostics.toml",
+            )
         raise
     else:
         return analysis_result

--- a/src/chemex/optimize/mcmc.py
+++ b/src/chemex/optimize/mcmc.py
@@ -132,6 +132,10 @@ def _mcmc_publication_error(
 ) -> ArtifactPublicationError:
     failure = ArtifactPublicationError(operation, path, error)
     if preserved_from is not None:
+        if isinstance(preserved_from, KeyboardInterrupt) or (
+            getattr(preserved_from, "terminal", None) == "interrupted"
+        ):
+            object.__setattr__(failure, "terminal", "interrupted")
         for name in ("evidence_path", "diagnostics_path"):
             value = getattr(preserved_from, name, None)
             if isinstance(value, Path):
@@ -1049,6 +1053,15 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
                 analysis_result=analysis_result,
                 timings=timings,
             )
+            if isinstance(
+                error,
+                (ArtifactPublicationError, NativeMcmcIncompleteError),
+            ):
+                object.__setattr__(
+                    error,
+                    "diagnostics_path",
+                    statistic_path / "diagnostics.toml",
+                )
         except OSError as publication_error:
             if isinstance(error, NativeMcmcIncompleteError):
                 remove_paths_best_effort(
@@ -1069,20 +1082,12 @@ def run_native_mcmc(  # noqa: C901 - closed execution/publication lifecycle
                 (statistic_path / "diagnostics.toml",),
                 error,
             )
-            raise error from publication_error
         except KeyboardInterrupt:
             raise
-        except Exception as publication_error:
+        except Exception as publication_error:  # noqa: BLE001 - preserve primary failure
             error.add_note(
                 "ChemEx could not publish incomplete MCMC diagnostics: "
                 f"{type(publication_error).__name__}: {publication_error}"
-            )
-            raise error from publication_error
-        if isinstance(error, (ArtifactPublicationError, NativeMcmcIncompleteError)):
-            object.__setattr__(
-                error,
-                "diagnostics_path",
-                statistic_path / "diagnostics.toml",
             )
         raise
     else:

--- a/src/chemex/optimize/method_plan_execution.py
+++ b/src/chemex/optimize/method_plan_execution.py
@@ -25,7 +25,7 @@ from chemex.optimize.native_deterministic import (
     run_native_deterministic,
 )
 from chemex.optimize.resampling import run_native_resampling
-from chemex.run_info import RunInfo, mark_failure_stage
+from chemex.run_info import RunInfo, mark_failure_stage, mark_method_step
 from chemex.runtime import AnalysisSession
 
 
@@ -65,6 +65,7 @@ def _run_native_statistics(
     step_name: str = "DEFAULT",
 ) -> None:
     committed = session.analysis_values.snapshot()
+    primary_error: BaseException | None = None
     try:
         for kind, request in (
             ("mc", statistics.mc),
@@ -100,9 +101,16 @@ def _run_native_statistics(
                     )
                 ),
             )
+    except (Exception, KeyboardInterrupt) as error:
+        primary_error = error
+        raise
     finally:
         if session.analysis_values.snapshot() != committed:
-            raise RuntimeError("Native statistics mutated the committed central fit")
+            message = "Native statistics mutated the committed central fit"
+            if primary_error is None:
+                raise RuntimeError(message)
+            invariant_error = RuntimeError(message)
+            raise invariant_error from primary_error
 
 
 def _requests_only_mcmc(statistics: StatisticsPlan) -> bool:
@@ -143,6 +151,7 @@ def _run_requested_native_statistics(
         )
     except (Exception, KeyboardInterrupt) as error:
         mark_failure_stage(error, "statistics")
+        mark_method_step(error, step_name)
         raise
 
 
@@ -174,16 +183,20 @@ def execute_method_plan(
         )
         step_path = path / section if len(plan.steps) > 1 else path
         step_name = section or "DEFAULT"
-        fit = run_native_deterministic(
-            experiments,
-            step_path,
-            plot_level,
-            session=session,
-            parameterization=parameterization,
-            search=step.search,
-            run_info=run_info,
-            step_name=step_name,
-        )
+        try:
+            fit = run_native_deterministic(
+                experiments,
+                step_path,
+                plot_level,
+                session=session,
+                parameterization=parameterization,
+                search=step.search,
+                run_info=run_info,
+                step_name=step_name,
+            )
+        except (Exception, KeyboardInterrupt) as error:
+            mark_method_step(error, step_name)
+            raise
         _run_requested_native_statistics(
             experiments,
             step_path,

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -182,9 +182,16 @@ def _propagate_uncertainty_interruption(
     raise error
 
 
-def _propagate_output_failure(error: BaseException, path: Path) -> Never:
+def _propagate_output_failure(
+    error: BaseException,
+    path: Path,
+    *,
+    interrupted: bool = False,
+) -> Never:
     """Add deterministic output context without reclassifying non-I/O failures."""
     if isinstance(error, ArtifactPublicationError):
+        if interrupted:
+            object.__setattr__(error, "terminal", "interrupted")
         raise error
     if isinstance(error, OSError):
         filename = error.filename
@@ -195,6 +202,8 @@ def _propagate_output_failure(error: BaseException, path: Path) -> Never:
             error,
         )
         mark_failure_stage(failure, "output")
+        if interrupted:
+            object.__setattr__(failure, "terminal", "interrupted")
         raise failure from error
     mark_failure_stage(error, "output")
     raise error
@@ -683,7 +692,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
         except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
             if uncertainty_interrupted:
                 if isinstance(error, OSError):
-                    _propagate_output_failure(error, path)
+                    _propagate_output_failure(error, path, interrupted=True)
                 _propagate_uncertainty_interruption(error)
             _propagate_output_failure(error, path)
         if uncertainty_interrupted:
@@ -706,7 +715,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
     except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
         if uncertainty_interrupted:
             if isinstance(error, OSError):
-                _propagate_output_failure(error, path)
+                _propagate_output_failure(error, path, interrupted=True)
             _propagate_uncertainty_interruption(error)
         _propagate_output_failure(error, path)
     if uncertainty_interrupted:

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -22,6 +22,7 @@ from chemex.evaluation.native import (
     EvaluationResult,
     ResolvedEvaluationValues,
 )
+from chemex.exceptions import ArtifactPublicationError, ChemExError
 from chemex.messages import (
     MinimizationProgressReporter,
     UncertaintyProgressReporter,
@@ -31,6 +32,7 @@ from chemex.messages import (
 )
 from chemex.optimize.de_direct_trf import (
     DeCoordinateSemantics,
+    DeSearchExecution,
     DeSearchInvocation,
     DeSearchTerminal,
     execute_de_search,
@@ -50,6 +52,7 @@ from chemex.optimize.direct_trf import (
     FitCommitOperation,
     FitCommitTerminal,
     OptimizationProblem,
+    TerminalFailure,
     build_bounded_independent_frame,
     execute_fit_commit,
 )
@@ -85,6 +88,89 @@ from chemex.runtime.environment import RuntimeEnvironment
 _TRF_OBJECTIVE_REQUESTS_PER_DIMENSION = 2000
 
 
+type DeterministicTerminalRecord = (
+    DeSearchExecution
+    | EvaluationFailure
+    | FitCommitOperation
+    | GroupedDirectTrfOutcome
+    | ProfiledGridOutcome
+)
+
+
+class NativeDeterministicAnalysisError(ChemExError, RuntimeError):
+    """Recognized deterministic terminal state with no committed fit."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: str,
+        outcome: DeterministicTerminalRecord,
+        failures: tuple[TerminalFailure, ...],
+    ) -> None:
+        super().__init__(message)
+        self.terminal = "failed"
+        self.reason = reason
+        self.outcome = outcome
+        self.failures = failures
+
+
+class NativeDeterministicInternalError(RuntimeError):
+    """Unexpected deterministic failure retaining its terminal evidence."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        outcome: DeterministicTerminalRecord,
+        failures: tuple[TerminalFailure, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.outcome = outcome
+        self.failures = failures
+
+
+def _is_known_analysis_failure(failure: TerminalFailure) -> bool:
+    evaluation_failure = failure.evaluation_failure
+    return failure.category in {
+        "non_converged",
+        "objective_budget_exhausted",
+        "objective_scalarization_failure",
+    } or (
+        evaluation_failure is not None
+        and evaluation_failure.validity == "INVALID_TRIAL"
+    )
+
+
+def _known_grouped_analysis_error(
+    outcome: GroupedDirectTrfOutcome,
+) -> NativeDeterministicAnalysisError | None:
+    failures = tuple(
+        component.failure
+        for component in outcome.components
+        if component.failure is not None
+    )
+    if (
+        outcome.terminal.value != "component_failure"
+        or not failures
+        or not all(_is_known_analysis_failure(failure) for failure in failures)
+    ):
+        return None
+    categories = {failure.category for failure in failures}
+    if "objective_budget_exhausted" in categories:
+        reason = "The objective-evaluation budget was exhausted."
+    elif categories == {"non_converged"}:
+        reason = "The optimizer did not converge."
+    else:
+        reason = "The optimizer encountered an invalid numerical trial."
+    return NativeDeterministicAnalysisError(
+        "Native deterministic fitting did not produce an accepted fit.",
+        reason=reason,
+        outcome=outcome,
+        failures=failures,
+    )
+
+
 def _propagate_uncertainty_interruption(
     finalization_error: BaseException | None = None,
 ) -> Never:
@@ -93,6 +179,24 @@ def _propagate_uncertainty_interruption(
     if finalization_error is not None:
         error.add_note("ChemEx could not publish interrupted uncertainty output.")
         raise error from finalization_error
+    raise error
+
+
+def _propagate_output_failure(error: BaseException, path: Path) -> Never:
+    """Add deterministic output context without reclassifying non-I/O failures."""
+    if isinstance(error, ArtifactPublicationError):
+        raise error
+    if isinstance(error, OSError):
+        filename = error.filename
+        destination = Path(filename) if isinstance(filename, str) else path
+        failure = ArtifactPublicationError(
+            "publish deterministic analysis output",
+            destination,
+            error,
+        )
+        mark_failure_stage(failure, "output")
+        raise failure from error
+    mark_failure_stage(error, "output")
     raise error
 
 
@@ -284,9 +388,20 @@ def _run_product_de_search(
     candidate = outcome.best_candidate
     if not outcome.restart_eligible or candidate is None:
         failure = outcome.failure
-        detail = "" if failure is None else f": {failure.category}: {failure.message}"
-        raise RuntimeError(
-            f"Selected-coordinate DE search produced no eligible candidate{detail}"
+        if (
+            outcome.terminal is DeSearchTerminal.BUDGET_EXHAUSTED
+            and failure is not None
+        ):
+            raise NativeDeterministicAnalysisError(
+                "Selected-coordinate DE search produced no eligible candidate.",
+                reason="The objective-evaluation budget was exhausted.",
+                outcome=outcome,
+                failures=(failure,),
+            )
+        raise NativeDeterministicInternalError(
+            "Selected-coordinate DE search produced no eligible candidate",
+            outcome=outcome,
+            failures=() if failure is None else (failure,),
         )
     return problem.restart_from(candidate.full_vector)
 
@@ -366,9 +481,27 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
         )
         evaluated = engine.new_evaluator().evaluate(frame)
         if isinstance(evaluated, EvaluationFailure):
-            raise RuntimeError(
-                "Native deterministic evaluation failed: "
-                f"{evaluated.category}: {evaluated.message}"
+            if evaluated.validity == "INVALID_TRIAL":
+                failure = TerminalFailure(
+                    evaluated.category,
+                    evaluated.message,
+                    evaluated,
+                )
+                raise NativeDeterministicAnalysisError(
+                    "Native deterministic evaluation did not produce a valid result.",
+                    reason="The requested parameter state produced an invalid numerical trial.",
+                    outcome=evaluated,
+                    failures=(failure,),
+                )
+            failure = TerminalFailure(
+                evaluated.category,
+                evaluated.message,
+                evaluated,
+            )
+            raise NativeDeterministicInternalError(
+                "Native deterministic evaluation failed",
+                outcome=evaluated,
+                failures=(failure,),
             )
         result = evaluated
         continuity_snapshot = _commit_resolved_continuity_if_changed(
@@ -378,8 +511,8 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
         )
         if continuity_snapshot is not None and run_info is not None:
             run_info.publish_restart(continuity_snapshot)
+        _materialize_evaluation(experiments, result)
         try:
-            _materialize_evaluation(experiments, result)
             execute_post_fit(
                 experiments,
                 path,
@@ -390,9 +523,8 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
                 parameter_values=result.resolved_values,
                 parameterization=parameterization,
             )
-        except (Exception, KeyboardInterrupt) as error:
-            mark_failure_stage(error, "output")
-            raise
+        except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
+            _propagate_output_failure(error, path)
         return None
 
     problem = OptimizationProblem.from_native(
@@ -451,36 +583,32 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
     if outcome.terminal.value in {"cancelled", "interrupted"}:
         raise KeyboardInterrupt("Native deterministic fit interrupted")
     if commit is None:
-        component_failures = (
+        if isinstance(outcome, GroupedDirectTrfOutcome):
+            known_error = _known_grouped_analysis_error(outcome)
+            if known_error is not None:
+                raise known_error
+        failures = (
             tuple(
-                (component.controlled_ids, component.failure)
+                component.failure
                 for component in outcome.components
                 if component.failure is not None
             )
             if isinstance(outcome, GroupedDirectTrfOutcome)
             else ()
         )
-        if component_failures:
-            detail = ": " + "; ".join(
-                f"{controlled_ids!r}: {failure.category}: {failure.message}"
-                for controlled_ids, failure in component_failures
-            )
-        elif isinstance(outcome, ProfiledGridOutcome) and outcome.failure is not None:
-            detail = f": {outcome.failure.category}: {outcome.failure.message}"
-        else:
-            detail = ""
-        msg = (
-            f"Native deterministic fit did not commit: {outcome.terminal.value}{detail}"
+        if isinstance(outcome, ProfiledGridOutcome) and outcome.failure is not None:
+            failures = (outcome.failure,)
+        raise NativeDeterministicInternalError(
+            f"Native deterministic fit did not commit: {outcome.terminal.value}",
+            outcome=outcome,
+            failures=failures,
         )
-        raise RuntimeError(msg)
     if commit.terminal is not FitCommitTerminal.COMMITTED:
         failure = commit.failure
-        detail = (
-            commit.terminal.value
-            if failure is None
-            else f"{failure.category.value}: {failure.message}"
+        raise NativeDeterministicInternalError(
+            "Native deterministic fit commit failed",
+            outcome=commit,
         )
-        raise RuntimeError(f"Native deterministic fit did not commit: {detail}")
     committed_snapshot = commit.committed_snapshot
     if committed_snapshot is None:
         raise RuntimeError("Committed native fit lacks its central-value snapshot")
@@ -528,7 +656,6 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
     except (Exception, KeyboardInterrupt) as error:
         if uncertainty_interrupted:
             _propagate_uncertainty_interruption(error)
-        mark_failure_stage(error, "output")
         raise
     variable_count = len(problem.controlled_ids)
     if isinstance(search, GridSearch):
@@ -553,11 +680,12 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
                 parameterization=parameterization,
                 fitted_ids=problem.controlled_ids,
             )
-        except (Exception, KeyboardInterrupt) as error:
+        except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
             if uncertainty_interrupted:
+                if isinstance(error, OSError):
+                    _propagate_output_failure(error, path)
                 _propagate_uncertainty_interruption(error)
-            mark_failure_stage(error, "output")
-            raise
+            _propagate_output_failure(error, path)
         if uncertainty_interrupted:
             _propagate_uncertainty_interruption()
         return fit
@@ -575,11 +703,12 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
             parameterization=parameterization,
             fitted_ids=problem.controlled_ids,
         )
-    except (Exception, KeyboardInterrupt) as error:
+    except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
         if uncertainty_interrupted:
+            if isinstance(error, OSError):
+                _propagate_output_failure(error, path)
             _propagate_uncertainty_interruption(error)
-        mark_failure_stage(error, "output")
-        raise
+        _propagate_output_failure(error, path)
     if uncertainty_interrupted:
         _propagate_uncertainty_interruption()
     return fit

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -2420,6 +2420,7 @@ class McmcOperation:
     raw_capture: RawMcmcCapture | None = None
     validation: McmcChainValidation | None = None
     backend_transition_evidence: BackendTransitionEvidence | None = None
+    failure: Exception | None = field(default=None, repr=False, compare=False)
     _occurrence_witness: _McmcEvidenceWitness | None = field(
         default=None,
         repr=False,
@@ -2444,6 +2445,7 @@ class McmcOperation:
             raise McmcConstructionError(
                 "Non-completed MCMC operation requires typed failure evidence"
             )
+        self._validate_failure()
         if self.raw_capture is None or self.backend_transition_evidence is None:
             raise McmcConstructionError(
                 "Every MCMC operation requires raw and backend diagnostic evidence"
@@ -2477,6 +2479,19 @@ class McmcOperation:
         ):
             raise McmcConstructionError(
                 "MCMC operation must come from one canonical execution occurrence"
+            )
+
+    def _validate_failure(self) -> None:
+        if self.terminal is McmcOperationTerminal.FAILED and self.failure is None:
+            raise McmcConstructionError(
+                "Failed MCMC operation requires its original exception"
+            )
+        if (
+            self.terminal is not McmcOperationTerminal.FAILED
+            and self.failure is not None
+        ):
+            raise McmcConstructionError(
+                "Only failed MCMC operation may retain an original exception"
             )
 
     def _content_identity(self) -> str:
@@ -2549,16 +2564,19 @@ def _mint_mcmc_operation(
     raw_capture: RawMcmcCapture,
     validation: McmcChainValidation | None,
     backend_transition_evidence: BackendTransitionEvidence,
+    *,
+    failure: Exception | None = None,
 ) -> McmcOperation:
     return McmcOperation(
-        terminal,
-        evidence,
-        failure_category,
-        failure_message,
-        raw_capture,
-        validation,
-        backend_transition_evidence,
-        _mint_mcmc_evidence_witness("operation"),
+        terminal=terminal,
+        evidence=evidence,
+        failure_category=failure_category,
+        failure_message=failure_message,
+        raw_capture=raw_capture,
+        validation=validation,
+        backend_transition_evidence=backend_transition_evidence,
+        failure=failure,
+        _occurrence_witness=_mint_mcmc_evidence_witness("operation"),
     )
 
 
@@ -3965,6 +3983,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     validation: McmcChainValidation | None = None
     backend_transition_evidence: BackendTransitionEvidence | None = None
     evidence: McmcEvidence | None = None
+    failure: Exception | None = None
 
     def checkpoint(next_stage: McmcExecutionStage) -> None:
         nonlocal stage
@@ -4113,6 +4132,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
         terminal = McmcOperationTerminal.FAILED
         category = type(error).__name__
         message = str(error)
+        failure = error
         if initialization_outcome is McmcInitializationOutcome.NOT_STARTED:
             initialization_outcome = McmcInitializationOutcome.FAILED
     if raw_capture is None or terminal is not McmcOperationTerminal.INTERRUPTED:
@@ -4157,6 +4177,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
         raw_capture,
         validation,
         backend_transition_evidence,
+        failure=failure,
     )
 
 

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -74,8 +74,11 @@ def _resampling_publication_error(
     samples_published: bool = False,
     failures_published: bool = False,
     diagnostics_published: bool = False,
+    interrupted: bool = False,
 ) -> ArtifactPublicationError:
     failure = ArtifactPublicationError(operation, path, error)
+    if interrupted:
+        object.__setattr__(failure, "terminal", "interrupted")
     statistic_path = path.parent
     if samples_published:
         object.__setattr__(failure, "samples_path", statistic_path / "samples.tsv")
@@ -496,6 +499,7 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                     "publish interrupted resampling diagnostics",
                     statistic_path / "diagnostics.toml",
                     publication_error,
+                    interrupted=True,
                 ) from publication_error
             error.add_note(
                 "ChemEx could not publish incomplete resampling diagnostics: "
@@ -670,6 +674,7 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                     publication_error,
                     failures_published=failures_published,
                     diagnostics_published=diagnostics_published,
+                    interrupted=True,
                 ) from publication_error
             except (Exception, KeyboardInterrupt):  # noqa: BLE001
                 error.add_note(
@@ -692,6 +697,7 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                     publication_error,
                     samples_published=samples_published,
                     diagnostics_published=diagnostics_published,
+                    interrupted=True,
                 ) from publication_error
             except (Exception, KeyboardInterrupt):  # noqa: BLE001
                 error.add_note(
@@ -722,6 +728,7 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                     publication_error,
                     samples_published=samples_published,
                     failures_published=failures_published,
+                    interrupted=True,
                 ) from publication_error
             if isinstance(error, NativeResamplingIncompleteError):
                 remove_paths_best_effort(
@@ -764,7 +771,6 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 (statistic_path / "diagnostics.toml",),
                 error,
             )
-            raise error from publication_error
         except (Exception, KeyboardInterrupt):  # noqa: BLE001
             error.add_note(
                 "ChemEx could not publish incomplete resampling diagnostics."

--- a/src/chemex/optimize/resampling.py
+++ b/src/chemex/optimize/resampling.py
@@ -12,6 +12,7 @@ import numpy as np
 from chemex.atomic import open_text_atomic, remove_paths_best_effort, write_text_atomic
 from chemex.configuration.method_plan import ResamplingKind, ResamplingRequest
 from chemex.containers.experiments import Experiments
+from chemex.exceptions import ArtifactPublicationError, ChemExError
 from chemex.messages import print_running_statistics
 from chemex.optimize.direct_trf import AcceptedFitResult
 from chemex.optimize.native_deterministic import NativeDeterministicFit
@@ -46,12 +47,47 @@ class _ResamplingMethod:
     iterations: int
 
 
-class NativeResamplingIncompleteError(RuntimeError):
+class NativeResamplingIncompleteError(ChemExError, RuntimeError):
     """Raised after truthful incomplete native statistics have been published."""
 
-    def __init__(self, message: str, *, terminal: str = "failed") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        terminal: str = "failed",
+        diagnostics_path: Path | None = None,
+        samples_path: Path | None = None,
+        failures_path: Path | None = None,
+    ) -> None:
         super().__init__(message)
         self.terminal = terminal
+        self.diagnostics_path = diagnostics_path
+        self.samples_path = samples_path
+        self.failures_path = failures_path
+
+
+def _resampling_publication_error(
+    operation: str,
+    path: Path,
+    error: OSError,
+    *,
+    samples_published: bool = False,
+    failures_published: bool = False,
+    diagnostics_published: bool = False,
+) -> ArtifactPublicationError:
+    failure = ArtifactPublicationError(operation, path, error)
+    statistic_path = path.parent
+    if samples_published:
+        object.__setattr__(failure, "samples_path", statistic_path / "samples.tsv")
+    if failures_published:
+        object.__setattr__(failure, "failures_path", statistic_path / "failures.tsv")
+    if diagnostics_published:
+        object.__setattr__(
+            failure,
+            "diagnostics_path",
+            statistic_path / "diagnostics.toml",
+        )
+    return failure
 
 
 def _resampling_result_and_samples(
@@ -229,7 +265,7 @@ def _native_dataset(
 ) -> ResamplingDatasetManifest:
     profiles = tuple(profile for experiment in experiments for profile in experiment)
     if len(profiles) != len(fit.engine.plan.profiles):
-        raise NativeResamplingIncompleteError(
+        raise RuntimeError(
             "Native resampling profile population differs from the accepted fit"
         )
     references: list[bool] = []
@@ -237,7 +273,7 @@ def _native_dataset(
     descriptors: list[str] = []
     for profile, profile_plan in zip(profiles, fit.engine.plan.profiles, strict=True):
         if profile.data.size != profile_plan.observation_count:
-            raise NativeResamplingIncompleteError(
+            raise RuntimeError(
                 "Native resampling profile shape differs from the accepted fit"
             )
         references.extend(bool(value) for value in profile.data.refs)
@@ -259,10 +295,10 @@ def _native_dataset(
     )
 
 
-def _write_native_failures(path: Path, outcomes: Sequence[ReplicateOutcome]) -> None:
+def _write_native_failures(path: Path, outcomes: Sequence[ReplicateOutcome]) -> bool:
     failed = tuple(outcome for outcome in outcomes if outcome.failure is not None)
     if not failed:
-        return
+        return False
     with open_text_atomic(path / "failures.tsv") as output:
         output.write("ordinal\tdisposition\tcategory\tmessage\n")
         for outcome in failed:
@@ -274,6 +310,7 @@ def _write_native_failures(path: Path, outcomes: Sequence[ReplicateOutcome]) -> 
                 f"{outcome.ordinal}\t{outcome.disposition.value}\t"
                 f"{failure.category}\t{message}\n"
             )
+    return True
 
 
 def _write_native_samples(
@@ -382,19 +419,28 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
     root_seed: int,
 ) -> None:
     statistic_path = path / "Statistics" / method.directory
-    statistic_path.mkdir(parents=True, exist_ok=True)
-    _clear_native_statistics_artifacts(statistic_path)
     parameter_ids = fit.accepted.controlled_ids
     parameter_names = _format_parameter_names(list(parameter_ids), fit.parameter_model)
     worker_count = min(execution.workers, method.iterations)
-    _write_native_state_diagnostics(
-        statistic_path,
-        method=method,
-        workers=worker_count,
-        parameter_ids=parameter_ids,
-        root_seed=root_seed,
-        status="running",
-    )
+    try:
+        statistic_path.mkdir(parents=True, exist_ok=True)
+        _clear_native_statistics_artifacts(statistic_path)
+        _write_native_state_diagnostics(
+            statistic_path,
+            method=method,
+            workers=worker_count,
+            parameter_ids=parameter_ids,
+            root_seed=root_seed,
+            status="running",
+        )
+    except OSError as error:
+        filename = error.filename
+        destination = Path(filename) if isinstance(filename, str) else statistic_path
+        raise ArtifactPublicationError(
+            "prepare resampling diagnostics",
+            destination,
+            error,
+        ) from error
     try:
         dataset = _native_dataset(experiments, fit)
         width = max(6, len(str(method.iterations)))
@@ -444,11 +490,25 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 terminal=terminal,
                 failure=error,
             )
-        except (Exception, KeyboardInterrupt):
-            if terminal != "interrupted":
-                raise
+        except OSError as publication_error:
+            if isinstance(error, KeyboardInterrupt):
+                raise _resampling_publication_error(
+                    "publish interrupted resampling diagnostics",
+                    statistic_path / "diagnostics.toml",
+                    publication_error,
+                ) from publication_error
             error.add_note(
-                "ChemEx could not publish interrupted resampling diagnostics."
+                "ChemEx could not publish incomplete resampling diagnostics: "
+                f"{type(publication_error).__name__}: {publication_error}"
+            )
+            remove_paths_best_effort(
+                (statistic_path / "diagnostics.toml",),
+                error,
+            )
+        except (Exception, KeyboardInterrupt) as publication_error:  # noqa: BLE001
+            error.add_note(
+                "ChemEx could not publish incomplete resampling diagnostics: "
+                f"{type(publication_error).__name__}: {publication_error}"
             )
             remove_paths_best_effort(
                 (statistic_path / "diagnostics.toml",),
@@ -461,20 +521,31 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
             f"Native {method.message} produced no replicate evidence",
             terminal=operation.terminal.value,
         )
-        _write_native_state_diagnostics(
-            statistic_path,
-            method=method,
-            workers=worker_count,
-            parameter_ids=parameter_ids,
-            root_seed=root_seed,
-            status="incomplete",
-            sample_counts=_disposition_counts(unstarted=method.iterations),
-            terminal=operation.terminal.value,
-            failure=error,
-        )
+        try:
+            _write_native_state_diagnostics(
+                statistic_path,
+                method=method,
+                workers=worker_count,
+                parameter_ids=parameter_ids,
+                root_seed=root_seed,
+                status="incomplete",
+                sample_counts=_disposition_counts(unstarted=method.iterations),
+                terminal=operation.terminal.value,
+                failure=error,
+            )
+        except OSError as publication_error:
+            raise ArtifactPublicationError(
+                "publish incomplete resampling diagnostics",
+                statistic_path / "diagnostics.toml",
+                publication_error,
+            ) from publication_error
+        error.diagnostics_path = statistic_path / "diagnostics.toml"
         raise error
     samples_published = False
     failures_published = False
+    diagnostics_published = False
+    publication_operation: str | None = None
+    publication_path: Path | None = None
     result: ResamplingAnalysisResult | None = None
     operational_interruption = operation.terminal is OperationTerminal.INTERRUPTED
     try:
@@ -491,12 +562,20 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
         samples = np.asarray(sample_rows, dtype=float).reshape(
             (len(sample_rows), len(parameter_ids))
         )
+        publication_operation = "publish resampling samples"
+        publication_path = statistic_path / "samples.tsv"
         _write_native_samples(statistic_path, parameter_names, analysis_samples)
         samples_published = True
         if not complete:
-            _write_native_failures(statistic_path, evidence.outcomes)
-            failures_published = True
+            publication_operation = "publish resampling failures"
+            publication_path = statistic_path / "failures.tsv"
+            failures_published = _write_native_failures(
+                statistic_path,
+                evidence.outcomes,
+            )
             disposition_source = evidence if result is None else result
+            publication_operation = "publish incomplete resampling diagnostics"
+            publication_path = statistic_path / "diagnostics.toml"
             _write_native_state_diagnostics(
                 statistic_path,
                 method=method,
@@ -507,18 +586,25 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 sample_counts=_disposition_counts(disposition_source),
                 terminal=operation.terminal.value,
             )
+            diagnostics_published = True
         else:
             summary = cast("ResamplingAnalysisSummary", result.summary)
+            publication_operation = "publish the resampling summary"
+            publication_path = statistic_path / "summary.toml"
             _write_resampling_summary(
                 statistic_path,
                 parameter_names=parameter_names,
                 summary=summary,
             )
+            publication_operation = "publish resampling correlations"
+            publication_path = statistic_path / "correlations.tsv"
             correlations = _write_resampling_correlations(
                 statistic_path,
                 parameter_names=parameter_names,
                 summary=summary,
             )
+            publication_operation = "publish resampling plots"
+            publication_path = statistic_path / "plots.pdf"
             write_resampling_plots(
                 statistic_path,
                 method=method.message,
@@ -533,6 +619,8 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                     ReplicateDisposition.SUCCEEDED
                 ),
             )
+            publication_operation = "publish resampling diagnostics"
+            publication_path = statistic_path / "diagnostics.toml"
             _write_resampling_diagnostics(
                 statistic_path,
                 method=method.message,
@@ -575,6 +663,14 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                     diagnostic_samples,
                 )
                 samples_published = True
+            except OSError as publication_error:
+                raise _resampling_publication_error(
+                    "publish interrupted resampling samples",
+                    statistic_path / "samples.tsv",
+                    publication_error,
+                    failures_published=failures_published,
+                    diagnostics_published=diagnostics_published,
+                ) from publication_error
             except (Exception, KeyboardInterrupt):  # noqa: BLE001
                 error.add_note(
                     "ChemEx could not publish interrupted resampling samples."
@@ -585,8 +681,18 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 )
         if terminal == "interrupted" and not failures_published:
             try:
-                _write_native_failures(statistic_path, evidence.outcomes)
-                failures_published = True
+                failures_published = _write_native_failures(
+                    statistic_path,
+                    evidence.outcomes,
+                )
+            except OSError as publication_error:
+                raise _resampling_publication_error(
+                    "publish interrupted resampling failures",
+                    statistic_path / "failures.tsv",
+                    publication_error,
+                    samples_published=samples_published,
+                    diagnostics_published=diagnostics_published,
+                ) from publication_error
             except (Exception, KeyboardInterrupt):  # noqa: BLE001
                 error.add_note(
                     "ChemEx could not publish interrupted resampling failures."
@@ -607,6 +713,58 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 terminal=terminal,
                 failure=error,
             )
+            diagnostics_published = True
+        except OSError as publication_error:
+            if terminal == "interrupted":
+                raise _resampling_publication_error(
+                    "publish incomplete resampling diagnostics",
+                    statistic_path / "diagnostics.toml",
+                    publication_error,
+                    samples_published=samples_published,
+                    failures_published=failures_published,
+                ) from publication_error
+            if isinstance(error, NativeResamplingIncompleteError):
+                remove_paths_best_effort(
+                    (statistic_path / "diagnostics.toml",),
+                    error,
+                )
+                raise _resampling_publication_error(
+                    "publish incomplete resampling diagnostics",
+                    statistic_path / "diagnostics.toml",
+                    publication_error,
+                    samples_published=samples_published,
+                    failures_published=failures_published,
+                ) from publication_error
+            if (
+                isinstance(error, OSError)
+                and publication_operation is not None
+                and publication_path is not None
+            ):
+                failure = _resampling_publication_error(
+                    publication_operation,
+                    publication_path,
+                    error,
+                    samples_published=samples_published,
+                    failures_published=failures_published,
+                )
+                failure.add_note(
+                    "ChemEx also could not publish incomplete resampling diagnostics: "
+                    f"{type(publication_error).__name__}: {publication_error}"
+                )
+                remove_paths_best_effort(
+                    (statistic_path / "diagnostics.toml",),
+                    failure,
+                )
+                raise failure from error
+            error.add_note(
+                "ChemEx could not publish incomplete resampling diagnostics: "
+                f"{type(publication_error).__name__}: {publication_error}"
+            )
+            remove_paths_best_effort(
+                (statistic_path / "diagnostics.toml",),
+                error,
+            )
+            raise error from publication_error
         except (Exception, KeyboardInterrupt):  # noqa: BLE001
             error.add_note(
                 "ChemEx could not publish incomplete resampling diagnostics."
@@ -615,16 +773,59 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
                 (statistic_path / "diagnostics.toml",),
                 error,
             )
+        if (
+            isinstance(error, OSError)
+            and publication_operation is not None
+            and publication_path is not None
+        ):
+            publication_error = _resampling_publication_error(
+                publication_operation,
+                publication_path,
+                error,
+                samples_published=samples_published,
+                failures_published=failures_published,
+                diagnostics_published=diagnostics_published,
+            )
+            raise publication_error from error
         if operational_interruption and not isinstance(error, KeyboardInterrupt):
             interrupted_error = NativeResamplingIncompleteError(
                 f"Native {method.message} completed {evidence.successful_count} of "
                 f"{method.iterations} requested replicates",
                 terminal="interrupted",
+                diagnostics_path=(
+                    statistic_path / "diagnostics.toml"
+                    if diagnostics_published
+                    else None
+                ),
+                samples_path=(
+                    statistic_path / "samples.tsv" if samples_published else None
+                ),
+                failures_path=(
+                    statistic_path / "failures.tsv" if failures_published else None
+                ),
             )
             interrupted_error.add_note(
                 "ChemEx could not publish interrupted resampling output."
             )
             raise interrupted_error from error
+        if diagnostics_published:
+            object.__setattr__(
+                error,
+                "diagnostics_path",
+                statistic_path / "diagnostics.toml",
+            )
+        if samples_published:
+            object.__setattr__(
+                error,
+                "samples_path",
+                statistic_path / "samples.tsv",
+            )
+        if failures_published:
+            object.__setattr__(
+                error,
+                "failures_path",
+                statistic_path / "failures.tsv",
+            )
         raise
     if operational_interruption or (
         result is not None and result.status is ResamplingAnalysisStatus.INCOMPLETE
@@ -633,6 +834,15 @@ def _run_native_resampling_method(  # noqa: C901 - closed execution/publication 
             f"Native {method.message} completed {evidence.successful_count} of "
             f"{method.iterations} requested replicates",
             terminal="interrupted" if operational_interruption else "failed",
+            diagnostics_path=(
+                statistic_path / "diagnostics.toml" if diagnostics_published else None
+            ),
+            samples_path=(
+                statistic_path / "samples.tsv" if samples_published else None
+            ),
+            failures_path=(
+                statistic_path / "failures.tsv" if failures_published else None
+            ),
         )
 
 

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -1,7 +1,6 @@
 """Index, configure, and expose ChemEx analysis parameters."""
 
 import re
-import sys
 from collections import Counter, defaultdict
 from collections.abc import Hashable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -10,9 +9,8 @@ from typing import Protocol
 import numpy as np
 
 from chemex.configuration.parameters import DefaultListType
+from chemex.exceptions import ChemExError
 from chemex.messages import (
-    print_error_constraints,
-    print_error_grid_settings,
     print_warning_negative_jch,
     print_warning_positive_jnh,
 )
@@ -28,14 +26,14 @@ _LIST = rf"([(](({_FLOAT})(,|[)]$))+)"
 _GRID_DEFINTION = (_LINEAR, _GEOMETRIC, _LIST)
 
 
-class ConstraintExpressionError(ValueError):
+class ConstraintExpressionError(ChemExError, ValueError):
     def __init__(self, expression: str, detail: str) -> None:
         super().__init__(detail)
         self.expression = expression
         self.detail = detail
 
 
-class GridExpressionError(ValueError):
+class GridExpressionError(ChemExError, ValueError):
     def __init__(self, entry: str, detail: str) -> None:
         super().__init__(detail)
         self.entry = entry
@@ -376,14 +374,10 @@ class ParameterCatalog:
         ids_modified: set[str] = set()
         ids_pool = set(self._parameters)
 
-        try:
-            for expression in reversed(expression_list):
-                ids_changed = self._set_expression(expression, ids_pool)
-                ids_pool -= ids_changed
-                ids_modified.update(ids_changed)
-        except ConstraintExpressionError as error:
-            print_error_constraints(error.expression, error.detail)
-            sys.exit(1)
+        for expression in reversed(expression_list):
+            ids_changed = self._set_expression(expression, ids_pool)
+            ids_pool -= ids_changed
+            ids_modified.update(ids_changed)
 
         return self._count_per_section(ids_modified)
 
@@ -416,19 +410,14 @@ class ParameterCatalog:
 
         grid_values: dict[str, Array] = {}
 
-        try:
-            for entry in reversed(grid_entries):
-                name, expression = self._split_grid_entry(entry)
-                ids_selected = self.get_matching_ids(ParamName.from_section(name))
-                ids_changed = ids_selected & ids_pool
-                values = _convert_grid_expression_to_values(expression)
+        for entry in reversed(grid_entries):
+            name, expression = self._split_grid_entry(entry)
+            ids_selected = self.get_matching_ids(ParamName.from_section(name))
+            ids_changed = ids_selected & ids_pool
+            values = _convert_grid_expression_to_values(expression)
 
-                grid_values.update(dict.fromkeys(ids_changed, values))
-                ids_pool -= ids_changed
-
-        except GridExpressionError as error:
-            print_error_grid_settings(error.entry, error.detail)
-            sys.exit(1)
+            grid_values.update(dict.fromkeys(ids_changed, values))
+            ids_pool -= ids_changed
 
         return grid_values
 

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -11,6 +11,7 @@ from enum import StrEnum
 
 import numpy as np
 
+from chemex.exceptions import ChemExError
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     BinaryExpression,
@@ -36,7 +37,7 @@ _SCHUR_RANGE_ATOL = 1.0e-12
 _DIFFERENTIAL_STEP_RELATIVE = math.sqrt(np.finfo(np.float64).eps)
 
 
-class ScientificFeasibilityError(ValueError):
+class ScientificFeasibilityError(ChemExError, ValueError):
     """A public ChemEx state violates a model-owned scientific domain."""
 
 

--- a/src/chemex/run_info.py
+++ b/src/chemex/run_info.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Literal
 
 from chemex.atomic import write_text_atomic
+from chemex.exceptions import ArtifactPublicationError, InputFileReadError
 from chemex.parameters.parameterization import (
     ParameterRole,
     SealedParameterModel,
@@ -32,6 +33,7 @@ RunOutcomeStatus = Literal["running", "complete", "incomplete"]
 FailureStage = Literal[
     "deterministic_fit",
     "restart_publication",
+    "simulation",
     "uncertainty",
     "statistics",
     "output",
@@ -45,6 +47,13 @@ def mark_failure_stage(error: BaseException, stage: FailureStage) -> BaseExcepti
     """Assign a product failure stage without changing the exception type."""
     if getattr(error, "failure_stage", None) is None:
         error.failure_stage = stage  # ty: ignore[unresolved-attribute]
+    return error
+
+
+def mark_method_step(error: BaseException, step: str) -> BaseException:
+    """Assign a Method Step without changing the propagated failure type."""
+    if getattr(error, "method_step", None) is None:
+        error.method_step = step  # ty: ignore[unresolved-attribute]
     return error
 
 
@@ -94,6 +103,14 @@ class RunInfo:
             )
             write_text_atomic(self.path / "restart.toml", text)
             self.restart_revision = snapshot.revision
+        except OSError as error:
+            failure = ArtifactPublicationError(
+                "publish the restart state",
+                self.path / "restart.toml",
+                error,
+            )
+            mark_failure_stage(failure, "restart_publication")
+            raise failure from error
         except (Exception, KeyboardInterrupt) as error:
             mark_failure_stage(error, "restart_publication")
             raise
@@ -133,6 +150,14 @@ class RunInfo:
             text = run_path.read_text(encoding="utf-8") + "\n".join(lines)
             write_text_atomic(run_path, text)
             self.stochastic_operations += (record,)
+        except OSError as error:
+            failure = ArtifactPublicationError(
+                "record the stochastic operation",
+                self.path / "run.toml",
+                error,
+            )
+            mark_failure_stage(failure, "run_info")
+            raise failure from error
         except (Exception, KeyboardInterrupt) as error:
             mark_failure_stage(error, "run_info")
             raise
@@ -158,6 +183,14 @@ class RunInfo:
                 restart_revision=self.restart_revision,
                 failure_stage=stage,
             )
+        except OSError as error:
+            failure = ArtifactPublicationError(
+                f"publish the {status} run outcome",
+                self.path / "outcome.toml",
+                error,
+            )
+            mark_failure_stage(failure, "run_info")
+            raise failure from error
         except (Exception, KeyboardInterrupt) as error:
             mark_failure_stage(error, "run_info")
             raise
@@ -259,9 +292,11 @@ def capture_input_files(
             continue
         for path in paths:
             resolved_path = _resolve_path(path, cwd)
-            files.append(
-                InputFile(category, path, resolved_path, resolved_path.read_bytes())
-            )
+            try:
+                content = resolved_path.read_bytes()
+            except OSError as error:
+                raise InputFileReadError(resolved_path, error) from error
+            files.append(InputFile(category, path, resolved_path, content))
     return tuple(files)
 
 
@@ -521,6 +556,47 @@ def write_run_outcome(
 
 
 def write_run_info(
+    args: Namespace,
+    *,
+    parameter_model: SealedParameterModel,
+    starting_values: AnalysisValuesSnapshot,
+    execution: ExecutionSettings | None = None,
+    input_files: Sequence[InputFile] | None = None,
+    argv: Sequence[str] | None = None,
+    working_directory: Path | None = None,
+    timestamp: datetime | None = None,
+) -> RunInfo:
+    """Publish the invocation record, contextualizing only concrete I/O failures."""
+    output_directory = _resolve_path(
+        args.output,
+        Path.cwd().resolve()
+        if working_directory is None
+        else working_directory.resolve(),
+    )
+    try:
+        return _write_run_info(
+            args,
+            parameter_model=parameter_model,
+            starting_values=starting_values,
+            execution=execution,
+            input_files=input_files,
+            argv=argv,
+            working_directory=working_directory,
+            timestamp=timestamp,
+        )
+    except InputFileReadError:
+        raise
+    except OSError as error:
+        failure = ArtifactPublicationError(
+            "publish run information",
+            output_directory / "run_info",
+            error,
+        )
+        mark_failure_stage(failure, "run_info")
+        raise failure from error
+
+
+def _write_run_info(
     args: Namespace,
     *,
     parameter_model: SealedParameterModel,

--- a/src/chemex/terminal.py
+++ b/src/chemex/terminal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 
-from chemex.exceptions import ChemExError
+from chemex.exceptions import ArtifactPublicationError, ChemExError
 
 
 def _fields(headline: str, *fields: tuple[str, str | None]) -> str:
@@ -56,6 +56,15 @@ def format_interruption(error: BaseException) -> str:
     lines = ["Analysis interrupted by user."]
     if context:
         lines.append(f"During: {context}")
+    if isinstance(error, ArtifactPublicationError):
+        lines.extend(
+            (
+                "Interruption finalization failed.",
+                f"Operation: {error.operation}",
+                f"Path: {error.path}",
+                f"Reason: {error.error}",
+            )
+        )
     paths = _paths(error)
     if paths:
         lines.append("Preserved:")

--- a/src/chemex/terminal.py
+++ b/src/chemex/terminal.py
@@ -1,0 +1,348 @@
+"""Presentation-only normalization for trusted terminal failures."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from chemex.exceptions import ChemExError
+
+
+def _fields(headline: str, *fields: tuple[str, str | None]) -> str:
+    lines = [headline]
+    lines.extend(f"{label}: {value}" for label, value in fields if value)
+    return "\n".join(lines)
+
+
+def _paths(error: BaseException) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    for name in (
+        "diagnostics_path",
+        "evidence_path",
+        "samples_path",
+        "failures_path",
+        "restart_path",
+        "outcome_path",
+    ):
+        value = getattr(error, name, None)
+        if isinstance(value, Path) and value not in paths:
+            paths.append(value)
+    return tuple(paths)
+
+
+def _preserved_fields(error: BaseException) -> tuple[tuple[str, str | None], ...]:
+    paths = _paths(error)
+    return (("Preserved", ", ".join(str(path) for path in paths)),) if paths else ()
+
+
+def _analysis_fields(error: BaseException) -> tuple[tuple[str, str | None], ...]:
+    stage = getattr(error, "failure_stage", None)
+    step = getattr(error, "method_step", None)
+    return (
+        ("During", stage.replace("_", " ") if isinstance(stage, str) else None),
+        ("Method Step", step if isinstance(step, str) else None),
+    )
+
+
+def format_interruption(error: BaseException) -> str:
+    """Format a user interruption from verified orchestration facts only."""
+    stage = getattr(error, "failure_stage", None)
+    step = getattr(error, "method_step", None)
+    context = None
+    if isinstance(stage, str):
+        context = stage.replace("_", " ")
+    if isinstance(step, str):
+        context = f"{context or 'analysis'} (Method Step {step})"
+    lines = ["Analysis interrupted by user."]
+    if context:
+        lines.append(f"During: {context}")
+    paths = _paths(error)
+    if paths:
+        lines.append("Preserved:")
+        lines.extend(f"  {path}" for path in paths)
+    return "\n".join(lines)
+
+
+def _validation_reason(error: object) -> str:
+    errors = getattr(error, "errors", None)
+    if not callable(errors):
+        return "The configuration does not match the required schema."
+    items = errors()
+    if not items:
+        return "The configuration does not match the required schema."
+    first = items[0]
+    location = " -> ".join(str(item) for item in first.get("loc", ()))
+    message = str(first.get("msg", "Invalid value"))
+    return f"{location}: {message}" if location else message
+
+
+type _Formatter = Callable[[ChemExError], str | None]
+
+
+def _format_path_error(error: ChemExError) -> str | None:
+    from chemex.exceptions import ArtifactPublicationError, InputFileReadError
+
+    if isinstance(error, InputFileReadError):
+        return _fields(
+            "Input file could not be read.",
+            ("Input", str(error.path)),
+            ("Reason", str(error.error)),
+            ("Next", "Check the input path and read permissions."),
+        )
+    if isinstance(error, ArtifactPublicationError):
+        return _fields(
+            "ChemEx could not publish an output artifact.",
+            ("Operation", error.operation),
+            ("Path", str(error.path)),
+            ("Reason", str(error.error)),
+            *_analysis_fields(error),
+            *_preserved_fields(error),
+            ("Next", "Check available space and write permissions."),
+        )
+    return None
+
+
+def _format_toml(error: ChemExError) -> str | None:
+    from chemex.toml import TomlReadError
+
+    if not isinstance(error, TomlReadError):
+        return None
+    if isinstance(error.error, OSError):
+        return _fields(
+            "Input file could not be read.",
+            ("Input", str(error.filename)),
+            ("Reason", str(error.error)),
+            ("Next", "Check the input path and read permissions."),
+        )
+    return _fields(
+        "TOML input is invalid.",
+        ("Input", str(error.filename)),
+        ("Reason", str(error.error)),
+        ("Next", "Check the file against the TOML format."),
+    )
+
+
+def _format_method(error: ChemExError) -> str | None:
+    from chemex.configuration.method_plan import MethodFormatError
+
+    if not isinstance(error, MethodFormatError):
+        return None
+    return _fields(
+        "Method Plan is invalid.",
+        ("Input", str(error.source.filename)),
+        ("Method Step", error.source.step),
+        ("Field", error.source.field),
+        ("Reason", error.message),
+    )
+
+
+def _format_parameters(error: ChemExError) -> str | None:
+    from chemex.configuration.parameters import ParameterConfigurationError
+
+    if not isinstance(error, ParameterConfigurationError):
+        return None
+    return _fields(
+        "Parameter configuration is invalid.",
+        ("Input", ", ".join(str(path) for path in error.filenames)),
+        ("Reason", error.explanation),
+    )
+
+
+def _format_model(error: ChemExError) -> str | None:
+    from chemex.models.model import ModelSelectionError
+
+    if not isinstance(error, ModelSelectionError):
+        return None
+    return _fields(
+        "Exchange model selection is invalid.",
+        ("Model", error.name),
+        ("Reason", error.explanation),
+        ("Available", ", ".join(error.available)),
+    )
+
+
+def _format_experiment(error: ChemExError) -> str | None:
+    from chemex.containers.dataset import DatasetLoadError
+    from chemex.experiments.experiment_types import (
+        ExperimentConfigurationError,
+        ExperimentDataError,
+        ExperimentFileError,
+        ExperimentNameError,
+        ExperimentTomlError,
+        UnknownExperimentTypeError,
+    )
+
+    if isinstance(error, ExperimentFileError):
+        return _fields(
+            "Experiment input could not be read.",
+            ("Input", str(error.filename)),
+            ("Reason", str(error.error)),
+            ("Next", "Check the input path and read permissions."),
+        )
+    if isinstance(error, ExperimentTomlError):
+        return _fields(
+            "Experiment TOML is invalid.",
+            ("Input", str(error.filename)),
+            ("Reason", str(error.error)),
+            ("Next", "Check the file against the TOML format."),
+        )
+    if isinstance(error, ExperimentNameError):
+        return _fields(
+            "Experiment name is missing or invalid.",
+            ("Input", str(error.filename)),
+            ("Reason", "The [experiment] table requires a name field."),
+            ("Next", "Run 'chemex info' to list available Experiment Types."),
+        )
+    if isinstance(error, UnknownExperimentTypeError):
+        return _fields(
+            "Experiment Type is not available.",
+            ("Input", str(error.filename)),
+            ("Experiment Type", error.experiment_type_name),
+            ("Next", "Run 'chemex info' to list available Experiment Types."),
+        )
+    if isinstance(error, ExperimentConfigurationError):
+        return _fields(
+            "Experiment configuration is invalid.",
+            ("Input", str(error.filename)),
+            ("Reason", _validation_reason(error.error)),
+        )
+    if isinstance(error, ExperimentDataError):
+        if isinstance(error.error, DatasetLoadError):
+            return _fields(
+                "Experimental data is invalid.",
+                ("Input", str(error.error.filename)),
+                ("Experiment", str(error.filename)),
+                ("Reason", error.error.explanation),
+            )
+        return _fields(
+            "Experimental data could not be read.",
+            ("Experiment", str(error.filename)),
+            ("Reason", str(error.error)),
+            ("Next", "Check the data path and read permissions."),
+        )
+    return None
+
+
+def _format_scientific(error: ChemExError) -> str:
+    return _fields(
+        "The parameter state is scientifically invalid.",
+        ("Reason", str(error)),
+        *_analysis_fields(error),
+        *_preserved_fields(error),
+        ("Next", "Check the reported relaxation parameters and constraints."),
+    )
+
+
+def _format_parameter_expression(error: ChemExError) -> str | None:
+    from chemex.parameters.database import (
+        ConstraintExpressionError,
+        GridExpressionError,
+    )
+
+    if isinstance(error, ConstraintExpressionError):
+        return _fields(
+            "Parameter constraint is invalid.",
+            ("Constraint", error.expression),
+            ("Reason", error.detail),
+        )
+    if isinstance(error, GridExpressionError):
+        return _fields(
+            "Parameter grid definition is invalid.",
+            ("Grid", error.entry),
+            ("Reason", error.detail),
+        )
+    return None
+
+
+def _format_deterministic(error: ChemExError) -> str | None:
+    from chemex.optimize.native_deterministic import NativeDeterministicAnalysisError
+
+    if not isinstance(error, NativeDeterministicAnalysisError):
+        return None
+    details = "; ".join(
+        failure.message for failure in error.failures if failure.message
+    )
+    return _fields(
+        "Deterministic analysis did not produce an accepted fit.",
+        ("Reason", error.reason),
+        ("Details", details),
+        *_analysis_fields(error),
+        *_preserved_fields(error),
+        ("Next", "Review the fit settings and starting parameter values."),
+    )
+
+
+def _format_mcmc(error: ChemExError) -> str | None:
+    from chemex.optimize.mcmc import McmcConfigurationError, NativeMcmcIncompleteError
+
+    if isinstance(error, McmcConfigurationError):
+        return _fields(
+            "MCMC configuration is invalid.",
+            ("Reason", error.explanation),
+            *_analysis_fields(error),
+            *_preserved_fields(error),
+            ("Next", "Adjust the MCMC settings or fitted parameter bounds."),
+        )
+
+    if not isinstance(error, NativeMcmcIncompleteError):
+        return None
+    diagnostics = getattr(error, "diagnostics_path", None)
+    return _fields(
+        "MCMC analysis is incomplete; posterior products were withheld.",
+        ("Reason", str(error)),
+        *_analysis_fields(error),
+        *_preserved_fields(error),
+        (
+            "Next",
+            "Inspect the MCMC diagnostics before changing the analysis."
+            if isinstance(diagnostics, Path)
+            else None,
+        ),
+    )
+
+
+def _format_resampling(error: ChemExError) -> str | None:
+    from chemex.optimize.resampling import NativeResamplingIncompleteError
+
+    if not isinstance(error, NativeResamplingIncompleteError):
+        return None
+    diagnostics = getattr(error, "diagnostics_path", None)
+    failures = getattr(error, "failures_path", None)
+    if isinstance(diagnostics, Path) and isinstance(failures, Path):
+        next_action = "Inspect the resampling diagnostics and failed replicates."
+    elif isinstance(diagnostics, Path):
+        next_action = "Inspect the resampling diagnostics."
+    elif isinstance(failures, Path):
+        next_action = "Inspect the failed resampling replicates."
+    else:
+        next_action = None
+    return _fields(
+        "Resampling analysis is incomplete; summary products were withheld.",
+        ("Reason", str(error)),
+        *_analysis_fields(error),
+        *_preserved_fields(error),
+        ("Next", next_action),
+    )
+
+
+_FORMATTERS: dict[str, _Formatter] = {
+    "chemex.configuration.method_plan": _format_method,
+    "chemex.configuration.parameters": _format_parameters,
+    "chemex.exceptions": _format_path_error,
+    "chemex.experiments.experiment_types": _format_experiment,
+    "chemex.models.model": _format_model,
+    "chemex.optimize.mcmc": _format_mcmc,
+    "chemex.optimize.native_deterministic": _format_deterministic,
+    "chemex.optimize.resampling": _format_resampling,
+    "chemex.parameters.database": _format_parameter_expression,
+    "chemex.parameters.feasible_coordinates": _format_scientific,
+    "chemex.toml": _format_toml,
+}
+
+
+def format_known_failure(error: ChemExError) -> str:
+    """Format one trusted ChemEx failure without importing Rich into its source."""
+    formatter = _FORMATTERS.get(type(error).__module__)
+    if formatter is not None and (message := formatter(error)):
+        return message
+    return str(error) or "ChemEx could not complete the requested operation."

--- a/src/chemex/toml.py
+++ b/src/chemex/toml.py
@@ -1,10 +1,21 @@
-import sys
 import tomllib
 from collections.abc import Iterable, MutableMapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from chemex.messages import print_file_not_found, print_toml_error
+from chemex.exceptions import ChemExError
+
+
+@dataclass(eq=False)
+class TomlReadError(ChemExError):
+    """A user-supplied TOML file could not be read or parsed."""
+
+    filename: Path
+    error: OSError | UnicodeDecodeError | tomllib.TOMLDecodeError
+
+    def __post_init__(self) -> None:
+        super().__init__(str(self.error))
 
 
 def _deep_update(target: dict, src: dict) -> dict:
@@ -27,12 +38,10 @@ def read_toml(filename: Path) -> dict[str, Any]:
     """Read and parse the experiment configuration file with 'toml."""
     try:
         config = load_toml(filename)
-    except FileNotFoundError:
-        print_file_not_found(filename)
-        sys.exit(1)
-    except (tomllib.TOMLDecodeError, TypeError) as error:
-        print_toml_error(filename, error)
-        sys.exit(1)
+    except OSError as error:
+        raise TomlReadError(filename, error) from error
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise TomlReadError(filename, error) from error
 
     return config
 

--- a/src/chemex/tools/pick_cest/cest_picker.py
+++ b/src/chemex/tools/pick_cest/cest_picker.py
@@ -1,4 +1,3 @@
-import sys
 from argparse import Namespace
 from collections.abc import Callable
 from typing import Any
@@ -12,6 +11,7 @@ from matplotlib.widgets import Button, Slider
 from chemex.configuration.methods import Selection
 from chemex.containers.experiment import Experiment
 from chemex.containers.experiments import Experiments
+from chemex.exceptions import ChemExError
 from chemex.experiments.builder import build_experiments
 from chemex.runtime import AnalysisSession
 from chemex.tools.pick_cest.buttons import Buttons
@@ -91,9 +91,9 @@ def pick_cest(args: Namespace) -> None:
 
     for experiment in experiments:
         if not is_cest_experiment(experiment):
-            sys.exit(
-                f"\nError: '{experiment.name}' experiment not supported. "
-                "The command 'chemex pick_cest' only works with CEST experiments.\n",
+            raise ChemExError(
+                f"Experiment {experiment.name!r} is not supported by 'chemex "
+                "pick_cest'; select a CEST experiment."
             )
         if experiment.name.startswith(("dcest", "coscest")):
             sw = 4.0

--- a/src/chemex/tools/plot_param.py
+++ b/src/chemex/tools/plot_param.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import configparser
 from argparse import Namespace
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 
 import chemex.parameters.name as cpn
 import chemex.parameters.spin_system as cns
 from chemex.configuration.parameters import ParameterConfigurationError
-from chemex.exceptions import ChemExError
+from chemex.exceptions import ChemExError, InputFileReadError
 from chemex.messages import print_making_plots, print_section
 
 
@@ -24,10 +25,11 @@ def plot_param(args: Namespace) -> None:
 
     filename = args.parameters.pop()
     try:
-        loaded = params.read(str(filename))
-        if not loaded:
-            raise FileNotFoundError(filename)
-    except (OSError, configparser.Error) as error:
+        with Path(filename).open(encoding="utf-8") as input_file:
+            params.read_file(input_file)
+    except OSError as error:
+        raise InputFileReadError(Path(filename), error) from error
+    except (UnicodeDecodeError, configparser.Error) as error:
         raise ParameterConfigurationError(
             (filename,),
             "The fitted parameter file could not be parsed.",

--- a/src/chemex/tools/plot_param.py
+++ b/src/chemex/tools/plot_param.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import configparser
-import sys
 from argparse import Namespace
 
 import matplotlib.pyplot as plt
 
 import chemex.parameters.name as cpn
 import chemex.parameters.spin_system as cns
+from chemex.configuration.parameters import ParameterConfigurationError
+from chemex.exceptions import ChemExError
 from chemex.messages import print_making_plots, print_section
 
 
@@ -16,34 +17,49 @@ def plot_param(args: Namespace) -> None:
     params = configparser.ConfigParser()
 
     if len(args.parameters) > 1:
-        sys.exit(
-            "\nError: Multiple parameter files were given. 'chemex plot_param' "
-            "should only be run with a single parameter file.\n",
+        raise ChemExError(
+            "Multiple parameter files were given. 'chemex plot_param' "
+            "requires exactly one parameter file."
         )
 
-    params.read(str(args.parameters.pop()))
+    filename = args.parameters.pop()
+    try:
+        loaded = params.read(str(filename))
+        if not loaded:
+            raise FileNotFoundError(filename)
+    except (OSError, configparser.Error) as error:
+        raise ParameterConfigurationError(
+            (filename,),
+            "The fitted parameter file could not be parsed.",
+        ) from error
     param_name = cpn.ParamName.from_section(args.parname)
     curves = {}
 
     print_making_plots()
 
-    for section in params.sections():
-        section_name = cpn.ParamName.from_section(section.strip('"'))
-        if param_name.match(section_name):
-            print_section(section)
-            residues: list[int] = []
-            values: list[float] = []
-            errors: list[float] = []
-            for key, entry in params.items(section):
-                residues.append(int(cns.SpinSystem(name=key).numbers["i"]))
-                split = entry.split()
-                values.append(float(split[0]))
-                try:
-                    error = float(split[2].strip("±"))
-                except ValueError:
-                    error = 0.0
-                errors.append(error)
-            curves[section] = (residues, values, errors)
+    try:
+        for section in params.sections():
+            section_name = cpn.ParamName.from_section(section.strip('"'))
+            if param_name.match(section_name):
+                print_section(section)
+                residues: list[int] = []
+                values: list[float] = []
+                errors: list[float] = []
+                for key, entry in params.items(section):
+                    residues.append(int(cns.SpinSystem(name=key).numbers["i"]))
+                    split = entry.split()
+                    values.append(float(split[0]))
+                    try:
+                        uncertainty = float(split[2].strip("±"))
+                    except ValueError:
+                        uncertainty = 0.0
+                    errors.append(uncertainty)
+                curves[section] = (residues, values, errors)
+    except (IndexError, KeyError, ValueError, configparser.Error) as error:
+        raise ParameterConfigurationError(
+            (filename,),
+            "The fitted parameter values could not be parsed.",
+        ) from error
 
     _, axis = plt.subplots(figsize=(12, 5))
     axis.yaxis.grid(visible=True)

--- a/tests/experiments/test_experiment_types.py
+++ b/tests/experiments/test_experiment_types.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import sys
 from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
-import chemex.chemex as chemex_module
+import chemex.experiments.builder as builder_module
 from chemex.configuration.methods import Selection
 from chemex.containers.dataset import DatasetLoadError
 from chemex.containers.experiment import NoDuplicateNoiseNotice
@@ -214,6 +213,18 @@ def test_open_reports_expected_input_failures(tmp_path: Path) -> None:
     with pytest.raises(ExperimentFileError):
         experiment_types.open(tmp_path / "missing.toml")
 
+
+def test_open_reports_invalid_utf8_as_typed_experiment_toml_error(
+    tmp_path: Path,
+) -> None:
+    filename = tmp_path / "experiment.toml"
+    filename.write_bytes(b"[experiment]\nname = \xff\n")
+
+    with pytest.raises(ExperimentTomlError) as error_info:
+        experiment_types.open(filename)
+
+    assert isinstance(error_info.value.__cause__, UnicodeDecodeError)
+
     invalid = tmp_path / "invalid.toml"
     invalid.write_text("[experiment\n", encoding="utf-8")
     with pytest.raises(ExperimentTomlError):
@@ -284,38 +295,24 @@ def test_build_reports_malformed_dataset_content(tmp_path: Path) -> None:
     assert isinstance(error_info.value.error.__cause__, ValueError)
 
 
-def test_malformed_dataset_cli_failure_has_no_traceback(
+def test_experiment_builder_preserves_typed_dataset_failure(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capfd: pytest.CaptureFixture[str],
 ) -> None:
     data_file = tmp_path / "malformed.dat"
     data_file.write_text("not-a-number 1.0 0.1\n", encoding="utf-8")
     filename = _write_relaxation_input(tmp_path, data_file.name)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "chemex",
-            "simulate",
-            "-e",
-            str(filename),
-            "-p",
-            str(tmp_path / "unused-parameters.toml"),
-            "--plot",
-            "nothing",
-        ],
-    )
+    session = AnalysisSession.create()
+    session.set_model("2st")
 
-    with pytest.raises(SystemExit) as error_info:
-        chemex_module.main()
+    with pytest.raises(ExperimentDataError) as error_info:
+        builder_module.build_experiments(
+            [filename],
+            ALL_PROFILES,
+            session=session,
+        )
 
-    output = capfd.readouterr()
-    assert error_info.value.code == 1
-    assert "Invalid data" in output.err
-    # Rich may wrap long temporary paths; line breaks are presentation only.
-    assert "malformed.dat" in output.err.replace("\n", "")
-    assert "Traceback" not in output.out + output.err
+    assert isinstance(error_info.value.error, DatasetLoadError)
+    assert error_info.value.error.filename == data_file
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_model_extensions.py
+++ b/tests/models/test_model_extensions.py
@@ -1,7 +1,7 @@
 import pytest
 
 from chemex.models.loader import register_kinetic_settings
-from chemex.models.model import ModelSpec
+from chemex.models.model import ModelSelectionError, ModelSpec
 
 
 def setup_module() -> None:
@@ -19,5 +19,8 @@ def test_model_spec_parses_suffix_combinations() -> None:
 
 
 def test_model_spec_rejects_unknown_suffix() -> None:
-    with pytest.raises(SystemExit):
+    with pytest.raises(ModelSelectionError) as error_info:
         ModelSpec.from_name("2st.xyz")
+
+    assert error_info.value.name == "2st.xyz"
+    assert error_info.value.__cause__ is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 from chemex.chemex import _read_fit_methods
 from chemex.cli import build_parser
 from chemex.configuration.method_plan import FormatOrigin
+from chemex.toml import TomlReadError
 
 
 def _fit_args(method: Path) -> Namespace:
@@ -53,20 +54,17 @@ def test_fit_cli_does_not_emit_v1_deprecation_warning_for_v2(
     assert "Method format v1 is deprecated" not in capsys.readouterr().out
 
 
-def test_fit_cli_reports_method_errors_on_stderr(
+def test_fit_method_reader_preserves_typed_toml_error(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     method = tmp_path / "invalid.toml"
     method.write_text("[STEP\n", encoding="utf-8")
 
-    with pytest.raises(SystemExit) as error_info:
+    with pytest.raises(TomlReadError) as error_info:
         _read_fit_methods(_fit_args(method))
 
-    output = capsys.readouterr()
-    assert error_info.value.code == 1
-    assert "Error in the TOML file" in output.err
-    assert "Traceback (most recent call last)" not in output.out + output.err
+    assert error_info.value.filename == method
+    assert error_info.value.__cause__ is not None
 
 
 def test_fit_parser_defaults_execution_arguments_to_auto() -> None:

--- a/tests/test_constraint_expressions.py
+++ b/tests/test_constraint_expressions.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-import chemex.parameters.database as database_module
-from chemex.parameters.database import ParameterCatalog
+from chemex.parameters.database import ConstraintExpressionError, ParameterCatalog
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
 from chemex.parameters.spin_system import SpinSystem
@@ -36,76 +35,39 @@ def test_constraint_reference_uses_non_self_match_when_available() -> None:
     assert get_expression(catalog, local_pb.id_) == global_pb.id_
 
 
-def test_constraint_reference_exits_on_missing_match(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_constraint_reference_raises_typed_error_on_missing_match() -> None:
     global_pb = make_param("PB")
     catalog = make_catalog(global_pb)
-    recorded: dict[str, str] = {}
 
-    monkeypatch.setattr(
-        database_module,
-        "print_error_constraints",
-        lambda expression, detail=None: recorded.update(
-            {"expression": expression, "detail": detail or ""}
-        ),
-    )
-
-    with pytest.raises(SystemExit):
+    with pytest.raises(ConstraintExpressionError) as error_info:
         catalog.set_expressions(["PB = [BOGUS]"])
 
-    assert recorded == {
-        "expression": "PB = [BOGUS]",
-        "detail": 'No parameter matches reference "[BOGUS]"',
-    }
+    assert error_info.value.expression == "PB = [BOGUS]"
+    assert error_info.value.detail == 'No parameter matches reference "[BOGUS]"'
     assert get_expression(catalog, global_pb.id_) == ""
 
 
-def test_constraint_reference_exits_on_missing_separator(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_constraint_reference_raises_typed_error_on_missing_separator() -> None:
     global_pb = make_param("PB")
     catalog = make_catalog(global_pb)
-    recorded: dict[str, str] = {}
-
-    monkeypatch.setattr(
-        database_module,
-        "print_error_constraints",
-        lambda expression, detail=None: recorded.update(
-            {"expression": expression, "detail": detail or ""}
-        ),
-    )
-
-    with pytest.raises(SystemExit):
+    with pytest.raises(ConstraintExpressionError) as error_info:
         catalog.set_expressions(["PB [BOGUS]"])
 
-    assert recorded == {
-        "expression": "PB [BOGUS]",
-        "detail": "Expected exactly one '=' in the constraint expression",
-    }
+    assert error_info.value.expression == "PB [BOGUS]"
+    assert error_info.value.detail == (
+        "Expected exactly one '=' in the constraint expression"
+    )
     assert get_expression(catalog, global_pb.id_) == ""
 
 
-def test_constraint_reference_exits_on_self_only_match(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_constraint_reference_raises_typed_error_on_self_only_match() -> None:
     local_pb = make_param("PB", "L55HD2")
     catalog = make_catalog(local_pb)
-    recorded: dict[str, str] = {}
-
-    monkeypatch.setattr(
-        database_module,
-        "print_error_constraints",
-        lambda expression, detail=None: recorded.update(
-            {"expression": expression, "detail": detail or ""}
-        ),
-    )
-
-    with pytest.raises(SystemExit):
+    with pytest.raises(ConstraintExpressionError) as error_info:
         catalog.set_expressions(["PB, NUC->L55HD2 = [PB]"])
 
-    assert recorded == {
-        "expression": "PB, NUC->L55HD2 = [PB]",
-        "detail": 'Reference "[PB]" resolves only to the constrained parameter',
-    }
+    assert error_info.value.expression == "PB, NUC->L55HD2 = [PB]"
+    assert error_info.value.detail == (
+        'Reference "[PB]" resolves only to the constrained parameter'
+    )
     assert get_expression(catalog, local_pb.id_) == ""

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -13,6 +13,7 @@ import pytest
 
 from chemex import chemex as application_module
 from chemex.configuration.parameters import ParameterConfigurationError
+from chemex.exceptions import InputFileReadError
 
 TRACEBACK_HEADER = "Traceback (most recent call last)"
 SECRET_CANARY = "SECRET_CANARY"  # noqa: S105 - security regression canary
@@ -356,10 +357,29 @@ def test_plot_param_missing_input_is_a_known_cli_failure(
 
     combined = completed.stdout + completed.stderr
     assert completed.returncode == 1
-    assert "Parameter configuration is invalid" in completed.stderr
+    assert "Input file could not be read" in completed.stderr
     assert str(missing) in completed.stderr
     assert "unexpected internal error" not in combined
     assert TRACEBACK_HEADER not in combined
+
+
+def test_plot_param_missing_input_retains_original_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing-fitted.toml"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["chemex", "plot_param", "-p", str(missing), "-n", "PB"],
+    )
+
+    with pytest.raises(InputFileReadError) as error_info:
+        application_module.main()
+
+    assert error_info.value.path == missing
+    assert isinstance(error_info.value.__cause__, FileNotFoundError)
+    assert error_info.value.error is error_info.value.__cause__
 
 
 def test_programmatic_main_retains_ordinary_exception_semantics(
@@ -470,6 +490,20 @@ def test_cli_bootstrap_debug_reraises_unexpected_failure_with_cause() -> None:
     assert "The above exception was the direct cause" in combined
 
 
+def test_debug_token_after_end_of_options_does_not_expose_internal_failure() -> None:
+    completed = _run_bootstrap(
+        f"raise RuntimeError('{SECRET_CANARY}')",
+        arguments=("--", "--debug"),
+    )
+
+    _assert_bootstrap_result(
+        completed,
+        1,
+        UNEXPECTED_MESSAGE,
+        absent=(SECRET_CANARY,),
+    )
+
+
 def test_cli_bootstrap_reports_incomplete_resampling_artifacts_once() -> None:
     completed = _run_bootstrap(
         """
@@ -558,6 +592,34 @@ def test_cli_bootstrap_reports_contextualized_publication_failure() -> None:
     assert "No space left on device" in rendered
     assert "Output/run_info/outcome.toml" in rendered
     assert "unexpected internal error" not in rendered
+    assert TRACEBACK_HEADER not in rendered
+
+
+def test_interrupted_publication_failure_keeps_exit_130_and_integrity_details() -> None:
+    completed = _run_bootstrap(
+        """
+        from pathlib import Path
+        from chemex.exceptions import ArtifactPublicationError
+        cause = OSError(28, "No space left on device")
+        error = ArtifactPublicationError(
+            "publish the interrupted run outcome",
+            Path("Output/run_info/outcome.toml"),
+            cause,
+        )
+        error.terminal = "interrupted"
+        error.restart_path = Path("Output/run_info/restart.toml")
+        raise error from cause
+        """
+    )
+
+    rendered = " ".join(completed.stderr.split())
+    assert completed.returncode == 130
+    assert "Analysis interrupted by user" in rendered
+    assert "Interruption finalization failed" in rendered
+    assert "publish the interrupted run outcome" in rendered
+    assert "Output/run_info/outcome.toml" in rendered
+    assert "No space left on device" in rendered
+    assert "Output/run_info/restart.toml" in rendered
     assert TRACEBACK_HEADER not in rendered
 
 

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -12,11 +12,15 @@ from pathlib import Path
 import pytest
 
 from chemex import chemex as application_module
+from chemex.configuration.parameters import ParameterConfigurationError
 
 TRACEBACK_HEADER = "Traceback (most recent call last)"
 SECRET_CANARY = "SECRET_CANARY"  # noqa: S105 - security regression canary
-UNEXPECTED_MESSAGE = "ChemEx encountered an unexpected error."
-INTERRUPTED_MESSAGE = "ChemEx interrupted."
+UNEXPECTED_MESSAGE = (
+    "ChemEx encountered an unexpected internal error.\n"
+    "Rerun with --debug to show the traceback and chained causes."
+)
+INTERRUPTED_MESSAGE = "Analysis interrupted by user."
 ROOT = Path(__file__).parent.parent
 EXAMPLE = ROOT / "examples/Experiments/RELAXATION_HZNZ"
 EXPERIMENT = EXAMPLE / "Experiments/800mhz.toml"
@@ -49,6 +53,7 @@ def _run_bootstrap(
     *,
     setup_source: str = "",
     messages_source: str = "",
+    arguments: Sequence[str] = (),
 ) -> subprocess.CompletedProcess[str]:
     failure = textwrap.indent(textwrap.dedent(failure_source).strip(), "    ")
     source = f"""
@@ -67,7 +72,7 @@ sys.modules["chemex.chemex"] = application
 from chemex._entrypoint import main
 main()
 """
-    return _run((sys.executable, "-c"), source)
+    return _run((sys.executable, "-c"), source, *arguments)
 
 
 def _assert_bootstrap_result(
@@ -163,6 +168,26 @@ def test_cli_entrypoints_preserve_argparse_behavior(
 
 
 @pytest.mark.parametrize("command", _entry_commands())
+@pytest.mark.parametrize("subcommand", ("fit", "simulate", "pick_cest", "plot_param"))
+@pytest.mark.parametrize("debug_first", (False, True))
+def test_global_debug_option_is_discoverable_for_every_command(
+    command: tuple[str, ...],
+    subcommand: str,
+    debug_first: bool,
+) -> None:
+    arguments = (
+        ("--debug", subcommand, "--help")
+        if debug_first
+        else (subcommand, "--debug", "--help")
+    )
+    completed = _run(command, *arguments)
+
+    assert completed.returncode == 0
+    assert "--debug" in completed.stdout
+    assert TRACEBACK_HEADER not in completed.stderr
+
+
+@pytest.mark.parametrize("command", _entry_commands())
 @pytest.mark.parametrize("model", ("missing-model", "2st.unsupported"))
 def test_cli_entrypoints_report_invalid_model_as_unsuccessful_error(
     command: tuple[str, ...],
@@ -183,8 +208,68 @@ def test_cli_entrypoints_report_invalid_model_as_unsuccessful_error(
 
     combined = completed.stdout + completed.stderr
     assert completed.returncode == 1
-    assert "ERROR:" in completed.stderr
+    assert "Exchange model selection is invalid" in completed.stderr
     assert model in completed.stderr
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+@pytest.mark.parametrize("input_kind", ("experiment", "parameters"))
+def test_cli_entrypoints_report_malformed_input_with_source(
+    command: tuple[str, ...],
+    input_kind: str,
+    tmp_path: Path,
+) -> None:
+    malformed = tmp_path / f"malformed-{input_kind}.toml"
+    malformed.write_text("[broken\n", encoding="utf-8")
+    experiment = malformed if input_kind == "experiment" else EXPERIMENT
+    parameters = malformed if input_kind == "parameters" else PARAMETERS
+
+    completed = _run(
+        command,
+        "simulate",
+        "-e",
+        str(experiment),
+        "-p",
+        str(parameters),
+        "--plot",
+        "nothing",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert str(malformed) in completed.stderr
+    assert "TOML" in completed.stderr
+    assert "unexpected internal error" not in completed.stderr
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+def test_cli_entrypoints_report_invalid_method_plan_with_source(
+    command: tuple[str, ...],
+    tmp_path: Path,
+) -> None:
+    method = tmp_path / "invalid-method.toml"
+    method.write_text("[DEFAULT]\nFIT = 42\n", encoding="utf-8")
+
+    completed = _run(
+        command,
+        "fit",
+        "-e",
+        str(EXPERIMENT),
+        "-p",
+        str(PARAMETERS),
+        "-m",
+        str(method),
+        "--plot",
+        "nothing",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert "Method Plan is invalid" in completed.stderr
+    assert str(method) in completed.stderr
+    assert "unexpected internal error" not in completed.stderr
     assert TRACEBACK_HEADER not in combined
 
 
@@ -212,7 +297,7 @@ def test_cli_entrypoints_preserve_no_selected_profiles_success(
 
 
 @pytest.mark.parametrize("command", _entry_commands())
-def test_cli_entrypoints_translate_uncaught_runtime_failure(
+def test_cli_entrypoints_report_invalid_plot_parameter_input(
     command: tuple[str, ...],
 ) -> None:
     completed = _run(
@@ -226,8 +311,54 @@ def test_cli_entrypoints_translate_uncaught_runtime_failure(
 
     combined = completed.stdout + completed.stderr
     assert completed.returncode == 1
-    assert completed.stderr == f"{UNEXPECTED_MESSAGE}\n"
+    assert "Parameter configuration is invalid" in completed.stderr
+    assert str(ROOT / "pyproject.toml") in completed.stderr
     assert "parsing errors" not in combined
+    assert "unexpected internal error" not in combined
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+def test_plot_param_multiple_inputs_is_a_known_cli_failure(
+    command: tuple[str, ...],
+) -> None:
+    completed = _run(
+        command,
+        "plot_param",
+        "-p",
+        str(PARAMETERS),
+        str(PARAMETERS),
+        "-n",
+        "PB",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert completed.stderr.count("Multiple parameter files were given") == 1
+    assert "unexpected internal error" not in combined
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+def test_plot_param_missing_input_is_a_known_cli_failure(
+    command: tuple[str, ...],
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing-fitted.toml"
+    completed = _run(
+        command,
+        "plot_param",
+        "-p",
+        str(missing),
+        "-n",
+        "PB",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert "Parameter configuration is invalid" in completed.stderr
+    assert str(missing) in completed.stderr
+    assert "unexpected internal error" not in combined
     assert TRACEBACK_HEADER not in combined
 
 
@@ -240,8 +371,10 @@ def test_programmatic_main_retains_ordinary_exception_semantics(
         ["chemex", "plot_param", "-p", "pyproject.toml", "-n", "BAD"],
     )
 
-    with pytest.raises(ConfigParserError):
+    with pytest.raises(ParameterConfigurationError) as error_info:
         application_module.main()
+
+    assert isinstance(error_info.value.__cause__, ConfigParserError)
 
 
 @pytest.mark.parametrize(
@@ -251,7 +384,8 @@ def test_programmatic_main_retains_ordinary_exception_semantics(
         (
             "; ".join(
                 (
-                    f"error = RuntimeError('{SECRET_CANARY}')",
+                    "from chemex.exceptions import ChemExError",
+                    f"error = ChemExError('{SECRET_CANARY}')",
                     f"error.add_note('ChemEx {SECRET_CANARY}')",
                     "error.terminal = 'interrupted'",
                     "raise error",
@@ -261,6 +395,7 @@ def test_programmatic_main_retains_ordinary_exception_semantics(
             INTERRUPTED_MESSAGE,
         ),
         (f"raise RuntimeError('{SECRET_CANARY}')", 1, UNEXPECTED_MESSAGE),
+        (f"raise AssertionError('{SECRET_CANARY}')", 1, UNEXPECTED_MESSAGE),
         ("raise RuntimeError('[bold]literal[/]')", 1, UNEXPECTED_MESSAGE),
         ("raise RuntimeError", 1, UNEXPECTED_MESSAGE),
     ],
@@ -278,6 +413,152 @@ def test_cli_bootstrap_translates_terminal_failures(
         expected_message,
         absent=(SECRET_CANARY,),
     )
+
+
+def test_cli_bootstrap_renders_known_chemex_failure_once() -> None:
+    completed = _run_bootstrap(
+        "from chemex.exceptions import ChemExError; "
+        "raise ChemExError('Known ChemEx failure.')"
+    )
+
+    _assert_bootstrap_result(completed, 1, "Known ChemEx failure.")
+
+
+def test_cli_bootstrap_keeps_known_failure_concise_in_debug_mode() -> None:
+    completed = _run_bootstrap(
+        "from chemex.exceptions import ChemExError; "
+        "raise ChemExError('Known ChemEx failure.')",
+        arguments=("--debug",),
+    )
+
+    _assert_bootstrap_result(completed, 1, "Known ChemEx failure.")
+
+
+def test_cli_bootstrap_does_not_trust_interrupted_attribute_on_unknown_error() -> None:
+    completed = _run_bootstrap(
+        f"error = RuntimeError('{SECRET_CANARY}'); "
+        "error.terminal = 'interrupted'; raise error"
+    )
+
+    _assert_bootstrap_result(
+        completed,
+        1,
+        UNEXPECTED_MESSAGE,
+        absent=(SECRET_CANARY,),
+    )
+
+
+def test_cli_bootstrap_debug_reraises_unexpected_failure_with_cause() -> None:
+    completed = _run_bootstrap(
+        f"""
+        try:
+            raise ValueError("ROOT_CAUSE")
+        except ValueError as cause:
+            error = RuntimeError("{SECRET_CANARY}")
+            error.add_note("DEBUG_NOTE")
+            raise error from cause
+        """,
+        arguments=("--debug",),
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert TRACEBACK_HEADER in combined
+    assert "ValueError: ROOT_CAUSE" in combined
+    assert f"RuntimeError: {SECRET_CANARY}" in combined
+    assert "DEBUG_NOTE" in combined
+    assert "The above exception was the direct cause" in combined
+
+
+def test_cli_bootstrap_reports_incomplete_resampling_artifacts_once() -> None:
+    completed = _run_bootstrap(
+        """
+        from pathlib import Path
+        from chemex.optimize.resampling import NativeResamplingIncompleteError
+        error = NativeResamplingIncompleteError("completed 1 of 2 requested replicates")
+        error.diagnostics_path = Path("Output/Statistics/MonteCarlo/diagnostics.toml")
+        error.samples_path = Path("Output/Statistics/MonteCarlo/samples.tsv")
+        error.failures_path = Path("Output/Statistics/MonteCarlo/failures.tsv")
+        raise error
+        """
+    )
+
+    rendered = " ".join(completed.stderr.split())
+    assert completed.returncode == 1
+    assert rendered.count("Resampling analysis is incomplete") == 1
+    assert "completed 1 of 2 requested replicates" in rendered
+    assert "diagnostics.toml" in rendered
+    assert "samples.tsv" in rendered
+    assert "failures.tsv" in rendered
+    assert "Inspect the resampling diagnostics and failed replicates" in rendered
+    assert "unexpected internal error" not in rendered
+
+
+def test_incomplete_statistics_without_artifacts_does_not_invent_advice() -> None:
+    completed = _run_bootstrap(
+        """
+        from chemex.optimize.mcmc import NativeMcmcIncompleteError
+        raise NativeMcmcIncompleteError("scientific interpretation was withheld")
+        """
+    )
+
+    rendered = " ".join(completed.stderr.split())
+    assert completed.returncode == 1
+    assert "MCMC analysis is incomplete" in rendered
+    assert "Next:" not in rendered
+    assert "Inspect the MCMC diagnostics" not in rendered
+
+
+def test_cli_bootstrap_reports_recognized_deterministic_nonconvergence() -> None:
+    completed = _run_bootstrap(
+        """
+        from types import SimpleNamespace
+        from chemex.optimize.direct_trf import TerminalFailure
+        from chemex.optimize.native_deterministic import NativeDeterministicAnalysisError
+        failure = TerminalFailure("non_converged", "maximum evaluations reached")
+        raise NativeDeterministicAnalysisError(
+            "Native deterministic fitting did not produce an accepted fit.",
+            reason="The optimizer did not converge.",
+            outcome=SimpleNamespace(),
+            failures=(failure,),
+        )
+        """
+    )
+
+    rendered = " ".join(completed.stderr.split())
+    assert completed.returncode == 1
+    assert rendered.count("Deterministic analysis did not produce") == 1
+    assert "optimizer did not converge" in rendered
+    assert "maximum evaluations reached" in rendered
+    assert "unexpected internal error" not in rendered
+    assert TRACEBACK_HEADER not in rendered
+
+
+def test_cli_bootstrap_reports_contextualized_publication_failure() -> None:
+    completed = _run_bootstrap(
+        """
+        from pathlib import Path
+        from chemex.exceptions import ArtifactPublicationError
+        cause = OSError(28, "No space left on device")
+        error = ArtifactPublicationError(
+            "publish the restart state",
+            Path("Output/run_info/restart.toml"),
+            cause,
+        )
+        error.outcome_path = Path("Output/run_info/outcome.toml")
+        raise error from cause
+        """
+    )
+
+    rendered = " ".join(completed.stderr.split())
+    assert completed.returncode == 1
+    assert "could not publish an output artifact" in rendered
+    assert "publish the restart state" in rendered
+    assert "Output/run_info/restart.toml" in rendered
+    assert "No space left on device" in rendered
+    assert "Output/run_info/outcome.toml" in rendered
+    assert "unexpected internal error" not in rendered
+    assert TRACEBACK_HEADER not in rendered
 
 
 def test_cli_bootstrap_ignores_all_exception_notes() -> None:
@@ -365,7 +646,8 @@ def test_cli_bootstrap_ignores_all_exception_notes() -> None:
         ),
         pytest.param(
             """
-            error = RuntimeError("SECRET_CANARY")
+            from chemex.exceptions import ChemExError
+            error = ChemExError("SECRET_CANARY")
             error.add_note("ChemEx SECRET_CANARY")
             error.terminal = Terminal.INTERRUPTED
             raise error
@@ -424,6 +706,14 @@ def test_cli_bootstrap_handles_hostile_exception_metadata(
     ("failure_source", "expected_status", "expected_message"),
     (
         (f"raise RuntimeError('{SECRET_CANARY}')", 1, UNEXPECTED_MESSAGE),
+        (
+            (
+                "from chemex.exceptions import ChemExError; "
+                "raise ChemExError('Known ChemEx failure.')"
+            ),
+            1,
+            "Known ChemEx failure.",
+        ),
         ("raise KeyboardInterrupt", 130, INTERRUPTED_MESSAGE),
     ),
 )
@@ -490,6 +780,21 @@ def test_cli_bootstrap_handles_protected_application_import_baseexceptions(
         assert completed.stdout == completed.stderr == ""
 
 
+def test_debug_reraises_application_import_failure(tmp_path: Path) -> None:
+    env = _application_import_failure_env(
+        tmp_path,
+        f"RuntimeError('{SECRET_CANARY}')",
+    )
+
+    completed = _run((sys.executable, "-m", "chemex"), "--debug", env=env)
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert TRACEBACK_HEADER in combined
+    assert f"RuntimeError: {SECRET_CANARY}" in combined
+    assert UNEXPECTED_MESSAGE not in combined
+
+
 def test_real_fit_interruption_flows_through_run_info_and_shared_bootstrap(
     tmp_path: Path,
 ) -> None:
@@ -547,7 +852,10 @@ direct_trf.least_squares = interrupt_third_fit
 
     combined = completed.stdout + completed.stderr
     assert completed.returncode == 130
-    assert completed.stderr.count("ChemEx interrupted.") == 1
+    assert completed.stderr.count("Analysis interrupted by user.") == 1
+    assert "During: deterministic fit (Method Step STEP2)" in completed.stderr
+    assert str(output / "run_info" / "outcome.toml") in completed.stderr
+    assert str(output / "run_info" / "restart.toml") in completed.stderr
     assert TRACEBACK_HEADER not in combined
     assert (output / "STEP1" / "Parameters" / "fitted.toml").is_file()
     assert not (output / "STEP2" / "Parameters" / "fitted.toml").exists()

--- a/tests/test_grid_entries.py
+++ b/tests/test_grid_entries.py
@@ -1,7 +1,6 @@
 import pytest
 
-import chemex.parameters.database as database_module
-from chemex.parameters.database import ParameterCatalog
+from chemex.parameters.database import GridExpressionError, ParameterCatalog
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import ParamSetting
 from chemex.parameters.spin_system import SpinSystem
@@ -52,47 +51,21 @@ def test_parse_grid_last_matching_entry_wins() -> None:
     assert grid[local_pb.id_].tolist() == [1.0, 2.0]
 
 
-def test_parse_grid_exits_on_missing_separator(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_parse_grid_raises_typed_error_on_missing_separator() -> None:
     catalog = make_catalog(make_param("PB"))
-    recorded: dict[str, str] = {}
 
-    monkeypatch.setattr(
-        database_module,
-        "print_error_grid_settings",
-        lambda entry, detail=None: recorded.update(
-            {"entry": entry, "detail": detail or ""}
-        ),
-    )
-
-    with pytest.raises(SystemExit):
+    with pytest.raises(GridExpressionError) as error_info:
         catalog.parse_grid(["PB lin(1, 2, 2)"])
 
-    assert recorded == {
-        "entry": "PB lin(1, 2, 2)",
-        "detail": "Expected exactly one '=' in the grid entry",
-    }
+    assert error_info.value.entry == "PB lin(1, 2, 2)"
+    assert error_info.value.detail == "Expected exactly one '=' in the grid entry"
 
 
-def test_parse_grid_exits_on_invalid_definition(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_parse_grid_raises_typed_error_on_invalid_definition() -> None:
     catalog = make_catalog(make_param("PB"))
-    recorded: dict[str, str] = {}
 
-    monkeypatch.setattr(
-        database_module,
-        "print_error_grid_settings",
-        lambda entry, detail=None: recorded.update(
-            {"entry": entry, "detail": detail or ""}
-        ),
-    )
-
-    with pytest.raises(SystemExit):
+    with pytest.raises(GridExpressionError) as error_info:
         catalog.parse_grid(["PB = bad(1, 2, 2)"])
 
-    assert recorded == {
-        "entry": "PB = bad(1, 2, 2)",
-        "detail": "Unsupported grid definition",
-    }
+    assert error_info.value.entry == "PB = bad(1, 2, 2)"
+    assert error_info.value.detail == "Unsupported grid definition"

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -508,6 +508,7 @@ def test_parallel_worker_failure_enters_typed_failed_lifecycle() -> None:
         worker_pids = {pid for pid, _evaluator, _environment in evaluation_observations}
 
     assert operation.terminal is McmcOperationTerminal.FAILED
+    assert isinstance(operation.failure, native_mcmc.McmcExecutionError)
     assert operation.failure_category == "McmcExecutionError"
     assert "MCMC worker failed: McmcExecutionError" in (operation.failure_message)
     assert "kernel_exception: worker kernel failure" in operation.failure_message
@@ -552,6 +553,7 @@ def test_parallel_worker_initialization_failure_is_typed_and_does_not_hang(
     )
 
     assert operation.terminal is McmcOperationTerminal.FAILED
+    assert isinstance(operation.failure, native_mcmc.McmcExecutionError)
     assert operation.failure_category == "McmcExecutionError"
     assert "MCMC worker failed: McmcExecutionError" in operation.failure_message
     assert "foreign parameterization" in operation.failure_message
@@ -1796,6 +1798,8 @@ def test_initialization_failure_and_later_failure_preserve_only_complete_prefix(
         checkpoint_observer=fail_initialization,
     )
     assert initial_failure.terminal is McmcOperationTerminal.FAILED
+    assert isinstance(initial_failure.failure, RuntimeError)
+    assert str(initial_failure.failure) == "initialization failure"
     assert initial_failure.complete_state_count == 0
     assert initial_failure.evidence is None
     assert initial_failure.raw_capture is not None
@@ -1814,6 +1818,8 @@ def test_initialization_failure_and_later_failure_preserve_only_complete_prefix(
         checkpoint_observer=fail_after_two_transitions,
     )
     assert later_failure.terminal is McmcOperationTerminal.FAILED
+    assert isinstance(later_failure.failure, RuntimeError)
+    assert str(later_failure.failure) == "later failure"
     assert later_failure.complete_state_count == 3
     assert later_failure.evidence is not None
     assert tuple(state.ordinal for state in later_failure.evidence.states) == (0, 1, 2)

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -27,13 +27,19 @@ import chemex.printers.grid as grid_printer_module
 import chemex.run_info as run_info_module
 from chemex.chemex import run, run_fit
 from chemex.cli import build_parser
+from chemex.configuration.method_plan import MethodFormatError
 from chemex.configuration.methods import Method, Selection
 from chemex.configuration.parameters import read_defaults
 from chemex.containers.experiments import Experiments
 from chemex.evaluation.native import BoundEvaluator, EvaluationFailure
+from chemex.exceptions import ArtifactPublicationError, ChemExError
 from chemex.experiments.builder import build_experiments
 from chemex.optimize.fitting import run_methods
-from chemex.optimize.mcmc import NativeMcmcIncompleteError
+from chemex.optimize.mcmc import McmcConfigurationError, NativeMcmcIncompleteError
+from chemex.optimize.native_deterministic import (
+    NativeDeterministicAnalysisError,
+    NativeDeterministicInternalError,
+)
 from chemex.optimize.progress import ProgressPhase
 from chemex.optimize.resampling import NativeResamplingIncompleteError
 from chemex.optimize.uncertainty import ParameterUnit
@@ -408,7 +414,7 @@ def test_simulation_plot_interruption_preserves_written_results_and_propagates(
 
     with (
         patch.object(Experiments, "plot_simulation", side_effect=KeyboardInterrupt),
-        pytest.raises(KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt) as error_info,
     ):
         run(
             _simulation_arguments(output, plot_level="normal"),
@@ -417,8 +423,45 @@ def test_simulation_plot_interruption_preserves_written_results_and_propagates(
 
     assert (output / "Data" / "800mhz.dat").is_file()
     assert (output / "Parameters" / "fixed.toml").is_file()
+    assert error_info.value.failure_stage == "output"
     rendered = capsys.readouterr()
     assert "Plotting cancelled" not in rendered.out + rendered.err
+
+
+def test_simulation_os_failure_retains_output_path_and_cause(tmp_path: Path) -> None:
+    output = tmp_path / "Output"
+    failed_path = output / "Data" / "800mhz.dat"
+    cause = OSError(28, "No space left on device", str(failed_path))
+
+    with (
+        patch("chemex.optimize.helper._write_simulation_files", side_effect=cause),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(_simulation_arguments(output), session=AnalysisSession.create())
+
+    assert error_info.value.__cause__ is cause
+    assert error_info.value.operation == "publish simulation output"
+    assert error_info.value.path == failed_path
+    assert error_info.value.failure_stage == "output"
+    assert not (output / "run_info").exists()
+
+
+def test_simulation_scientific_failure_retains_simulation_stage(
+    tmp_path: Path,
+) -> None:
+    failure = ScientificFeasibilityError("relaxation state is infeasible")
+
+    with (
+        patch("chemex.chemex.execute_simulation", side_effect=failure),
+        pytest.raises(ScientificFeasibilityError) as error_info,
+    ):
+        run(
+            _simulation_arguments(tmp_path / "Output"),
+            session=AnalysisSession.create(),
+        )
+
+    assert error_info.value is failure
+    assert error_info.value.failure_stage == "simulation"
 
 
 def test_fit_plot_interruption_preserves_committed_results_and_propagates(
@@ -451,12 +494,14 @@ def _run_real_fit_cli(
     *,
     check: bool = True,
     env: dict[str, str] | None = None,
+    debug: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(  # noqa: S603 - fixed local CLI and repository-owned fixtures
         [
             sys.executable,
             "-m",
             "chemex",
+            *(("--debug",) if debug else ()),
             "fit",
             "-e",
             str(EXPERIMENT),
@@ -848,11 +893,13 @@ def test_product_fit_rejects_a_stale_aggregate_commit_atomically(
             "execute_fit_commit",
             side_effect=advance_revision_then_commit,
         ),
-        pytest.raises(RuntimeError, match="stale_revision"),
+        pytest.raises(NativeDeterministicInternalError) as error_info,
     ):
         run(_fit_arguments(output), session=session)
 
     assert session.analysis_values.snapshot().revision == 1
+    assert error_info.value.outcome.failure is not None
+    assert error_info.value.outcome.failure.category.value == "stale_revision"
     assert not (output / "run_info" / "restart.toml").exists()
     outcome = _read_outcome(output)
     assert outcome["latest_committed_revision"] == 1
@@ -1294,11 +1341,13 @@ def test_invalid_fitmethod_fails_before_defaults_and_output_invalidation(
             "chemex.parameters.database.ParameterStore.set_defaults",
             side_effect=AssertionError("parameter defaults were resolved"),
         ),
-        pytest.raises(SystemExit) as raised,
+        pytest.raises(MethodFormatError) as error_info,
     ):
         run(_fit_arguments(output, method), session=AnalysisSession.create())
 
-    assert raised.value.code == 1
+    assert error_info.value.source.filename == method
+    assert error_info.value.source.field == "FITMETHOD"
+    assert error_info.value.__cause__ is not None
     assert preserved.read_text(encoding="utf-8") == "existing result\n"
     assert not (output / "run_info").exists()
 
@@ -1370,7 +1419,7 @@ def test_failed_deterministic_rerun_invalidates_prior_results_and_is_incomplete(
     assert outcome["restart_revision"] == 0
     assert outcome["terminal"] == "failed"
     assert outcome["failure_stage"] == "deterministic_fit"
-    assert outcome["failure_type"] == "RuntimeError"
+    assert outcome["failure_type"] == "NativeDeterministicInternalError"
     assert not (output / "Parameters").exists()
     assert not (output / "Data").exists()
     assert not (output / "Plots").exists()
@@ -1382,16 +1431,26 @@ def test_planned_output_cleanup_failure_is_classified_as_output(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
+    stale = output / "statistics.toml"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("stale\n", encoding="utf-8")
+    cause = OSError(13, "Permission denied", str(stale))
+    real_unlink = Path.unlink
+
+    def deny_stale_unlink(path: Path, *args, **kwargs) -> None:
+        if path == stale:
+            raise cause
+        real_unlink(path, *args, **kwargs)
 
     with (
-        patch(
-            "chemex.chemex.invalidate_planned_outputs",
-            side_effect=OSError("planned output cleanup failed"),
-        ),
-        pytest.raises(OSError, match="planned output cleanup failed"),
+        patch.object(Path, "unlink", deny_stale_unlink),
+        pytest.raises(ArtifactPublicationError) as error_info,
     ):
         run(_fit_arguments(output), session=AnalysisSession.create())
 
+    assert error_info.value.__cause__ is cause
+    assert error_info.value.operation == "invalidate planned analysis output"
+    assert error_info.value.path == stale
     assert _read_outcome(output) == {
         "schema_version": 2,
         "status": "incomplete",
@@ -1399,8 +1458,8 @@ def test_planned_output_cleanup_failure_is_classified_as_output(
         "restart_revision": 0,
         "terminal": "failed",
         "failure_stage": "output",
-        "failure_type": "OSError",
-        "failure_message": "planned output cleanup failed",
+        "failure_type": "ArtifactPublicationError",
+        "failure_message": "[Errno 13] Permission denied",
     }
 
 
@@ -1442,6 +1501,32 @@ def test_data_writer_failure_after_commit_cannot_complete_or_retain_stale_result
     assert not (output / "statistics.toml").exists()
 
 
+def test_data_writer_os_failure_retains_exact_path_and_preserved_outputs(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    failed_path = output / "Data" / "profiles"
+    cause = OSError(13, "Permission denied", str(failed_path))
+
+    with (
+        patch(
+            "chemex.containers.experiments.Experiments.write",
+            side_effect=cause,
+        ),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(_fit_arguments(output), session=AnalysisSession.create())
+
+    error = error_info.value
+    assert error.__cause__ is cause
+    assert error.operation == "publish deterministic analysis output"
+    assert error.path == failed_path
+    assert error.restart_path == output / "run_info" / "restart.toml"
+    assert error.outcome_path == output / "run_info" / "outcome.toml"
+    assert (output / "Parameters" / "fitted.toml").is_file()
+    assert _read_outcome(output)["failure_type"] == "ArtifactPublicationError"
+
+
 def test_first_restart_publication_failure_preserves_committed_authority(
     tmp_path: Path,
 ) -> None:
@@ -1456,10 +1541,15 @@ def test_first_restart_publication_failure_preserves_committed_authority(
 
     with (
         patch.object(run_info_module, "write_text_atomic", side_effect=fail_restart),
-        pytest.raises(OSError, match="restart publication failed"),
+        pytest.raises(
+            ArtifactPublicationError, match="restart publication failed"
+        ) as error_info,
     ):
         run(_fit_arguments(output), session=session)
 
+    assert isinstance(error_info.value.__cause__, OSError)
+    assert error_info.value.path == output / "run_info" / "restart.toml"
+    assert error_info.value.operation == "publish the restart state"
     assert session.analysis_values.snapshot().revision == 1
     assert not (output / "run_info" / "restart.toml").exists()
     assert not (output / "Parameters").exists()
@@ -1470,7 +1560,7 @@ def test_first_restart_publication_failure_preserves_committed_authority(
         "restart_revision": 0,
         "terminal": "failed",
         "failure_stage": "restart_publication",
-        "failure_type": "OSError",
+        "failure_type": "ArtifactPublicationError",
         "failure_message": "restart publication failed",
     }
 
@@ -1559,7 +1649,7 @@ FIX = ["PB", "KEX_AB"]
         "restart_revision": 1,
         "terminal": "failed",
         "failure_stage": "restart_publication",
-        "failure_type": "OSError",
+        "failure_type": "ArtifactPublicationError",
         "failure_message": "second restart publication failed",
     }
 
@@ -1645,11 +1735,14 @@ def test_final_complete_outcome_write_failure_is_terminal_and_propagates(
             "write_text_atomic",
             side_effect=fail_complete_outcome,
         ),
-        pytest.raises(OSError, match="complete outcome publication failed"),
+        pytest.raises(ArtifactPublicationError) as error_info,
     ):
         run(_fit_arguments(output), session=session)
 
     assert session.analysis_values.snapshot().revision == 1
+    assert error_info.value.operation == "publish the complete run outcome"
+    assert error_info.value.path == output / "run_info" / "outcome.toml"
+    assert isinstance(error_info.value.__cause__, OSError)
     assert (output / "Parameters" / "fitted.toml").is_file()
     assert _read_outcome(output) == {
         "schema_version": 2,
@@ -1658,9 +1751,78 @@ def test_final_complete_outcome_write_failure_is_terminal_and_propagates(
         "restart_revision": 1,
         "terminal": "failed",
         "failure_stage": "run_info",
-        "failure_type": "OSError",
+        "failure_type": "ArtifactPublicationError",
         "failure_message": "complete outcome publication failed",
     }
+
+
+def test_incomplete_outcome_failure_does_not_replace_primary_failure(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    real_atomic_write = run_info_module.write_text_atomic
+    primary = RuntimeError("primary output failure")
+
+    def fail_incomplete_outcome(destination: Path, content: str) -> None:
+        if 'status = "incomplete"' in content:
+            raise OSError("incomplete outcome publication failed")
+        real_atomic_write(destination, content)
+
+    with (
+        patch(
+            "chemex.chemex.invalidate_planned_outputs",
+            side_effect=primary,
+        ),
+        patch.object(
+            run_info_module,
+            "write_text_atomic",
+            side_effect=fail_incomplete_outcome,
+        ),
+        pytest.raises(RuntimeError, match="primary output failure") as error_info,
+    ):
+        run(_fit_arguments(output), session=AnalysisSession.create())
+
+    assert error_info.value is primary
+    assert error_info.value.__notes__ == [
+        (
+            "ChemEx could not publish the incomplete run outcome: "
+            "ArtifactPublicationError: incomplete outcome publication failed"
+        )
+    ]
+    assert _read_outcome(output)["status"] == "running"
+
+
+def test_interrupted_outcome_publication_failure_supersedes_interruption(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    real_atomic_write = run_info_module.write_text_atomic
+    cause = OSError(28, "No space left on device")
+
+    def fail_incomplete_outcome(destination: Path, content: str) -> None:
+        if 'status = "incomplete"' in content:
+            raise cause
+        real_atomic_write(destination, content)
+
+    with (
+        patch.object(Experiments, "plot", side_effect=KeyboardInterrupt),
+        patch.object(
+            run_info_module,
+            "write_text_atomic",
+            side_effect=fail_incomplete_outcome,
+        ),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(
+            _fit_arguments(output, plot_level="normal"),
+            session=AnalysisSession.create(),
+        )
+
+    error = error_info.value
+    assert error.__cause__ is cause
+    assert error.operation == "publish the incomplete run outcome"
+    assert error.path == output / "run_info" / "outcome.toml"
+    assert error.restart_path == output / "run_info" / "restart.toml"
 
 
 def test_real_grouped_direct_fit_uses_native_aggregate_commit(
@@ -2041,6 +2203,40 @@ def test_interrupted_uncertainty_publication_failure_preserves_interruption(
         "ChemEx could not publish interrupted uncertainty output."
     ]
     assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_interrupted_uncertainty_io_failure_supersedes_interruption(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    original_svd = uncertainty_module.svd
+    failed_path = output / "Statistics" / "Covariance" / "uncertainty.json"
+    cause = OSError(28, "No space left on device", str(failed_path))
+
+    def rank_deficient_svd(*args, **kwargs):
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        singular[-1] = 0.0
+        return left, singular, right
+
+    with (
+        patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_svd),
+        patch.object(
+            deterministic_uncertainty_module,
+            "execute_root_anchored_block_covariance",
+            side_effect=KeyboardInterrupt,
+        ),
+        patch("chemex.optimize.helper.write_uncertainty", side_effect=cause),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(
+            _fit_arguments(output, include=("G2N-HN", "H3N-HN")),
+            session=AnalysisSession.create(),
+        )
+
+    assert error_info.value.__cause__ is cause
+    assert error_info.value.operation == "publish deterministic analysis output"
+    assert error_info.value.path == failed_path
 
 
 def test_shared_parameter_coupling_is_not_split_into_covariance_blocks(
@@ -2592,7 +2788,7 @@ def test_automatic_mcmc_burn_failure_preserves_only_incomplete_raw_evidence(
         pytest.raises(
             NativeMcmcIncompleteError,
             match="authoritative MCMC posterior summarization was withheld",
-        ),
+        ) as error_info,
     ):
         run(
             _fit_arguments(failed_output, method, parameters=parameters),
@@ -2604,6 +2800,8 @@ def test_automatic_mcmc_burn_failure_preserves_only_incomplete_raw_evidence(
     assert central.revision == failed.revision == 1
     assert central.items() == failed.items()
     statistics = failed_output / "Statistics" / "MCMC"
+    assert error_info.value.diagnostics_path == statistics / "diagnostics.toml"
+    assert error_info.value.evidence_path == statistics / "raw_chain.tsv"
     diagnostics = tomllib.loads(
         (statistics / "diagnostics.toml").read_text(encoding="utf-8")
     )
@@ -2803,7 +3001,7 @@ def test_tentative_automatic_mcmc_burn_publishes_complete_outputs_with_warning(
     assert "5 sampled steps; at least 7 recommended" in rendered
 
 
-def test_incomplete_mcmc_reports_specific_error_before_entrypoint_boundary(
+def test_incomplete_mcmc_reports_one_specific_cli_error(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -2832,11 +3030,15 @@ native_mcmc.emcee.autocorr.integrated_time = lambda *_args, **_kwargs: object()
 
     rendered = " ".join((completed.stdout + completed.stderr).split())
     assert completed.returncode == 1
-    assert "MCMC analysis is incomplete; posterior products were withheld" in rendered
+    assert rendered.count("MCMC analysis is incomplete") == 1
+    assert "posterior products were withheld" in rendered
+    assert "During: statistics" in rendered
+    assert "Method Step: DEFAULT" in rendered
     assert "diagnostics.toml" in rendered
-    assert rendered.index("MCMC analysis is incomplete") < rendered.index(
-        "ChemEx encountered an unexpected error"
-    )
+    assert "raw_chain.tsv" in rendered
+    assert "run_info/restart.toml" in rendered
+    assert "run_info/outcome.toml" in rendered
+    assert "ChemEx encountered an unexpected internal error" not in rendered
     assert "Traceback (most recent call last)" not in rendered
 
 
@@ -2971,7 +3173,10 @@ def test_explicitly_unbounded_native_mcmc_fails_closed_after_central_fit(
     parameters = _explicitly_unbounded_parameters(tmp_path / "parameters.toml")
     session = AnalysisSession.create()
 
-    with pytest.raises(ValueError, match="finite lower and upper bounds"):
+    with pytest.raises(
+        McmcConfigurationError,
+        match="finite lower and upper bounds",
+    ) as error_info:
         run(
             _fit_arguments(output, method, parameters=parameters),
             session=session,
@@ -2984,6 +3189,7 @@ def test_explicitly_unbounded_native_mcmc_fails_closed_after_central_fit(
     )
     assert diagnostics["status"] == "incomplete"
     assert diagnostics["terminal"] == "failed"
+    assert error_info.value.diagnostics_path == statistics / "diagnostics.toml"
     assert "finite lower and upper bounds" in diagnostics["failure_message"]
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "samples.tsv").exists()
@@ -3139,6 +3345,10 @@ def test_interrupted_native_mcmc_publishes_unqualified_raw_capture(
 
     assert error_info.value.terminal == "interrupted"
     statistics = output / "Statistics" / "MCMC"
+    assert error_info.value.diagnostics_path == statistics / "diagnostics.toml"
+    assert error_info.value.evidence_path == statistics / "raw_capture.tsv"
+    assert error_info.value.restart_path == output / "run_info" / "restart.toml"
+    assert error_info.value.outcome_path == output / "run_info" / "outcome.toml"
     diagnostics = tomllib.loads(
         (statistics / "diagnostics.toml").read_text(encoding="utf-8")
     )
@@ -3175,7 +3385,7 @@ def test_interruption_after_mcmc_qualification_publishes_only_qualified_chain(
             "derive_mcmc_analysis_result",
             side_effect=KeyboardInterrupt,
         ),
-        pytest.raises(KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt) as error_info,
     ):
         run(
             _fit_arguments(output, method, parameters=parameters),
@@ -3183,6 +3393,10 @@ def test_interruption_after_mcmc_qualification_publishes_only_qualified_chain(
         )
 
     statistics = output / "Statistics" / "MCMC"
+    assert error_info.value.diagnostics_path == statistics / "diagnostics.toml"
+    assert error_info.value.evidence_path == statistics / "raw_chain.tsv"
+    assert error_info.value.restart_path == output / "run_info" / "restart.toml"
+    assert error_info.value.outcome_path == output / "run_info" / "outcome.toml"
     diagnostics = tomllib.loads(
         (statistics / "diagnostics.toml").read_text(encoding="utf-8")
     )
@@ -3292,6 +3506,183 @@ def test_interrupted_mcmc_publication_failure_preserves_interruption(
         "ChemEx could not publish interrupted MCMC execution capture."
     ]
     assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_interrupted_mcmc_io_failure_reports_published_evidence(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    cause = OSError(28, "No space left on device")
+    real_diagnostics = mcmc_module._write_native_mcmc_state_diagnostics
+
+    def fail_incomplete_diagnostics(*args, **kwargs):
+        if kwargs.get("status") == "incomplete":
+            raise cause
+        return real_diagnostics(*args, **kwargs)
+
+    with (
+        patch.object(
+            mcmc_module,
+            "derive_mcmc_analysis_result",
+            side_effect=KeyboardInterrupt,
+        ),
+        patch.object(
+            mcmc_module,
+            "_write_native_mcmc_state_diagnostics",
+            side_effect=fail_incomplete_diagnostics,
+        ),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    error = error_info.value
+    statistics = output / "Statistics" / "MCMC"
+    assert error.__cause__ is cause
+    assert error.operation == "publish interrupted MCMC diagnostics"
+    assert error.path == statistics / "diagnostics.toml"
+    assert error.evidence_path == statistics / "raw_chain.tsv"
+    assert error.restart_path == output / "run_info" / "restart.toml"
+    assert error.outcome_path == output / "run_info" / "outcome.toml"
+
+
+def test_internal_mcmc_operation_failure_is_not_scientific_incompleteness(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    cause = AssertionError("MCMC_INTERNAL_CANARY")
+    real_execute = native_mcmc_module.execute_mcmc_evidence
+
+    def fail_operation(accepted, plan, **kwargs):
+        def fail_initialization(_stage, _count):
+            raise cause
+
+        return real_execute(
+            accepted,
+            plan,
+            checkpoint_observer=fail_initialization,
+            **kwargs,
+        )
+
+    with (
+        patch.object(
+            mcmc_module,
+            "execute_mcmc_evidence",
+            side_effect=fail_operation,
+        ),
+        pytest.raises(AssertionError) as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    assert error_info.value is cause
+    assert not isinstance(error_info.value, ChemExError)
+    diagnostics = output / "Statistics" / "MCMC" / "diagnostics.toml"
+    assert "MCMC_INTERNAL_CANARY" in diagnostics.read_text(encoding="utf-8")
+
+
+def test_internal_mcmc_failure_is_private_unless_debug_is_requested(
+    tmp_path: Path,
+) -> None:
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    (tmp_path / "sitecustomize.py").write_text(
+        """
+import chemex.optimize.mcmc as mcmc
+import chemex.optimize.native_mcmc as native_mcmc
+
+real_execute = native_mcmc.execute_mcmc_evidence
+
+def fail_operation(accepted, plan, **kwargs):
+    def fail_initialization(_stage, _count):
+        raise AssertionError("MCMC_INTERNAL_CANARY")
+
+    return real_execute(
+        accepted,
+        plan,
+        checkpoint_observer=fail_initialization,
+        **kwargs,
+    )
+
+mcmc.execute_mcmc_evidence = fail_operation
+""".lstrip(),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(tmp_path), env.get("PYTHONPATH", "")))
+    )
+
+    normal = _run_real_fit_cli(
+        tmp_path / "Normal",
+        method,
+        parameters,
+        check=False,
+        env=env,
+    )
+    debug = _run_real_fit_cli(
+        tmp_path / "Debug",
+        method,
+        parameters,
+        check=False,
+        env=env,
+        debug=True,
+    )
+
+    normal_output = normal.stdout + normal.stderr
+    debug_output = debug.stdout + debug.stderr
+    assert normal.returncode == 1
+    assert "unexpected internal error" in normal_output
+    assert "MCMC_INTERNAL_CANARY" not in normal_output
+    assert "Traceback (most recent call last)" not in normal_output
+    assert debug.returncode == 1
+    assert "AssertionError: MCMC_INTERNAL_CANARY" in debug_output
+    assert "Traceback (most recent call last)" in debug_output
+
+
+def test_statistics_invariant_remains_internal_and_chains_primary_failure(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    session = AnalysisSession.create()
+    primary = NativeMcmcIncompleteError("primary MCMC failure")
+
+    def mutate_then_fail(*_args, **_kwargs):
+        current = session.analysis_values.snapshot()
+        session.analysis_values.commit(
+            dict(current),
+            expected=current,
+            scope=tuple(current),
+        )
+        raise primary
+
+    with (
+        patch.object(
+            method_execution_module,
+            "run_native_mcmc",
+            side_effect=mutate_then_fail,
+        ),
+        pytest.raises(
+            RuntimeError,
+            match="Native statistics mutated the committed central fit",
+        ) as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=session,
+        )
+
+    assert error_info.value.__cause__ is primary
 
 
 def test_native_mcmc_postprocessing_failure_replaces_running_diagnostics(
@@ -3604,7 +3995,7 @@ def test_failed_native_replicate_keeps_central_fit_and_suppresses_complete_produ
             "chemex.optimize.direct_trf.least_squares",
             side_effect=fail_first_replicate,
         ),
-        pytest.raises(NativeResamplingIncompleteError, match="1 of 2"),
+        pytest.raises(NativeResamplingIncompleteError, match="1 of 2") as error_info,
     ):
         run(_fit_arguments(output, method), session=session)
 
@@ -3614,6 +4005,9 @@ def test_failed_native_replicate_keeps_central_fit_and_suppresses_complete_produ
     fitted_value = float(fitted_record.split("=", 1)[1].split()[0])
     assert fitted_value == pytest.approx(2.34742, rel=5.0e-6)
     statistics = output / "Statistics" / "MonteCarlo"
+    assert error_info.value.diagnostics_path == statistics / "diagnostics.toml"
+    assert error_info.value.samples_path == statistics / "samples.tsv"
+    assert error_info.value.failures_path == statistics / "failures.tsv"
     assert (
         len((statistics / "samples.tsv").read_text(encoding="utf-8").splitlines()) == 2
     )
@@ -3630,6 +4024,57 @@ def test_failed_native_replicate_keeps_central_fit_and_suppresses_complete_produ
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()
+
+
+def test_incomplete_resampling_reports_one_specific_cli_error(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 2')
+    (tmp_path / "sitecustomize.py").write_text(
+        """
+import chemex.optimize.direct_trf as direct_trf
+
+real_least_squares = direct_trf.least_squares
+call_count = 0
+
+def fail_first_replicate(*args, **kwargs):
+    global call_count
+    call_count += 1
+    if call_count == 2:
+        raise RuntimeError("replicate backend failed")
+    return real_least_squares(*args, **kwargs)
+
+direct_trf.least_squares = fail_first_replicate
+""".lstrip(),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(tmp_path), env.get("PYTHONPATH", "")))
+    )
+
+    completed = _run_real_fit_cli(
+        output,
+        method,
+        PARAMETERS,
+        check=False,
+        env=env,
+    )
+
+    rendered = " ".join((completed.stdout + completed.stderr).split())
+    assert completed.returncode == 1
+    assert rendered.count("Resampling analysis is incomplete") == 1
+    assert "summary products were withheld" in rendered
+    assert "During: statistics" in rendered
+    assert "Method Step: DEFAULT" in rendered
+    assert "diagnostics.toml" in rendered
+    assert "samples.tsv" in rendered
+    assert "failures.tsv" in rendered
+    assert "run_info/restart.toml" in rendered
+    assert "run_info/outcome.toml" in rendered
+    assert "unexpected internal error" not in rendered
+    assert "Traceback (most recent call last)" not in rendered
 
 
 def test_interrupted_native_statistics_report_truthful_disposition_counts(
@@ -3663,6 +4108,11 @@ def test_interrupted_native_statistics_report_truthful_disposition_counts(
 
     assert error_info.value.terminal == "interrupted"
     statistics = output / "Statistics" / "MonteCarlo"
+    assert error_info.value.diagnostics_path == statistics / "diagnostics.toml"
+    assert error_info.value.samples_path == statistics / "samples.tsv"
+    assert error_info.value.failures_path == statistics / "failures.tsv"
+    assert error_info.value.restart_path == output / "run_info" / "restart.toml"
+    assert error_info.value.outcome_path == output / "run_info" / "outcome.toml"
     diagnostics = tomllib.loads(
         (statistics / "diagnostics.toml").read_text(encoding="utf-8")
     )
@@ -3688,6 +4138,118 @@ def test_interrupted_native_statistics_report_truthful_disposition_counts(
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()
     assert _read_outcome(output)["terminal"] == "interrupted"
+
+
+def test_mcmc_diagnostics_failure_does_not_replace_primary_failure(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    real_write = mcmc_module._write_native_mcmc_state_diagnostics
+
+    def fail_incomplete_diagnostics(*args, **kwargs):
+        if kwargs.get("status") == "incomplete":
+            raise RuntimeError("diagnostics finalization failed")
+        return real_write(*args, **kwargs)
+
+    with (
+        patch.object(
+            mcmc_module,
+            "derive_mcmc_analysis_result",
+            side_effect=RuntimeError("primary postprocessing failure"),
+        ),
+        patch.object(
+            mcmc_module,
+            "_write_native_mcmc_state_diagnostics",
+            side_effect=fail_incomplete_diagnostics,
+        ),
+        pytest.raises(
+            RuntimeError, match="primary postprocessing failure"
+        ) as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    assert error_info.value.__notes__ == [
+        (
+            "ChemEx could not publish incomplete MCMC diagnostics: "
+            "RuntimeError: diagnostics finalization failed"
+        )
+    ]
+    assert _read_outcome(output)["failure_message"] == (
+        "primary postprocessing failure"
+    )
+
+
+def test_incomplete_mcmc_diagnostics_io_failure_reports_preserved_evidence(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _automatic_mcmc_method(tmp_path / "method.toml")
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    cause = OSError(28, "No space left on device")
+    real_diagnostics = mcmc_module._write_native_mcmc_state_diagnostics
+
+    def fail_incomplete_diagnostics(*args, **kwargs):
+        if kwargs.get("status") == "incomplete":
+            raise cause
+        return real_diagnostics(*args, **kwargs)
+
+    with (
+        patch.object(
+            native_mcmc_module.emcee.autocorr,
+            "integrated_time",
+            side_effect=ValueError("autocorrelation calculation failed"),
+        ),
+        patch.object(
+            mcmc_module,
+            "_write_native_mcmc_state_diagnostics",
+            side_effect=fail_incomplete_diagnostics,
+        ),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    error = error_info.value
+    statistics = output / "Statistics" / "MCMC"
+    assert error.__cause__ is cause
+    assert error.operation == "publish incomplete MCMC diagnostics"
+    assert error.path == statistics / "diagnostics.toml"
+    assert error.evidence_path == statistics / "raw_chain.tsv"
+    assert not (statistics / "diagnostics.toml").exists()
+
+
+def test_complete_mcmc_output_failure_reports_republished_diagnostics(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    cause = OSError(28, "No space left on device")
+
+    with (
+        patch.object(mcmc_module, "_write_summary", side_effect=cause),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    error = error_info.value
+    statistics = output / "Statistics" / "MCMC"
+    assert error.__cause__ is cause
+    assert error.operation == "publish MCMC summary"
+    assert error.path == statistics / "summary.toml"
+    assert error.diagnostics_path == statistics / "diagnostics.toml"
+    assert (statistics / "diagnostics.toml").is_file()
+    assert not (statistics / "summary.toml").exists()
 
 
 def test_interrupted_resampling_publication_failure_preserves_interruption(
@@ -3725,6 +4287,46 @@ def test_interrupted_resampling_publication_failure_preserves_interruption(
     assert _read_outcome(output)["terminal"] == "interrupted"
 
 
+def test_interrupted_resampling_io_failure_reports_published_samples(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 3')
+    cause = OSError(28, "No space left on device")
+    real_diagnostics = resampling_module._write_native_state_diagnostics
+
+    def fail_incomplete_diagnostics(*args, **kwargs):
+        if kwargs.get("status") == "incomplete":
+            raise cause
+        return real_diagnostics(*args, **kwargs)
+
+    with (
+        patch.object(
+            resampling_module,
+            "_resampling_result_and_samples",
+            side_effect=KeyboardInterrupt,
+        ),
+        patch.object(
+            resampling_module,
+            "_write_native_state_diagnostics",
+            side_effect=fail_incomplete_diagnostics,
+        ),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    error = error_info.value
+    statistics = output / "Statistics" / "MonteCarlo"
+    assert error.__cause__ is cause
+    assert error.operation == "publish incomplete resampling diagnostics"
+    assert error.path == statistics / "diagnostics.toml"
+    assert error.samples_path == statistics / "samples.tsv"
+    assert not hasattr(error, "failures_path")
+    assert not (statistics / "failures.tsv").exists()
+    assert error.restart_path == output / "run_info" / "restart.toml"
+    assert error.outcome_path == output / "run_info" / "outcome.toml"
+
+
 def test_ctrl_c_after_resampling_operation_preserves_validated_sample_values(
     tmp_path: Path,
 ) -> None:
@@ -3737,7 +4339,7 @@ def test_ctrl_c_after_resampling_operation_preserves_validated_sample_values(
             "_resampling_result_and_samples",
             side_effect=KeyboardInterrupt,
         ),
-        pytest.raises(KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt) as error_info,
     ):
         run(_fit_arguments(output, method), session=AnalysisSession.create())
 
@@ -3749,6 +4351,9 @@ def test_ctrl_c_after_resampling_operation_preserves_validated_sample_values(
     )
     assert diagnostics["terminal"] == "interrupted"
     assert diagnostics["completed_samples"] == 3
+    assert error_info.value.samples_path == statistics / "samples.tsv"
+    assert not hasattr(error_info.value, "failures_path")
+    assert not (statistics / "failures.tsv").exists()
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()
@@ -3838,6 +4443,35 @@ def test_native_resampling_publication_failure_is_terminal_and_fail_closed(
     assert _read_outcome(output)["status"] == "incomplete"
 
 
+def test_resampling_os_publication_failure_retains_path_and_cause(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 1')
+    cause = OSError(28, "No space left on device")
+
+    with (
+        patch(
+            "chemex.optimize.resampling._write_resampling_correlations",
+            side_effect=cause,
+        ),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    error = error_info.value
+    statistics = output / "Statistics" / "MonteCarlo"
+    assert error.__cause__ is cause
+    assert error.operation == "publish resampling correlations"
+    assert error.path == statistics / "correlations.tsv"
+    assert error.samples_path == statistics / "samples.tsv"
+    assert error.diagnostics_path == statistics / "diagnostics.toml"
+    assert error.restart_path == output / "run_info" / "restart.toml"
+    assert error.outcome_path == output / "run_info" / "outcome.toml"
+    assert not (statistics / "correlations.tsv").exists()
+    assert _read_outcome(output)["failure_type"] == "ArtifactPublicationError"
+
+
 def test_native_resampling_result_failure_replaces_running_diagnostics(
     tmp_path: Path,
 ) -> None:
@@ -3906,6 +4540,66 @@ def test_resampling_diagnostics_failure_preserves_original_publication_error(
     outcome = _read_outcome(output)
     assert outcome["status"] == "incomplete"
     assert outcome["failure_message"] == "correlation publication failed"
+
+
+def test_resampling_writer_error_stays_contextual_when_diagnostics_also_fail(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 1')
+    writer_error = OSError(28, "samples disk full")
+    diagnostics_error = OSError(13, "diagnostics permission denied")
+    real_atomic_write = resampling_module.write_text_atomic
+
+    def fail_incomplete_diagnostics(destination: Path, content: str) -> None:
+        if (
+            destination.name == "diagnostics.toml"
+            and 'status = "incomplete"' in content
+        ):
+            raise diagnostics_error
+        real_atomic_write(destination, content)
+
+    with (
+        patch.object(
+            resampling_module,
+            "_write_native_samples",
+            side_effect=writer_error,
+        ),
+        patch.object(
+            resampling_module,
+            "write_text_atomic",
+            side_effect=fail_incomplete_diagnostics,
+        ),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    error = error_info.value
+    assert error.__cause__ is writer_error
+    assert error.operation == "publish resampling samples"
+    assert error.path == output / "Statistics" / "MonteCarlo" / "samples.tsv"
+    assert "diagnostics permission denied" in " ".join(error.__notes__ or ())
+
+
+def test_resampling_processing_oserror_remains_unclassified(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _statistics_method(tmp_path / "method.toml", '"MC" = 1')
+    cause = OSError("in-memory result defect")
+
+    with (
+        patch.object(
+            resampling_module,
+            "_resampling_result_and_samples",
+            side_effect=cause,
+        ),
+        pytest.raises(OSError) as error_info,
+    ):
+        run(_fit_arguments(output, method), session=AnalysisSession.create())
+
+    assert error_info.value is cause
+    assert not isinstance(error_info.value, ChemExError)
 
 
 def test_real_grid_fit_writes_profiled_surfaces_and_withholds_covariance(
@@ -4526,7 +5220,7 @@ def test_seed_publication_failure_prevents_de_from_starting(tmp_path: Path) -> N
         "restart_revision": 0,
         "terminal": "failed",
         "failure_stage": "run_info",
-        "failure_type": "OSError",
+        "failure_type": "ArtifactPublicationError",
         "failure_message": "seed publication failed",
     }
 
@@ -4849,7 +5543,7 @@ FIX = ["PB", "KEX_AB"]
     assert outcome["restart_revision"] == 1
 
 
-def test_planned_invalidation_rejects_a_step_root_outside_the_output(
+def test_method_plan_rejects_a_step_root_outside_the_output(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -4866,11 +5560,16 @@ FIX = ["PB", "KEX_AB"]
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="outside the output directory"):
+    with pytest.raises(
+        MethodFormatError,
+        match="must remain inside the output directory",
+    ) as error_info:
         run(_fit_arguments(output, method), session=AnalysisSession.create())
 
+    assert error_info.value.source.filename == method
+    assert error_info.value.source.step == "../external"
     assert external_result.read_text(encoding="utf-8") == "keep me\n"
-    assert _read_outcome(output)["status"] == "incomplete"
+    assert not (output / "run_info").exists()
 
 
 def test_native_backend_failure_cannot_commit_or_publish_fitted_output(
@@ -4894,6 +5593,165 @@ def test_native_backend_failure_cannot_commit_or_publish_fitted_output(
     assert not (output / "Parameters").exists()
     assert not (output / "Data").exists()
     assert not (output / "Statistics" / "Covariance").exists()
+
+
+def test_native_nonconvergence_retains_typed_terminal_evidence(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+
+    def nonconverged_backend(fun, x0, **_settings):
+        vector = np.asarray(x0, dtype=np.float64)
+        residuals = np.asarray(fun(vector), dtype=np.float64)
+        return SimpleNamespace(
+            x=vector,
+            fun=residuals,
+            status=0,
+            success=False,
+            message="maximum evaluations reached",
+            nfev=1,
+            njev=0,
+            cost=0.5 * float(np.dot(residuals, residuals)),
+            optimality=1.0,
+            active_mask=np.zeros_like(vector, dtype=np.int64),
+            jac=np.zeros((residuals.size, vector.size), dtype=np.float64),
+        )
+
+    with (
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            side_effect=nonconverged_backend,
+        ),
+        pytest.raises(NativeDeterministicAnalysisError) as error_info,
+    ):
+        run(_fit_arguments(output), session=AnalysisSession.create())
+
+    error = error_info.value
+    assert error.reason == "The optimizer did not converge."
+    assert [failure.category for failure in error.failures] == ["non_converged"]
+    assert error.outcome.terminal.value == "component_failure"
+    assert _read_outcome(output)["failure_type"] == ("NativeDeterministicAnalysisError")
+
+
+def test_native_nonconvergence_is_a_known_cli_failure(tmp_path: Path) -> None:
+    output = tmp_path / "Output"
+    (tmp_path / "sitecustomize.py").write_text(
+        """
+import chemex.optimize.direct_trf as direct_trf
+
+real_least_squares = direct_trf.least_squares
+
+def nonconverged(*args, **kwargs):
+    result = real_least_squares(*args, **kwargs)
+    result.status = 0
+    result.success = False
+    result.message = "maximum evaluations reached"
+    return result
+
+direct_trf.least_squares = nonconverged
+""".lstrip(),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(tmp_path), env.get("PYTHONPATH", "")))
+    )
+
+    completed = _run_real_fit_cli(
+        output,
+        METHOD,
+        PARAMETERS,
+        check=False,
+        env=env,
+    )
+
+    rendered = " ".join((completed.stdout + completed.stderr).split())
+    assert completed.returncode == 1
+    assert rendered.count("Deterministic analysis did not produce") == 1
+    assert "optimizer did not converge" in rendered
+    assert "maximum evaluations reached" in rendered
+    assert "Method Step: DEFAULT" in rendered
+    assert "run_info/outcome.toml" in rendered
+    assert "unexpected internal error" not in rendered
+    assert "Traceback (most recent call last)" not in rendered
+
+
+def test_native_budget_exhaustion_is_a_known_analysis_failure(
+    tmp_path: Path,
+) -> None:
+    def exceed_budget(fun, x0, **_settings):
+        fun(np.asarray(x0, dtype=np.float64))
+        fun(np.asarray(x0, dtype=np.float64))
+        raise AssertionError("objective budget did not stop the backend")
+
+    with (
+        patch.object(
+            native_deterministic_module,
+            "_objective_request_budget",
+            return_value=1,
+        ),
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            side_effect=exceed_budget,
+        ),
+        pytest.raises(NativeDeterministicAnalysisError) as error_info,
+    ):
+        run(
+            _fit_arguments(tmp_path / "Output"),
+            session=AnalysisSession.create(),
+        )
+
+    assert error_info.value.reason == ("The objective-evaluation budget was exhausted.")
+    assert [failure.category for failure in error_info.value.failures] == [
+        "objective_budget_exhausted"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("validity", "known"),
+    (("INVALID_TRIAL", True), ("INVALID_PLAN_OR_BINDING", False)),
+)
+def test_native_evaluation_failure_classification_is_conservative(
+    tmp_path: Path,
+    validity: str,
+    known: bool,
+) -> None:
+    def fail_trial(evaluator: BoundEvaluator, frame) -> EvaluationFailure:
+        return EvaluationFailure(
+            evaluator.plan.identity,
+            frame.parameterization_identity,
+            "kernel" if known else "binding",
+            "non_finite_calculation" if known else "invalid_binding",
+            validity,  # ty: ignore[invalid-argument-type]
+            message="typed evaluation failure",
+        )
+
+    with (
+        patch.object(BoundEvaluator, "evaluate_residuals", fail_trial),
+        pytest.raises(RuntimeError) as error_info,
+    ):
+        run(
+            _fit_arguments(tmp_path / f"Output-{validity}"),
+            session=AnalysisSession.create(),
+        )
+
+    assert isinstance(error_info.value, NativeDeterministicAnalysisError) is known
+
+
+def test_native_implementation_failure_remains_unclassified(
+    tmp_path: Path,
+) -> None:
+    with (
+        patch(
+            "chemex.optimize.direct_trf.least_squares",
+            side_effect=RuntimeError("backend implementation failed"),
+        ),
+        pytest.raises(NativeDeterministicInternalError) as error_info,
+    ):
+        run(_fit_arguments(tmp_path / "Output"), session=AnalysisSession.create())
+
+    assert "did not commit" in str(error_info.value)
+    assert error_info.value.outcome.terminal.value == "execution_failure"
 
 
 def test_v1_constraint_and_profile_selection_reach_native_product_fit(

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -1792,7 +1792,7 @@ def test_incomplete_outcome_failure_does_not_replace_primary_failure(
     assert _read_outcome(output)["status"] == "running"
 
 
-def test_interrupted_outcome_publication_failure_supersedes_interruption(
+def test_interrupted_outcome_publication_failure_retains_interruption(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -1820,6 +1820,7 @@ def test_interrupted_outcome_publication_failure_supersedes_interruption(
 
     error = error_info.value
     assert error.__cause__ is cause
+    assert error.terminal == "interrupted"
     assert error.operation == "publish the incomplete run outcome"
     assert error.path == output / "run_info" / "outcome.toml"
     assert error.restart_path == output / "run_info" / "restart.toml"
@@ -2205,7 +2206,7 @@ def test_interrupted_uncertainty_publication_failure_preserves_interruption(
     assert _read_outcome(output)["terminal"] == "interrupted"
 
 
-def test_interrupted_uncertainty_io_failure_supersedes_interruption(
+def test_interrupted_uncertainty_io_failure_retains_interruption(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -2235,6 +2236,7 @@ def test_interrupted_uncertainty_io_failure_supersedes_interruption(
         )
 
     assert error_info.value.__cause__ is cause
+    assert error_info.value.terminal == "interrupted"
     assert error_info.value.operation == "publish deterministic analysis output"
     assert error_info.value.path == failed_path
 
@@ -3543,6 +3545,7 @@ def test_interrupted_mcmc_io_failure_reports_published_evidence(
     error = error_info.value
     statistics = output / "Statistics" / "MCMC"
     assert error.__cause__ is cause
+    assert error.terminal == "interrupted"
     assert error.operation == "publish interrupted MCMC diagnostics"
     assert error.path == statistics / "diagnostics.toml"
     assert error.evidence_path == statistics / "raw_chain.tsv"
@@ -4147,6 +4150,9 @@ def test_mcmc_diagnostics_failure_does_not_replace_primary_failure(
     method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
     parameters = _bounded_parameters(tmp_path / "parameters.toml")
     real_write = mcmc_module._write_native_mcmc_state_diagnostics
+    original_cause = ValueError("original postprocessing cause")
+    primary = RuntimeError("primary postprocessing failure")
+    primary.__cause__ = original_cause
 
     def fail_incomplete_diagnostics(*args, **kwargs):
         if kwargs.get("status") == "incomplete":
@@ -4157,7 +4163,7 @@ def test_mcmc_diagnostics_failure_does_not_replace_primary_failure(
         patch.object(
             mcmc_module,
             "derive_mcmc_analysis_result",
-            side_effect=RuntimeError("primary postprocessing failure"),
+            side_effect=primary,
         ),
         patch.object(
             mcmc_module,
@@ -4179,6 +4185,8 @@ def test_mcmc_diagnostics_failure_does_not_replace_primary_failure(
             "RuntimeError: diagnostics finalization failed"
         )
     ]
+    assert error_info.value is primary
+    assert error_info.value.__cause__ is original_cause
     assert _read_outcome(output)["failure_message"] == (
         "primary postprocessing failure"
     )
@@ -4252,6 +4260,50 @@ def test_complete_mcmc_output_failure_reports_republished_diagnostics(
     assert not (statistics / "summary.toml").exists()
 
 
+def test_mcmc_diagnostics_io_failure_does_not_report_removed_diagnostics(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "Output"
+    method = _nested_mcmc_method(tmp_path / "method.toml", workers=1)
+    parameters = _bounded_parameters(tmp_path / "parameters.toml")
+    output_cause = OSError(28, "No space left on device")
+    diagnostics_cause = OSError(5, "Input/output error")
+    real_diagnostics = mcmc_module._write_native_mcmc_state_diagnostics
+
+    def fail_incomplete_diagnostics(*args, **kwargs):
+        if kwargs.get("status") == "incomplete":
+            raise diagnostics_cause
+        return real_diagnostics(*args, **kwargs)
+
+    with (
+        patch.object(mcmc_module, "_write_summary", side_effect=output_cause),
+        patch.object(
+            mcmc_module,
+            "_write_native_mcmc_state_diagnostics",
+            side_effect=fail_incomplete_diagnostics,
+        ),
+        pytest.raises(ArtifactPublicationError) as error_info,
+    ):
+        run(
+            _fit_arguments(output, method, parameters=parameters),
+            session=AnalysisSession.create(),
+        )
+
+    error = error_info.value
+    statistics = output / "Statistics" / "MCMC"
+    assert error.__cause__ is output_cause
+    assert error.operation == "publish MCMC summary"
+    assert error.path == statistics / "summary.toml"
+    assert not hasattr(error, "diagnostics_path")
+    assert not (statistics / "diagnostics.toml").exists()
+    assert error.__notes__ == [
+        (
+            "ChemEx could not publish incomplete MCMC diagnostics: "
+            "OSError: [Errno 5] Input/output error"
+        )
+    ]
+
+
 def test_interrupted_resampling_publication_failure_preserves_interruption(
     tmp_path: Path,
 ) -> None:
@@ -4318,6 +4370,7 @@ def test_interrupted_resampling_io_failure_reports_published_samples(
     error = error_info.value
     statistics = output / "Statistics" / "MonteCarlo"
     assert error.__cause__ is cause
+    assert error.terminal == "interrupted"
     assert error.operation == "publish incomplete resampling diagnostics"
     assert error.path == statistics / "diagnostics.toml"
     assert error.samples_path == statistics / "samples.tsv"
@@ -4508,6 +4561,9 @@ def test_resampling_diagnostics_failure_preserves_original_publication_error(
     output = tmp_path / "Output"
     method = _statistics_method(tmp_path / "method.toml", '"MC" = 1')
     real_atomic_write = resampling_module.write_text_atomic
+    original_cause = ValueError("original correlation cause")
+    primary = RuntimeError("correlation publication failed")
+    primary.__cause__ = original_cause
 
     def fail_incomplete_diagnostics(destination: Path, content: str) -> None:
         if (
@@ -4521,14 +4577,16 @@ def test_resampling_diagnostics_failure_preserves_original_publication_error(
         patch.object(
             resampling_module,
             "_write_resampling_correlations",
-            side_effect=RuntimeError("correlation publication failed"),
+            side_effect=primary,
         ),
         patch.object(
             resampling_module,
             "write_text_atomic",
             side_effect=fail_incomplete_diagnostics,
         ),
-        pytest.raises(RuntimeError, match="correlation publication failed"),
+        pytest.raises(
+            RuntimeError, match="correlation publication failed"
+        ) as error_info,
     ):
         run(_fit_arguments(output, method), session=AnalysisSession.create())
 
@@ -4537,6 +4595,8 @@ def test_resampling_diagnostics_failure_preserves_original_publication_error(
     assert not (statistics / "summary.toml").exists()
     assert not (statistics / "correlations.tsv").exists()
     assert not (statistics / "plots.pdf").exists()
+    assert error_info.value is primary
+    assert error_info.value.__cause__ is original_cause
     outcome = _read_outcome(output)
     assert outcome["status"] == "incomplete"
     assert outcome["failure_message"] == "correlation publication failed"

--- a/tests/test_run_info.py
+++ b/tests/test_run_info.py
@@ -11,6 +11,7 @@ import pytest
 from chemex import __version__
 from chemex import run_info as run_info_module
 from chemex.configuration.parameters import read_defaults
+from chemex.exceptions import InputFileReadError
 from chemex.parameters.name import ParamName
 from chemex.parameters.parameterization import (
     ParameterDeclaration,
@@ -114,6 +115,17 @@ def _write_input(path: Path, content: str = "[input]\nvalue = 1\n") -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def test_capture_input_files_preserves_path_and_os_cause(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.toml"
+    args = Namespace(experiments=[missing], parameters=[], method=None)
+
+    with pytest.raises(InputFileReadError) as error_info:
+        run_info_module.capture_input_files(args, tmp_path)
+
+    assert error_info.value.path == missing
+    assert isinstance(error_info.value.__cause__, FileNotFoundError)
 
 
 def test_write_run_info_captures_inputs_parameters_and_runtime(
@@ -606,7 +618,7 @@ def test_failed_staging_preserves_existing_run_info(
     missing_input = tmp_path / "missing.toml"
     monkeypatch.setattr(run_info_module, "_git_metadata", lambda: None)
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(InputFileReadError) as error_info:
         _write_run_info(
             Namespace(
                 experiments=[missing_input],
@@ -618,6 +630,8 @@ def test_failed_staging_preserves_existing_run_info(
             working_directory=tmp_path,
         )
 
+    assert error_info.value.path == missing_input
+    assert isinstance(error_info.value.__cause__, FileNotFoundError)
     assert existing_run.read_text(encoding="utf-8") == "schema_version = 1\n"
     assert not list(output.glob(".run_info-*"))
 

--- a/tests/test_toml_io.py
+++ b/tests/test_toml_io.py
@@ -4,46 +4,120 @@ from pathlib import Path
 
 import pytest
 
+import chemex.configuration.parameters as parameter_configuration_module
 import chemex.toml as toml_module
+from chemex.configuration.parameters import ParameterConfigurationError, read_defaults
 
 
-def test_read_toml_exits_with_formatted_missing_file_error(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+def test_read_toml_raises_typed_missing_file_error(tmp_path: Path) -> None:
     missing_file = tmp_path / "missing.toml"
-    recorded: dict[str, Path] = {}
 
-    monkeypatch.setattr(
-        toml_module,
-        "print_file_not_found",
-        lambda filename: recorded.update({"filename": filename}),
-    )
-
-    with pytest.raises(SystemExit):
+    with pytest.raises(toml_module.TomlReadError) as error_info:
         toml_module.read_toml(missing_file)
 
-    assert recorded == {"filename": missing_file}
+    assert error_info.value.filename == missing_file
+    assert isinstance(error_info.value.__cause__, FileNotFoundError)
 
 
-def test_read_toml_exits_with_formatted_parse_error(
+def test_read_toml_raises_typed_parse_error(tmp_path: Path) -> None:
+    invalid_toml = tmp_path / "invalid.toml"
+    invalid_toml.write_text("[section\nvalue = 1", encoding="utf-8")
+    with pytest.raises(toml_module.TomlReadError) as error_info:
+        toml_module.read_toml(invalid_toml)
+
+    assert error_info.value.filename == invalid_toml
+    assert type(error_info.value.__cause__).__name__ == "TOMLDecodeError"
+
+
+def test_read_toml_raises_typed_invalid_utf8_error(tmp_path: Path) -> None:
+    invalid_toml = tmp_path / "invalid-utf8.toml"
+    invalid_toml.write_bytes(b"[section]\nvalue = \xff\n")
+
+    with pytest.raises(toml_module.TomlReadError) as error_info:
+        toml_module.read_toml(invalid_toml)
+
+    assert error_info.value.filename == invalid_toml
+    assert isinstance(error_info.value.__cause__, UnicodeDecodeError)
+
+
+def test_internal_toml_loader_type_error_is_not_misclassified(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    invalid_toml = tmp_path / "invalid.toml"
-    invalid_toml.write_text("[section\nvalue = 1", encoding="utf-8")
-    recorded: dict[str, object] = {}
+    cause = TypeError("loader contract defect")
+
+    def fail_loader(_filename: Path) -> None:
+        raise cause
+
+    monkeypatch.setattr(toml_module, "load_toml", fail_loader)
+
+    with pytest.raises(TypeError, match="loader contract defect") as error_info:
+        toml_module.read_toml(tmp_path / "parameters.toml")
+
+    assert error_info.value is cause
+
+
+def test_read_toml_contextualizes_permission_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    filename = tmp_path / "private.toml"
+    cause = PermissionError(13, "Permission denied", str(filename))
+
+    def deny_read(_filename: Path) -> None:
+        raise cause
+
+    monkeypatch.setattr(toml_module, "load_toml", deny_read)
+
+    with pytest.raises(toml_module.TomlReadError) as error_info:
+        toml_module.read_toml(filename)
+
+    assert error_info.value.filename == filename
+    assert error_info.value.__cause__ is cause
+
+
+def test_parameter_configuration_error_retains_source_and_cause(tmp_path: Path) -> None:
+    parameter_file = tmp_path / "parameters.toml"
+    parameter_file.write_text('"[global]" = "not-a-table"\n', encoding="utf-8")
+
+    with pytest.raises(ParameterConfigurationError) as error_info:
+        read_defaults([parameter_file])
+
+    assert error_info.value.filenames == (parameter_file,)
+    assert error_info.value.__cause__ is not None
+
+
+def test_empty_parameter_values_are_a_typed_configuration_failure(
+    tmp_path: Path,
+) -> None:
+    parameter_file = tmp_path / "parameters.toml"
+    parameter_file.write_text("[GLOBAL]\nPB = []\n", encoding="utf-8")
+
+    with pytest.raises(ParameterConfigurationError) as error_info:
+        read_defaults([parameter_file])
+
+    assert error_info.value.filenames == (parameter_file,)
+    assert error_info.value.__cause__ is not None
+    assert "at least 1" in error_info.value.explanation
+
+
+def test_unexpected_parameter_builder_failure_is_not_misclassified(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    parameter_file = tmp_path / "parameters.toml"
+    parameter_file.write_text("[GLOBAL]\nPB = 0.1\n", encoding="utf-8")
+
+    def fail_builder(_config: object) -> None:
+        raise TypeError("builder defect")
 
     monkeypatch.setattr(
-        toml_module,
-        "print_toml_error",
-        lambda filename, error: recorded.update(
-            {"filename": filename, "error_type": type(error).__name__}
-        ),
+        parameter_configuration_module,
+        "build_default_list",
+        fail_builder,
     )
 
-    with pytest.raises(SystemExit):
-        toml_module.read_toml(invalid_toml)
+    with pytest.raises(TypeError, match="builder defect") as error_info:
+        parameter_configuration_module.read_defaults([parameter_file])
 
-    assert recorded["filename"] == invalid_toml
-    assert recorded["error_type"] == "TOMLDecodeError"
+    assert not isinstance(error_info.value, ParameterConfigurationError)


### PR DESCRIPTION
## Summary

ChemEx already retained useful structured information for many failures and interruptions, but final CLI presentation often discarded that information or rendered it inconsistently.

This PR centralizes final failure presentation at the CLI boundary while preserving domain and scientific authority.

## Main changes

- Introduces a minimal `ChemExError` seam for failures deliberately safe for concise presentation.
- Establishes a single terminal presentation boundary with concise known-failure diagnostics.
- Handles Ctrl-C cleanly with exit 130 and reports only verified preserved artifacts.
- Treats unexpected internal failures safely by default, with global `--debug` support for natural traceback and cause diagnostics.
- Migrates relevant experiment, TOML, method, parameter, model, and constraint errors away from deep print-and-exit behavior.
- Preserves typed deterministic optimizer terminal outcomes.
- Improves scientifically incomplete MCMC and resampling diagnostics.
- Contextualizes selected I/O and publication failures.
- Prevents secondary finalization errors from masking the primary failure.

## Scientific/compatibility guarantees

- No scientific calculations changed.
- MCMC/resampling `AnalysisResult` authority is unchanged.
- Artifact-withholding rules are unchanged.
- TOML schemas are unchanged.
- Parameter semantics are unchanged.
- Successful-run output formats are unchanged.
- Argparse, help, and version behavior remain native.
- “No selected profiles” behavior is unchanged.

## Representative UX

- Malformed input reports the relevant input and reason once.
- Recognized non-convergence is reported as an analysis failure rather than an “unexpected error.”
- Incomplete MCMC/resampling reports confirmed diagnostics and evidence.
- Ctrl-C reports interruption cleanly.
- Internal failures suppress arbitrary exception contents normally and expose the full traceback only with `--debug`.

## Validation

- Full suite: `1310 passed`
- Native production fitting: `154 passed`
- CLI/configuration/provenance subset: `117 passed`
- Ruff lint: passed
- Ruff formatting: passed
- `ty`: passed
- `git diff --check`: passed
- Strict post-implementation specification audit: PASS with 0 remaining findings
