### PR TITLE
docs: fix configuration examples and validate experiment docs

### DIFF
--- a/src/chemex/cli.py
+++ b/src/chemex/cli.py
@@ -270,7 +270,7 @@ def build_parser() -> ArgumentParser:
     # parser for the positional argument "pick_cest"
     plot_param_parser = subparsers.add_parser(
         "plot_param",
-        help="Plot one selected parameter from a 'parameters.fit' file",
+        help="Plot one selected parameter from a 'Parameters/fitted.toml' file",
     )
 
     _add_debug_argument(plot_param_parser, inherit_default=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,3 +136,7 @@ def test_simulate_parser_does_not_accept_execution_arguments() -> None:
                 "2",
             ],
         )
+
+
+def test_plot_param_help_names_current_fitted_parameter_output() -> None:
+    assert "Parameters/fitted.toml" in build_parser().format_help()

--- a/tests/test_experiment_documentation.py
+++ b/tests/test_experiment_documentation.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import TypeIs
+
+import pytest
+from pydantic import BaseModel
+
+from chemex.experiments.experiment_types import (
+    ExperimentType,
+    registered_experiment_types,
+)
+from chemex.experiments.loader import register_experiments
+
+ROOT = Path(__file__).parents[1]
+EXPERIMENT_DOCS = ROOT / "website" / "docs" / "experiments"
+EXPERIMENT_CONFIG = re.compile(
+    r'^```toml title="experiment\.toml"\n(?P<config>.*?)^```$',
+    flags=re.DOTALL | re.MULTILINE,
+)
+EXPERIMENT_PAGES = tuple(sorted(EXPERIMENT_DOCS.rglob("*.md")))
+
+type ConfigurationTable = dict[str, object]
+
+
+def _is_configuration_table(value: object) -> TypeIs[ConfigurationTable]:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
+def _find_unknown_keys(
+    raw: ConfigurationTable,
+    validated: BaseModel,
+    path: tuple[str, ...] = (),
+) -> Iterator[str]:
+    fields = type(validated).model_fields
+    for key, raw_value in raw.items():
+        normalized_key = key.lower()
+        key_path = (*path, key)
+        if normalized_key not in fields:
+            yield ".".join(key_path)
+            continue
+        validated_value = getattr(validated, normalized_key)
+        if _is_configuration_table(raw_value) and isinstance(
+            validated_value,
+            BaseModel,
+        ):
+            yield from _find_unknown_keys(raw_value, validated_value, key_path)
+
+
+@pytest.fixture(scope="module")
+def experiment_types() -> Mapping[str, ExperimentType]:
+    register_experiments()
+    return registered_experiment_types()
+
+
+def test_experiment_documentation_discovery_is_not_empty() -> None:
+    assert EXPERIMENT_PAGES, f"No experiment pages found under {EXPERIMENT_DOCS}"
+
+
+@pytest.mark.parametrize("page", EXPERIMENT_PAGES, ids=lambda page: page.stem)
+def test_experiment_page_configuration_matches_current_schema(
+    page: Path,
+    experiment_types: Mapping[str, ExperimentType],
+) -> None:
+    matches = tuple(EXPERIMENT_CONFIG.finditer(page.read_text(encoding="utf-8")))
+    assert len(matches) == 1, (
+        f"{page.relative_to(ROOT)} must contain exactly one copyable "
+        '```toml title="experiment.toml" configuration'
+    )
+
+    raw_config = tomllib.loads(matches[0].group("config"))
+    experiment_name = raw_config["experiment"]["name"]
+    assert experiment_name == page.stem
+    assert experiment_name in experiment_types
+
+    config = experiment_types[experiment_name].config_type.model_validate(raw_config)
+    assert not tuple(_find_unknown_keys(raw_config, config))
+
+
+def test_unknown_documented_keys_are_detected_when_pydantic_ignores_them(
+    experiment_types: Mapping[str, ExperimentType],
+) -> None:
+    raw_config: ConfigurationTable = {
+        "experiment": {"name": "shift_15n_sqmq"},
+        "conditions": {},
+        "data": {"shifts": "shifts.dat"},
+    }
+    config = experiment_types["shift_15n_sqmq"].config_type.model_validate(raw_config)
+
+    assert tuple(_find_unknown_keys(raw_config, config)) == ("data.shifts",)

--- a/website/docs/experiments/cest/cest_13c.md
+++ b/website/docs/experiments/cest/cest_13c.md
@@ -113,7 +113,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/cest/cest_15n.md
+++ b/website/docs/experiments/cest/cest_15n.md
@@ -104,7 +104,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/cest/cest_15n_cw.md
+++ b/website/docs/experiments/cest/cest_15n_cw.md
@@ -49,12 +49,6 @@ carrier = 118.0
 ## B1 radio-frequency field strength, in Hz
 b1_frq = 25.0
 
-## B1 inhomogeneity distribution (replaces b1_inh_scale/b1_inh_res)
-[experiment.b1_distribution]
-type = "gaussian"
-scale = 0.1
-res = 11
-
 ## Position of the ¹H carrier during the ¹H CW decoupling, in ppm
 carrier_dec = 8.3
 
@@ -71,6 +65,12 @@ b1_frq_dec = 1000.0
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
+
+## B1 inhomogeneity distribution (replaces b1_inh_scale/b1_inh_res)
+[experiment.b1_distribution]
+type = "gaussian"
+scale = 0.1
+res = 11
 
 [conditions]
 
@@ -106,7 +106,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/cest/cest_15n_tr.md
+++ b/website/docs/experiments/cest/cest_15n_tr.md
@@ -104,7 +104,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/cest/cest_1hn_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ap.md
@@ -98,7 +98,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/cest/cest_1hn_ip_ap.md
+++ b/website/docs/experiments/cest/cest_1hn_ip_ap.md
@@ -35,12 +35,12 @@ and is discussed [there](../../examples/cest_ip_ap.md).
 ## Sample configuration file
 
 ```toml title="experiment.toml"
-## This is a sample configuration file for the module 'coscest_1hn_ip_ap'
+## This is a sample configuration file for the module 'cest_1hn_ip_ap'
 
 [experiment]
 
 ## Name of the chemex module corresponding to the experiment
-name = "coscest_1hn_ip_ap"
+name = "cest_1hn_ip_ap"
 
 ## Recycle delay, in seconds
 d1 = 0.1
@@ -51,23 +51,8 @@ time_t1 = 0.5
 ## Position of the carrier during the CEST period, in ppm
 carrier = 8.3
 
-## Cosine "spectral width", in Hz
-sw = 800.0
-
-## Number of excitation frequencies
-cos_n = 3
-
-## Number of points used to simulate the cosine-modulated shape
-# cos_res = 10
-
 ## B1 radio-frequency field strength, in Hz
 b1_frq = 25.0
-
-## B1 inhomogeneity distribution (replaces b1_inh_scale/b1_inh_res)
-[experiment.b1_distribution]
-type = "gaussian"
-scale = 0.1
-res = 11
 
 ## Initial condition: equilibrium preparation (all states populated according to
 ## their equilibrium populations). Set start_state for non-equilibrium
@@ -79,6 +64,12 @@ res = 11
 
 ## State of the observed resonance [optional, default: "a"]
 # observed_state = "a"
+
+## B1 inhomogeneity distribution (replaces b1_inh_scale/b1_inh_res)
+[experiment.b1_distribution]
+type = "gaussian"
+scale = 0.1
+res = 11
 
 [conditions]
 
@@ -113,7 +104,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/cest/cest_ch3_1h_ip_ap.md
+++ b/website/docs/experiments/cest/cest_ch3_1h_ip_ap.md
@@ -107,7 +107,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/dcest/coscest_1hn_ip_ap.md
+++ b/website/docs/experiments/dcest/coscest_1hn_ip_ap.md
@@ -109,7 +109,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/dcest/dcest_13c.md
+++ b/website/docs/experiments/dcest/dcest_13c.md
@@ -117,7 +117,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/dcest/dcest_15n.md
+++ b/website/docs/experiments/dcest/dcest_15n.md
@@ -134,7 +134,7 @@ h_larmor_frq = 800.0
 ## List of offsets relative to the main resonance position
 ## (nu) and bandwidths (delta_nu) defining regions where
 ## points are excluded from the calculation (nu +/- 0.5 * delta_nu),
-## both are in Hz [optional, default: [[0.0, 0.0]] ]
+## both are in Hz [optional, default: [] ]
 # filter_offsets = [
 #   [0.0, 0.0],
 # ]

--- a/website/docs/experiments/shift/shift_15n_sqmq.md
+++ b/website/docs/experiments/shift/shift_15n_sqmq.md
@@ -63,10 +63,9 @@ h_larmor_frq = 800.0
 
 [data]
 
-## Directory containing the profiles [optional, default: "./"]
-# path = "./"
-
-## Filename of the file containing the list of the shifts in ppb.
+## Path to the file containing the list of shifts in ppb. Unlike profile-based
+## experiments, a shift experiment points directly to its data file rather than
+## to a profile directory.
 ## The file should be formatted as follow:
 ##
 ## #     name   shift  error
@@ -78,5 +77,5 @@ h_larmor_frq = 800.0
 ##
 ## The name of the spin systems should follow the Sparky-NMR
 ## conventions.
-shifts = "sqmq.txt"
+path = "sqmq.txt"
 ```

--- a/website/docs/user_guide/additional_modules.mdx
+++ b/website/docs/user_guide/additional_modules.mdx
@@ -34,7 +34,7 @@ import CestProfile from '@site/static/img/cest_26hz_simu.png'; import CpmgProfil
 | `-e`, `--experiments`     | Specifies the files containing experimental setup and data location   |
 | `-p`, `--parameters`      | Specifies the files containing the initial parameter values           |
 | `-d`, `--model`           | Specifies the exchange model used for simulation (default: `2st`)     |
-| `-o`, `--output`          | Specifies the output directory (default: `./Output`)                  |
+| `-o`, `--output`          | Specifies the output directory (default: `./OutputSim`)               |
 | `--plot {nothing,normal}` | Sets the plotting level (default: `normal`)                           |
 | `--include`               | Residues to include in the simulation (optional)                      |
 | `--exclude`               | Residues to exclude from the simulation (optional)                    |

--- a/website/docs/user_guide/fitting/chemex_fit.md
+++ b/website/docs/user_guide/fitting/chemex_fit.md
@@ -20,7 +20,7 @@ The table below lists the available options for `chemex fit`. Each option links 
 | ---- | ----------- |
 | [`-e`](experiment_files.md) or [`--experiments`](experiment_files.md) | Specify files containing experimental setup and data. |
 | [`-p`](parameter_files.md) or [`--parameters`](parameter_files.md) | Specify files containing initial fitting parameters. |
-| [`-m`](method_files.md) or [`--methods`](method_files.md) | Indicate the fitting method file (optional). |
+| [`-m`](method_files.md) or [`--method`](method_files.md) | Indicate the fitting method file (optional). |
 | [`-d`](kinetic_models.md) or [`--model`](kinetic_models.md) | Specify the kinetic model for fitting (optional, default: `2st`). |
 | [`-o`](outputs.mdx) or [`--output`](outputs.mdx) | Set the output directory (optional, default: `./Output`). |
 | `--plot {nothing, normal, all}` | Select the plotting level (optional, default: `normal`). |

--- a/website/docs/user_guide/fitting/experiment_files.md
+++ b/website/docs/user_guide/fitting/experiment_files.md
@@ -189,7 +189,7 @@ The `error` key specifies the method for estimating uncertainties:
 | Value         | Description                                                                                                                               |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `"file"`      | Use uncertainties directly from the data file.                                                                                            |
-| `"duplicates"`| Calculate uncertainty using pooled standard deviation, or return average error if duplicates are not available.                           |
+| `"duplicates"`| Calculate uncertainty from duplicate points. If no profile in the experiment contains duplicates, keep the uncertainties from the data files. |
 | `"scatter"`   | Estimate uncertainty by assuming additive Gaussian noise on the profile, suitable for CEST data.                                          |
 
 #### `filter_offsets`

--- a/website/docs/user_guide/running_chemex.md
+++ b/website/docs/user_guide/running_chemex.md
@@ -31,4 +31,7 @@ For detailed options specific to each sub-command, append `--help` after the sub
 chemex <subcommand> --help
 ```
 
+Use `--debug` before or after the sub-command to show tracebacks and chained
+causes for unexpected internal errors.
+
 :::


### PR DESCRIPTION
## Summary

- Fixes three incorrect copyable experiment configurations: cest_1hn_ip_ap, cest_15n_cw, and shift_15n_sqmq.
- Corrects small CLI option, output-default, help, and documentation drift.
- Corrects the documented filter_offsets default and duplicate-error fallback behavior.
- Adds automated validation for current experiment-page TOML blocks, including detection of keys silently ignored by Pydantic validation.
- Leaves frozen website/versioned_docs/** snapshots untouched.
- Intentionally defers broader onboarding, scientific-concepts, reference, and navigation improvements.

## Validation

- Focused tests: 129 passed.
- Changed-file ty check: passed.
- Repository-wide ty check: passed.
- Ruff check: passed.
- Ruff format --check: passed.
- Git diff --check: passed.
- Website build from the audited implementation pass: passed.