### PR TITLE
fix: preserve two-state populations at slow rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- Two-state stationary populations now preserve the ratio of all positive rates
+  regardless of absolute exchange timescale. Positive rates at or below the former
+  approximate-zero threshold (`1e-8 s^-1` under the current NumPy behavior) were
+  previously treated as absent, so affected very-slow exchange populations can
+  change materially. The exact both-zero compatibility fallback is unchanged;
+  exact-zero model semantics have not changed.
 - Oligomerization concentration solving now uses the unique bracketed physical
   solution for supported positive inputs, preventing silent failed or inaccurate
   HYBR roots and negative algebraic branches. Strongly associated cases affected

--- a/src/chemex/models/constraints.py
+++ b/src/chemex/models/constraints.py
@@ -6,15 +6,15 @@ from scipy import linalg
 
 @lru_cache(maxsize=100)
 def pop_2st(kab: float = 0.0, kba: float = 0.0) -> dict[str, float]:
-    if np.isclose(kab, 0.0):
+    scale = max(abs(kab), abs(kba))
+    if scale == 0.0:
         return {"pa": 1.0, "pb": 0.0}
 
-    if np.isclose(kba, 0.0):
-        return {"pa": 0.0, "pb": 1.0}
+    kab_scaled = kab / scale
+    kba_scaled = kba / scale
+    total = kab_scaled + kba_scaled
 
-    kex = kab + kba
-
-    return {"pa": kba / kex, "pb": kab / kex}
+    return {"pa": kba_scaled / total, "pb": kab_scaled / total}
 
 
 @lru_cache(maxsize=100)

--- a/tests/models/test_constraints.py
+++ b/tests/models/test_constraints.py
@@ -2,12 +2,94 @@
 
 from __future__ import annotations
 
+import sys
+
 import numpy as np
 import pytest
 
-from chemex.models.constraints import pop_3st
+from chemex.models.constraints import pop_2st, pop_3st
 
 Rates3State = tuple[float, float, float, float, float, float]
+
+
+@pytest.mark.parametrize(
+    ("kab", "kba"),
+    [(1.0, 1.0), (1.0, 3.0), (1.0, 1000.0), (1000.0, 1.0)],
+)
+def test_two_state_positive_rates_have_stationary_ratio(kab: float, kba: float) -> None:
+    populations = pop_2st(kab, kba)
+    swapped = pop_2st(kba, kab)
+
+    assert sum(populations.values()) == pytest.approx(1.0, abs=1e-15)
+    assert all(population >= 0.0 for population in populations.values())
+    assert populations == pytest.approx(
+        {"pa": kba / (kab + kba), "pb": kab / (kab + kba)}
+    )
+    assert swapped == pytest.approx({"pa": populations["pb"], "pb": populations["pa"]})
+    assert kab * populations["pa"] == pytest.approx(kba * populations["pb"])
+
+
+@pytest.mark.parametrize("scale", [1.0, 1.0e-8, 1.0e-20, 1.0e-250])
+def test_two_state_populations_are_invariant_to_rate_scale(scale: float) -> None:
+    populations = pop_2st(3.0 * scale, 7.0 * scale)
+
+    assert populations == pytest.approx(pop_2st(3.0, 7.0), rel=1e-15)
+
+
+def test_two_state_equal_rates_are_continuous_across_historical_cutoff() -> None:
+    cutoff = 1.0e-8
+    rates = (
+        np.nextafter(cutoff, 0.0),
+        cutoff,
+        np.nextafter(cutoff, np.inf),
+    )
+
+    for rate in rates:
+        assert pop_2st(rate, rate) == pytest.approx({"pa": 0.5, "pb": 0.5})
+
+
+def test_two_state_asymmetric_rates_avoid_historical_cutoff_plateau() -> None:
+    cutoff = 1.0e-8
+    scales = (
+        np.nextafter(cutoff / 3.0, 0.0),
+        cutoff / 3.0,
+        np.nextafter(cutoff / 3.0, np.inf),
+        np.nextafter(cutoff, 0.0),
+        cutoff,
+        np.nextafter(cutoff, np.inf),
+    )
+
+    for scale in scales:
+        assert pop_2st(3.0 * scale, scale) == pytest.approx({"pa": 0.25, "pb": 0.75})
+
+
+def test_two_state_subnormal_positive_rates_remain_active() -> None:
+    smallest_subnormal = np.nextafter(0.0, 1.0)
+
+    assert pop_2st(smallest_subnormal, smallest_subnormal) == pytest.approx(
+        {"pa": 0.5, "pb": 0.5}
+    )
+    assert pop_2st(smallest_subnormal, 2.0 * smallest_subnormal) == pytest.approx(
+        {"pa": 2 / 3, "pb": 1 / 3}
+    )
+
+
+def test_two_state_maximum_finite_rates_do_not_overflow() -> None:
+    maximum = sys.float_info.max
+
+    assert pop_2st(maximum, maximum) == pytest.approx({"pa": 0.5, "pb": 0.5})
+    assert pop_2st(maximum / 2.0, maximum) == pytest.approx({"pa": 2 / 3, "pb": 1 / 3})
+
+
+@pytest.mark.parametrize("positive", [1.0, np.nextafter(0.0, 1.0)])
+def test_two_state_exact_one_way_endpoints(positive: float) -> None:
+    assert pop_2st(0.0, positive) == {"pa": 1.0, "pb": 0.0}
+    assert pop_2st(positive, 0.0) == {"pa": 0.0, "pb": 1.0}
+
+
+def test_two_state_both_zero_preserves_compatibility_fallback() -> None:
+    # This historical fallback is not a unique stationary distribution.
+    assert pop_2st(0.0, 0.0) == {"pa": 1.0, "pb": 0.0}
 
 
 def _assert_stationary(rates: Rates3State, populations: dict[str, float]) -> None:
@@ -50,6 +132,12 @@ def test_literal_zero_represents_a_structurally_absent_edge() -> None:
 
 def test_literal_zeros_preserve_disconnected_state_behavior() -> None:
     assert pop_3st(4.0, 2.0, 0.0, 0.0, 0.0, 0.0) == pytest.approx(
+        {"pa": 1 / 3, "pb": 2 / 3, "pc": 0.0}
+    )
+
+
+def test_slow_reduced_two_state_edge_preserves_rate_ratio() -> None:
+    assert pop_3st(4.0e-9, 2.0e-9, 0.0, 0.0, 0.0, 0.0) == pytest.approx(
         {"pa": 1 / 3, "pb": 2 / 3, "pc": 0.0}
     )
 


### PR DESCRIPTION
### Summary

- Preserve the stationary population ratio for all positive two-state exchange rates, regardless of absolute timescale.
- Remove the accidental approximate-zero classification of positive rates.
- Normalize rates before forming the stationary ratio to avoid overflow for very large finite rates.
- Preserve exact-zero compatibility behavior.

### Scientific basis

For finite non-negative rates with `KAB + KBA > 0`, the unique stationary two-state populations are:

- `PA = KBA / (KAB + KBA)`
- `PB = KAB / (KAB + KBA)`

These depend only on the rate ratio, not on the common exchange timescale.

The previous implementation used `np.isclose(rate, 0.0)`, which under current NumPy defaults classified positive rates up to `1e-8 s^-1` as zero. This produced discontinuous and sometimes qualitatively wrong populations for very slow exchange.

### Numerical behavior

The implementation now:

- scales rates by their common magnitude before normalization;
- preserves positive subnormal rates when representable;
- avoids overflow from directly summing two maximum-float rates;
- retains exact one-way endpoints.

The exact both-zero compatibility fallback remains:

`PA = 1`, `PB = 0`.

This PR does not claim that this fallback is a unique stationary distribution for an exact frozen two-state system.

### Compatibility

Ordinary positive-rate behavior is unchanged to floating-point precision.

Positive rates at or below the former approximate-zero threshold can change materially because they were previously treated as absent.

Exact `(0,0)` fallback behavior remains unchanged.

### Reduced three-state behavior

`pop_3st` production code is unchanged.

Reduced two-state subgraphs delegated to `pop_2st` now correctly preserve arbitrarily slow positive edge ratios.

### Validation

The audited candidate passed:

- constraint tests: 23 passed
- kinetic-model suite: 158 passed
- full suite: 1,463 passed
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`

Independent numerical/code audit:

- Standards: PASS — 0 findings
- Spec / Numerical correctness: PASS — 0 findings

Closure review:

- PASS — 0 closure findings
- `READY TO COMMIT THE AUDITED DIFF`

### Out of scope

This PR deliberately does not change:

- model-specific exact-zero population authority;
- exact oligomerization `KOFF=0`;
- exact `KD=0`;
- positive `KD < 1e-32`;
- the oligomerization `KON` floor;
- Eyring underflow policy;
- generic disconnected `pop_3st` or higher-state topology semantics.