### PR TITLE
fix: preserve uncertainty units in duplicate fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- Corrected `error = "duplicates"` weighting for mixed experiments where only
+  some profiles contain duplicates. Duplicate-free profiles now contribute the
+  mean of their file-provided variances; affected mixed fits may therefore have
+  different residual weighting, fitted results, and reported statistics.
 - Corrected scaled-profile fit statistics to count analytically fitted
   per-profile normalization factors in residual degrees of freedom and χ²
   goodness-of-fit, and in the AIC/BIC model dimension. This changes reported

--- a/src/chemex/uncertainty.py
+++ b/src/chemex/uncertainty.py
@@ -17,8 +17,8 @@ def _variance_from_duplicates(data: Data) -> float:
 
     This function calculates the variance using the pooled standard deviation method.
     It groups the data points by their metadata and computes the variance for each
-    group. If no duplicates are found, the average of the experimental error values is
-    returned.
+    group. If no duplicates are found, the mean variance represented by the file
+    uncertainties is returned.
 
     Args:
         data (Data): The data containing experimental values and associated metadata.
@@ -42,7 +42,7 @@ def _variance_from_duplicates(data: Data) -> float:
             variances.append(np.var(group, ddof=1))
             weights.append(group_size - 1)
     if not variances:
-        return float(np.mean(data.err))
+        return float(np.mean(np.square(data.err)))
     return float(np.average(variances, weights=weights))
 
 

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from chemex.containers.data import Data
+from chemex.containers.experiment import Experiment, NoDuplicateNoiseNotice
+from chemex.containers.profile import Profile
+from chemex.uncertainty import estimate_noise_variance
+
+
+@dataclass
+class _NoiseProfile:
+    data: Data
+
+    def any_duplicate(self) -> bool:
+        return self.data.any_duplicate()
+
+    def set_noise(self, value: float) -> None:
+        self.data.err[:] = value
+        self.data.mark_dirty()
+
+
+def _profile(
+    experimental: list[float],
+    errors: list[float],
+    metadata: list[float],
+) -> _NoiseProfile:
+    return _NoiseProfile(
+        Data(
+            exp=np.asarray(experimental),
+            err=np.asarray(errors),
+            metadata=np.asarray(metadata),
+        )
+    )
+
+
+def _experiment(*profiles: _NoiseProfile) -> Experiment:
+    return Experiment(
+        Path("experiment.toml"),
+        "test",
+        cast("list[Profile]", list(profiles)),
+        cast("Any", object()),
+        cast("Any", object()),
+    )
+
+
+@pytest.mark.parametrize(
+    ("errors", "expected_variance"),
+    (([0.04, 0.04], 0.0016), ([0.03, 0.05], 0.0017)),
+)
+def test_duplicate_variance_fallback_uses_mean_file_variance(
+    errors: list[float],
+    expected_variance: float,
+) -> None:
+    profile = _profile([1.0, 2.0], errors, [1.0, 2.0])
+
+    variance = estimate_noise_variance["duplicates"](profile.data)
+
+    assert variance == pytest.approx(expected_variance, rel=1.0e-12, abs=0.0)
+
+
+@pytest.mark.parametrize("global_error", (False, True))
+def test_all_no_duplicate_profiles_preserve_pointwise_file_uncertainties(
+    global_error: bool,
+) -> None:
+    first = _profile([1.0, 2.0], [0.03, 0.05], [1.0, 2.0])
+    second = _profile([3.0, 4.0], [0.07, 0.09], [3.0, 4.0])
+    experiment = _experiment(first, second)
+    before = tuple(np.array(profile.data.err, copy=True) for profile in (first, second))
+
+    experiment.estimate_noise("duplicates", global_error=global_error)
+
+    for profile, expected in zip((first, second), before, strict=True):
+        np.testing.assert_array_equal(profile.data.err, expected)
+    assert experiment.noise_notices == (NoDuplicateNoiseNotice(experiment.filename),)
+
+
+@pytest.mark.parametrize(
+    ("file_errors", "expected_file_uncertainty"),
+    (([0.04, 0.04], 0.04), ([0.03, 0.05], np.sqrt(0.0017))),
+)
+def test_mixed_duplicate_noise_is_profile_local_in_local_mode(
+    file_errors: list[float],
+    expected_file_uncertainty: float,
+) -> None:
+    duplicate = _profile([1.0, 1.2, 3.0], [0.5, 0.5, 0.5], [1.0, 1.0, 2.0])
+    no_duplicate = _profile([4.0, 5.0], file_errors, [3.0, 4.0])
+
+    _experiment(duplicate, no_duplicate).estimate_noise(
+        "duplicates",
+        global_error=False,
+    )
+
+    np.testing.assert_allclose(
+        duplicate.data.err,
+        np.sqrt(0.02),
+        rtol=1.0e-12,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        no_duplicate.data.err,
+        expected_file_uncertainty,
+        rtol=1.0e-12,
+        atol=0.0,
+    )
+
+
+def test_mixed_duplicate_noise_contributes_file_variance_to_global_pool() -> None:
+    duplicate = _profile([1.0, 1.2, 3.0], [0.5, 0.5, 0.5], [1.0, 1.0, 2.0])
+    no_duplicate = _profile([4.0, 5.0], [0.04, 0.04], [3.0, 4.0])
+
+    _experiment(duplicate, no_duplicate).estimate_noise(
+        "duplicates",
+        global_error=True,
+    )
+
+    expected = np.sqrt((0.02 + 0.0016) / 2.0)
+    np.testing.assert_allclose(
+        duplicate.data.err,
+        expected,
+        rtol=1.0e-12,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        no_duplicate.data.err,
+        expected,
+        rtol=1.0e-12,
+        atol=0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("global_error", "expected"),
+    (
+        (False, (np.sqrt(0.02), np.sqrt(0.08))),
+        (True, (np.sqrt(0.05), np.sqrt(0.05))),
+    ),
+)
+def test_every_profile_with_duplicates_preserves_pooled_variance_behavior(
+    global_error: bool,
+    expected: tuple[float, float],
+) -> None:
+    first = _profile([1.0, 1.2], [0.5, 0.5], [1.0, 1.0])
+    second = _profile([2.0, 2.4], [0.5, 0.5], [2.0, 2.0])
+
+    _experiment(first, second).estimate_noise(
+        "duplicates",
+        global_error=global_error,
+    )
+
+    np.testing.assert_allclose(
+        first.data.err,
+        expected[0],
+        rtol=1.0e-12,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        second.data.err,
+        expected[1],
+        rtol=1.0e-12,
+        atol=0.0,
+    )


### PR DESCRIPTION
## Problem

For `error = "duplicates"`, ChemEx estimates a variance for each profile and later takes its square root to obtain the profile uncertainty.

In a mixed experiment where some profiles contain duplicate measurements and others do not, the duplicate-free fallback returned `mean(err)` even though `err` contains standard uncertainties and the helper's contract is variance-valued. The caller then applied `sqrt`, so a uniform file uncertainty of `0.04` became `0.2`.

## Correction

For a duplicate-free profile inside such a mixed experiment, the fallback variance is now `mean(err**2)`. This represents the mean pointwise variance supplied by the file.

- Local mode uses `sqrt(mean(err**2))`, the RMS file uncertainty.
- Global mode feeds that variance into the existing equal-profile variance pool.
- Duplicate-bearing profiles retain their existing pooled duplicate variance.

For heterogeneous errors `0.03` and `0.05`, `mean(err**2) = 0.0017` and the resulting local uncertainty is approximately `0.0412311`. This intentionally differs from `mean(err)**2 = 0.0016`.

## Compatibility boundary

Potentially affected only when `error = "duplicates"` and some, but not all, profiles in the experiment contain usable duplicate groups.

Unchanged:

- `error = "file"`;
- `error = "scatter"`;
- experiments where every profile has duplicates;
- experiments where no profile has duplicates — these continue to preserve the original pointwise file uncertainties and `NoDuplicateNoiseNotice`.

The repository scan found 38 active shipped duplicate-error configurations covering 1,661 profiles, and every shipped profile contains duplicates. Therefore no current shipped example changes numerically.

Affected user datasets may see changes in residual weighting, χ²/statistics, fitted central parameters, and parameter uncertainties.

## Validation

- Focused uncertainty/experiment tests: 31 passed.
- Complete collection: 1,365 tests.
- Sandbox full-suite result: 1,362 passed, with exactly three multiprocessing tests blocked solely by socket restrictions.
- Those exact three tests rerun unrestricted: 3 passed; effectively all 1,365 tests passed.
- `ty check`: passed.
- Ruff lint: passed.
- Ruff formatting: passed.
- `git diff --check`: passed.
- Representative real duplicate-error CPMG workflow: unchanged.

PR #758's fit-statistics correction is untouched. The separate `chi2.sf()` issue is intentionally out of scope. No website or frozen documentation changes are included.
