### PR TITLE
fix: enforce oligomerization KD domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- Oligomerization models now retain literal semantics for every finite positive
+  `KD`, including sub-`1e-32` values; the hidden `1e-32` effective-KD floor has
+  been removed, so affected results can change materially. Exact `KD = 0` is now
+  rejected because it is not representable by these finite reversible kinetic
+  parameterizations. Concentrations and tagged rates use stable log-domain and
+  detailed-balance evaluation, and the eager derived `KON`/`KON1`/`KON2`
+  outputs have been removed. Independent `KD` and `KOFF` inputs, their physical
+  meanings, and exact-`KOFF = 0` population behavior are unchanged.
 - `2st_hd` populations are now derived directly from `D2O` and `PHI`, preserving
   the model's equilibrium H/D composition as `KDH` tends to zero. Exact
   `KDH = 0` therefore changes from the former generic state-A fallback;

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -31,6 +31,7 @@ from chemex.optimize.fitting import invalidate_planned_outputs
 from chemex.optimize.helper import execute_simulation
 from chemex.optimize.method_plan_execution import execute_method_plan
 from chemex.parameters.parameterization import (
+    ConstraintDomainError,
     IncompleteParameterDependenciesError,
 )
 from chemex.parameters.sealed import InvalidConfigurationError
@@ -247,11 +248,18 @@ def run(
             (
                 IncompleteParameterDependenciesError,
                 InvalidConfigurationError,
+                ConstraintDomainError,
             ),
         ):
+            explanation = str(construction_error)
+            if isinstance(construction_error, ConstraintDomainError) and isinstance(
+                construction_error.__cause__,
+                (ArithmeticError, ValueError),
+            ):
+                explanation = str(construction_error.__cause__)
             raise ParameterConfigurationError(
                 tuple(args.parameters),
-                str(construction_error),
+                explanation,
             ) from construction_error
         raise RuntimeError(f"{msg}: {construction_error}") from construction_error
 

--- a/src/chemex/models/kinetic/_oligomerization.py
+++ b/src/chemex/models/kinetic/_oligomerization.py
@@ -2,45 +2,110 @@ from __future__ import annotations
 
 import math
 import sys
+from dataclasses import dataclass
 
 from scipy.optimize import brentq
 
+MIN_POSITIVE_FLOAT = math.nextafter(0.0, 1.0)
+LOG_MIN_POSITIVE_FLOAT = math.log(MIN_POSITIVE_FLOAT)
+
 _MASS_BALANCE_TOLERANCE = 64.0 * sys.float_info.epsilon
+_LOG_BALANCE_TOLERANCE = 4096.0 * sys.float_info.epsilon
+_LOG_MAX_FLOAT = math.log(sys.float_info.max)
+
+
+@dataclass(frozen=True, slots=True)
+class OligomerizationEquilibrium:
+    """Normalized species fractions and their retained logarithms."""
+
+    monomer_fraction: float
+    oligomer_fractions: tuple[float, ...]
+    log_monomer_fraction: float
+    log_oligomer_fractions: tuple[float, ...]
+    log_tagged_fractions: tuple[float, ...]
+
+
+def validate_oligomerization_kd(kd: float) -> float:
+    """Return a KD only when it has finite reversible-kinetic semantics."""
+    if not math.isfinite(kd) or kd <= 0.0:
+        msg = "Oligomerization KD must be finite and strictly positive"
+        raise ValueError(msg)
+    return kd
+
+
+def log_equilibrium_coefficient(
+    p_total: float,
+    p_total_power: int,
+    *kds: float,
+) -> float:
+    """Build an equilibrium coefficient logarithm without eager products."""
+    if not math.isfinite(p_total) or p_total <= 0.0:
+        msg = "Oligomerization P_total must be finite and strictly positive"
+        raise ValueError(msg)
+    if p_total_power < 0:
+        msg = "Oligomerization concentration solver received an invalid power"
+        raise ValueError(msg)
+    validated_kds = tuple(validate_oligomerization_kd(kd) for kd in kds)
+    return p_total_power * math.log(p_total) - math.fsum(
+        math.log(kd) for kd in validated_kds
+    )
+
+
+def _logsumexp(values: tuple[float, ...]) -> float:
+    maximum = max(values)
+    return maximum + math.log(math.fsum(math.exp(value - maximum) for value in values))
 
 
 def solve_oligomerization_fractions(
     terms: tuple[tuple[int, float], ...],
-) -> tuple[float, tuple[float, ...]]:
-    """Solve a positive normalized oligomerization mass balance."""
+) -> OligomerizationEquilibrium:
+    """Solve normalized oligomerization mass balance from log coefficients."""
     if not terms:
         msg = "Oligomerization concentration solver requires at least one term"
-        raise RuntimeError(msg)
+        raise ValueError(msg)
 
     weighted_terms: list[tuple[int, float, float]] = []
-    for stoichiometry, coefficient in terms:
-        weighted_coefficient = stoichiometry * coefficient
+    for stoichiometry, log_coefficient in terms:
         if (
             stoichiometry < 2
-            or not math.isfinite(coefficient)
-            or coefficient <= 0.0
-            or not math.isfinite(weighted_coefficient)
+            or not math.isfinite(log_coefficient)
+            or isinstance(stoichiometry, bool)
         ):
             msg = "Oligomerization concentration solver received an invalid term"
-            raise RuntimeError(msg)
-        weighted_terms.append((stoichiometry, coefficient, weighted_coefficient))
+            raise ValueError(msg)
+        weighted_terms.append(
+            (
+                stoichiometry,
+                log_coefficient,
+                math.log(stoichiometry) + log_coefficient,
+            )
+        )
 
-    def mass_balance(monomer_fraction: float) -> float:
-        contributions = [
-            weighted_coefficient * monomer_fraction**stoichiometry
-            for stoichiometry, _, weighted_coefficient in weighted_terms
-        ]
-        return math.fsum((monomer_fraction, *contributions)) - 1.0
+    def log_mass_balance(log_monomer_fraction: float) -> float:
+        return _logsumexp(
+            (
+                log_monomer_fraction,
+                *(
+                    log_weighted_coefficient + stoichiometry * log_monomer_fraction
+                    for stoichiometry, _, log_weighted_coefficient in weighted_terms
+                ),
+            ),
+        )
 
-    monomer_fraction, result = brentq(
-        mass_balance,
+    # At y=0 the monomer term alone is one, so the balance is non-negative.
+    # This finite lower endpoint makes every one of N positive mass terms at
+    # most exp(-1) / N, giving a deterministic strict negative bracket.
+    intercept_maximum = max(
         0.0,
-        1.0,
-        xtol=sys.float_info.min,
+        *(log_weighted for _, _, log_weighted in weighted_terms),
+    )
+    term_count = len(weighted_terms) + 1
+    lower = -(intercept_maximum + math.log(term_count) + 1.0)
+    log_monomer_fraction, result = brentq(
+        log_mass_balance,
+        lower,
+        0.0,
+        xtol=MIN_POSITIVE_FLOAT,
         rtol=4.0 * sys.float_info.epsilon,
         maxiter=256,
         full_output=True,
@@ -49,43 +114,196 @@ def solve_oligomerization_fractions(
     if not result.converged:
         msg = "Oligomerization concentration solver did not converge"
         raise RuntimeError(msg)
-    if (
-        not math.isfinite(monomer_fraction)
-        or monomer_fraction < 0.0
-        or monomer_fraction > 1.0
-    ):
+    if not math.isfinite(log_monomer_fraction) or log_monomer_fraction > 0.0:
         msg = (
             "Oligomerization concentration solver returned an invalid monomer fraction"
         )
         raise RuntimeError(msg)
 
-    oligomer_fractions = tuple(
-        coefficient * monomer_fraction**stoichiometry
-        for stoichiometry, coefficient, _ in weighted_terms
+    raw_log_oligomer_fractions = tuple(
+        log_coefficient + stoichiometry * log_monomer_fraction
+        for stoichiometry, log_coefficient, _ in weighted_terms
     )
-    if any(
-        not math.isfinite(fraction) or fraction < 0.0 for fraction in oligomer_fractions
-    ):
-        msg = (
-            "Oligomerization concentration solver returned an invalid oligomer fraction"
-        )
-        raise RuntimeError(msg)
-
-    normalized_mass = math.fsum(
-        (
-            monomer_fraction,
-            *(
-                stoichiometry * fraction
-                for (stoichiometry, _, _), fraction in zip(
-                    weighted_terms,
-                    oligomer_fractions,
-                    strict=True,
-                )
-            ),
+    raw_log_tagged_fractions = (
+        log_monomer_fraction,
+        *(
+            math.log(stoichiometry) + log_fraction
+            for (stoichiometry, _, _), log_fraction in zip(
+                weighted_terms,
+                raw_log_oligomer_fractions,
+                strict=True,
+            )
         ),
     )
-    if abs(normalized_mass - 1.0) > _MASS_BALANCE_TOLERANCE:
+    log_normalizer = _logsumexp(raw_log_tagged_fractions)
+    if abs(log_normalizer) > _LOG_BALANCE_TOLERANCE:
         msg = "Oligomerization concentration solver violated mass conservation"
         raise RuntimeError(msg)
+    log_tagged_fractions = tuple(
+        log_fraction - log_normalizer for log_fraction in raw_log_tagged_fractions
+    )
+    tagged_fractions = [math.exp(log_fraction) for log_fraction in log_tagged_fractions]
 
-    return monomer_fraction, oligomer_fractions
+    # Exponentiation can miss one last bit of unit mass. Correct only the
+    # largest tagged component, deterministically, at floating-point scale.
+    normalized_mass = math.fsum(tagged_fractions)
+    correction = 1.0 - normalized_mass
+    largest_index = max(range(len(tagged_fractions)), key=tagged_fractions.__getitem__)
+    corrected_largest = tagged_fractions[largest_index] + correction
+    if (
+        abs(correction) > _MASS_BALANCE_TOLERANCE
+        or corrected_largest < 0.0
+        or not math.isfinite(corrected_largest)
+    ):
+        msg = "Oligomerization concentration solver violated mass conservation"
+        raise RuntimeError(msg)
+    tagged_fractions[largest_index] = corrected_largest
+
+    monomer_fraction = tagged_fractions[0]
+    oligomer_fractions = tuple(
+        tagged_fraction / stoichiometry
+        for tagged_fraction, (stoichiometry, _, _) in zip(
+            tagged_fractions[1:],
+            weighted_terms,
+            strict=True,
+        )
+    )
+    log_oligomer_fractions = tuple(
+        log_tagged_fraction - math.log(stoichiometry)
+        for log_tagged_fraction, (stoichiometry, _, _) in zip(
+            log_tagged_fractions[1:],
+            weighted_terms,
+            strict=True,
+        )
+    )
+
+    return OligomerizationEquilibrium(
+        monomer_fraction=monomer_fraction,
+        oligomer_fractions=oligomer_fractions,
+        log_monomer_fraction=log_tagged_fractions[0],
+        log_oligomer_fractions=log_oligomer_fractions,
+        log_tagged_fractions=log_tagged_fractions,
+    )
+
+
+def _validate_positive_rate_log(log_rate: float, *, description: str) -> None:
+    if not math.isfinite(log_rate) or log_rate > _LOG_MAX_FLOAT:
+        msg = f"{description} exceeds the maximum finite binary64 value"
+        raise ValueError(msg)
+    if log_rate < LOG_MIN_POSITIVE_FLOAT:
+        msg = f"Positive {description} is below binary64 representability"
+        raise ValueError(msg)
+
+
+def _positive_rate_from_log(log_rate: float, *, description: str) -> float:
+    _validate_positive_rate_log(log_rate, description=description)
+    rate = math.exp(log_rate)
+    if rate == 0.0:
+        msg = f"Positive {description} is below binary64 representability"
+        raise ValueError(msg)
+    if not math.isfinite(rate):
+        msg = f"{description} exceeds the maximum finite binary64 value"
+        raise ValueError(msg)
+    return rate
+
+
+def concentration_from_log_fraction(p_total: float, log_fraction: float) -> float:
+    """Reconstruct a concentration without first rounding its fraction."""
+    if not math.isfinite(p_total) or p_total <= 0.0:
+        msg = "Oligomerization P_total must be finite and strictly positive"
+        raise ValueError(msg)
+    if not math.isfinite(log_fraction):
+        msg = "Oligomerization species fraction log must be finite"
+        raise ValueError(msg)
+
+    log_concentration = math.log(p_total) + log_fraction
+    if log_concentration < LOG_MIN_POSITIVE_FLOAT:
+        return 0.0
+    if log_concentration > _LOG_MAX_FLOAT:
+        msg = "Oligomerization concentration exceeds the maximum finite binary64 value"
+        raise ValueError(msg)
+    return math.exp(log_concentration)
+
+
+def concentrations_from_log_fractions(
+    p_total: float,
+    species: tuple[tuple[int, float], ...],
+) -> tuple[float, ...]:
+    """Reconstruct species concentrations with a last-bit mass correction."""
+    concentrations = [
+        concentration_from_log_fraction(p_total, log_fraction)
+        for _, log_fraction in species
+    ]
+    tagged_mass_fractions = [
+        stoichiometry * (concentration / p_total)
+        for concentration, (stoichiometry, _) in zip(
+            concentrations,
+            species,
+            strict=True,
+        )
+    ]
+    correction = 1.0 - math.fsum(tagged_mass_fractions)
+    largest_index = max(
+        range(len(concentrations)),
+        key=tagged_mass_fractions.__getitem__,
+    )
+    largest_stoichiometry = species[largest_index][0]
+    corrected_largest = (
+        concentrations[largest_index] + correction * p_total / largest_stoichiometry
+    )
+    if (
+        abs(correction) > _LOG_BALANCE_TOLERANCE
+        or corrected_largest < 0.0
+        or not math.isfinite(corrected_largest)
+    ):
+        msg = "Oligomerization concentration reconstruction violated mass conservation"
+        raise RuntimeError(msg)
+    concentrations[largest_index] = corrected_largest
+    return tuple(concentrations)
+
+
+def scale_reversible_rate(rate: float, factor: float) -> float:
+    """Scale a non-negative rate while rejecting structural under/overflow."""
+    if not math.isfinite(rate) or rate < 0.0:
+        msg = "Oligomerization reverse rate must be finite and non-negative"
+        raise ValueError(msg)
+    if not math.isfinite(factor) or factor <= 0.0:
+        msg = "Oligomerization rate scale must be finite and strictly positive"
+        raise ValueError(msg)
+    if rate == 0.0:
+        return 0.0
+    log_scaled_rate = math.log(rate) + math.log(factor)
+    _validate_positive_rate_log(
+        log_scaled_rate,
+        description="tagged reverse rate",
+    )
+    scaled_rate = rate * factor
+    if scaled_rate == 0.0:
+        msg = "Positive tagged reverse rate is below binary64 representability"
+        raise ValueError(msg)
+    if not math.isfinite(scaled_rate):
+        msg = "Tagged reverse rate exceeds the maximum finite binary64 value"
+        raise ValueError(msg)
+    return scaled_rate
+
+
+def detailed_balance_forward_rate(
+    reverse_rate: float,
+    log_source_fraction: float,
+    log_destination_fraction: float,
+) -> float:
+    """Construct one tagged forward rate without an eager population ratio."""
+    if not math.isfinite(reverse_rate) or reverse_rate < 0.0:
+        msg = "Oligomerization reverse rate must be finite and non-negative"
+        raise ValueError(msg)
+    if not math.isfinite(log_source_fraction) or not math.isfinite(
+        log_destination_fraction
+    ):
+        msg = "Oligomerization tagged population logs must be finite"
+        raise ValueError(msg)
+    if reverse_rate == 0.0:
+        return 0.0
+    return _positive_rate_from_log(
+        math.log(reverse_rate) + log_destination_fraction - log_source_fraction,
+        description="tagged forward rate",
+    )

--- a/src/chemex/models/kinetic/settings_2st_monomer_dimer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_dimer.py
@@ -9,7 +9,15 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_2st
 from chemex.models.factory import model_factory
-from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
+from chemex.models.kinetic._oligomerization import (
+    MIN_POSITIVE_FLOAT,
+    OligomerizationEquilibrium,
+    concentrations_from_log_fractions,
+    detailed_balance_forward_rate,
+    log_equilibrium_coefficient,
+    solve_oligomerization_fractions,
+    validate_oligomerization_kd,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -34,19 +42,48 @@ def calculate_residuals(
 
 
 @lru_cache(maxsize=100)
+def _calculate_equilibrium(p_total: float, kd: float) -> OligomerizationEquilibrium:
+    return solve_oligomerization_fractions(
+        ((2, log_equilibrium_coefficient(p_total, 1, kd)),),
+    )
+
+
+@lru_cache(maxsize=100)
 def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
-    if math.isfinite(p_total) and p_total > 0.0 and math.isfinite(kd) and kd >= 1e-32:
-        monomer_fraction, (dimer_fraction,) = solve_oligomerization_fractions(
-            ((2, p_total / kd),),
+    validate_oligomerization_kd(kd)
+    if math.isfinite(p_total) and p_total > 0.0:
+        equilibrium = _calculate_equilibrium(p_total, kd)
+        monomer, dimer = concentrations_from_log_fractions(
+            p_total,
+            (
+                (1, equilibrium.log_monomer_fraction),
+                (2, equilibrium.log_oligomer_fractions[0]),
+            ),
         )
         return {
-            "monomer": p_total * monomer_fraction,
-            "dimer": p_total * dimer_fraction,
+            "monomer": monomer,
+            "dimer": dimer,
         }
 
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "dimer": results["x"][1]}
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(p_total: float, kd: float, koff: float) -> dict[str, float]:
+    validate_oligomerization_kd(kd)
+    if p_total == 0.0:
+        detailed_balance_forward_rate(koff, 0.0, 0.0)
+        return {"kab": 0.0}
+    equilibrium = _calculate_equilibrium(p_total, kd)
+    return {
+        "kab": detailed_balance_forward_rate(
+            koff,
+            equilibrium.log_tagged_fractions[0],
+            equilibrium.log_tagged_fractions[1],
+        ),
+    }
 
 
 def make_settings_2st_monomer_dimer(
@@ -67,14 +104,9 @@ def make_settings_2st_monomer_dimer(
         "kd": ParamLocalSetting(
             name_setting=NameSetting("kd", "", ("temperature",)),
             value=1e-6,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
-        ),
-        "kon": ParamLocalSetting(
-            name_setting=NameSetting("kon", "", ("temperature",)),
-            min=0.0,
-            expr="{koff} / max({kd}, 1e-32)",
         ),
         "c_monomer": ParamLocalSetting(
             name_setting=NameSetting("c_monomer", "", TP),
@@ -86,7 +118,7 @@ def make_settings_2st_monomer_dimer(
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TP),
-            expr="2.0 * {kon} * {c_monomer}",
+            expr=f"rates({p_total}, {{kd}}, {{koff}})['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TP),
@@ -107,6 +139,7 @@ def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_2st_monomer_dimer)
     user_functions = {
         "concentrations": calculate_concentrations,
+        "rates": calculate_rates,
         "pop_2st": pop_2st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)

--- a/src/chemex/models/kinetic/settings_2st_monomer_tetramer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_tetramer.py
@@ -9,7 +9,15 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_2st
 from chemex.models.factory import model_factory
-from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
+from chemex.models.kinetic._oligomerization import (
+    MIN_POSITIVE_FLOAT,
+    OligomerizationEquilibrium,
+    concentrations_from_log_fractions,
+    detailed_balance_forward_rate,
+    log_equilibrium_coefficient,
+    solve_oligomerization_fractions,
+    validate_oligomerization_kd,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -34,24 +42,48 @@ def calculate_residuals(
 
 
 @lru_cache(maxsize=100)
+def _calculate_equilibrium(p_total: float, kd: float) -> OligomerizationEquilibrium:
+    return solve_oligomerization_fractions(
+        ((4, log_equilibrium_coefficient(p_total, 3, kd)),),
+    )
+
+
+@lru_cache(maxsize=100)
 def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
-    if math.isfinite(p_total) and p_total > 0.0 and math.isfinite(kd) and kd >= 1e-32:
-        try:
-            coefficient = p_total**3 / kd
-        except OverflowError:
-            msg = "Oligomerization concentration solver produced an invalid coefficient"
-            raise RuntimeError(msg) from None
-        monomer_fraction, (tetramer_fraction,) = solve_oligomerization_fractions(
-            ((4, coefficient),),
+    validate_oligomerization_kd(kd)
+    if math.isfinite(p_total) and p_total > 0.0:
+        equilibrium = _calculate_equilibrium(p_total, kd)
+        monomer, tetramer = concentrations_from_log_fractions(
+            p_total,
+            (
+                (1, equilibrium.log_monomer_fraction),
+                (4, equilibrium.log_oligomer_fractions[0]),
+            ),
         )
         return {
-            "monomer": p_total * monomer_fraction,
-            "tetramer": p_total * tetramer_fraction,
+            "monomer": monomer,
+            "tetramer": tetramer,
         }
 
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "tetramer": results["x"][1]}
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(p_total: float, kd: float, koff: float) -> dict[str, float]:
+    validate_oligomerization_kd(kd)
+    if p_total == 0.0:
+        detailed_balance_forward_rate(koff, 0.0, 0.0)
+        return {"kab": 0.0}
+    equilibrium = _calculate_equilibrium(p_total, kd)
+    return {
+        "kab": detailed_balance_forward_rate(
+            koff,
+            equilibrium.log_tagged_fractions[0],
+            equilibrium.log_tagged_fractions[1],
+        ),
+    }
 
 
 def make_settings_2st_monomer_tetramer(
@@ -72,14 +104,9 @@ def make_settings_2st_monomer_tetramer(
         "kd": ParamLocalSetting(
             name_setting=NameSetting("kd", "", ("temperature",)),
             value=1e-6,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
-        ),
-        "kon": ParamLocalSetting(
-            name_setting=NameSetting("kon", "", ("temperature",)),
-            min=0.0,
-            expr="{koff} / max({kd}, 1e-32)",
         ),
         "c_monomer": ParamLocalSetting(
             name_setting=NameSetting("c_monomer", "", TP),
@@ -91,7 +118,7 @@ def make_settings_2st_monomer_tetramer(
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TP),
-            expr="4.0 * {kon} * {c_monomer} * {c_monomer} * {c_monomer}",
+            expr=f"rates({p_total}, {{kd}}, {{koff}})['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TP),
@@ -112,6 +139,7 @@ def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_2st_monomer_tetramer)
     user_functions = {
         "concentrations": calculate_concentrations,
+        "rates": calculate_rates,
         "pop_2st": pop_2st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)

--- a/src/chemex/models/kinetic/settings_2st_monomer_trimer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_trimer.py
@@ -9,7 +9,15 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_2st
 from chemex.models.factory import model_factory
-from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
+from chemex.models.kinetic._oligomerization import (
+    MIN_POSITIVE_FLOAT,
+    OligomerizationEquilibrium,
+    concentrations_from_log_fractions,
+    detailed_balance_forward_rate,
+    log_equilibrium_coefficient,
+    solve_oligomerization_fractions,
+    validate_oligomerization_kd,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -34,24 +42,48 @@ def calculate_residuals(
 
 
 @lru_cache(maxsize=100)
+def _calculate_equilibrium(p_total: float, kd: float) -> OligomerizationEquilibrium:
+    return solve_oligomerization_fractions(
+        ((3, log_equilibrium_coefficient(p_total, 2, kd)),),
+    )
+
+
+@lru_cache(maxsize=100)
 def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
-    if math.isfinite(p_total) and p_total > 0.0 and math.isfinite(kd) and kd >= 1e-32:
-        try:
-            coefficient = p_total**2 / kd
-        except OverflowError:
-            msg = "Oligomerization concentration solver produced an invalid coefficient"
-            raise RuntimeError(msg) from None
-        monomer_fraction, (trimer_fraction,) = solve_oligomerization_fractions(
-            ((3, coefficient),),
+    validate_oligomerization_kd(kd)
+    if math.isfinite(p_total) and p_total > 0.0:
+        equilibrium = _calculate_equilibrium(p_total, kd)
+        monomer, trimer = concentrations_from_log_fractions(
+            p_total,
+            (
+                (1, equilibrium.log_monomer_fraction),
+                (3, equilibrium.log_oligomer_fractions[0]),
+            ),
         )
         return {
-            "monomer": p_total * monomer_fraction,
-            "trimer": p_total * trimer_fraction,
+            "monomer": monomer,
+            "trimer": trimer,
         }
 
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "trimer": results["x"][1]}
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(p_total: float, kd: float, koff: float) -> dict[str, float]:
+    validate_oligomerization_kd(kd)
+    if p_total == 0.0:
+        detailed_balance_forward_rate(koff, 0.0, 0.0)
+        return {"kab": 0.0}
+    equilibrium = _calculate_equilibrium(p_total, kd)
+    return {
+        "kab": detailed_balance_forward_rate(
+            koff,
+            equilibrium.log_tagged_fractions[0],
+            equilibrium.log_tagged_fractions[1],
+        ),
+    }
 
 
 def make_settings_2st_monomer_trimer(
@@ -72,14 +104,9 @@ def make_settings_2st_monomer_trimer(
         "kd": ParamLocalSetting(
             name_setting=NameSetting("kd", "", ("temperature",)),
             value=1e-6,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
-        ),
-        "kon": ParamLocalSetting(
-            name_setting=NameSetting("kon", "", ("temperature",)),
-            min=0.0,
-            expr="{koff} / max({kd}, 1e-32)",
         ),
         "c_monomer": ParamLocalSetting(
             name_setting=NameSetting("c_monomer", "", TP),
@@ -91,7 +118,7 @@ def make_settings_2st_monomer_trimer(
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TP),
-            expr="3.0 * {kon} * {c_monomer} * {c_monomer}",
+            expr=f"rates({p_total}, {{kd}}, {{koff}})['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TP),
@@ -112,6 +139,7 @@ def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_2st_monomer_trimer)
     user_functions = {
         "concentrations": calculate_concentrations,
+        "rates": calculate_rates,
         "pop_2st": pop_2st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)

--- a/src/chemex/models/kinetic/settings_3st_monomer_dimer_tetramer.py
+++ b/src/chemex/models/kinetic/settings_3st_monomer_dimer_tetramer.py
@@ -9,7 +9,15 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
-from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
+from chemex.models.kinetic._oligomerization import (
+    MIN_POSITIVE_FLOAT,
+    OligomerizationEquilibrium,
+    concentrations_from_log_fractions,
+    detailed_balance_forward_rate,
+    log_equilibrium_coefficient,
+    solve_oligomerization_fractions,
+    validate_oligomerization_kd,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -36,36 +44,41 @@ def calculate_residuals(
 
 
 @lru_cache(maxsize=100)
+def _calculate_equilibrium(
+    p_total: float,
+    kd1: float,
+    kd2: float,
+) -> OligomerizationEquilibrium:
+    return solve_oligomerization_fractions(
+        (
+            (2, log_equilibrium_coefficient(p_total, 1, kd1)),
+            (4, log_equilibrium_coefficient(p_total, 3, kd1, kd1, kd2)),
+        ),
+    )
+
+
+@lru_cache(maxsize=100)
 def calculate_concentrations(
     p_total: float,
     kd1: float,
     kd2: float,
 ) -> dict[str, float]:
-    if (
-        math.isfinite(p_total)
-        and p_total > 0.0
-        and math.isfinite(kd1)
-        and kd1 >= 1e-32
-        and math.isfinite(kd2)
-        and kd2 >= 1e-32
-    ):
-        try:
-            tetramer_coefficient = p_total**3 / (kd1**2 * kd2)
-        except OverflowError:
-            msg = "Oligomerization concentration solver produced an invalid coefficient"
-            raise RuntimeError(msg) from None
-        monomer_fraction, (dimer_fraction, tetramer_fraction) = (
-            solve_oligomerization_fractions(
-                (
-                    (2, p_total / kd1),
-                    (4, tetramer_coefficient),
-                ),
-            )
+    validate_oligomerization_kd(kd1)
+    validate_oligomerization_kd(kd2)
+    if math.isfinite(p_total) and p_total > 0.0:
+        equilibrium = _calculate_equilibrium(p_total, kd1, kd2)
+        monomer, dimer, tetramer = concentrations_from_log_fractions(
+            p_total,
+            (
+                (1, equilibrium.log_monomer_fraction),
+                (2, equilibrium.log_oligomer_fractions[0]),
+                (4, equilibrium.log_oligomer_fractions[1]),
+            ),
         )
         return {
-            "monomer": p_total * monomer_fraction,
-            "dimer": p_total * dimer_fraction,
-            "tetramer": p_total * tetramer_fraction,
+            "monomer": monomer,
+            "dimer": dimer,
+            "tetramer": tetramer,
         }
 
     concentrations_start = (p_total, 0.0, 0.0)
@@ -74,6 +87,29 @@ def calculate_concentrations(
         "monomer": results["x"][0],
         "dimer": results["x"][1],
         "tetramer": results["x"][2],
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(
+    p_total: float,
+    kd1: float,
+    kd2: float,
+    koff1: float,
+    koff2: float,
+) -> dict[str, float]:
+    validate_oligomerization_kd(kd1)
+    validate_oligomerization_kd(kd2)
+    if p_total == 0.0:
+        detailed_balance_forward_rate(koff1, 0.0, 0.0)
+        detailed_balance_forward_rate(koff2, 0.0, 0.0)
+        return {"kab": 0.0, "kbc": 0.0}
+
+    equilibrium = _calculate_equilibrium(p_total, kd1, kd2)
+    log_pa, log_pb, log_pc = equilibrium.log_tagged_fractions
+    return {
+        "kab": detailed_balance_forward_rate(koff1, log_pa, log_pb),
+        "kbc": detailed_balance_forward_rate(koff2, log_pb, log_pc),
     }
 
 
@@ -88,14 +124,14 @@ def make_settings_3st_monomer_dimer_tetramer(
         "kd1": ParamLocalSetting(
             name_setting=NameSetting("kd1", "", ("temperature",)),
             value=1e-6,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
         "kd2": ParamLocalSetting(
             name_setting=NameSetting("kd2", "", ("temperature",)),
             value=1e-6,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -113,16 +149,6 @@ def make_settings_3st_monomer_dimer_tetramer(
             max=1.0e6,
             vary=True,
         ),
-        "kon1": ParamLocalSetting(
-            name_setting=NameSetting("kon1", "", ("temperature",)),
-            min=0.0,
-            expr="{koff1} / max({kd1}, 1e-32)",
-        ),
-        "kon2": ParamLocalSetting(
-            name_setting=NameSetting("kon2", "", ("temperature",)),
-            min=0.0,
-            expr="{koff2} / max({kd2}, 1e-32)",
-        ),
         "c_monomer": ParamLocalSetting(
             name_setting=NameSetting("c_monomer", "", TP),
             expr=f"concentrations({p_total}, {{kd1}}, {{kd2}})['monomer']",
@@ -137,7 +163,7 @@ def make_settings_3st_monomer_dimer_tetramer(
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TP),
-            expr="2.0 * {kon1} * {c_monomer}",
+            expr=f"rates({p_total}, {{kd1}}, {{kd2}}, {{koff1}}, {{koff2}})['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TP),
@@ -145,7 +171,7 @@ def make_settings_3st_monomer_dimer_tetramer(
         ),
         "kbc": ParamLocalSetting(
             name_setting=NameSetting("kbc", "", TP),
-            expr="2.0 * {kon2} * {c_dimer}",
+            expr=f"rates({p_total}, {{kd1}}, {{kd2}}, {{koff1}}, {{koff2}})['kbc']",
         ),
         "kcb": ParamLocalSetting(
             name_setting=NameSetting("kcb", "", TP),
@@ -173,6 +199,7 @@ def register() -> None:
     )
     user_functions = {
         "concentrations": calculate_concentrations,
+        "rates": calculate_rates,
         "pop_3st": pop_3st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)

--- a/src/chemex/models/kinetic/settings_3st_monomer_dimer_trimer.py
+++ b/src/chemex/models/kinetic/settings_3st_monomer_dimer_trimer.py
@@ -9,7 +9,16 @@ from scipy.optimize import root
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
-from chemex.models.kinetic._oligomerization import solve_oligomerization_fractions
+from chemex.models.kinetic._oligomerization import (
+    MIN_POSITIVE_FLOAT,
+    OligomerizationEquilibrium,
+    concentrations_from_log_fractions,
+    detailed_balance_forward_rate,
+    log_equilibrium_coefficient,
+    scale_reversible_rate,
+    solve_oligomerization_fractions,
+    validate_oligomerization_kd,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
 from chemex.parameters.userfunctions import user_function_registry
 from chemex.typing import Array
@@ -36,36 +45,41 @@ def calculate_residuals(
 
 
 @lru_cache(maxsize=100)
+def _calculate_equilibrium(
+    p_total: float,
+    kd1: float,
+    kd2: float,
+) -> OligomerizationEquilibrium:
+    return solve_oligomerization_fractions(
+        (
+            (2, log_equilibrium_coefficient(p_total, 1, kd1)),
+            (3, log_equilibrium_coefficient(p_total, 2, kd1, kd2)),
+        ),
+    )
+
+
+@lru_cache(maxsize=100)
 def calculate_concentrations(
     p_total: float,
     kd1: float,
     kd2: float,
 ) -> dict[str, float]:
-    if (
-        math.isfinite(p_total)
-        and p_total > 0.0
-        and math.isfinite(kd1)
-        and kd1 >= 1e-32
-        and math.isfinite(kd2)
-        and kd2 >= 1e-32
-    ):
-        try:
-            trimer_coefficient = p_total**2 / (kd1 * kd2)
-        except OverflowError:
-            msg = "Oligomerization concentration solver produced an invalid coefficient"
-            raise RuntimeError(msg) from None
-        monomer_fraction, (dimer_fraction, trimer_fraction) = (
-            solve_oligomerization_fractions(
-                (
-                    (2, p_total / kd1),
-                    (3, trimer_coefficient),
-                ),
-            )
+    validate_oligomerization_kd(kd1)
+    validate_oligomerization_kd(kd2)
+    if math.isfinite(p_total) and p_total > 0.0:
+        equilibrium = _calculate_equilibrium(p_total, kd1, kd2)
+        monomer, dimer, trimer = concentrations_from_log_fractions(
+            p_total,
+            (
+                (1, equilibrium.log_monomer_fraction),
+                (2, equilibrium.log_oligomer_fractions[0]),
+                (3, equilibrium.log_oligomer_fractions[1]),
+            ),
         )
         return {
-            "monomer": p_total * monomer_fraction,
-            "dimer": p_total * dimer_fraction,
-            "trimer": p_total * trimer_fraction,
+            "monomer": monomer,
+            "dimer": dimer,
+            "trimer": trimer,
         }
 
     concentrations_start = (p_total, 0.0, 0.0)
@@ -74,6 +88,33 @@ def calculate_concentrations(
         "monomer": results["x"][0],
         "dimer": results["x"][1],
         "trimer": results["x"][2],
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(
+    p_total: float,
+    kd1: float,
+    kd2: float,
+    koff1: float,
+    koff2: float,
+) -> dict[str, float]:
+    validate_oligomerization_kd(kd1)
+    validate_oligomerization_kd(kd2)
+    kca = scale_reversible_rate(koff2, 1.0 / 3.0)
+    kcb = scale_reversible_rate(koff2, 2.0 / 3.0)
+    if p_total == 0.0:
+        detailed_balance_forward_rate(koff1, 0.0, 0.0)
+        return {"kab": 0.0, "kac": 0.0, "kca": kca, "kbc": 0.0, "kcb": kcb}
+
+    equilibrium = _calculate_equilibrium(p_total, kd1, kd2)
+    log_pa, log_pb, log_pc = equilibrium.log_tagged_fractions
+    return {
+        "kab": detailed_balance_forward_rate(koff1, log_pa, log_pb),
+        "kac": detailed_balance_forward_rate(kca, log_pa, log_pc),
+        "kca": kca,
+        "kbc": detailed_balance_forward_rate(kcb, log_pb, log_pc),
+        "kcb": kcb,
     }
 
 
@@ -88,14 +129,14 @@ def make_settings_3st_monomer_dimer_trimer(
         "kd1": ParamLocalSetting(
             name_setting=NameSetting("kd1", "", ("temperature",)),
             value=1e-6,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
         "kd2": ParamLocalSetting(
             name_setting=NameSetting("kd2", "", ("temperature",)),
             value=1e-6,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -113,16 +154,6 @@ def make_settings_3st_monomer_dimer_trimer(
             max=1.0e6,
             vary=True,
         ),
-        "kon1": ParamLocalSetting(
-            name_setting=NameSetting("kon1", "", ("temperature",)),
-            min=0.0,
-            expr="{koff1} / max({kd1}, 1e-32)",
-        ),
-        "kon2": ParamLocalSetting(
-            name_setting=NameSetting("kon2", "", ("temperature",)),
-            min=0.0,
-            expr="{koff2} / max({kd2}, 1e-32)",
-        ),
         "c_monomer": ParamLocalSetting(
             name_setting=NameSetting("c_monomer", "", TP),
             expr=f"concetrations({p_total}, {{kd1}}, {{kd2}})['monomer']",
@@ -137,7 +168,7 @@ def make_settings_3st_monomer_dimer_trimer(
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TP),
-            expr="2.0 * {kon1} * {c_monomer}",
+            expr=f"rates({p_total}, {{kd1}}, {{kd2}}, {{koff1}}, {{koff2}})['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TP),
@@ -145,19 +176,19 @@ def make_settings_3st_monomer_dimer_trimer(
         ),
         "kac": ParamLocalSetting(
             name_setting=NameSetting("kac", "", TP),
-            expr="{kon2} * {c_dimer}",
+            expr=f"rates({p_total}, {{kd1}}, {{kd2}}, {{koff1}}, {{koff2}})['kac']",
         ),
         "kca": ParamLocalSetting(
             name_setting=NameSetting("kca", "", TP),
-            expr="{koff2} / 3.0",
+            expr=f"rates({p_total}, {{kd1}}, {{kd2}}, {{koff1}}, {{koff2}})['kca']",
         ),
         "kbc": ParamLocalSetting(
             name_setting=NameSetting("kbc", "", TP),
-            expr="{kon2} * {c_monomer}",
+            expr=f"rates({p_total}, {{kd1}}, {{kd2}}, {{koff1}}, {{koff2}})['kbc']",
         ),
         "kcb": ParamLocalSetting(
             name_setting=NameSetting("kcb", "", TP),
-            expr="2.0 * {koff2} / 3.0",
+            expr=f"rates({p_total}, {{kd1}}, {{kd2}}, {{koff1}}, {{koff2}})['kcb']",
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TP),
@@ -181,6 +212,7 @@ def register() -> None:
     )
     user_functions = {
         "concetrations": calculate_concentrations,
+        "rates": calculate_rates,
         "pop_3st": pop_3st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)

--- a/tests/models/kinetic/test_oligomerization_models.py
+++ b/tests/models/kinetic/test_oligomerization_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+import sys
 from collections.abc import Mapping
 from types import SimpleNamespace
 
@@ -10,8 +12,16 @@ import pytest
 from chemex.configuration.conditions import Conditions
 from chemex.configuration.parameters import DefaultSetting
 from chemex.models.factory import model_factory
+from chemex.models.kinetic import (
+    settings_3st_monomer_dimer_tetramer as dimer_tetramer_model,
+)
+from chemex.models.kinetic import (
+    settings_3st_monomer_dimer_trimer as dimer_trimer_model,
+)
 from chemex.nmr.basis import Basis
 from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import ConstraintDomainError
+from chemex.parameters.sealed import InvalidConfigurationError
 from chemex.parameters.spin_system import SpinSystem
 from chemex.runtime import AnalysisSession
 
@@ -22,11 +32,11 @@ ABSOLUTE_TOLERANCE = 1.0e-14
 EQUILIBRIUM_ABSOLUTE_TOLERANCE = 1.0e-24
 
 
-def _construct_and_resolve(
+def _prepare_model(
     model_name: str,
     p_total: float,
-    defaults: Mapping[str, float],
-) -> tuple[dict[str, str], dict[str, str], dict[str, float]]:
+    defaults: Mapping[str, float | DefaultSetting],
+) -> tuple[AnalysisSession, dict[str, str], dict[str, str]]:
     conditions = Conditions(
         h_larmor_frq=600.0,
         temperature=25.0,
@@ -53,13 +63,25 @@ def _construct_and_resolve(
     )
     session.parameters.set_defaults(
         [
-            (ParamName.from_section(name), DefaultSetting(value))
+            (
+                ParamName.from_section(name),
+                value if isinstance(value, DefaultSetting) else DefaultSetting(value),
+            )
             for name, value in defaults.items()
         ],
     )
     assert session.parameter_factory.try_seal_definitions(), repr(
         session.parameter_factory.native_construction_error,
     )
+    return session, name_map, local_ids
+
+
+def _construct_and_resolve(
+    model_name: str,
+    p_total: float,
+    defaults: Mapping[str, float | DefaultSetting],
+) -> tuple[dict[str, str], dict[str, str], dict[str, float]]:
+    session, name_map, local_ids = _prepare_model(model_name, p_total, defaults)
     assert session.try_build_analysis_values(), repr(
         session.parameter_factory.native_construction_error,
     )
@@ -123,14 +145,16 @@ def test_direct_oligomerization_resolves_tagged_chemical_equilibrium(
         rel=RELATIVE_TOLERANCE,
         abs=ABSOLUTE_TOLERANCE,
     )
-    assert values["kon"] == pytest.approx(values["koff"] / values["kd"])
     assert values["kd"] * oligomer_concentration == pytest.approx(
         values["c_monomer"] ** stoichiometry,
         rel=RELATIVE_TOLERANCE,
         abs=EQUILIBRIUM_ABSOLUTE_TOLERANCE,
     )
     assert values["kab"] == pytest.approx(
-        stoichiometry * values["kon"] * values["c_monomer"] ** (stoichiometry - 1),
+        stoichiometry
+        * values["koff"]
+        / values["kd"]
+        * values["c_monomer"] ** (stoichiometry - 1),
         rel=RELATIVE_TOLERANCE,
         abs=ABSOLUTE_TOLERANCE,
     )
@@ -153,7 +177,6 @@ def test_direct_dimer_resolved_oracle_is_unchanged() -> None:
         {
             "koff": 83.0,
             "kd": 2.7e-3,
-            "kon": 30740.74074074074,
             "c_monomer": 0.0008118170701199257,
             "c_dimer": 0.0002440914649400371,
             "kab": 49.91171616292876,
@@ -201,8 +224,6 @@ def test_sequential_dimer_trimer_resolved_oracle_and_tagged_equilibrium() -> Non
             abs=ABSOLUTE_TOLERANCE,
         )
 
-    assert values["kon1"] == pytest.approx(values["koff1"] / values["kd1"])
-    assert values["kon2"] == pytest.approx(values["koff2"] / values["kd2"])
     assert values["kd1"] * values["c_dimer"] == pytest.approx(
         values["c_monomer"] ** 2,
         rel=RELATIVE_TOLERANCE,
@@ -214,12 +235,16 @@ def test_sequential_dimer_trimer_resolved_oracle_and_tagged_equilibrium() -> Non
         abs=EQUILIBRIUM_ABSOLUTE_TOLERANCE,
     )
     assert values["kab"] == pytest.approx(
-        2.0 * values["kon1"] * values["c_monomer"],
+        2.0 * values["koff1"] / values["kd1"] * values["c_monomer"],
     )
     assert values["kba"] == pytest.approx(values["koff1"])
-    assert values["kac"] == pytest.approx(values["kon2"] * values["c_dimer"])
+    assert values["kac"] == pytest.approx(
+        values["koff2"] / values["kd2"] * values["c_dimer"]
+    )
     assert values["kca"] == pytest.approx(values["koff2"] / 3.0)
-    assert values["kbc"] == pytest.approx(values["kon2"] * values["c_monomer"])
+    assert values["kbc"] == pytest.approx(
+        values["koff2"] / values["kd2"] * values["c_monomer"]
+    )
     assert values["kcb"] == pytest.approx(2.0 * values["koff2"] / 3.0)
     for left_population, forward_rate, right_population, reverse_rate in (
         ("pa", "kab", "pb", "kba"),
@@ -238,8 +263,6 @@ def test_sequential_dimer_trimer_resolved_oracle_and_tagged_equilibrium() -> Non
             "kd2": 6.3e-4,
             "koff1": 73.0,
             "koff2": 149.0,
-            "kon1": 42941.17647058824,
-            "kon2": 236507.9365079365,
             "c_monomer": 0.0005239890527646985,
             "c_dimer": 0.0001615085455406397,
             "c_trimer": 0.00013433128538467405,
@@ -308,8 +331,6 @@ def test_sequential_dimer_tetramer_constructs_distinct_tagged_equilibrium() -> N
             abs=ABSOLUTE_TOLERANCE,
         )
 
-    assert values["kon1"] == pytest.approx(values["koff1"] / values["kd1"])
-    assert values["kon2"] == pytest.approx(values["koff2"] / values["kd2"])
     assert values["kd1"] * values["c_dimer"] == pytest.approx(
         values["c_monomer"] ** 2,
         rel=RELATIVE_TOLERANCE,
@@ -321,11 +342,11 @@ def test_sequential_dimer_tetramer_constructs_distinct_tagged_equilibrium() -> N
         abs=EQUILIBRIUM_ABSOLUTE_TOLERANCE,
     )
     assert values["kab"] == pytest.approx(
-        2.0 * values["kon1"] * values["c_monomer"],
+        2.0 * values["koff1"] / values["kd1"] * values["c_monomer"],
     )
     assert values["kba"] == pytest.approx(values["koff1"])
     assert values["kbc"] == pytest.approx(
-        2.0 * values["kon2"] * values["c_dimer"],
+        2.0 * values["koff2"] / values["kd2"] * values["c_dimer"],
     )
     assert values["kcb"] == pytest.approx(values["koff2"])
     for left_population, forward_rate, right_population, reverse_rate in (
@@ -344,8 +365,6 @@ def test_sequential_dimer_tetramer_constructs_distinct_tagged_equilibrium() -> N
             "kd2": 4.1e-4,
             "koff1": 79.0,
             "koff2": 163.0,
-            "kon1": 41578.94736842105,
-            "kon2": 397560.97560975613,
             "c_monomer": 0.0005706471522611405,
             "c_dimer": 0.00017138851179980075,
             "c_tetramer": 7.164395603481447e-5,
@@ -360,3 +379,322 @@ def test_sequential_dimer_tetramer_constructs_distinct_tagged_equilibrium() -> N
         rel=RELATIVE_TOLERANCE,
         abs=ABSOLUTE_TOLERANCE,
     )
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    (
+        "2st_monomer_dimer",
+        "2st_monomer_trimer",
+        "2st_monomer_tetramer",
+        "3st_monomer_dimer_trimer",
+        "3st_monomer_dimer_tetramer",
+    ),
+)
+def test_oligomerization_models_do_not_construct_eager_kon_settings(
+    model_name: str,
+) -> None:
+    settings = model_factory.create(
+        model_name,
+        Conditions(h_larmor_frq=600.0, temperature=25.0, p_total=1e-3),
+    )
+
+    assert {"kon", "kon1", "kon2"}.isdisjoint(settings)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "defaults", "concentration_names", "expected_rates"),
+    (
+        (
+            "2st_monomer_dimer",
+            {"kd": 1e-6, "koff": 90.0},
+            ("c_monomer", "c_dimer"),
+            {"kab": 0.0, "kba": 90.0},
+        ),
+        (
+            "2st_monomer_trimer",
+            {"kd": 1e-6, "koff": 90.0},
+            ("c_monomer", "c_trimer"),
+            {"kab": 0.0, "kba": 90.0},
+        ),
+        (
+            "2st_monomer_tetramer",
+            {"kd": 1e-6, "koff": 90.0},
+            ("c_monomer", "c_tetramer"),
+            {"kab": 0.0, "kba": 90.0},
+        ),
+        (
+            "3st_monomer_dimer_trimer",
+            {"kd1": 1e-6, "kd2": 2e-6, "koff1": 90.0, "koff2": 150.0},
+            ("c_monomer", "c_dimer", "c_trimer"),
+            {
+                "kab": 0.0,
+                "kba": 90.0,
+                "kac": 0.0,
+                "kca": 50.0,
+                "kbc": 0.0,
+                "kcb": 100.0,
+            },
+        ),
+        (
+            "3st_monomer_dimer_tetramer",
+            {"kd1": 1e-6, "kd2": 2e-6, "koff1": 90.0, "koff2": 150.0},
+            ("c_monomer", "c_dimer", "c_tetramer"),
+            {"kab": 0.0, "kba": 90.0, "kbc": 0.0, "kcb": 150.0},
+        ),
+    ),
+)
+def test_zero_total_full_model_retains_zero_association_and_state_a(
+    model_name: str,
+    defaults: dict[str, float],
+    concentration_names: tuple[str, ...],
+    expected_rates: dict[str, float],
+) -> None:
+    _, _, values = _construct_and_resolve(model_name, 0.0, defaults)
+
+    assert {name: values[name] for name in concentration_names} == dict.fromkeys(
+        concentration_names, 0.0
+    )
+    assert {name: values[name] for name in expected_rates} == pytest.approx(
+        expected_rates
+    )
+    assert values["pa"] == 1.0
+    assert values["pb"] == 0.0
+    if "pc" in values:
+        assert values["pc"] == 0.0
+
+
+KD_STRESS = (
+    1e-31,
+    1e-32,
+    1e-33,
+    1e-50,
+    1e-100,
+    sys.float_info.min,
+    math.nextafter(0.0, 1.0),
+)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "oligomer", "stoichiometry"),
+    (
+        ("2st_monomer_dimer", "dimer", 2),
+        ("2st_monomer_trimer", "trimer", 3),
+        ("2st_monomer_tetramer", "tetramer", 4),
+    ),
+)
+@pytest.mark.parametrize("kd", KD_STRESS)
+def test_direct_positive_kd_stress_resolves_finite_detailed_balance(
+    model_name: str,
+    oligomer: str,
+    stoichiometry: int,
+    kd: float,
+) -> None:
+    p_total = 1e-100
+    _, _, values = _construct_and_resolve(
+        model_name,
+        p_total,
+        {"kd": kd, "koff": 1.0},
+    )
+
+    assert values["kd"] == kd
+    assert all(
+        math.isfinite(values[name]) and values[name] >= 0.0
+        for name in ("c_monomer", f"c_{oligomer}", "kab", "kba", "pa", "pb")
+    )
+    assert values["c_monomer"] + stoichiometry * values[f"c_{oligomer}"] == (
+        pytest.approx(p_total, rel=2e-12, abs=math.nextafter(0.0, 1.0))
+    )
+    assert values["pa"] * values["kab"] == pytest.approx(
+        values["pb"] * values["kba"],
+        rel=2e-12,
+        abs=math.nextafter(0.0, 1.0),
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "higher", "higher_stoichiometry"),
+    (
+        ("3st_monomer_dimer_trimer", "trimer", 3),
+        ("3st_monomer_dimer_tetramer", "tetramer", 4),
+    ),
+)
+@pytest.mark.parametrize("vary", ("kd1", "kd2", "both"))
+@pytest.mark.parametrize("kd", KD_STRESS)
+def test_sequential_positive_kd_stress_resolves_finite_detailed_balance(
+    model_name: str,
+    higher: str,
+    higher_stoichiometry: int,
+    vary: str,
+    kd: float,
+) -> None:
+    p_total = 1e-100
+    kd1 = kd if vary in {"kd1", "both"} else 1e-6
+    kd2 = kd if vary in {"kd2", "both"} else 1e-6
+    model = (
+        dimer_trimer_model
+        if model_name == "3st_monomer_dimer_trimer"
+        else dimer_tetramer_model
+    )
+    log_pa, log_pb, log_pc = model._calculate_equilibrium(
+        p_total,
+        kd1,
+        kd2,
+    ).log_tagged_fractions
+    koff1 = math.exp(min(0.0, log_pa - log_pb))
+    koff2 = math.exp(min(0.0, log_pa - log_pc, log_pb - log_pc))
+    _, _, values = _construct_and_resolve(
+        model_name,
+        p_total,
+        {"kd1": kd1, "kd2": kd2, "koff1": koff1, "koff2": koff2},
+    )
+
+    assert values["kd1"] == kd1
+    assert values["kd2"] == kd2
+    names = {
+        "c_monomer",
+        "c_dimer",
+        f"c_{higher}",
+        "kab",
+        "kba",
+        "kbc",
+        "kcb",
+        "pa",
+        "pb",
+        "pc",
+    }
+    if higher == "trimer":
+        names |= {"kac", "kca"}
+    assert all(math.isfinite(values[name]) and values[name] >= 0.0 for name in names)
+    assert (
+        values["c_monomer"]
+        + 2.0 * values["c_dimer"]
+        + higher_stoichiometry * values[f"c_{higher}"]
+    ) == pytest.approx(
+        p_total,
+        rel=2e-12,
+        abs=math.nextafter(0.0, 1.0),
+    )
+    edges = [("pa", "kab", "pb", "kba"), ("pb", "kbc", "pc", "kcb")]
+    if higher == "trimer":
+        edges.append(("pa", "kac", "pc", "kca"))
+    for source, forward, destination, reverse in edges:
+        assert values[source] * values[forward] == pytest.approx(
+            values[destination] * values[reverse],
+            rel=2e-10,
+            abs=ABSOLUTE_TOLERANCE,
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "defaults"),
+    (
+        ("2st_monomer_dimer", {"kd": 0.0}),
+        ("2st_monomer_trimer", {"kd": 0.0}),
+        ("2st_monomer_tetramer", {"kd": 0.0}),
+        ("3st_monomer_dimer_trimer", {"kd1": 0.0}),
+        ("3st_monomer_dimer_trimer", {"kd2": 0.0}),
+        ("3st_monomer_dimer_tetramer", {"kd1": 0.0}),
+        ("3st_monomer_dimer_tetramer", {"kd2": 0.0}),
+    ),
+)
+def test_zero_kd_is_rejected_by_default_parameter_bounds(
+    model_name: str,
+    defaults: dict[str, float],
+) -> None:
+    session, _, _ = _prepare_model(model_name, 1e-3, defaults)
+
+    assert not session.try_build_analysis_values()
+    assert isinstance(
+        session.parameter_factory.native_construction_error,
+        InvalidConfigurationError,
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "kd_name"),
+    (
+        ("2st_monomer_dimer", "kd"),
+        ("2st_monomer_trimer", "kd"),
+        ("2st_monomer_tetramer", "kd"),
+        ("3st_monomer_dimer_trimer", "kd1"),
+        ("3st_monomer_dimer_trimer", "kd2"),
+        ("3st_monomer_dimer_tetramer", "kd1"),
+        ("3st_monomer_dimer_tetramer", "kd2"),
+    ),
+)
+def test_zero_kd_override_reaches_runtime_domain_authority(
+    model_name: str,
+    kd_name: str,
+) -> None:
+    session, _, _ = _prepare_model(
+        model_name,
+        1e-3,
+        {kd_name: DefaultSetting(0.0, min=0.0, max=1.0)},
+    )
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "KD must be finite and strictly positive" in str(error.__cause__)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "p_total", "defaults", "message"),
+    (
+        (
+            "2st_monomer_dimer",
+            sys.float_info.max,
+            {"kd": math.nextafter(0.0, 1.0), "koff": 1.0},
+            "exceeds the maximum finite binary64 value",
+        ),
+        (
+            "2st_monomer_tetramer",
+            1e-100,
+            {"kd": 1e-31, "koff": 1e-100},
+            "below binary64 representability",
+        ),
+    ),
+)
+def test_unrepresentable_actual_forward_rate_is_constraint_domain_error(
+    model_name: str,
+    p_total: float,
+    defaults: dict[str, float],
+    message: str,
+) -> None:
+    session, _, _ = _prepare_model(model_name, p_total, defaults)
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert message in str(error.__cause__)
+
+
+def test_monomer_trimer_rejects_upward_rounded_subminimum_forward_rate() -> None:
+    p_total = math.exp((-744.5 - math.log(3.0)) / 2.0)
+    session, _, _ = _prepare_model(
+        "2st_monomer_trimer",
+        p_total,
+        {"kd": 1.0, "koff": 1.0},
+    )
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "below binary64 representability" in str(error.__cause__)
+
+
+def test_zero_koff_retains_exact_zero_forward_rate_policy() -> None:
+    _, _, values = _construct_and_resolve(
+        "2st_monomer_dimer",
+        1e-3,
+        {"kd": math.nextafter(0.0, 1.0), "koff": 0.0},
+    )
+
+    assert values["kab"] == 0.0
+    assert values["kba"] == 0.0
+    assert values["pa"] == 1.0
+    assert values["pb"] == 0.0

--- a/tests/models/kinetic/test_oligomerization_solver.py
+++ b/tests/models/kinetic/test_oligomerization_solver.py
@@ -36,15 +36,24 @@ from chemex.models.kinetic.settings_3st_monomer_dimer_trimer import (
 ConcentrationSolver = Callable[..., dict[str, float]]
 
 MASS_TOLERANCE = 64.0 * sys.float_info.epsilon
-EQUILIBRIUM_TOLERANCE = 256.0 * sys.float_info.epsilon
+EQUILIBRIUM_TOLERANCE = 4096.0 * sys.float_info.epsilon
 
 DIRECT_MODELS = (dimer_model, trimer_model, tetramer_model)
 SEQUENTIAL_MODELS = (dimer_trimer_model, dimer_tetramer_model)
 UNSUPPORTED_P_TOTALS = (("zero-p-total", 0.0), ("non-finite-p-total", math.nan))
 UNSUPPORTED_KDS = (
     ("zero-kd", 0.0),
-    ("sub-threshold-kd", 0.5e-32),
+    ("negative-kd", -1.0),
     ("non-finite-kd", math.inf),
+)
+POSITIVE_KD_STRESS = (
+    1e-31,
+    1e-32,
+    1e-33,
+    1e-50,
+    1e-100,
+    sys.float_info.min,
+    math.nextafter(0.0, 1.0),
 )
 
 
@@ -133,7 +142,7 @@ def test_historical_hybr_failures_use_physical_solution(
             (1e-9, 1.0),
             (1e-6, 1e-6),
             (1e-3, 1e-12),
-            (1e-1, 1e-32),
+            *((1e-100, kd) for kd in POSITIVE_KD_STRESS),
         )
     ],
 )
@@ -169,10 +178,10 @@ def test_direct_positive_domain_stress(
         )
         for p_total, kd1, kd2 in (
             (1e-9, 1.0, 1.0),
-            (1e-6, 1e-32, 1e-3),
             (1e-3, 1e-5, 1e-3),
-            (1e-2, 1e-3, 1e-32),
-            (1e-1, 1e-32, 1e-32),
+            *((1e-100, kd, 1e-6) for kd in POSITIVE_KD_STRESS),
+            *((1e-100, 1e-6, kd) for kd in POSITIVE_KD_STRESS),
+            *((1e-100, kd, kd) for kd in POSITIVE_KD_STRESS),
         )
     ],
 )
@@ -209,10 +218,10 @@ def test_helper_rejects_non_converged_solver_result(
     )
 
     with pytest.raises(RuntimeError, match="did not converge"):
-        _oligomerization.solve_oligomerization_fractions(((2, 1.0),))
+        _oligomerization.solve_oligomerization_fractions(((2, 0.0),))
 
 
-@pytest.mark.parametrize("root", [math.nan, math.inf, -0.1, 1.1])
+@pytest.mark.parametrize("root", [math.nan, math.inf, 0.1])
 def test_helper_rejects_invalid_root(
     monkeypatch: pytest.MonkeyPatch,
     root: float,
@@ -224,7 +233,7 @@ def test_helper_rejects_invalid_root(
     )
 
     with pytest.raises(RuntimeError, match="invalid monomer fraction"):
-        _oligomerization.solve_oligomerization_fractions(((2, 1.0),))
+        _oligomerization.solve_oligomerization_fractions(((2, 0.0),))
 
 
 def test_helper_rejects_reconstructed_state_that_violates_mass(
@@ -237,7 +246,7 @@ def test_helper_rejects_reconstructed_state_that_violates_mass(
     )
 
     with pytest.raises(RuntimeError, match="violated mass conservation"):
-        _oligomerization.solve_oligomerization_fractions(((2, 1.0),))
+        _oligomerization.solve_oligomerization_fractions(((2, 0.0),))
 
 
 @pytest.mark.parametrize(
@@ -248,27 +257,12 @@ def test_helper_rejects_reconstructed_state_that_violates_mass(
         for case, p_total in UNSUPPORTED_P_TOTALS
     ]
     + [
-        pytest.param(model, (1e-3, kd), id=f"{model.NAME}-{case}")
-        for model in DIRECT_MODELS
-        for case, kd in UNSUPPORTED_KDS
-    ]
-    + [
         pytest.param(model, (p_total, 1e-3, 1e-3), id=f"{model.NAME}-{case}")
         for model in SEQUENTIAL_MODELS
         for case, p_total in UNSUPPORTED_P_TOTALS
-    ]
-    + [
-        pytest.param(model, (1e-3, kd, 1e-3), id=f"{model.NAME}-kd1-{case}")
-        for model in SEQUENTIAL_MODELS
-        for case, kd in UNSUPPORTED_KDS
-    ]
-    + [
-        pytest.param(model, (1e-3, 1e-3, kd), id=f"{model.NAME}-kd2-{case}")
-        for model in SEQUENTIAL_MODELS
-        for case, kd in UNSUPPORTED_KDS
     ],
 )
-def test_unsupported_domain_routes_to_legacy_hybr(
+def test_unsupported_p_total_retains_legacy_hybr_policy(
     monkeypatch: pytest.MonkeyPatch,
     model: ModuleType,
     arguments: tuple[float, ...],
@@ -289,6 +283,76 @@ def test_unsupported_domain_routes_to_legacy_hybr(
         assert legacy_call_count == 1
     finally:
         calculator.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("model", "arguments"),
+    [
+        pytest.param(model, (1e-3, kd), id=f"{model.NAME}-{case}")
+        for model in DIRECT_MODELS
+        for case, kd in UNSUPPORTED_KDS
+    ]
+    + [
+        pytest.param(model, (1e-3, kd, 1e-3), id=f"{model.NAME}-kd1-{case}")
+        for model in SEQUENTIAL_MODELS
+        for case, kd in UNSUPPORTED_KDS
+    ]
+    + [
+        pytest.param(model, (1e-3, 1e-3, kd), id=f"{model.NAME}-kd2-{case}")
+        for model in SEQUENTIAL_MODELS
+        for case, kd in UNSUPPORTED_KDS
+    ],
+)
+def test_every_oligomerization_kd_position_rejects_invalid_domain(
+    model: ModuleType,
+    arguments: tuple[float, ...],
+) -> None:
+    model.calculate_concentrations.cache_clear()
+    try:
+        with pytest.raises(ValueError, match="KD must be finite and strictly positive"):
+            model.calculate_concentrations(*arguments)
+    finally:
+        model.calculate_concentrations.cache_clear()
+
+
+@pytest.mark.parametrize("kd", POSITIVE_KD_STRESS)
+@pytest.mark.parametrize("model", (*DIRECT_MODELS, *SEQUENTIAL_MODELS))
+def test_positive_kd_never_dispatches_to_legacy_hybr(
+    monkeypatch: pytest.MonkeyPatch,
+    model: ModuleType,
+    kd: float,
+) -> None:
+    def fail_legacy(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("positive KD dispatched to legacy HYBR")
+
+    arguments = (1e-100, kd) if model in DIRECT_MODELS else (1e-100, kd, kd)
+    model.calculate_concentrations.cache_clear()
+    try:
+        monkeypatch.setattr(model, "root", fail_legacy)
+        model.calculate_concentrations(*arguments)
+    finally:
+        model.calculate_concentrations.cache_clear()
+
+
+@pytest.mark.parametrize("p_total", [-1.0, math.inf, math.nan])
+@pytest.mark.parametrize("model", (*DIRECT_MODELS, *SEQUENTIAL_MODELS))
+def test_rate_functions_retain_negative_and_non_finite_total_rejection(
+    model: ModuleType,
+    p_total: float,
+) -> None:
+    arguments = (
+        (p_total, 1e-3, 1.0)
+        if model in DIRECT_MODELS
+        else (p_total, 1e-3, 1e-3, 1.0, 1.0)
+    )
+    model.calculate_rates.cache_clear()
+    try:
+        with pytest.raises(
+            ValueError, match="P_total must be finite and strictly positive"
+        ):
+            model.calculate_rates(*arguments)
+    finally:
+        model.calculate_rates.cache_clear()
 
 
 def _assert_physical_concentrations(
@@ -314,3 +378,259 @@ def _assert_normalized_mass(
 def _assert_scale_aware_close(left: float, right: float) -> None:
     scale = max(abs(left), abs(right), sys.float_info.min)
     assert abs(left - right) <= EQUILIBRIUM_TOLERANCE * scale
+
+
+@pytest.mark.parametrize("kd", [1e-33, 1e-50])
+def test_direct_dimer_uses_literal_sub_floor_kd(kd: float) -> None:
+    concentrations = calculate_dimer(1e-3, kd)
+
+    assert concentrations["monomer"] ** 2 / concentrations["dimer"] == (
+        pytest.approx(kd, rel=1e-12, abs=0.0)
+    )
+
+
+def test_sub_floor_values_are_not_treated_as_legacy_effective_kd() -> None:
+    baseline = calculate_dimer(1e-3, 1e-32)
+    below = calculate_dimer(1e-3, 1e-33)
+    far_below = calculate_dimer(1e-3, 1e-50)
+
+    assert below["monomer"] / baseline["monomer"] == pytest.approx(
+        math.sqrt(0.1),
+        rel=1e-12,
+    )
+    assert far_below["monomer"] / baseline["monomer"] == pytest.approx(
+        1e-9,
+        rel=1e-12,
+    )
+    assert dimer_model.calculate_rates(1e-3, 1e-33, 1.0)["kab"] != (
+        pytest.approx(
+            dimer_model.calculate_rates(1e-3, 1e-32, 1.0)["kab"],
+            rel=1e-3,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "stoichiometry"),
+    ((dimer_model, 2), (trimer_model, 3), (tetramer_model, 4)),
+)
+@pytest.mark.parametrize("kd", POSITIVE_KD_STRESS)
+def test_direct_stress_equilibrium_is_satisfied_in_log_space(
+    model: ModuleType,
+    stoichiometry: int,
+    kd: float,
+) -> None:
+    p_total = 1e-100
+    equilibrium = model._calculate_equilibrium(p_total, kd)
+    log_monomer = math.log(p_total) + equilibrium.log_monomer_fraction
+    log_oligomer = math.log(p_total) + equilibrium.log_oligomer_fractions[0]
+
+    assert math.log(kd) + log_oligomer == pytest.approx(
+        stoichiometry * log_monomer,
+        abs=2e-12,
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "higher_stoichiometry"),
+    ((dimer_trimer_model, 3), (dimer_tetramer_model, 4)),
+)
+@pytest.mark.parametrize("vary", ("kd1", "kd2", "both"))
+@pytest.mark.parametrize("kd", POSITIVE_KD_STRESS)
+def test_sequential_stress_equilibria_are_satisfied_in_log_space(
+    model: ModuleType,
+    higher_stoichiometry: int,
+    vary: str,
+    kd: float,
+) -> None:
+    p_total = 1e-100
+    kd1 = kd if vary in {"kd1", "both"} else 1e-6
+    kd2 = kd if vary in {"kd2", "both"} else 1e-6
+    equilibrium = model._calculate_equilibrium(p_total, kd1, kd2)
+    log_p_total = math.log(p_total)
+    log_monomer = log_p_total + equilibrium.log_monomer_fraction
+    log_dimer = log_p_total + equilibrium.log_oligomer_fractions[0]
+    log_higher = log_p_total + equilibrium.log_oligomer_fractions[1]
+
+    assert math.log(kd1) + log_dimer == pytest.approx(
+        2.0 * log_monomer,
+        abs=2e-12,
+    )
+    right = log_monomer + log_dimer if higher_stoichiometry == 3 else 2.0 * log_dimer
+    assert math.log(kd2) + log_higher == pytest.approx(right, abs=2e-12)
+
+
+def test_minimum_subnormal_kd_does_not_fail_on_coefficient_overflow() -> None:
+    kd = math.nextafter(0.0, 1.0)
+    concentrations = calculate_tetramer(1e-3, kd)
+
+    _assert_physical_concentrations(concentrations, 1e-3)
+    _assert_normalized_mass(
+        1e-3,
+        ((1, concentrations["monomer"]), (4, concentrations["tetramer"])),
+    )
+
+
+@pytest.mark.parametrize("kd", [0.0, -1.0, math.inf, math.nan])
+def test_shared_helper_rejects_non_positive_or_non_finite_kd(kd: float) -> None:
+    with pytest.raises(ValueError, match="KD must be finite and strictly positive"):
+        _oligomerization.validate_oligomerization_kd(kd)
+
+
+def test_log_equilibrium_retains_underflowed_fraction_authority() -> None:
+    log_coefficient = _oligomerization.log_equilibrium_coefficient(
+        1e-100,
+        3,
+        1e-31,
+    )
+    equilibrium = _oligomerization.solve_oligomerization_fractions(
+        ((4, log_coefficient),)
+    )
+
+    assert equilibrium.oligomer_fractions[0] > 0.0
+    assert 1e-100 * equilibrium.oligomer_fractions[0] == 0.0
+    assert math.isfinite(equilibrium.log_oligomer_fractions[0])
+    assert (
+        math.log(1e-31) + equilibrium.log_oligomer_fractions[0] + math.log(1e-100)
+    ) == pytest.approx(
+        4.0 * (math.log(1e-100) + equilibrium.log_monomer_fraction),
+        abs=2e-12,
+    )
+
+
+def test_concentration_reconstruction_keeps_representable_absolute_value() -> None:
+    log_fraction = -750.0
+
+    assert math.exp(log_fraction) == 0.0
+    concentration = _oligomerization.concentration_from_log_fraction(
+        1e100,
+        log_fraction,
+    )
+
+    assert concentration > 0.0
+    assert concentration == pytest.approx(
+        math.exp(math.log(1e100) + log_fraction),
+        rel=2e-13,
+    )
+
+
+def test_concentration_reconstruction_keeps_representable_fraction() -> None:
+    assert _oligomerization.concentration_from_log_fraction(
+        1e3,
+        math.log(0.25),
+    ) == pytest.approx(250.0)
+
+
+def test_concentration_reconstruction_returns_zero_only_below_representability() -> (
+    None
+):
+    assert _oligomerization.concentration_from_log_fraction(1e-100, -750.0) == 0.0
+
+
+def test_dimer_trimer_reconstructs_audited_subnormal_trimer_concentration() -> None:
+    concentrations = calculate_dimer_trimer(
+        1e100,
+        math.nextafter(0.0, 1.0),
+        sys.float_info.max,
+    )
+
+    # Rounded binary64 value of the independently evaluated high-precision
+    # equilibrium concentration 4.3715130080390679...e-321.
+    assert concentrations["trimer"] == float.fromhex("0x0.0000000000375p-1022")
+
+
+def test_koff_over_kd_may_overflow_when_direct_final_rate_is_finite() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+
+    assert math.isinf(1.0 / minimum)
+    rate = dimer_model.calculate_rates(minimum, minimum, 1.0)["kab"]
+    assert math.isfinite(rate) and rate > 0.0
+
+
+def test_koff_over_kd_may_overflow_when_sequential_final_rates_are_finite() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+
+    assert math.isinf(1.0 / minimum)
+    rates = dimer_trimer_model.calculate_rates(
+        minimum,
+        minimum,
+        minimum,
+        1.0,
+        1.0,
+    )
+    assert all(math.isfinite(rate) and rate > 0.0 for rate in rates.values())
+
+
+def test_population_ratio_may_overflow_when_log_product_rate_is_finite() -> None:
+    reverse_rate = 1e-308
+    log_source = -710.0
+    log_destination = 0.0
+
+    with pytest.raises(OverflowError):
+        math.exp(log_destination - log_source)
+    forward_rate = _oligomerization.detailed_balance_forward_rate(
+        reverse_rate,
+        log_source,
+        log_destination,
+    )
+
+    assert forward_rate == pytest.approx(
+        math.exp(math.log(reverse_rate) + 710.0),
+        rel=2e-13,
+    )
+
+
+def test_actual_positive_forward_rate_overflow_is_rejected() -> None:
+    with pytest.raises(ValueError, match="exceeds the maximum finite binary64"):
+        _oligomerization.detailed_balance_forward_rate(
+            sys.float_info.max,
+            -1.0,
+            0.0,
+        )
+
+
+def test_actual_positive_forward_rate_underflow_is_rejected() -> None:
+    with pytest.raises(ValueError, match="below binary64 representability"):
+        _oligomerization.detailed_balance_forward_rate(
+            math.nextafter(0.0, 1.0),
+            0.0,
+            -1.0,
+        )
+
+
+@pytest.mark.parametrize("log_rate", [-745.5, -744.5])
+def test_positive_forward_rate_below_exact_minimum_is_rejected_before_rounding(
+    log_rate: float,
+) -> None:
+    assert log_rate < _oligomerization.LOG_MIN_POSITIVE_FLOAT
+
+    with pytest.raises(ValueError, match="below binary64 representability"):
+        _oligomerization.detailed_balance_forward_rate(1.0, 0.0, log_rate)
+
+
+@pytest.mark.parametrize(
+    "rate",
+    [
+        math.nextafter(0.0, 1.0),
+        math.nextafter(math.nextafter(0.0, 1.0), math.inf),
+    ],
+)
+def test_positive_forward_rate_at_or_above_exact_minimum_is_accepted(
+    rate: float,
+) -> None:
+    assert _oligomerization.detailed_balance_forward_rate(rate, 0.0, 0.0) == rate
+
+
+def test_scaled_positive_rate_uses_exact_minimum_boundary() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+    next_above = math.nextafter(minimum, math.inf)
+
+    for factor in (0.25, 0.75):
+        with pytest.raises(ValueError, match="below binary64 representability"):
+            _oligomerization.scale_reversible_rate(minimum, factor)
+    assert _oligomerization.scale_reversible_rate(minimum, 1.0) == minimum
+    assert _oligomerization.scale_reversible_rate(next_above, 1.0) == next_above
+
+
+def test_exact_zero_reverse_rate_returns_exact_zero_forward_rate() -> None:
+    assert _oligomerization.detailed_balance_forward_rate(0.0, -1000.0, 0.0) == 0.0

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -26,6 +26,9 @@ ROOT = Path(__file__).parent.parent
 EXAMPLE = ROOT / "examples/Experiments/RELAXATION_HZNZ"
 EXPERIMENT = EXAMPLE / "Experiments/800mhz.toml"
 PARAMETERS = EXAMPLE / "Parameters/parameters.toml"
+OLIGOMERIZATION_EXAMPLE = ROOT / "examples/Experiments/CPMG_15N_IP"
+OLIGOMERIZATION_DATA = OLIGOMERIZATION_EXAMPLE / "Data/500MHz"
+OLIGOMERIZATION_PARAMETERS = OLIGOMERIZATION_EXAMPLE / "Parameters/parameters.toml"
 
 
 def _entry_commands() -> tuple[tuple[str, ...], ...]:
@@ -211,6 +214,64 @@ def test_cli_entrypoints_report_invalid_model_as_unsuccessful_error(
     assert completed.returncode == 1
     assert "Exchange model selection is invalid" in completed.stderr
     assert model in completed.stderr
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+def test_cli_reports_configured_zero_oligomerization_kd_as_parameter_error(
+    command: tuple[str, ...],
+    tmp_path: Path,
+) -> None:
+    experiment = tmp_path / "oligomerization.toml"
+    experiment.write_text(
+        f"""
+[experiment]
+name = "cpmg_15n_ip"
+carrier = 118.559
+pw90 = 40.6625e-6
+time_equil = 2.0e-3
+time_t2 = 30.0e-3
+
+[conditions]
+h_larmor_frq = 500.0
+temperature = 25.0
+p_total = 1.0e-3
+label = ["2H"]
+
+[data]
+error = "file"
+path = "{OLIGOMERIZATION_DATA.as_posix()}"
+
+[data.profiles]
+1N = "1N-HN.out"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    zero_kd = tmp_path / "zero-kd.toml"
+    zero_kd.write_text("[GLOBAL]\nKD = [0.0, 0.0, 1.0]\nKOFF = 100.0\n")
+
+    completed = _run(
+        command,
+        "simulate",
+        "-e",
+        str(experiment),
+        "-p",
+        str(OLIGOMERIZATION_PARAMETERS),
+        str(zero_kd),
+        "-o",
+        str(tmp_path / "output"),
+        "-d",
+        "2st_monomer_dimer",
+        "--plot",
+        "nothing",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert "Parameter configuration is invalid" in completed.stderr
+    assert str(zero_kd) in completed.stderr
+    assert "KD must be finite and strictly positive" in completed.stderr
+    assert "unexpected internal error" not in combined
     assert TRACEBACK_HEADER not in combined
 
 

--- a/tests/test_standard_parameter_bounds.py
+++ b/tests/test_standard_parameter_bounds.py
@@ -66,6 +66,13 @@ def test_approved_kinetic_family_domains_apply_only_to_independent_settings() ->
     }
     direct_rates = {"kab", "kba", "kbc", "kcb"}
     approved_equilibria = {"keq", "keq_l", "keq_pl"}
+    oligomerization_models = {
+        "2st_monomer_dimer",
+        "2st_monomer_trimer",
+        "2st_monomer_tetramer",
+        "3st_monomer_dimer_trimer",
+        "3st_monomer_dimer_tetramer",
+    }
 
     for model_name in sorted(model_factory.set):
         for local_name, setting in model_factory.create(
@@ -77,6 +84,8 @@ def test_approved_kinetic_family_domains_apply_only_to_independent_settings() ->
                 expected = (0.0, 1.0e6)
             elif local_name in approved_equilibria:
                 expected = expected_domains["keq"]
+            elif model_name in oligomerization_models and local_name.startswith("kd"):
+                expected = (math.nextafter(0.0, 1.0), 1.0)
             else:
                 family = next(
                     (


### PR DESCRIPTION
### Summary

- Preserve literal semantics for every finite positive oligomerization KD value.
- Remove the hidden `1e-32` KD floor and small-KD legacy solver dispatch.
- Reject exact zero KD as unsupported by these finite reversible kinetic parameterizations.
- Solve equilibrium in log space and derive tagged forward rates by detailed balance, avoiding false intermediate overflow.
- Reject only genuinely unrepresentable positive rates.
- Preserve historical `P_total=0` and exact-KOFF-zero behavior.

### Scientific policy

For all five oligomerization models, every finite:

`KD > 0`

now retains exactly the equilibrium constant supplied by the user.

ChemEx no longer substitutes:

`max(KD, 1e-32)`.

Exact `KD=0` is rejected because it cannot in general define a finite reversible `(KD, KOFF)` kinetic parameterization. Some chemical zero-KD limits are unique while others are path-dependent, so zero is not given a synthetic kinetic convention.

Historical KD meanings and dimensions are unchanged.

### Numerical implementation

Equilibrium concentrations are solved through a monotone normalized mass balance in log space.

The implementation:

- avoids explicitly forming overflow-prone equilibrium coefficients;
- retains logarithmic equilibrium fractions;
- reconstructs representable absolute concentrations directly from their final logarithms;
- derives tagged forward rates from detailed balance;
- avoids eager `KOFF/KD` and overflowing population-ratio intermediates;
- rejects true final-rate overflow;
- rejects mathematically positive rates below the minimum positive binary64 magnitude rather than silently converting them to structural zero.

A bracketed Brent solve remains the scalar root authority.

### Compatibility

Ordinary supported-domain values agree with independent high-precision references at approximately binary64 precision.

Positive KD values below the former `1e-32` floor can change materially because they were previously assigned a different effective kinetic KD.

Exact KD zero, previously accepted syntactically without scientifically authoritative behavior, is now rejected with a parameter-configuration error.

The eager derived oligomerization parameters:

- `KON`
- `KON1`
- `KON2`

were removed because they can overflow even when all actual tagged rates are finite.

Repository-wide audit found no shipped example, method/default file, documentation, output fixture, or external expression depending on those oligomerization-derived names.

Unrelated binding-model KON parameters remain unchanged.

### Preserved behavior

This PR does not change:

- tagged stoichiometric mappings;
- historical KD dimensions;
- `P_total` monomer-equivalent meaning;
- exact-KOFF-zero population authority;
- generic `pop_2st` / `pop_3st`;
- optimizer invalid-trial policy.

`P_total=0` retains its historical behavior: zero concentrations and forward association rates with the established reverse-rate mappings.

### Error behavior

Configured invalid KD values surface as the existing concise `ParameterConfigurationError`.

During fitting, scientific constraint failures retain the existing `ConstraintDomainError -> INVALID_TRIAL` behavior.

No clipping, infinity propagation, hidden KD substitution, or silent structural-zero conversion is used.

### Validation

Final remediated candidate:

- oligomerization solver/model tests: 352 passed
- complete kinetic suite: 450 passed
- parameter-bound tests: 17 passed
- entrypoint/configuration tests: 91 passed
- focused evaluator/TRF checks: 18 passed
- full suite: 1,757 passed
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- deterministic high-precision numerical audit matrix

Independent audit initially found:

- 3 Medium numerical/spec findings
- 1 Low test-quality finding

All were remediated.

Closure review:

- `PASS — 0 closure findings`
- `READY TO COMMIT THE AUDITED DIFF`

### Deferred

Exact-KOFF-zero population authority remains a separate follow-up and is not reinterpreted here.

This PR also does not address Eyring, specialized binding, `KD_EFF`, higher-state topology, aliases, modifiers, or statistics.