### PR TITLE
fix: harden oligomerization concentration solving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- Oligomerization concentration solving now uses the unique bracketed physical
+  solution for supported positive inputs, preventing silent failed or inaccurate
+  HYBR roots and negative algebraic branches. Strongly associated cases affected
+  by those failures can change numerically; kinetic equations, historical KD
+  semantics, and exact-zero semantics are unchanged.
 - Corrected direct monomer-trimer and monomer-tetramer tagged association rates
   to quadratic and cubic monomer-concentration dependence, restoring dimensional
   consistency and agreement between NMR stationary and chemical monomer-equivalent

--- a/src/chemex/models/kinetic/_oligomerization.py
+++ b/src/chemex/models/kinetic/_oligomerization.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import math
+import sys
+
+from scipy.optimize import brentq
+
+_MASS_BALANCE_TOLERANCE = 64.0 * sys.float_info.epsilon
+
+
+def solve_oligomerization_fractions(
+    terms: tuple[tuple[int, float], ...],
+) -> tuple[float, tuple[float, ...]]:
+    """Solve a positive normalized oligomerization mass balance."""
+    if not terms:
+        msg = "Oligomerization concentration solver requires at least one term"
+        raise RuntimeError(msg)
+
+    weighted_terms: list[tuple[int, float, float]] = []
+    for stoichiometry, coefficient in terms:
+        weighted_coefficient = stoichiometry * coefficient
+        if (
+            stoichiometry < 2
+            or not math.isfinite(coefficient)
+            or coefficient <= 0.0
+            or not math.isfinite(weighted_coefficient)
+        ):
+            msg = "Oligomerization concentration solver received an invalid term"
+            raise RuntimeError(msg)
+        weighted_terms.append((stoichiometry, coefficient, weighted_coefficient))
+
+    def mass_balance(monomer_fraction: float) -> float:
+        contributions = [
+            weighted_coefficient * monomer_fraction**stoichiometry
+            for stoichiometry, _, weighted_coefficient in weighted_terms
+        ]
+        return math.fsum((monomer_fraction, *contributions)) - 1.0
+
+    monomer_fraction, result = brentq(
+        mass_balance,
+        0.0,
+        1.0,
+        xtol=sys.float_info.min,
+        rtol=4.0 * sys.float_info.epsilon,
+        maxiter=256,
+        full_output=True,
+        disp=False,
+    )
+    if not result.converged:
+        msg = "Oligomerization concentration solver did not converge"
+        raise RuntimeError(msg)
+    if (
+        not math.isfinite(monomer_fraction)
+        or monomer_fraction < 0.0
+        or monomer_fraction > 1.0
+    ):
+        msg = (
+            "Oligomerization concentration solver returned an invalid monomer fraction"
+        )
+        raise RuntimeError(msg)
+
+    oligomer_fractions = tuple(
+        coefficient * monomer_fraction**stoichiometry
+        for stoichiometry, coefficient, _ in weighted_terms
+    )
+    if any(
+        not math.isfinite(fraction) or fraction < 0.0 for fraction in oligomer_fractions
+    ):
+        msg = (
+            "Oligomerization concentration solver returned an invalid oligomer fraction"
+        )
+        raise RuntimeError(msg)
+
+    normalized_mass = math.fsum(
+        (
+            monomer_fraction,
+            *(
+                stoichiometry * fraction
+                for (stoichiometry, _, _), fraction in zip(
+                    weighted_terms,
+                    oligomer_fractions,
+                    strict=True,
+                )
+            ),
+        ),
+    )
+    if abs(normalized_mass - 1.0) > _MASS_BALANCE_TOLERANCE:
+        msg = "Oligomerization concentration solver violated mass conservation"
+        raise RuntimeError(msg)
+
+    return monomer_fraction, oligomer_fractions

--- a/src/chemex/models/kinetic/settings_2st_monomer_dimer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_dimer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 
 import numpy as np
@@ -8,6 +9,7 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_2st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -33,6 +35,15 @@ def calculate_residuals(
 
 @lru_cache(maxsize=100)
 def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
+    if math.isfinite(p_total) and p_total > 0.0 and math.isfinite(kd) and kd >= 1e-32:
+        monomer_fraction, (dimer_fraction,) = solve_oligomerization_fractions(
+            ((2, p_total / kd),),
+        )
+        return {
+            "monomer": p_total * monomer_fraction,
+            "dimer": p_total * dimer_fraction,
+        }
+
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "dimer": results["x"][1]}

--- a/src/chemex/models/kinetic/settings_2st_monomer_tetramer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_tetramer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 
 import numpy as np
@@ -8,6 +9,7 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_2st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -33,6 +35,20 @@ def calculate_residuals(
 
 @lru_cache(maxsize=100)
 def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
+    if math.isfinite(p_total) and p_total > 0.0 and math.isfinite(kd) and kd >= 1e-32:
+        try:
+            coefficient = p_total**3 / kd
+        except OverflowError:
+            msg = "Oligomerization concentration solver produced an invalid coefficient"
+            raise RuntimeError(msg) from None
+        monomer_fraction, (tetramer_fraction,) = solve_oligomerization_fractions(
+            ((4, coefficient),),
+        )
+        return {
+            "monomer": p_total * monomer_fraction,
+            "tetramer": p_total * tetramer_fraction,
+        }
+
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "tetramer": results["x"][1]}

--- a/src/chemex/models/kinetic/settings_2st_monomer_trimer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_trimer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 
 import numpy as np
@@ -8,6 +9,7 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_2st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -33,6 +35,20 @@ def calculate_residuals(
 
 @lru_cache(maxsize=100)
 def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
+    if math.isfinite(p_total) and p_total > 0.0 and math.isfinite(kd) and kd >= 1e-32:
+        try:
+            coefficient = p_total**2 / kd
+        except OverflowError:
+            msg = "Oligomerization concentration solver produced an invalid coefficient"
+            raise RuntimeError(msg) from None
+        monomer_fraction, (trimer_fraction,) = solve_oligomerization_fractions(
+            ((3, coefficient),),
+        )
+        return {
+            "monomer": p_total * monomer_fraction,
+            "trimer": p_total * trimer_fraction,
+        }
+
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "trimer": results["x"][1]}

--- a/src/chemex/models/kinetic/settings_3st_monomer_dimer_tetramer.py
+++ b/src/chemex/models/kinetic/settings_3st_monomer_dimer_tetramer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 
 import numpy as np
@@ -8,6 +9,7 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -39,6 +41,33 @@ def calculate_concentrations(
     kd1: float,
     kd2: float,
 ) -> dict[str, float]:
+    if (
+        math.isfinite(p_total)
+        and p_total > 0.0
+        and math.isfinite(kd1)
+        and kd1 >= 1e-32
+        and math.isfinite(kd2)
+        and kd2 >= 1e-32
+    ):
+        try:
+            tetramer_coefficient = p_total**3 / (kd1**2 * kd2)
+        except OverflowError:
+            msg = "Oligomerization concentration solver produced an invalid coefficient"
+            raise RuntimeError(msg) from None
+        monomer_fraction, (dimer_fraction, tetramer_fraction) = (
+            solve_oligomerization_fractions(
+                (
+                    (2, p_total / kd1),
+                    (4, tetramer_coefficient),
+                ),
+            )
+        )
+        return {
+            "monomer": p_total * monomer_fraction,
+            "dimer": p_total * dimer_fraction,
+            "tetramer": p_total * tetramer_fraction,
+        }
+
     concentrations_start = (p_total, 0.0, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd1, kd2))
     return {

--- a/src/chemex/models/kinetic/settings_3st_monomer_dimer_trimer.py
+++ b/src/chemex/models/kinetic/settings_3st_monomer_dimer_trimer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 
 import numpy as np
@@ -8,6 +9,7 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -39,6 +41,33 @@ def calculate_concentrations(
     kd1: float,
     kd2: float,
 ) -> dict[str, float]:
+    if (
+        math.isfinite(p_total)
+        and p_total > 0.0
+        and math.isfinite(kd1)
+        and kd1 >= 1e-32
+        and math.isfinite(kd2)
+        and kd2 >= 1e-32
+    ):
+        try:
+            trimer_coefficient = p_total**2 / (kd1 * kd2)
+        except OverflowError:
+            msg = "Oligomerization concentration solver produced an invalid coefficient"
+            raise RuntimeError(msg) from None
+        monomer_fraction, (dimer_fraction, trimer_fraction) = (
+            solve_oligomerization_fractions(
+                (
+                    (2, p_total / kd1),
+                    (3, trimer_coefficient),
+                ),
+            )
+        )
+        return {
+            "monomer": p_total * monomer_fraction,
+            "dimer": p_total * dimer_fraction,
+            "trimer": p_total * trimer_fraction,
+        }
+
     concentrations_start = (p_total, 0.0, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd1, kd2))
     return {

--- a/src/chemex/models/loader.py
+++ b/src/chemex/models/loader.py
@@ -21,6 +21,8 @@ def _load_register(name: str) -> Callable[[], None]:
 def register_kinetic_settings() -> None:
     """Loads the plugins defined in the plugins list."""
     for module in iter_modules(kinetic.__path__):
+        if module.name.startswith("_"):
+            continue
         module_name = f"{kinetic.__name__}.{module.name}"
         register = _load_register(module_name)
         register()

--- a/tests/models/kinetic/test_oligomerization_solver.py
+++ b/tests/models/kinetic/test_oligomerization_solver.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import math
+import sys
+from collections.abc import Callable
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from chemex.models.kinetic import _oligomerization
+from chemex.models.kinetic import settings_2st_monomer_dimer as dimer_model
+from chemex.models.kinetic import settings_2st_monomer_tetramer as tetramer_model
+from chemex.models.kinetic import settings_2st_monomer_trimer as trimer_model
+from chemex.models.kinetic import (
+    settings_3st_monomer_dimer_tetramer as dimer_tetramer_model,
+)
+from chemex.models.kinetic import (
+    settings_3st_monomer_dimer_trimer as dimer_trimer_model,
+)
+from chemex.models.kinetic.settings_2st_monomer_dimer import (
+    calculate_concentrations as calculate_dimer,
+)
+from chemex.models.kinetic.settings_2st_monomer_tetramer import (
+    calculate_concentrations as calculate_tetramer,
+)
+from chemex.models.kinetic.settings_2st_monomer_trimer import (
+    calculate_concentrations as calculate_trimer,
+)
+from chemex.models.kinetic.settings_3st_monomer_dimer_tetramer import (
+    calculate_concentrations as calculate_dimer_tetramer,
+)
+from chemex.models.kinetic.settings_3st_monomer_dimer_trimer import (
+    calculate_concentrations as calculate_dimer_trimer,
+)
+
+ConcentrationSolver = Callable[..., dict[str, float]]
+
+MASS_TOLERANCE = 64.0 * sys.float_info.epsilon
+EQUILIBRIUM_TOLERANCE = 256.0 * sys.float_info.epsilon
+
+DIRECT_MODELS = (dimer_model, trimer_model, tetramer_model)
+SEQUENTIAL_MODELS = (dimer_trimer_model, dimer_tetramer_model)
+UNSUPPORTED_P_TOTALS = (("zero-p-total", 0.0), ("non-finite-p-total", math.nan))
+UNSUPPORTED_KDS = (
+    ("zero-kd", 0.0),
+    ("sub-threshold-kd", 0.5e-32),
+    ("non-finite-kd", math.inf),
+)
+
+
+@pytest.mark.parametrize(
+    ("solver", "arguments", "expected"),
+    [
+        (
+            calculate_dimer,
+            (1e-3, 1e-20),
+            {
+                "monomer": 2.2360679749997897e-12,
+                "dimer": 4.999999988819660e-4,
+            },
+        ),
+        (
+            calculate_trimer,
+            (1e-3, 1e-16),
+            {
+                "monomer": 3.217952700630540e-7,
+                "trimer": 3.332260682433123e-4,
+            },
+        ),
+        (
+            calculate_tetramer,
+            (1e-3, 1e-19),
+            {
+                "monomer": 2.2348176281143595e-6,
+                "tetramer": 2.494412955929714e-4,
+            },
+        ),
+        (
+            calculate_dimer_trimer,
+            (1e-3, 1e-5, 1e-3),
+            {
+                "monomer": 6.524662842584409e-5,
+                "dimer": 4.257122520940166e-4,
+                "trimer": 2.777628912870757e-5,
+            },
+        ),
+        (
+            calculate_dimer_tetramer,
+            (1e-3, 1e-4, 1e-4),
+            {
+                "monomer": 1.1227497354437556e-4,
+                "dimer": 1.2605669684390233e-4,
+                "tetramer": 1.5890290819195495e-4,
+            },
+        ),
+        (
+            calculate_dimer_tetramer,
+            (1e-3, 1e-8, 1e-8),
+            {
+                "monomer": 1.2564002054890984e-7,
+                "dimer": 1.5785414763530487e-6,
+                "tetramer": 2.4917931925668625e-4,
+            },
+        ),
+    ],
+    ids=[
+        "dimer-failed-hybr",
+        "trimer-failed-hybr",
+        "tetramer-failed-hybr",
+        "dimer-trimer-negative-branch",
+        "dimer-tetramer-negative-branch",
+        "dimer-tetramer-successful-wrong-branch",
+    ],
+)
+def test_historical_hybr_failures_use_physical_solution(
+    solver: ConcentrationSolver,
+    arguments: tuple[float, ...],
+    expected: dict[str, float],
+) -> None:
+    assert solver(*arguments) == pytest.approx(expected, rel=2e-14, abs=0.0)
+
+
+@pytest.mark.parametrize(
+    ("solver", "oligomer", "stoichiometry", "p_total", "kd"),
+    [
+        (solver, oligomer, stoichiometry, p_total, kd)
+        for solver, oligomer, stoichiometry in (
+            (calculate_dimer, "dimer", 2),
+            (calculate_trimer, "trimer", 3),
+            (calculate_tetramer, "tetramer", 4),
+        )
+        for p_total, kd in (
+            (1e-9, 1.0),
+            (1e-6, 1e-6),
+            (1e-3, 1e-12),
+            (1e-1, 1e-32),
+        )
+    ],
+)
+def test_direct_positive_domain_stress(
+    solver: ConcentrationSolver,
+    oligomer: str,
+    stoichiometry: int,
+    p_total: float,
+    kd: float,
+) -> None:
+    concentrations = solver(p_total, kd)
+    monomer = concentrations["monomer"]
+    oligomer_concentration = concentrations[oligomer]
+
+    _assert_physical_concentrations(concentrations, p_total)
+    _assert_normalized_mass(
+        p_total,
+        ((1, monomer), (stoichiometry, oligomer_concentration)),
+    )
+    _assert_scale_aware_close(
+        kd * oligomer_concentration,
+        monomer**stoichiometry,
+    )
+
+
+@pytest.mark.parametrize(
+    ("solver", "higher_oligomer", "p_total", "kd1", "kd2"),
+    [
+        (solver, higher_oligomer, p_total, kd1, kd2)
+        for solver, higher_oligomer in (
+            (calculate_dimer_trimer, "trimer"),
+            (calculate_dimer_tetramer, "tetramer"),
+        )
+        for p_total, kd1, kd2 in (
+            (1e-9, 1.0, 1.0),
+            (1e-6, 1e-32, 1e-3),
+            (1e-3, 1e-5, 1e-3),
+            (1e-2, 1e-3, 1e-32),
+            (1e-1, 1e-32, 1e-32),
+        )
+    ],
+)
+def test_sequential_positive_domain_stress(
+    solver: ConcentrationSolver,
+    higher_oligomer: str,
+    p_total: float,
+    kd1: float,
+    kd2: float,
+) -> None:
+    concentrations = solver(p_total, kd1, kd2)
+    monomer = concentrations["monomer"]
+    dimer = concentrations["dimer"]
+    higher = concentrations[higher_oligomer]
+    higher_stoichiometry = 3 if higher_oligomer == "trimer" else 4
+
+    _assert_physical_concentrations(concentrations, p_total)
+    _assert_normalized_mass(
+        p_total,
+        ((1, monomer), (2, dimer), (higher_stoichiometry, higher)),
+    )
+    _assert_scale_aware_close(kd1 * dimer, monomer**2)
+    higher_equilibrium = monomer * dimer if higher_oligomer == "trimer" else dimer**2
+    _assert_scale_aware_close(kd2 * higher, higher_equilibrium)
+
+
+def test_helper_rejects_non_converged_solver_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _oligomerization,
+        "brentq",
+        lambda *_args, **_kwargs: (0.5, SimpleNamespace(converged=False)),
+    )
+
+    with pytest.raises(RuntimeError, match="did not converge"):
+        _oligomerization.solve_oligomerization_fractions(((2, 1.0),))
+
+
+@pytest.mark.parametrize("root", [math.nan, math.inf, -0.1, 1.1])
+def test_helper_rejects_invalid_root(
+    monkeypatch: pytest.MonkeyPatch,
+    root: float,
+) -> None:
+    monkeypatch.setattr(
+        _oligomerization,
+        "brentq",
+        lambda *_args, **_kwargs: (root, SimpleNamespace(converged=True)),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid monomer fraction"):
+        _oligomerization.solve_oligomerization_fractions(((2, 1.0),))
+
+
+def test_helper_rejects_reconstructed_state_that_violates_mass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _oligomerization,
+        "brentq",
+        lambda *_args, **_kwargs: (0.0, SimpleNamespace(converged=True)),
+    )
+
+    with pytest.raises(RuntimeError, match="violated mass conservation"):
+        _oligomerization.solve_oligomerization_fractions(((2, 1.0),))
+
+
+@pytest.mark.parametrize(
+    ("model", "arguments"),
+    [
+        pytest.param(model, (p_total, 1e-3), id=f"{model.NAME}-{case}")
+        for model in DIRECT_MODELS
+        for case, p_total in UNSUPPORTED_P_TOTALS
+    ]
+    + [
+        pytest.param(model, (1e-3, kd), id=f"{model.NAME}-{case}")
+        for model in DIRECT_MODELS
+        for case, kd in UNSUPPORTED_KDS
+    ]
+    + [
+        pytest.param(model, (p_total, 1e-3, 1e-3), id=f"{model.NAME}-{case}")
+        for model in SEQUENTIAL_MODELS
+        for case, p_total in UNSUPPORTED_P_TOTALS
+    ]
+    + [
+        pytest.param(model, (1e-3, kd, 1e-3), id=f"{model.NAME}-kd1-{case}")
+        for model in SEQUENTIAL_MODELS
+        for case, kd in UNSUPPORTED_KDS
+    ]
+    + [
+        pytest.param(model, (1e-3, 1e-3, kd), id=f"{model.NAME}-kd2-{case}")
+        for model in SEQUENTIAL_MODELS
+        for case, kd in UNSUPPORTED_KDS
+    ],
+)
+def test_unsupported_domain_routes_to_legacy_hybr(
+    monkeypatch: pytest.MonkeyPatch,
+    model: ModuleType,
+    arguments: tuple[float, ...],
+) -> None:
+    legacy_call_count = 0
+    sentinel = tuple(float(index) for index in range(len(arguments)))
+
+    def legacy_root(*_args: object, **_kwargs: object) -> dict[str, tuple[float, ...]]:
+        nonlocal legacy_call_count
+        legacy_call_count += 1
+        return {"x": sentinel}
+
+    calculator = model.calculate_concentrations
+    calculator.cache_clear()
+    try:
+        monkeypatch.setattr(model, "root", legacy_root)
+        calculator(*arguments)
+        assert legacy_call_count == 1
+    finally:
+        calculator.cache_clear()
+
+
+def _assert_physical_concentrations(
+    concentrations: dict[str, float],
+    p_total: float,
+) -> None:
+    assert all(math.isfinite(value) for value in concentrations.values())
+    assert all(value >= 0.0 for value in concentrations.values())
+    assert 0.0 <= concentrations["monomer"] <= p_total
+
+
+def _assert_normalized_mass(
+    p_total: float,
+    species: tuple[tuple[int, float], ...],
+) -> None:
+    normalized_mass = math.fsum(
+        stoichiometry * concentration / p_total
+        for stoichiometry, concentration in species
+    )
+    assert abs(normalized_mass - 1.0) <= MASS_TOLERANCE
+
+
+def _assert_scale_aware_close(left: float, right: float) -> None:
+    scale = max(abs(left), abs(right), sys.float_info.min)
+    assert abs(left - right) <= EQUILIBRIUM_TOLERANCE * scale


### PR DESCRIPTION
### Summary

* Replace unconstrained multidimensional concentration solving with the unique bracketed physical solution for supported positive oligomerization inputs.
* Solve the normalized free-monomer fraction on `[0, 1]` and reconstruct oligomer concentrations directly from equilibrium relations.
* Preserve the historical HYBR path for explicitly deferred zero, sub-`1e-32`, and non-finite edge inputs.
* Add regression and stress tests covering all five oligomerization models.

### Motivation

The previous `scipy.optimize.root` / HYBR implementation returned its solution unconditionally and could:

* report failure while returning inaccurate concentrations;
* report success on a negative, nonphysical algebraic branch;
* satisfy mass balance while substantially violating the equilibrium relation.

The positive-domain oligomerization equations reduce to a continuous, strictly monotone scalar mass-balance equation with a unique physical root.

### Numerical approach

For supported positive inputs, solve the normalized monomer fraction:

`x = [A] / P_total`

on the physical bracket `[0, 1]` using the Brent method.

The implementation:

* uses explicit tight root tolerances suitable for very small positive monomer fractions;
* checks convergence, finiteness, physical bounds, reconstruction, and normalized mass conservation;
* fails closed on impossible internal numerical states;
* retains the existing `lru_cache(maxsize=100)` behavior.

A private `_oligomerization.py` helper centralizes solver policy. The kinetic plugin loader now ignores underscore-prefixed private modules.

### Compatibility

All kinetic equations, tagged-rate mappings, population definitions, historical `KD = KOFF / KON` semantics, parameter names, and registered user-function names remain unchanged.

Ordinary PR #763 fixtures differ only at floating-point roundoff scale.

Material numerical changes are restricted to cases where the previous HYBR result was failed, inaccurate, or nonphysical.

### Deferred edge semantics

This PR deliberately does not redefine:

* exact `KD = 0`;
* positive `KD < 1e-32`;
* non-finite input behavior;
* exact `KOFF = 0`;
* very-slow-rate / `pop_2st` cutoff behavior.

Those inputs retain the historical solver path for now.

### Validation

The audited candidate passed:

* solver-specific tests: 65 passed
* PR #763 oligomerization invariants: 6 passed
* complete kinetic suite: 158 passed
* full suite on the identical production candidate: 1,421 passed
* loader/model-registration validation
* `ty`
* full Ruff check and format check
* independent numerical/code audit with zero numerical findings
* closure review with zero findings