### PR TITLE
docs: explain exchange and fit statistics conventions

### DIFF
--- a/website/docs/first_analysis.md
+++ b/website/docs/first_analysis.md
@@ -76,11 +76,14 @@ types in detail.
 
 The model calls the exchanging states A and B. These are stable labels; deciding
 which physical conformations they represent is the analyst's responsibility.
+ChemEx does not require A to be the major state or reorder the labels by fitted
+population. The complete conventions are defined in
+[Exchange States and Parameters](./user_guide/fitting/exchange_states_parameters.md).
 For this fit, the most important parameters are:
 
 - `PB`: the equilibrium population fraction of state B;
 - `KEX_AB`: the total A↔B exchange rate, in s⁻¹;
-- `DW_AB`: the profile-specific ¹⁵N chemical-shift difference
+- `DW_AB`: the residue-specific ¹⁵N chemical-shift difference
   (state B minus state A), in ppm.
 
 `PB` and `KEX_AB` are shared by all ten profiles: five residues measured at
@@ -183,9 +186,9 @@ available in `OutputTutorial/Plots/800mhz.exp`,
 
 ChemEx loaded the measured CPMG intensities, evaluated them under the selected
 two-state exchange model, and globally optimized shared exchange parameters
-together with profile-specific chemical-shift differences and relaxation
-rates. It then wrote the fitted parameters, back-calculated data, plots,
-fit-quality statistics, and run provenance.
+together with residue-specific chemical-shift differences and residue- and
+field-specific relaxation rates. It then wrote the fitted parameters,
+back-calculated data, plots, fit-quality statistics, and run provenance.
 
 ## Next steps
 
@@ -194,6 +197,7 @@ fit-quality statistics, and run provenance.
   parameters established by the five-residue subset.
 - Learn how to configure [experiments](./user_guide/fitting/experiment_files.md)
   and [data files](./user_guide/fitting/data_files.mdx).
+- Understand [profile scaling, uncertainties, residuals, and fit statistics](./user_guide/fitting/scaling_uncertainties_residuals.md).
 - Learn how to set [starting parameters and bounds](./user_guide/fitting/parameter_files.md).
 - Learn how [Method v2](./user_guide/fitting/method_files.md) controls profile
   selection, parameter roles, and multi-step fits.

--- a/website/docs/full_cpmg_analysis.md
+++ b/website/docs/full_cpmg_analysis.md
@@ -93,6 +93,9 @@ model-owned quantities such as `PA`, `KAB`, and `KBA` remain derived.
 | `DW_AB`   | One value per residue                               | Fitted        | Residue-specific B-minus-A ¹⁵N shift difference, in ppm |
 | `R2_A`    | One value per residue and magnetic field            | Fitted        | Profile baseline transverse relaxation rate, in s⁻¹     |
 
+See [Exchange States and Parameters](./user_guide/fitting/exchange_states_parameters.md)
+for the exact `PB`, `KEX_AB`, directional-rate, and `DW_AB` conventions.
+
 The shared parameters can be informed simultaneously by several profiles
 because the analysis assumes that they report on the same exchange process.
 `DW_AB` describes how an individual nucleus responds to that process, while
@@ -259,7 +262,9 @@ accepted result. Completion does not erase a diagnostic that deserves
 inspection, and a non-fatal boundary warning does not by itself mean that the
 staged workflow failed.
 
-See [Outputs](./user_guide/fitting/outputs.mdx#statistics) for the generated
+See [Scaling, Uncertainties, and Residuals](./user_guide/fitting/scaling_uncertainties_residuals.md)
+for the `N`, `P`, `G`, and `ν` counting convention, and
+[Outputs](./user_guide/fitting/outputs.mdx#statistics) for the generated
 `Statistics/Covariance/evidence.json` and the meaning of parameter annotations.
 
 ## Adapt the strategy to your data

--- a/website/docs/user_guide/additional_modules.mdx
+++ b/website/docs/user_guide/additional_modules.mdx
@@ -19,25 +19,28 @@ chemex simulate -e <FILE> \
 
 Example simulation results for CPMG and CEST experiments are shown below:
 
-import CestProfile from '@site/static/img/cest_26hz_simu.png'; import CpmgProfile from '@site/static/img/cpmg_800mhz_simu.png';
+import CestProfile from "@site/static/img/cest_26hz_simu.png";
+import CpmgProfile from "@site/static/img/cpmg_800mhz_simu.png";
 
 <figure>
-  <img src={CestProfile} alt="CEST profile" width="50%"/>
-  <img src={CpmgProfile} alt="CPMG profile" width="50%"/>
-  <figcaption align="center"><b>Examples of CEST and CPMG simulation results</b></figcaption>
+    <img src={CestProfile} alt="CEST profile" width="50%" />
+    <img src={CpmgProfile} alt="CPMG profile" width="50%" />
+    <figcaption align="center">
+        <b>Examples of CEST and CPMG simulation results</b>
+    </figcaption>
 </figure>
 
 ### Options
 
-| Option                    | Description                                                           |
-| ------------------------- | --------------------------------------------------------------------- |
-| `-e`, `--experiments`     | Specifies the files containing experimental setup and data location   |
-| `-p`, `--parameters`      | Specifies the files containing the initial parameter values           |
-| `-d`, `--model`           | Specifies the exchange model used for simulation (default: `2st`)     |
-| `-o`, `--output`          | Specifies the output directory (default: `./OutputSim`)               |
-| `--plot {nothing,normal}` | Sets the plotting level (default: `normal`)                           |
-| `--include`               | Residues to include in the simulation (optional)                      |
-| `--exclude`               | Residues to exclude from the simulation (optional)                    |
+| Option                    | Description                                                         |
+| ------------------------- | ------------------------------------------------------------------- |
+| `-e`, `--experiments`     | Specifies the files containing experimental setup and data location |
+| `-p`, `--parameters`      | Specifies the files containing the initial parameter values         |
+| `-d`, `--model`           | Specifies the exchange model used for simulation (default: `2st`)   |
+| `-o`, `--output`          | Specifies the output directory (default: `./OutputSim`)             |
+| `--plot {nothing,normal}` | Sets the plotting level (default: `normal`)                         |
+| `--include`               | Residues to include in the simulation (optional)                    |
+| `--exclude`               | Residues to exclude from the simulation (optional)                  |
 
 ### Example
 
@@ -72,7 +75,11 @@ These commands are also included in the `plot_param.sh` script in [this example]
 
 ## Initial Estimates of Δϖ for CEST Experiments
 
-In CEST (and D-CEST/COS-CEST) experiments, choosing appropriate initial values for Δϖ is crucial to avoid local minima in fitting. The `pick_cest` module in ChemEx facilitates manual selection of major and minor dips in CEST profiles, which correspond to the ground and excited states.
+In CEST (and D-CEST/COS-CEST) experiments, choosing appropriate initial values
+for Δϖ can help avoid local minima. The `pick_cest` module lets you assign two
+dips to the A and B labels and generates initial `CS_A` and `DW_AB` values. You
+may use a major/ground-state A and minor/excited-state B convention, but the tool
+does not establish that physical assignment or enforce a population ordering.
 
 Use the following command to launch the `pick_cest` module:
 
@@ -80,7 +87,15 @@ Use the following command to launch the `pick_cest` module:
 chemex pick_cest -e <FILE> -o <DIR>
 ```
 
-Upon running this command, a window displaying all CEST profiles will appear. For each profile, click first on the major dip, then on the minor dip(s). If only one dip is visible (indicating the minor dip overlaps with the major dip), click the major dip twice. Use the `Next` and `Previous` buttons to navigate profiles, `Swap` to switch between major and minor states, and `Clear` to reset selections on the current profile. During this process, two files are generated in real-time: `cs_a.toml` (chemical shifts of the major state) and `dw_ab.toml` (chemical shift differences between major and minor states).
+Upon running this command, a window displaying all CEST profiles appears. For
+each profile, click first on the dip to assign to A and then on the dip to assign
+to B. If only one dip is visible, click it twice. Use `Next` and `Previous` to
+navigate profiles, `Swap` to exchange the A/B assignments, and `Clear` to reset
+the current profile. The tool writes `cs_a.toml` and `dw_ab.toml` in real time,
+with `DW_AB = CS_B - CS_A`. These are initialization files; the assignments are
+not inferred or validated as major/minor states. See
+[Exchange States and Parameters](fitting/exchange_states_parameters.md) for the
+state-label and shift-sign conventions.
 
 ### Example
 

--- a/website/docs/user_guide/fitting/exchange_states_parameters.md
+++ b/website/docs/user_guide/fitting/exchange_states_parameters.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 6.5
+title: Exchange States and Parameters
+description: Interpret ChemEx state labels, populations, exchange rates, chemical-shift differences, and state-specific parameters.
+---
+
+# Exchange states and parameters
+
+ChemEx uses letters such as A, B, C, and D as stable identifiers for exchange
+states. The letters do not rank states by population or energy. In many analyses,
+an analyst assigns A to the major or ground state and B to a minor or excited
+state, but ChemEx does not enforce that convention or reorder labels after a fit.
+
+This page defines the common parameter conventions. Individual kinetic models
+can add constraints or use a different parameterization; see
+[Kinetic Models](kinetic_models.md) for the available model families.
+
+## State labels are identifiers
+
+Selecting the `2st` model creates states A and B in that order. A three-state
+model similarly uses A, B, and C. These labels remain attached to the same
+populations, rates, shifts, relaxation rates, and magnetization components
+throughout an analysis, regardless of their fitted populations.
+
+Consequently, a result with $P_B > P_A$ is allowed. It means that the state
+labeled B has the larger fitted population; it does not trigger a relabeling.
+Assign physical conformations to the labels deliberately and keep the assignment
+consistent across input files and experiments.
+
+## Populations in the two-state model
+
+`PB` is the equilibrium population fraction of state B. For `2st`, ChemEx fits
+`PB` by default and derives `PA` from normalization:
+
+$$
+P_A = 1 - P_B.
+$$
+
+Both populations are fractions. The default bounds on `PB` are 0 to 1, but
+nothing imposes $P_A > P_B$.
+
+## Two-state exchange rates
+
+`KEX_AB` is the total A↔B exchange rate, in s⁻¹:
+
+$$
+KEX_{AB} = K_{AB} + K_{BA}.
+$$
+
+The directional names describe the initial and final labels:
+
+- `KAB` means A → B;
+- `KBA` means B → A.
+
+For the `2st` parameterization, ChemEx derives them as
+
+$$
+K_{AB} = KEX_{AB} P_B
+$$
+
+and
+
+$$
+K_{BA} = KEX_{AB} P_A.
+$$
+
+Thus `KEX_AB` and `PB` are optimizer-controlled by default, whereas `KAB`,
+`KBA`, and `PA` are derived. A Method file can change whether eligible
+independent parameters are fitted or fixed, but it cannot turn a derived
+relationship into an unrelated independent parameter.
+
+Multi-state models preserve the same directional naming rule and stable state
+labels. Their allowed pathways and population/rate parameterizations vary by
+model, however, so do not extrapolate the two-state formulas to every
+multi-state topology.
+
+## Chemical-shift differences
+
+At the user-facing parameter level, chemical shifts and their differences are
+in ppm. ChemEx defines
+
+$$
+DW_{AB} = CS_B - CS_A.
+$$
+
+Where the common shift construction applies, ChemEx therefore derives
+
+$$
+CS_B = CS_A + DW_{AB}.
+$$
+
+`DW_AB` is generally specific to a spin system or residue: different nuclei can
+report different shift changes for the same shared exchange process. Internal
+frequency conversions used by a pulse-sequence calculation do not change the
+user-facing ppm convention.
+
+## State-specific parameters
+
+Names such as `R1_A`, `R2_A`, `R1_B`, and `R2_B` attach a quantity to a state.
+The suffix identifies the state; it does not say how the quantity is obtained.
+Depending on the experiment, kinetic model, and Method-file roles, a
+state-specific quantity may be fitted, fixed from an input value, or derived
+from another parameter or expression.
+
+For example, many common parameterizations initially make state-B relaxation
+rates equal to the corresponding state-A rates. Other experiments or Method
+roles can require separate state-specific values. Do not infer that every
+state-specific parameter is independently fitted merely because it appears in
+an output file.
+
+## What changes when A and B are swapped
+
+Relabeling a two-state description is a coordinated transformation, not a
+population sort. If old A becomes new B and old B becomes new A, then:
+
+- the new `PB` is the old $P_A = 1 - P_B$;
+- the new `KAB` represents the old B → A rate, and the new `KBA` represents the
+  old A → B rate;
+- the new `CS_A` is the old `CS_B`;
+- `DW_AB` reverses sign.
+
+All other state-specific quantities must be exchanged consistently. This simple
+two-state relabeling example does not imply that an arbitrary relabeling leaves
+every multi-state model or topology unchanged.
+
+## Practical interpretation checklist
+
+Before interpreting fitted state parameters, check that:
+
+- the physical assignment of each letter is documented outside ChemEx;
+- all experiment and parameter files use that assignment consistently;
+- directional rates are read from the first state to the second;
+- `DW_AB` is interpreted as B minus A;
+- fitted, fixed, and derived parameter roles are distinguished;
+- no conclusion depends only on assuming that A must be the most populated
+  state.
+
+For the next part of the fitting convention, see
+[Scaling, Uncertainties, and Residuals](scaling_uncertainties_residuals.md).

--- a/website/docs/user_guide/fitting/experiment_files.md
+++ b/website/docs/user_guide/fitting/experiment_files.md
@@ -57,15 +57,15 @@ Each experiment available in ChemEx includes a sample configuration file, which 
 
 The `[experiment]` section defines the type and settings of the pulse sequence. Common keys include:
 
-| Key               | Description                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------- |
-| `name`            | Pulse sequence name.                                                                                  |
-| `carrier`         | Carrier position during the experiment, in ppm.                                                       |
-| `time_t2`, `time_t1` | Relaxation delays in seconds (e.g., for CPMG relaxation dispersion experiments).                   |
-| `pw90`            | 90-degree pulse width, in seconds.                                                                    |
-| `b1_frq`          | B1 radio-frequency field strength, in Hz.                                                             |
-| `observed_state`  | Observed state; final-magnetization experiments also accept a list whose components are summed.       |
-| `start_state`     | Optional state or list of states used for non-equilibrium starting magnetization.                     |
+| Key                  | Description                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------------------- |
+| `name`               | Pulse sequence name.                                                                            |
+| `carrier`            | Carrier position during the experiment, in ppm.                                                 |
+| `time_t2`, `time_t1` | Relaxation delays in seconds (e.g., for CPMG relaxation dispersion experiments).                |
+| `pw90`               | 90-degree pulse width, in seconds.                                                              |
+| `b1_frq`             | B1 radio-frequency field strength, in Hz.                                                       |
+| `observed_state`     | Observed state; final-magnetization experiments also accept a list whose components are summed. |
+| `start_state`        | Optional state or list of states used for non-equilibrium starting magnetization.               |
 
 #### `observed_state`
 
@@ -150,12 +150,12 @@ fast-exchange lineshapes.
 
 The `[conditions]` section provides experimental and sample conditions, such as Larmor frequency, temperature, concentration, and labeling. `h_larmor_frq` (Larmor frequency) is required, while `temperature`, `p_total`, and `l_total` depend on the kinetic model used.
 
-| Key                 | Description                                                                                           |
-| ------------------- | ----------------------------------------------------------------------------------------------------- |
-| `h_larmor_frq`      | Larmor frequency in MHz.                                                                              |
-| `temperature`       | Sample temperature in °C (optional, required by certain kinetic models).                              |
-| `p_total`, `l_total`| Protein and ligand concentrations in M (optional, required by certain kinetic models).                |
-| `label`             | Labeling scheme for the sample.                                                                       |
+| Key                  | Description                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `h_larmor_frq`       | Larmor frequency in MHz.                                                               |
+| `temperature`        | Sample temperature in °C (optional, required by certain kinetic models).               |
+| `p_total`, `l_total` | Protein and ligand concentrations in M (optional, required by certain kinetic models). |
+| `label`              | Labeling scheme for the sample.                                                        |
 
 #### `label`
 
@@ -174,27 +174,38 @@ label = ["13C", "2H"]
 
 The `[data]` section specifies data file locations, spin system assignments, and methods for error estimation and data filtering.
 
-| Key              | Description                                                                                             |
-| ---------------- | ------------------------------------------------------------------------------------------------------- |
-| `path`           | Path to the directory containing data files.                                                            |
-| `error`          | Method for error estimation.                                                                            |
-| `filter_offsets` | List of offsets to exclude from calculations (e.g., in CEST experiments).                               |
-| `filter_planes`  | List of planes to exclude from calculations (e.g., in CEST and CPMG experiments).                       |
-| `[data.profiles]`| Subsection listing experimental profile file names with their spin-system assignments.                  |
+| Key                 | Description                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| `path`              | Path to the directory containing data files.                                                 |
+| `error`             | Source or estimator for experimental uncertainties.                                          |
+| `global_error`      | Pool profile variances within this experiment for estimated-error modes; defaults to `true`. |
+| `scaled`            | Analytically fit one amplitude per profile; defaults to `true` except for shift data.        |
+| `filter_offsets`    | Offset regions to exclude from the objective where supported.                                |
+| `filter_planes`     | Plane indices to exclude from the objective where supported.                                 |
+| `filter_ref_planes` | Whether reference planes are excluded from the objective where supported.                    |
+| `[data.profiles]`   | Subsection listing experimental profile file names with their spin-system assignments.       |
 
 #### `error`
 
 The `error` key specifies the method for estimating uncertainties:
 
-| Value         | Description                                                                                                                               |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `"file"`      | Use uncertainties directly from the data file.                                                                                            |
-| `"duplicates"`| Calculate uncertainty from duplicate points. If no profile in the experiment contains duplicates, keep the uncertainties from the data files. |
-| `"scatter"`   | Estimate uncertainty by assuming additive Gaussian noise on the profile, suitable for CEST data.                                          |
+| Value          | Description                                                                                                            |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `"file"`       | Use the pointwise uncertainties from the data file.                                                                    |
+| `"duplicates"` | Estimate profile variance from duplicate points, with a defined file-uncertainty fallback for duplicate-free profiles. |
+| `"scatter"`    | Estimate profile variance from local point-to-point scatter, for suitable sampled profiles such as CEST data.          |
+
+See [Scaling, Uncertainties, and Residuals](scaling_uncertainties_residuals.md)
+for the exact scaling formula, uncertainty fallbacks, experiment-level meaning
+of `global_error`, masking behavior, and residual definition.
 
 #### `filter_offsets`
 
-This key filters out specified offsets from CEST profiles, useful for removing artifacts like sidebands. Provide a list of offset and bandwidth pairs, where each pair specifies an offset relative to the main resonance and a bandwidth around the offset to exclude. Values are in Hz.
+This key filters specified offsets from the CEST fit objective, which is useful
+for removing artifacts such as sidebands. Filtered points remain available for
+calculation and output. Provide a list of offset and bandwidth pairs, where each
+pair specifies an offset relative to the main resonance and a bandwidth around
+the offset to exclude. Values are in Hz.
 
 Example:
 

--- a/website/docs/user_guide/fitting/kinetic_models.md
+++ b/website/docs/user_guide/fitting/kinetic_models.md
@@ -6,21 +6,27 @@ sidebar_position: 7
 
 The kinetic model (specified with the `-d` or `--model` option) defines the type of exchange model to be used for data analysis. Available models include:
 
-| Model Name    | Description                                                                     |
-| ------------- | ------------------------------------------------------------------------------- |
-| `2st`         | 2-state exchange model (default)                                                |
-| `3st`         | 3-state exchange model                                                          |
-| `4st`         | 4-state exchange model                                                          |
-| `2st_hd`      | 2-state exchange model for H/D solvent exchange studies                         |
-| `2st_eyring`  | 2-state exchange model for temperature-dependent studies                        |
-| `3st_eyring`  | Compatibility name for the linear 3-state Eyring model                          |
-| `3st_eyring_linear` | Linear A ↔ B ↔ C Eyring model for temperature-dependent studies          |
-| `3st_eyring_fork` | Fork B ↔ A ↔ C Eyring model for temperature-dependent studies                |
-| `4st_eyring`  | 4-state exchange model for temperature-dependent studies                        |
-| `2st_binding` | 2-state exchange model for ligand binding studies                               |
-| `4st_hd`      | 4-state exchange model for simultaneous normal and H/D solvent exchange studies |
+| Model Name          | Description                                                                     |
+| ------------------- | ------------------------------------------------------------------------------- |
+| `2st`               | 2-state exchange model (default)                                                |
+| `3st`               | 3-state exchange model                                                          |
+| `4st`               | 4-state exchange model                                                          |
+| `2st_hd`            | 2-state exchange model for H/D solvent exchange studies                         |
+| `2st_eyring`        | 2-state exchange model for temperature-dependent studies                        |
+| `3st_eyring`        | Compatibility name for the linear 3-state Eyring model                          |
+| `3st_eyring_linear` | Linear A ↔ B ↔ C Eyring model for temperature-dependent studies                 |
+| `3st_eyring_fork`   | Fork B ↔ A ↔ C Eyring model for temperature-dependent studies                   |
+| `4st_eyring`        | 4-state exchange model for temperature-dependent studies                        |
+| `2st_binding`       | 2-state exchange model for ligand binding studies                               |
+| `4st_hd`            | 4-state exchange model for simultaneous normal and H/D solvent exchange studies |
 
-In these models, each state in the exchange process is represented with a unique parameter suffix (`A`, `B`, `C`, `D`, etc.). For example, `R1_A` denotes the R<sub>1</sub> relaxation rate of the major (ground) state, while `R2_B` refers to the R<sub>2</sub> rate of the first minor state, and so forth.
+In these models, each state in the exchange process is represented with a unique
+parameter suffix (`A`, `B`, `C`, `D`, etc.). For example, `R1_A` and `R2_B`
+refer to the R<sub>1</sub> rate of state A and the R<sub>2</sub> rate of state B.
+In many analyses A is assigned to the major or ground state and B to a minor or
+excited state, but this is an analyst-defined convention rather than an ordering
+enforced by ChemEx. See [Exchange States and Parameters](exchange_states_parameters.md)
+for populations, directional rates, shift signs, and label swapping.
 
 :::note
 For any kinetic model, you can add the `.rs` suffix to make the kinetic parameters residue-specific (for example, `2st.rs` or `3st_eyring.rs`). Suffixes can be combined, such as `2st.rs.mf`. The legacy `2st_rs` name remains supported as an alias for `2st.rs`.
@@ -47,6 +53,7 @@ k_ij = (k_B * T / h) * exp(-ΔG‡_ij / RT)
 ```
 
 where:
+
 - `k_ij` is the rate constant for transition from state i to j (s⁻¹)
 - `k_B` is Boltzmann's constant (1.380649×10⁻²³ J/K)
 - `T` is temperature in Kelvin
@@ -65,10 +72,12 @@ The activation free energy is calculated from enthalpic and entropic contributio
 The `2st_eyring` model uses the following thermodynamic parameters:
 
 **State Energies (relative to state A):**
+
 - `DH_B`: Enthalpy difference (J/mol) for state B relative to A
 - `DS_B`: Entropy difference (J/mol/K) for state B relative to A
 
 **Transition Barriers:**
+
 - `DH_AB`: Activation enthalpy (J/mol) for A → B transition
 - `DS_AB`: Activation entropy (J/mol/K) for A → B transition
 
@@ -84,10 +93,12 @@ The model automatically calculates both forward (k_AB) and reverse (k_BA) rate c
 Both topologies use the following state parameters:
 
 **State Energies (relative to state A):**
+
 - `DH_B`, `DH_C`: Enthalpy differences (J/mol) for states B, C
 - `DS_B`, `DS_C`: Entropy differences (J/mol/K) for states B, C
 
 **Linear Transition Barriers (`3st_eyring`, `3st_eyring_linear`):**
+
 - `DH_AB`, `DH_BC`: Activation enthalpies (J/mol) for the AB and BC transitions
 - `DS_AB`, `DS_BC`: Activation entropies (J/mol/K) for the AB and BC transitions
 
@@ -95,6 +106,7 @@ The linear models calculate k_AB, k_BA, k_BC, and k_CB. There is no direct A ↔
 pathway.
 
 **Fork Transition Barriers (`3st_eyring_fork`):**
+
 - `DH_AB`, `DH_AC`: Activation enthalpies (J/mol) for the AB and AC transitions
 - `DS_AB`, `DS_AC`: Activation entropies (J/mol/K) for the AB and AC transitions
 
@@ -109,10 +121,12 @@ Parameter files used with `3st_eyring` or `3st_eyring_linear` should not contain
 The `4st_eyring` model implements a full 4-state system:
 
 **State Energies (relative to state A):**
+
 - `DH_B`, `DH_C`, `DH_D`: Enthalpy differences (J/mol) for states B, C, D
 - `DS_B`, `DS_C`, `DS_D`: Entropy differences (J/mol/K) for states B, C, D
 
 **Transition Barriers:**
+
 - `DH_AB`, `DH_AC`, `DH_AD`: Activation enthalpies (J/mol) for transitions from A
 - `DH_BC`, `DH_BD`, `DH_CD`: Activation enthalpies (J/mol) for transitions between B, C, D
 - `DS_AB`, `DS_AC`, `DS_AD`: Activation entropies (J/mol/K) for transitions from A

--- a/website/docs/user_guide/fitting/outputs.mdx
+++ b/website/docs/user_guide/fitting/outputs.mdx
@@ -183,7 +183,12 @@ import CpmgProfile from "@site/static/img/cpmg_800mhz_fit.png";
 </figure>
 
 :::note
-In (D-/cos-)CEST plots, solid and dashed vertical lines indicate ground and excited states, respectively, with lighter colors for filtered data points. "Folded" positions are marked with `*`.
+In (D-/cos-)CEST plots, vertical-line styles follow stable ChemEx state-label
+order: A uses the first, solid style, while B, C, and later labels use the
+subsequent dash and dot patterns. The styles do not encode physical state
+identity, population, or energy. See
+[Exchange States and Parameters](exchange_states_parameters.md) for the label
+convention. "Folded" positions are marked with `*`.
 :::
 
 ### `Data/`
@@ -255,10 +260,12 @@ Contains goodness-of-fit statistics, such as χ<sup>2</sup>.
 ```toml title='"statistics.toml"'
 "number of data points"                = 230
 "number of variables"                  = 17
-"chi-square"                           =  4.34824e+02
-"reduced-chi-square"                   =  2.14199e+00
-"Akaike Information Criterion (AIC)"   =  4.88824e+02
-"Bayesian Information Criterion (BIC)" =  5.81652e+02
+"chi-square"                           =  4.34555e+02
+"reduced-chi-square"                   =  2.14067e+00
+"chi-squared test"                     =  0.00000e+00
+"Kolmogorov-Smirnov test"              =  6.66833e-02
+"Akaike Information Criterion (AIC)"   =  4.88555e+02
+"Bayesian Information Criterion (BIC)" =  5.81383e+02
 ```
 
 `"number of variables"` reports the controlled optimizer coordinates (`P`).
@@ -266,6 +273,8 @@ Analytically fitted profile normalizations are not included in that field, but
 they are fitted nuisance parameters (`G`) when calculating residual degrees of
 freedom, the χ² goodness-of-fit test, AIC, and BIC. If `N - P - G` is not
 positive, the reduced χ² and χ² goodness-of-fit result are serialized as `nan`.
+See [Scaling, Uncertainties, and Residuals](scaling_uncertainties_residuals.md)
+for the residual definition and the complete `N`, `P`, `G`, and `ν` convention.
 
 ### `Statistics/`
 

--- a/website/docs/user_guide/fitting/parameter_files.md
+++ b/website/docs/user_guide/fitting/parameter_files.md
@@ -6,6 +6,10 @@ sidebar_position: 5
 
 ## Overview
 
+Parameter names use stable state labels and directional conventions. Before
+preparing values, read [Exchange States and Parameters](exchange_states_parameters.md),
+especially the definitions of `PB`, `KEX_AB`, `KAB`, `KBA`, and `DW_AB`.
+
 Parameter files contain initial estimates for the parameters used in the fitting process. These files are specified in ChemEx using the `-p` or `--parameters` option:
 
 ```shell
@@ -14,8 +18,8 @@ chemex fit [...] -p <parameter_file> [...]
 
 Parameter files are organized into sections:
 
--   The `[GLOBAL]` section applies parameters universally to all residues.
--   Residue-specific parameters are defined in sections named after each parameter, such as `[CS_A]`. Multiple parameter files can be provided if needed.
+- The `[GLOBAL]` section applies parameters universally to all residues.
+- Residue-specific parameters are defined in sections named after each parameter, such as `[CS_A]`. Multiple parameter files can be provided if needed.
 
 :::warning
 To ensure accurate results and avoid local minima, set appropriate initial values for each parameter, as the χ<sup>2</sup> minimization process involves multidimensional searching.

--- a/website/docs/user_guide/fitting/scaling_uncertainties_residuals.md
+++ b/website/docs/user_guide/fitting/scaling_uncertainties_residuals.md
@@ -1,0 +1,236 @@
+---
+sidebar_position: 6.6
+title: Scaling, Uncertainties, Residuals, and Fit Statistics
+description: Follow ChemEx data from profile scaling and uncertainty estimation to normalized residuals and fit statistics.
+---
+
+# Scaling, uncertainties, residuals, and fit statistics
+
+ChemEx fits a residual vector built from selected profiles and their retained
+observations. Profile scaling, uncertainty estimation, and masks determine the
+weight of every contribution, so they are part of the scientific model rather
+than presentation-only settings.
+
+## From experimental points to the fit objective
+
+For each selected profile, ChemEx:
+
+1. obtains point uncertainties from the data file or the configured estimator;
+2. calculates the profile for the current parameter values;
+3. identifies the observations retained by the active mask;
+4. analytically determines an amplitude scale from those observations when
+   `scaled = true`; and
+5. concatenates the normalized residuals from all retained observations.
+
+The optimizer minimizes the sum of squares of that residual vector.
+
+## Profile scaling
+
+`scaled = true` is the common default. Shift experiments override the default to
+`false`. Check the reference page for an experiment before deciding whether an
+amplitude scale is scientifically appropriate.
+
+For every scaled profile, ChemEx independently recomputes the weighted
+least-squares scale during evaluation. Using only retained observations, the
+scale is
+
+$$
+s =
+\frac{\sum_i y_i f_i / \sigma_i^2}
+{\sum_i f_i^2 / \sigma_i^2},
+$$
+
+where $y_i$ is the experimental value, $f_i$ is the unscaled calculated value,
+and $\sigma_i$ is the experimental uncertainty.
+
+The scaled calculation is $y_i^{\mathrm{calc}} = s f_i$. This lets an overall
+profile amplitude adjust analytically, so the fit is driven primarily by the
+profile shape. With `scaled = false`, ChemEx uses the unscaled calculation and
+retains absolute-amplitude information in the objective.
+
+## Experimental uncertainty modes
+
+The `[data]` table in an experiment file selects `error = "file"`,
+`"scatter"`, or `"duplicates"`.
+
+### `file`
+
+ChemEx uses the pointwise uncertainty supplied in the third column of each data
+file. The points in one profile may therefore have different weights.
+
+### `scatter`
+
+ChemEx estimates one noise variance per profile from local point-to-point
+scatter using a finite-difference estimator. The resulting scalar standard
+uncertainty replaces the file uncertainties for every point in that profile,
+unless experiment-level pooling is enabled as described below. This estimator
+is intended for suitable sampled profiles such as CEST data; it is not a
+universal uncertainty model.
+
+### `duplicates`
+
+Within a profile that contains repeated metadata values, ChemEx calculates the
+sample variance of each duplicate group and combines those variances with their
+within-group degrees of freedom. The resulting profile variance gives one
+standard uncertainty for that profile unless experiment-level pooling is
+enabled.
+
+Duplicate availability is handled as follows:
+
+- If every profile has duplicates, every profile contributes its
+  duplicate-derived variance.
+- If no profile in the constructed experiment has duplicates, ChemEx preserves
+  the original pointwise file uncertainties and emits a fallback notice. This
+  happens regardless of `global_error`.
+- If duplicate and duplicate-free profiles are mixed, a duplicate-free profile
+  contributes the mean of its pointwise file variances:
+
+$$
+v_{\mathrm{fallback}} = \frac{1}{n}\sum_i \sigma_i^2.
+$$
+
+With profile-specific estimation, the scalar uncertainty assigned to that
+duplicate-free profile is therefore the root-mean-square file uncertainty:
+
+$$
+\sigma_{\mathrm{fallback}} =
+\sqrt{\frac{1}{n}\sum_i \sigma_i^2}.
+$$
+
+For example, file uncertainties of 0.03 and 0.05 give
+$\sqrt{(0.03^2 + 0.05^2)/2} \approx 0.0412$.
+
+## Global versus profile-specific error estimation
+
+`global_error = true` is the default. It affects the `scatter` and `duplicates`
+estimated-error modes, but not `file` mode.
+
+- With `global_error = false`, each profile keeps its own estimated scalar
+  uncertainty.
+- With `global_error = true`, ChemEx takes the equal-profile mean of the
+  per-profile variances, takes its square root, and assigns that common scalar
+  uncertainty to every profile in the constructed experiment.
+
+For `duplicates`, this means each profile contributes one variance to the global
+pool. A profile with duplicates contributes its pooled duplicate variance; in a
+mixed experiment, a duplicate-free profile contributes its mean file variance.
+
+Here, **global means all profiles built from one experiment TOML file**. ChemEx
+does not pool error estimates across separate experiment files in the complete
+fit.
+
+## Selection, filtering, and active observations
+
+Only retained active observations contribute to the residual vector and χ².
+There are two distinct levels of selection:
+
+- data-file and Method-file selection determine which profiles are constructed
+  or active in a fit step;
+- experiment-specific filters set individual observations inactive within an
+  active profile.
+
+Common filters can exclude plane indices or offset regions. In CEST-style
+configuration, `filter_ref_planes = true` excludes reference planes from the
+objective; the common CEST default is `false`, while experiment types without
+usable reference planes can override it. A point is not excluded merely because
+it is marked as a reference plane.
+
+Masked observations are omitted from scaling, the residual vector, and χ².
+Calculated values can remain available in machine-readable `Data/` output when
+the relevant mechanism retains them. Plot visibility depends on the plotter and
+filter path: ordinary non-reference filtered observations may appear as lighter
+excluded points where supported, whereas CEST reference planes removed by
+`filter_ref_planes` may be omitted from the plotted profile. See the relevant
+[experiment reference](../../experiments/index.mdx) for supported filter keys
+and their physical meaning.
+
+## Normalized residuals
+
+For every retained observation, the native fitting residual is
+
+$$
+r_i =
+\frac{y_i^{\mathrm{calc}} - y_i^{\mathrm{exp}}}{\sigma_i}.
+$$
+
+The sign is calculated minus experimental. For scaled profiles,
+$y_i^{\mathrm{calc}}$ already includes the analytically optimized profile scale.
+Masking is applied before residuals are concatenated.
+
+Residuals are expressed in units of the supplied or estimated experimental
+uncertainty. Thus $|r_i| \approx 1$ means a discrepancy of about one standard
+uncertainty **if the uncertainty model itself is meaningful**. Normalizing a
+residual does not make it statistically normal or remove systematic structure.
+
+## χ² and residual degrees of freedom
+
+ChemEx uses these counts:
+
+- $N$: retained residual observations;
+- $P$: optimizer-controlled fit coordinates;
+- $G$: analytically fitted profile normalizations, one for each scaled active
+  profile;
+- $K = P + G$: total fitted model dimension used for AIC and BIC;
+- $\nu = N - P - G$: residual degrees of freedom.
+
+The objective is
+
+$$
+\chi^2 = \sum_i r_i^2.
+$$
+
+When $\nu > 0$, reduced χ² is
+
+$$
+\chi^2_\nu = \frac{\chi^2}{\nu}.
+$$
+
+The χ² goodness-of-fit calculation uses the same $\nu$. When $\nu \le 0$, the
+fit can still complete: χ², AIC, and BIC remain defined, while reduced χ² and the
+χ² goodness-of-fit result are reported as `nan`.
+
+:::note Artifact naming
+
+`"number of variables"` in `statistics.toml` reports $P$, the
+optimizer-controlled coordinates. It does not include the analytically profiled
+normalization count $G$. Nevertheless, $G$ contributes to residual degrees of
+freedom, the χ² goodness-of-fit calculation, AIC, and BIC. No separate $G$ field
+is currently serialized.
+
+:::
+
+For example, the first CPMG tutorial has $N = 230$, $P = 17$, and $G = 10$, so
+$\nu = 203$. See [Run Your First ChemEx Analysis](../../first_analysis.md) and
+the [full CPMG workflow](../../full_cpmg_analysis.md).
+
+## AIC and BIC
+
+Within ChemEx's weighted least-squares convention, the current statistics use
+$K = P + G$:
+
+$$
+AIC = \chi^2 + 2K
+$$
+
+and
+
+$$
+BIC = \chi^2 + K \ln N.
+$$
+
+This is why the model dimension used by AIC/BIC can exceed the serialized
+`"number of variables"`. See [Outputs](outputs.mdx#statisticstoml) for the
+artifact format.
+
+## Interpretation cautions
+
+A reduced χ² near 1 is consistent with residual scatter on the scale of the
+stated uncertainties, under the fitted model. It is not proof that the kinetic
+model is correct, parameters are identifiable, residuals are structure-free, or
+the uncertainty estimates are trustworthy.
+
+Likewise, optimizer success means that the requested numerical procedure
+completed under its convergence rules. It does not establish scientific model
+adequacy. Inspect residual patterns, parameter constraints and boundaries,
+covariance evidence, and sensitivity to scientifically plausible alternatives
+before drawing conclusions.

--- a/website/docs/user_guide/running_chemex.md
+++ b/website/docs/user_guide/running_chemex.md
@@ -14,7 +14,9 @@ ChemEx provides four primary **sub-commands**, each dedicated to a specific func
 
 - [`fit`](fitting/chemex_fit.md): Initiates the fitting of experimental data. This is the main sub-command for most ChemEx users.
 - `simulate`: Generates synthetic profiles based on specified experiments and models.
-- `pick_cest`: Opens a small GUI for plotting CEST, cos-CEST, and D-CEST profiles, enabling interactive peak picking and initial estimation of minor state positions.
+- `pick_cest`: Opens a small GUI for plotting CEST, cos-CEST, and D-CEST
+  profiles, assigning dips to state labels, and generating initial chemical-shift
+  parameters.
 - `plot_param`: Creates plots for selected parameters derived from fitting results.
 
 :::tip


### PR DESCRIPTION
## Summary

Adds two canonical scientific-concept references:

- **Exchange states and parameters**
- **Scaling, uncertainties, residuals, and fit statistics**

Updates the existing tutorials and references only where needed to link to these pages and correct related terminology.

## Documented conventions

### Exchange

- A/B/C are stable model labels, not population- or energy-ordered physical identities; ChemEx does not enforce A as major/ground or B as minor/excited.
- For `2st`, `PA = 1 - PB`, `KEX_AB = KAB + KBA`, `KAB = KEX_AB × PB` (A → B), and `KBA = KEX_AB × PA` (B → A).
- `DW_AB = CS_B - CS_A`.
- State-specific parameters may be fitted, fixed, or derived depending on the experiment and model.

### Data and objective

- Documents per-profile analytical scaling and its weighted formula.
- Defines the `file`, `scatter`, and `duplicates` uncertainty modes, including the #759 mixed duplicate/no-duplicate RMS fallback.
- Clarifies that `global_error` pools within one ChemEx experiment, not across the complete fit.
- Distinguishes profile selection, observation masking, machine-readable output, and plotter-dependent visibility.
- Defines the native residual as calculated minus experimental, normalized by uncertainty.

### Fit statistics

Documents the #758 counting authority:

- `N`: residual observations
- `P`: optimizer-controlled coordinates
- `G`: analytically fitted profile normalizations
- `K = P + G`
- `ν = N - P - G`
- Reduced χ² and χ² goodness-of-fit use `ν`; AIC/BIC use `K`.
- `"number of variables"` in `statistics.toml` remains `P`.
- For `ν <= 0`, degrees-of-freedom-dependent statistics are `nan`.

The integration edits remove misleading major/minor or ground/excited invariants, explain `pick_cest` as an assignment and initialization aid, correct CEST line-style semantics, clarify `DW_AB` scope, make masking/plot behavior precise, and link to the canonical references.

## Scope

- No runtime or scientific behavior changes.
- No Python or test changes.
- No frozen documentation changes.
- The known very-small χ² p-value underflow remains intentionally out of scope.

## Validation

- Focused scientific tests: 149 passed
- Representative multi-state tests: 11 passed
- Fresh first-CPMG tutorial fit validated current `N/P/G/ν` and statistics
- Prettier: passed
- `ruff check`: passed
- `ruff format --check`: passed
- `ty check`: passed
- `git diff --check`: passed
- Locked Docusaurus production build and internal-link validation: passed
