### PR TITLE
fix: preserve 2st_hd populations at zero exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- `2st_hd` populations are now derived directly from `D2O` and `PHI`, preserving
+  the model's equilibrium H/D composition as `KDH` tends to zero. Exact
+  `KDH = 0` therefore changes from the former generic state-A fallback;
+  positive-`KDH` behavior is unchanged.
 - Two-state stationary populations now preserve the ratio of all positive rates
   regardless of absolute exchange timescale. Positive rates at or below the former
   approximate-zero threshold (`1e-8 s^-1` under the current NumPy behavior) were

--- a/src/chemex/models/kinetic/settings_2st_hd.py
+++ b/src/chemex/models/kinetic/settings_2st_hd.py
@@ -48,11 +48,11 @@ def make_settings_2st_hd(conditions: Conditions) -> dict[str, ParamLocalSetting]
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "g", ("temperature", "d2o")),
-            expr="pop_2st({kab}, {kba})['pa']",
+            expr="(1.0 - {d2o}) / (1.0 + {d2o} * ({phi} - 1.0))",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "g", ("temperature", "d2o")),
-            expr="pop_2st({kab}, {kba})['pb']",
+            expr="{d2o} * {phi} / (1.0 + {d2o} * ({phi} - 1.0))",
         ),
     }
 

--- a/tests/models/kinetic/test_audited_model_repairs.py
+++ b/tests/models/kinetic/test_audited_model_repairs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from math import isfinite
 from types import SimpleNamespace
 
 import pytest
@@ -71,6 +72,173 @@ def _construct_and_resolve(
     )
 
     return name_map, {name: resolved[local_ids[name]] for name in resolved_names}
+
+
+def test_2st_hd_exact_zero_kdh_preserves_equilibrium_composition() -> None:
+    conditions = Conditions(
+        h_larmor_frq=600.0,
+        temperature=25.0,
+        d2o=0.25,
+    )
+
+    _, values = _construct_and_resolve(
+        "2st_hd",
+        conditions,
+        {"kdh": 0.0, "phi": 1.2},
+        {"kab", "kba", "pa", "pb"},
+    )
+
+    assert values == pytest.approx(
+        {
+            "kab": 0.0,
+            "kba": 0.0,
+            "pa": 5.0 / 7.0,
+            "pb": 2.0 / 7.0,
+        },
+        rel=RELATIVE_TOLERANCE,
+        abs=ABSOLUTE_TOLERANCE,
+    )
+
+
+def test_2st_hd_populations_are_invariant_to_kdh_scale() -> None:
+    conditions = Conditions(
+        h_larmor_frq=600.0,
+        temperature=25.0,
+        d2o=0.25,
+    )
+    expected_populations = {"pa": 5.0 / 7.0, "pb": 2.0 / 7.0}
+
+    for kdh in (0.0, 1.0e-20, 1.0, 1.0e6):
+        _, values = _construct_and_resolve(
+            "2st_hd",
+            conditions,
+            {"kdh": kdh, "phi": 1.2},
+            {"kab", "kba", "pa", "pb"},
+        )
+
+        assert {name: values[name] for name in ("pa", "pb")} == pytest.approx(
+            expected_populations,
+            rel=RELATIVE_TOLERANCE,
+            abs=ABSOLUTE_TOLERANCE,
+        )
+        if kdh > 0.0:
+            rate_sum = values["kab"] + values["kba"]
+            assert values["pa"] == pytest.approx(
+                values["kba"] / rate_sum,
+                rel=RELATIVE_TOLERANCE,
+                abs=ABSOLUTE_TOLERANCE,
+            )
+            assert values["pb"] == pytest.approx(
+                values["kab"] / rate_sum,
+                rel=RELATIVE_TOLERANCE,
+                abs=ABSOLUTE_TOLERANCE,
+            )
+
+
+def test_2st_hd_preserves_ordinary_positive_rate_behavior() -> None:
+    conditions = Conditions(
+        h_larmor_frq=600.0,
+        temperature=25.0,
+        d2o=0.2,
+    )
+
+    _, values = _construct_and_resolve(
+        "2st_hd",
+        conditions,
+        {"kdh": 10.0, "phi": 1.25},
+        {"kab", "kba", "pa", "pb"},
+    )
+
+    assert values == pytest.approx(
+        {
+            "kab": 2.5,
+            "kba": 8.0,
+            "pa": 8.0 / 10.5,
+            "pb": 2.5 / 10.5,
+        },
+        rel=RELATIVE_TOLERANCE,
+        abs=ABSOLUTE_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize(
+    ("d2o", "phi", "expected_populations"),
+    [
+        (0.0, 0.75, {"pa": 1.0, "pb": 0.0}),
+        (1.0, 1.5, {"pa": 0.0, "pb": 1.0}),
+    ],
+)
+def test_2st_hd_exact_zero_kdh_preserves_solvent_endpoints(
+    d2o: float,
+    phi: float,
+    expected_populations: dict[str, float],
+) -> None:
+    conditions = Conditions(
+        h_larmor_frq=600.0,
+        temperature=25.0,
+        d2o=0.25,
+    )
+
+    _, values = _construct_and_resolve(
+        "2st_hd",
+        conditions,
+        {"d2o": d2o, "kdh": 0.0, "phi": phi},
+        {"pa", "pb"},
+    )
+
+    assert values == pytest.approx(
+        expected_populations,
+        rel=RELATIVE_TOLERANCE,
+        abs=ABSOLUTE_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize(
+    ("d2o", "phi"),
+    [
+        (0.0, 0.75),
+        (1.0e-12, 1.5),
+        (0.25, 1.2),
+        (0.5, 1.0),
+        (1.0 - 1.0e-12, 0.75),
+        (1.0, 1.5),
+    ],
+)
+def test_2st_hd_populations_satisfy_equilibrium_invariants(
+    d2o: float,
+    phi: float,
+) -> None:
+    conditions = Conditions(
+        h_larmor_frq=600.0,
+        temperature=25.0,
+        d2o=0.25,
+    )
+
+    _, values = _construct_and_resolve(
+        "2st_hd",
+        conditions,
+        {"d2o": d2o, "kdh": 0.0, "phi": phi},
+        {"pa", "pb"},
+    )
+    denominator = 1.0 + d2o * (phi - 1.0)
+    expected = {
+        "pa": (1.0 - d2o) / denominator,
+        "pb": d2o * phi / denominator,
+    }
+
+    assert all(isfinite(values[name]) for name in ("pa", "pb"))
+    assert values["pa"] >= 0.0
+    assert values["pb"] >= 0.0
+    assert values["pa"] + values["pb"] == pytest.approx(
+        1.0,
+        rel=RELATIVE_TOLERANCE,
+        abs=ABSOLUTE_TOLERANCE,
+    )
+    assert values == pytest.approx(
+        expected,
+        rel=RELATIVE_TOLERANCE,
+        abs=ABSOLUTE_TOLERANCE,
+    )
 
 
 def test_4st_hd_constructs_the_conformer_hd_square_topology() -> None:

--- a/tests/test_native_production_fitting.py
+++ b/tests/test_native_production_fitting.py
@@ -2394,7 +2394,7 @@ FIX = ["KEX_AB"]
     assert "uncertainty unavailable: rank deficient" in rendered
 
 
-def test_unsupported_scientific_constraint_keeps_product_fitted_errors(
+def test_algebraic_hd_population_constraints_keep_product_fitted_errors(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "Output"
@@ -2435,7 +2435,19 @@ FIX = ["CS_A", "DW_AB", "KDH", "PHI", "R1_A", "R2_A", "R2_B"]
         encoding="utf-8"
     )
     assert "# ±" in fitted
-    assert "error unavailable: unsupported constrained derivative" in constrained
+    constrained_lines = constrained.splitlines()
+    for population in ("PA", "PB"):
+        header_index = next(
+            index
+            for index, line in enumerate(constrained_lines)
+            if line.startswith(f'["{population}, ')
+        )
+        population_record = constrained_lines[header_index + 1]
+        assert "# ±" in population_record
+        assert "error unavailable" not in population_record
+        population_error = float(population_record.split("# ±", 1)[1].split()[0])
+        assert math.isfinite(population_error)
+    assert "error unavailable: unsupported constrained derivative" not in constrained
     constrained_evidence = (
         output / "Statistics" / "Constrained" / "evidence.json"
     ).read_text(encoding="utf-8")

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -65,7 +65,11 @@ from chemex.optimize.uncertainty import (
     compile_constraint_linearization_capabilities,
     derive_uncertainty_evidence,
 )
-from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    FunctionExpression,
+    ReferenceExpression,
+)
 from chemex.parameters.spin_system import SpinSystem
 from chemex.printers.parameters import uncertainty_unavailable_reason
 from chemex.runtime import AnalysisSession
@@ -562,8 +566,38 @@ def _qualification_policy(controlled_id: str) -> UncertaintyPolicy:
     )
 
 
+def _with_pop_2st_pa_constraint(
+    parameterization: ActiveParameterization,
+) -> ActiveParameterization:
+    """Keep scientific-function capability tests independent of model policy."""
+    output_id = "__PA_1_0_1000"
+    kab_id = "__KAB_1_0_1000"
+    kba_id = "__KBA_1_0_1000"
+    replacement_expression = FunctionExpression(
+        "pop_2st",
+        (ReferenceExpression(kab_id), ReferenceExpression(kba_id)),
+        "pa",
+    )
+    constraints = tuple(
+        dataclasses.replace(
+            constraint,
+            expression=replacement_expression,
+            dependencies=(kab_id, kba_id),
+            expression_text=f"pop_2st({kab_id}, {kba_id})['pa']",
+        )
+        if constraint.target_id == output_id
+        else constraint
+        for constraint in parameterization.program.constraints
+    )
+    assert sum(item.target_id == output_id for item in constraints) == 1
+    program = dataclasses.replace(parameterization.program, constraints=constraints)
+    return dataclasses.replace(parameterization, program=program)
+
+
 def _hd_problem(
     method: Method,
+    *,
+    use_pop_2st_pa_constraint: bool = False,
 ) -> tuple[ActiveParameterization, EvaluationEngine, OptimizationProblem]:
     session = AnalysisSession.create()
     session.set_model("2st_hd")
@@ -577,6 +611,8 @@ def _hd_problem(
         session.parameter_factory.native_construction_error
     )
     parameterization = session.compile_parameterization(method, experiments.param_ids)
+    if use_pop_2st_pa_constraint:
+        parameterization = _with_pop_2st_pa_constraint(parameterization)
     engine = EvaluationEngine.from_experiments(experiments, parameterization)
     configuration = session.parameter_factory.sealed_configuration
     assert configuration is not None
@@ -599,7 +635,10 @@ def _accepted_hd_fit() -> tuple[
         fit=("D2O",),
         fix=("CS_A", "DW_AB", "KDH", "PHI", "R1_A", "R2_A", "R2_B"),
     )
-    parameterization, engine, problem = _hd_problem(method)
+    parameterization, engine, problem = _hd_problem(
+        method,
+        use_pop_2st_pa_constraint=True,
+    )
     outcome = execute_direct_trf(
         problem,
         DirectTrfInvocation.for_problem(problem, objective_request_budget=80),
@@ -2195,7 +2234,10 @@ def test_absolute_observation_uncertainties_do_not_apply_residual_scaling() -> N
 
 
 def test_product_request_excludes_unsupported_scientific_function_propagation() -> None:
-    parameterization, engine, problem = _hd_problem(Method())
+    parameterization, engine, problem = _hd_problem(
+        Method(),
+        use_pop_2st_pa_constraint=True,
+    )
     accepted = _accepted_reference_anchor(parameterization, engine, problem)
     uncertainty = _derive_product_uncertainty(
         accepted,


### PR DESCRIPTION
### Summary

- Derive `2st_hd` populations directly from `D2O` and `PHI`.
- Preserve the model’s equilibrium H/D composition as `KDH` approaches zero.
- Keep the kinetic `KAB`/`KBA` expressions and all parameter semantics unchanged.
- Preserve the existing `pop_2st` user-function registration.

### Scientific basis

The model rates are:

`KAB = D2O * KDH * PHI`

`KBA = (1 - D2O) * KDH`

For positive `KDH`, their stationary populations reduce exactly to:

`PA = (1 - D2O) / (1 + D2O * (PHI - 1))`

`PB = D2O * PHI / (1 + D2O * (PHI - 1))`

The populations therefore depend on `D2O` and `PHI`, not on the absolute `KDH` timescale.

At exact `KDH = 0`, the kinetic system itself is frozen and has no unique stationary distribution. This PR uses the equilibrium composition already encoded by the `2st_hd` model as its pre-equilibrated/continuity population convention.

### Compatibility

Positive-`KDH` populations are unchanged to floating-point precision.

At exact `KDH = 0`, populations can change from the previous generic `pop_2st(0,0) -> (1,0)` fallback to the H/D equilibrium composition.

Generic `pop_2st` behavior is unchanged.

### Validation

The audited candidate passed:

- H/D audited repair tests: 22 passed
- kinetic-model tests: 169 passed
- full suite: 1,474 passed
- `uv run ty check`
- full Ruff lint and format checks
- `git diff --check`

Independent audit:

- Spec / Scientific correctness: PASS — 0 findings
- one Low test-integrity finding was remediated

Closure review:

- Standards: PASS — 0 findings
- Spec: PASS — 0 findings
- `PASS — 0 closure findings`

The remediated integration test explicitly verifies finite propagated uncertainties for both `PA` and `PB`.

### Deferred

This PR does not resolve the pre-existing difference between the strict-interior `Conditions.d2o` validation and the inclusive `[0,1]` model parameter bounds.

It also does not change oligomerization zero-rate/KD policy, Eyring behavior, or generic topology semantics.