### PR TITLE
fix: unify association equilibrium authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,25 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- Category-A association models now use one equilibrium-composition authority
+  for reported populations and tagged detailed-balance rates. Exact-zero kinetic
+  scales therefore freeze exchange without erasing equilibrium species. Binding
+  equilibria now use a validated, cancellation-resistant finite-pool solution
+  instead of unchecked multidimensional roots; every finite positive binding
+  `KD` retains literal semantics without hidden floors, while exact zero is
+  rejected. `KD_EFF` in `4st_binding_3_bound_states` now reports the model's
+  actual apparent dissociation constant, `KD_APP`. Ordinary positive-domain
+  behavior is preserved except where the previous root was inaccurate. Binding
+  `KON` compatibility outputs are now evaluated only for reporting or explicit
+  requests, so a mathematically unrepresentable `KON` no longer blocks finite
+  tagged dynamics; representable values remain in parameter output, while an
+  unrepresentable report-only value is omitted. Positive directional exchange
+  rates that cannot be represented in binary64 are rejected instead of being
+  silently rounded to structural zero. Canonical association-population
+  constraints now carry deterministic propagated uncertainties.
+  `3st_binding_cs` and `3st_binding_if` retain their existing parameterizations
+  pending a separate equilibrium-authority pass; generic kinetic models are
+  unchanged.
 - Oligomerization models now retain literal semantics for every finite positive
   `KD`, including sub-`1e-32` values; the hidden `1e-32` effective-KD floor has
   been removed, so affected results can change materially. Exact `KD = 0` is now

--- a/src/chemex/chemex.py
+++ b/src/chemex/chemex.py
@@ -183,6 +183,7 @@ def run_sim(
             parameter_model=parameter_model,
             parameterization=parameterization,
             plot=plot,
+            report_only_values=session.resolve_report_only_values(),
         )
     except (Exception, KeyboardInterrupt) as error:
         mark_failure_stage(error, "simulation")

--- a/src/chemex/models/kinetic/_binding.py
+++ b/src/chemex/models/kinetic/_binding.py
@@ -1,0 +1,591 @@
+"""Validated finite-pool equilibrium authority for one-ligand binding models."""
+
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass
+
+MIN_POSITIVE_FLOAT = math.nextafter(0.0, 1.0)
+
+_LOG_TWO = math.log(2.0)
+_LOG_FOUR = math.log(4.0)
+_LOG_MIN_POSITIVE_FLOAT = math.log(MIN_POSITIVE_FLOAT)
+_LOG_MIN_NORMAL_FLOAT = math.log(sys.float_info.min)
+_LOG_MAX_FLOAT = math.log(sys.float_info.max)
+_BALANCE_TOLERANCE = 64.0 * sys.float_info.epsilon
+_LOG_EQUILIBRIUM_TOLERANCE = 4096.0 * sys.float_info.epsilon
+
+
+@dataclass(frozen=True, slots=True)
+class BindingEquilibrium:
+    """Physical species composition for one finite ligand pool."""
+
+    protein_free: float
+    ligand_free: float
+    bound_total: float
+    free_ligands: tuple[float, ...]
+    complexes: tuple[float, ...]
+    populations: tuple[float, ...]
+    log_populations: tuple[float, ...]
+    free_ligand_log_fractions: tuple[float, ...]
+    complex_log_fractions: tuple[float, ...]
+    edge_log_ratios: tuple[float, ...]
+    log_apparent_kd: float
+
+
+def validate_binding_totals(p_total: float, l_total: float) -> None:
+    """Validate the finite-pool concentration domain used by binding models."""
+    if not math.isfinite(p_total) or p_total <= 0.0:
+        msg = "Binding P_total must be finite and strictly positive"
+        raise ValueError(msg)
+    if not math.isfinite(l_total) or l_total < 0.0:
+        msg = "Binding L_total must be finite and non-negative"
+        raise ValueError(msg)
+
+
+def detailed_balance_rate(
+    reverse_rate: float,
+    log_source_population: float,
+    log_destination_population: float,
+) -> float:
+    """Construct a tagged forward rate from the canonical equilibrium ratio."""
+    if not math.isfinite(reverse_rate) or reverse_rate < 0.0:
+        msg = "Binding reverse rate must be finite and non-negative"
+        raise ValueError(msg)
+    if reverse_rate == 0.0 or log_destination_population == -math.inf:
+        return 0.0
+    if not math.isfinite(log_destination_population):
+        msg = "Binding destination population log is invalid"
+        raise ValueError(msg)
+    if log_source_population == -math.inf:
+        msg = "Tagged binding forward rate exceeds binary64 representability"
+        raise ValueError(msg)
+    if not math.isfinite(log_source_population):
+        msg = "Binding source population log is invalid"
+        raise ValueError(msg)
+    log_rate = (
+        math.log(reverse_rate) + log_destination_population - log_source_population
+    )
+    if log_rate > _LOG_MAX_FLOAT:
+        msg = "Tagged binding forward rate exceeds binary64 representability"
+        raise ValueError(msg)
+    if log_rate < _LOG_MIN_POSITIVE_FLOAT:
+        msg = "Positive tagged binding forward rate is below binary64 representability"
+        raise ValueError(msg)
+    rate = math.exp(log_rate)
+    if not math.isfinite(rate) or rate <= 0.0:
+        msg = "Tagged binding forward rate is outside binary64 representability"
+        raise ValueError(msg)
+    return rate
+
+
+def split_exchange_rate(
+    total_rate: float,
+    log_source_weight: float,
+    log_destination_weight: float,
+) -> tuple[float, float]:
+    """Split a total exchange scale by an equilibrium ratio, including zero."""
+    if not math.isfinite(total_rate) or total_rate < 0.0:
+        msg = "Binding exchange-rate scale must be finite and non-negative"
+        raise ValueError(msg)
+    if total_rate == 0.0:
+        return 0.0, 0.0
+    weights = (log_source_weight, log_destination_weight)
+    if any(math.isnan(weight) or weight == math.inf for weight in weights) or all(
+        weight == -math.inf for weight in weights
+    ):
+        msg = "Binding exchange-rate weights are invalid"
+        raise ValueError(msg)
+    log_source_fraction, log_destination_fraction = _normalized_log_weights(weights)
+    log_total_rate = math.log(total_rate)
+    forward = (
+        0.0
+        if log_destination_fraction == -math.inf
+        else _checked_positive_log_value(
+            log_total_rate + log_destination_fraction,
+            description="Binding forward exchange rate",
+        )
+    )
+    reverse = (
+        0.0
+        if log_source_fraction == -math.inf
+        else _checked_positive_log_value(
+            log_total_rate + log_source_fraction,
+            description="Binding reverse exchange rate",
+        )
+    )
+    rates = [forward, reverse]
+    correction = total_rate - math.fsum(rates)
+    largest = max(range(len(rates)), key=rates.__getitem__)
+    rates[largest] += correction
+    if rates[largest] <= 0.0 or not math.isfinite(rates[largest]):
+        msg = "Binding exchange rates could not preserve their total scale"
+        raise RuntimeError(msg)
+    return rates[0], rates[1]
+
+
+def log_binding_weight(kd: float) -> float:
+    """Return log(1 / KD) without constructing a possibly overflowing inverse."""
+    if not math.isfinite(kd) or kd <= 0.0:
+        msg = "Binding KD must be finite and strictly positive"
+        raise ValueError(msg)
+    return -math.log(kd)
+
+
+def log_equilibrium_ratio(ratio: float) -> float:
+    """Return a log equilibrium weight, preserving an exact-zero state removal."""
+    if not math.isfinite(ratio) or ratio < 0.0:
+        msg = "Binding equilibrium ratio must be finite and non-negative"
+        raise ValueError(msg)
+    return -math.inf if ratio == 0.0 else math.log(ratio)
+
+
+def _logsumexp(values: tuple[float, ...]) -> float:
+    maximum = max(values)
+    if maximum == -math.inf:
+        return -math.inf
+    return maximum + math.log(math.fsum(math.exp(value - maximum) for value in values))
+
+
+def _validate_log_weights(
+    weights: tuple[float, ...],
+    *,
+    description: str,
+) -> None:
+    if not weights or any(
+        math.isnan(weight) or weight == math.inf for weight in weights
+    ):
+        msg = f"Binding {description} weights must be finite or exact-zero"
+        raise ValueError(msg)
+    if all(weight == -math.inf for weight in weights):
+        msg = f"Binding {description} weights must retain at least one species"
+        raise ValueError(msg)
+
+
+def _normalized_weights(log_weights: tuple[float, ...]) -> tuple[float, ...]:
+    maximum = max(log_weights)
+    raw_weights = [
+        0.0 if log_weight == -math.inf else math.exp(log_weight - maximum)
+        for log_weight in log_weights
+    ]
+    raw_total = math.fsum(raw_weights)
+    weights = [weight / raw_total for weight in raw_weights]
+    correction = 1.0 - math.fsum(weights)
+    largest = max(range(len(weights)), key=weights.__getitem__)
+    weights[largest] += correction
+    if (
+        abs(correction) > _BALANCE_TOLERANCE
+        or weights[largest] < 0.0
+        or not math.isfinite(weights[largest])
+    ):
+        msg = "Binding equilibrium weights could not be normalized"
+        raise RuntimeError(msg)
+    return tuple(weights)
+
+
+def _normalized_log_weights(log_weights: tuple[float, ...]) -> tuple[float, ...]:
+    log_total = _logsumexp(log_weights)
+    return tuple(
+        -math.inf if log_weight == -math.inf else log_weight - log_total
+        for log_weight in log_weights
+    )
+
+
+def _checked_positive_log_value(log_value: float, *, description: str) -> float:
+    if log_value > _LOG_MAX_FLOAT:
+        msg = f"{description} exceeds binary64 representability"
+        raise ValueError(msg)
+    if log_value < _LOG_MIN_POSITIVE_FLOAT:
+        msg = f"Positive {description.lower()} is below binary64 representability"
+        raise ValueError(msg)
+    value = math.exp(log_value)
+    if not math.isfinite(value) or value <= 0.0:
+        msg = f"{description} is outside binary64 representability"
+        raise ValueError(msg)
+    return value
+
+
+def _distribute(total: float, fractions: tuple[float, ...]) -> tuple[float, ...]:
+    if total == 0.0:
+        return tuple(0.0 for _ in fractions)
+    concentrations = [total * fraction for fraction in fractions]
+    correction = total - math.fsum(concentrations)
+    largest = max(range(len(concentrations)), key=concentrations.__getitem__)
+    concentrations[largest] += correction
+    if (
+        abs(correction) > _BALANCE_TOLERANCE * total
+        or concentrations[largest] < 0.0
+        or not math.isfinite(concentrations[largest])
+    ):
+        msg = "Binding species concentrations could not be normalized"
+        raise RuntimeError(msg)
+    return tuple(concentrations)
+
+
+def _finite_pool_totals(
+    p_total: float,
+    l_total: float,
+    log_apparent_kd: float,
+) -> tuple[float, float, float, float, float, float]:
+    """Solve P + L <-> PL without cancellation in either occupancy limit."""
+    log_protein = math.log(p_total)
+    log_ligand = math.log(l_total)
+    log_sum = _logsumexp((log_protein, log_ligand, log_apparent_kd))
+    difference = abs(p_total - l_total)
+    log_difference = -math.inf if difference == 0.0 else math.log(difference)
+    log_discriminant = _logsumexp(
+        (
+            2.0 * log_difference,
+            _LOG_TWO + log_apparent_kd + _logsumexp((log_protein, log_ligand)),
+            2.0 * log_apparent_kd,
+        ),
+    )
+    log_sqrt_discriminant = 0.5 * log_discriminant
+    log_bound = (
+        _LOG_TWO
+        + log_protein
+        + log_ligand
+        - _logsumexp((log_sum, log_sqrt_discriminant))
+    )
+
+    limiting = min(p_total, l_total)
+    log_limiting = math.log(limiting)
+    if log_bound - log_limiting <= -_LOG_TWO:
+        bound = math.exp(log_bound)
+        protein_free = p_total - bound
+        ligand_free = l_total - bound
+        log_protein_free = math.log(protein_free)
+        log_ligand_free = math.log(ligand_free)
+    else:
+        log_linear = _logsumexp((log_difference, log_apparent_kd))
+        log_sqrt = 0.5 * _logsumexp(
+            (
+                2.0 * log_linear,
+                _LOG_FOUR + log_apparent_kd + log_limiting,
+            ),
+        )
+        log_free_limiting = (
+            _LOG_TWO
+            + log_apparent_kd
+            + log_limiting
+            - _logsumexp((log_linear, log_sqrt))
+        )
+        free_limiting = (
+            _equal_pool_free(limiting, log_apparent_kd)
+            if difference == 0.0
+            else math.exp(log_free_limiting)
+        )
+        if difference == 0.0 and free_limiting > 0.0:
+            log_free_limiting = math.log(free_limiting)
+        bound = limiting - free_limiting
+        if p_total <= l_total:
+            protein_free = free_limiting
+            ligand_free = difference + free_limiting
+            log_protein_free = log_free_limiting
+            log_ligand_free = _logsumexp((log_difference, log_free_limiting))
+        else:
+            ligand_free = free_limiting
+            protein_free = difference + free_limiting
+            log_ligand_free = log_free_limiting
+            log_protein_free = _logsumexp((log_difference, log_free_limiting))
+
+    return (
+        protein_free,
+        ligand_free,
+        bound,
+        log_protein_free,
+        log_ligand_free,
+        log_bound,
+    )
+
+
+def _equal_pool_free(total: float, log_apparent_kd: float) -> float:
+    """Evaluate the equal-pool free root without log subtraction error."""
+    if not _LOG_MIN_POSITIVE_FLOAT <= log_apparent_kd <= _LOG_MAX_FLOAT:
+        log_total = math.log(total)
+        log_free = 0.5 * (log_apparent_kd + log_total)
+        return math.exp(log_free)
+    kd = math.exp(log_apparent_kd)
+    scale = max(kd, total)
+    sqrt_kd = math.sqrt(kd / scale)
+    sqrt_sum = math.sqrt(kd / scale + 4.0 * (total / scale))
+    fraction = 2.0 * sqrt_kd / (sqrt_kd + sqrt_sum)
+    return total * fraction
+
+
+def _validate_concentration_domain(equilibrium: BindingEquilibrium) -> None:
+    concentrations = (
+        equilibrium.protein_free,
+        equilibrium.ligand_free,
+        equilibrium.bound_total,
+        *equilibrium.free_ligands,
+        *equilibrium.complexes,
+        *equilibrium.populations,
+    )
+    if any(not math.isfinite(value) or value < 0.0 for value in concentrations):
+        msg = "Binding equilibrium produced an invalid concentration"
+        raise RuntimeError(msg)
+
+
+def _validate_mass_balance(
+    equilibrium: BindingEquilibrium,
+    p_total: float,
+    l_total: float,
+) -> None:
+    if not math.isclose(
+        math.fsum((equilibrium.protein_free, equilibrium.bound_total)),
+        p_total,
+        rel_tol=_BALANCE_TOLERANCE,
+        abs_tol=MIN_POSITIVE_FLOAT,
+    ):
+        msg = "Binding equilibrium violated protein mass conservation"
+        raise RuntimeError(msg)
+    if not math.isclose(
+        math.fsum((equilibrium.ligand_free, equilibrium.bound_total)),
+        l_total,
+        rel_tol=_BALANCE_TOLERANCE,
+        abs_tol=MIN_POSITIVE_FLOAT,
+    ):
+        msg = "Binding equilibrium violated ligand mass conservation"
+        raise RuntimeError(msg)
+    if not math.isclose(
+        math.fsum(equilibrium.free_ligands),
+        equilibrium.ligand_free,
+        rel_tol=_BALANCE_TOLERANCE,
+        abs_tol=MIN_POSITIVE_FLOAT,
+    ) or not math.isclose(
+        math.fsum(equilibrium.complexes),
+        equilibrium.bound_total,
+        rel_tol=_BALANCE_TOLERANCE,
+        abs_tol=MIN_POSITIVE_FLOAT,
+    ):
+        msg = "Binding equilibrium species do not conserve their pools"
+        raise RuntimeError(msg)
+
+
+def _validate_populations(
+    equilibrium: BindingEquilibrium,
+    p_total: float,
+) -> None:
+    if not math.isclose(
+        math.fsum(equilibrium.populations),
+        1.0,
+        rel_tol=_BALANCE_TOLERANCE,
+        abs_tol=_BALANCE_TOLERANCE,
+    ):
+        msg = "Binding equilibrium populations are not normalized"
+        raise RuntimeError(msg)
+    expected_populations = tuple(
+        0.0 if log_population == -math.inf else math.exp(log_population)
+        for log_population in equilibrium.log_populations
+    )
+    if any(
+        not math.isclose(
+            actual,
+            expected,
+            rel_tol=_BALANCE_TOLERANCE,
+            abs_tol=_BALANCE_TOLERANCE,
+        )
+        for actual, expected in zip(
+            equilibrium.populations,
+            expected_populations,
+            strict=True,
+        )
+    ):
+        msg = "Binding equilibrium populations do not match their log authority"
+        raise RuntimeError(msg)
+    log_p_total = math.log(p_total)
+    species = (equilibrium.protein_free, *equilibrium.complexes)
+    for concentration, log_population in zip(
+        species,
+        equilibrium.log_populations,
+        strict=True,
+    ):
+        log_concentration = log_population + log_p_total
+        if concentration == 0.0:
+            consistent = (
+                log_population == -math.inf
+                or log_concentration <= _LOG_MIN_POSITIVE_FLOAT
+            )
+        elif (
+            concentration < sys.float_info.min
+            and log_concentration < _LOG_MIN_NORMAL_FLOAT
+        ):
+            consistent = True
+        else:
+            consistent = abs(math.log(concentration) - log_concentration) <= (
+                _LOG_EQUILIBRIUM_TOLERANCE * max(1.0, abs(log_concentration))
+            )
+        if not consistent:
+            msg = "Binding equilibrium populations disagree with species concentrations"
+            raise RuntimeError(msg)
+
+
+def _validate_species_distribution(
+    concentrations: tuple[float, ...],
+    total: float,
+    log_weights: tuple[float, ...],
+    fractions: tuple[float, ...],
+    *,
+    description: str,
+) -> None:
+    for concentration, log_weight, fraction in zip(
+        concentrations,
+        log_weights,
+        fractions,
+        strict=True,
+    ):
+        if log_weight == -math.inf and concentration != 0.0:
+            msg = f"Binding equilibrium retained a zero-weight {description}"
+            raise RuntimeError(msg)
+        expected = total * fraction
+        if not math.isclose(
+            concentration,
+            expected,
+            rel_tol=_BALANCE_TOLERANCE,
+            abs_tol=4.0 * MIN_POSITIVE_FLOAT,
+        ):
+            msg = f"Binding equilibrium violated a {description} relation"
+            raise RuntimeError(msg)
+
+
+def _validate_equilibrium(
+    equilibrium: BindingEquilibrium,
+    p_total: float,
+    l_total: float,
+    log_protein_free: float,
+    log_ligand_free: float,
+    log_bound: float,
+    free_ligand_log_weights: tuple[float, ...],
+    complex_log_weights: tuple[float, ...],
+    free_ligand_fractions: tuple[float, ...],
+    complex_fractions: tuple[float, ...],
+) -> None:
+    _validate_concentration_domain(equilibrium)
+    _validate_mass_balance(equilibrium, p_total, l_total)
+    _validate_populations(equilibrium, p_total)
+    if l_total > 0.0:
+        log_residual = (
+            log_protein_free + log_ligand_free - log_bound - equilibrium.log_apparent_kd
+        )
+        if abs(log_residual) > _LOG_EQUILIBRIUM_TOLERANCE * max(
+            1.0,
+            abs(equilibrium.log_apparent_kd),
+        ):
+            msg = "Binding equilibrium violated the association law"
+            raise RuntimeError(msg)
+        # The aggregate association law above and these normalized scientific
+        # weights together imply every individual species relation.  Compare
+        # against the fractions used to construct the result so the validator
+        # does not reject representable subnormal values merely because a
+        # second log/exp reconstruction rounds differently.
+        _validate_species_distribution(
+            equilibrium.free_ligands,
+            equilibrium.ligand_free,
+            free_ligand_log_weights,
+            free_ligand_fractions,
+            description="free-ligand species",
+        )
+        _validate_species_distribution(
+            equilibrium.complexes,
+            equilibrium.bound_total,
+            complex_log_weights,
+            complex_fractions,
+            description="complex",
+        )
+
+
+def solve_binding_equilibrium(
+    p_total: float,
+    l_total: float,
+    *,
+    free_ligand_log_weights: tuple[float, ...],
+    complex_log_weights: tuple[float, ...],
+    edge_log_ratios: tuple[float, ...] = (),
+) -> BindingEquilibrium:
+    """Solve one finite ligand pool and distribute its free and bound species."""
+    validate_binding_totals(p_total, l_total)
+    _validate_log_weights(free_ligand_log_weights, description="free-ligand")
+    _validate_log_weights(complex_log_weights, description="complex")
+    if any(math.isnan(ratio) or ratio == math.inf for ratio in edge_log_ratios):
+        msg = "Binding edge equilibrium ratios must be finite or exact-zero"
+        raise ValueError(msg)
+
+    free_fractions = _normalized_weights(free_ligand_log_weights)
+    complex_fractions = _normalized_weights(complex_log_weights)
+    free_log_fractions = _normalized_log_weights(free_ligand_log_weights)
+    complex_log_fractions = _normalized_log_weights(complex_log_weights)
+    log_free_weight = _logsumexp(free_ligand_log_weights)
+    log_complex_weight = _logsumexp(complex_log_weights)
+    log_apparent_kd = log_free_weight - log_complex_weight
+
+    if l_total == 0.0:
+        return BindingEquilibrium(
+            protein_free=p_total,
+            ligand_free=0.0,
+            bound_total=0.0,
+            free_ligands=tuple(0.0 for _ in free_fractions),
+            complexes=tuple(0.0 for _ in complex_fractions),
+            populations=(1.0, *(0.0 for _ in complex_fractions)),
+            log_populations=(0.0, *(-math.inf for _ in complex_fractions)),
+            free_ligand_log_fractions=free_log_fractions,
+            complex_log_fractions=complex_log_fractions,
+            edge_log_ratios=edge_log_ratios,
+            log_apparent_kd=log_apparent_kd,
+        )
+
+    (
+        protein_free,
+        ligand_free,
+        bound_total,
+        log_protein_free,
+        log_ligand_free,
+        log_bound,
+    ) = _finite_pool_totals(p_total, l_total, log_apparent_kd)
+    free_ligands = _distribute(ligand_free, free_fractions)
+    complexes = _distribute(bound_total, complex_fractions)
+    log_p_total = math.log(p_total)
+    raw_log_populations = (
+        log_protein_free - log_p_total,
+        *(
+            -math.inf
+            if log_weight == -math.inf
+            else log_bound + log_weight - log_complex_weight - log_p_total
+            for log_weight in complex_log_weights
+        ),
+    )
+    populations = _normalized_weights(raw_log_populations)
+    log_population_total = _logsumexp(raw_log_populations)
+    log_populations = tuple(
+        -math.inf
+        if log_population == -math.inf
+        else log_population - log_population_total
+        for log_population in raw_log_populations
+    )
+    equilibrium = BindingEquilibrium(
+        protein_free=protein_free,
+        ligand_free=ligand_free,
+        bound_total=bound_total,
+        free_ligands=free_ligands,
+        complexes=complexes,
+        populations=populations,
+        log_populations=log_populations,
+        free_ligand_log_fractions=free_log_fractions,
+        complex_log_fractions=complex_log_fractions,
+        edge_log_ratios=edge_log_ratios,
+        log_apparent_kd=log_apparent_kd,
+    )
+    _validate_equilibrium(
+        equilibrium,
+        p_total,
+        l_total,
+        log_protein_free,
+        log_ligand_free,
+        log_bound,
+        free_ligand_log_weights,
+        complex_log_weights,
+        free_fractions,
+        complex_fractions,
+    )
+    return equilibrium

--- a/src/chemex/models/kinetic/settings_2st_binding.py
+++ b/src/chemex/models/kinetic/settings_2st_binding.py
@@ -2,33 +2,38 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import numpy as np
-from scipy.optimize import root
-
 from chemex.configuration.conditions import Conditions
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._binding import (
+    MIN_POSITIVE_FLOAT,
+    BindingEquilibrium,
+    detailed_balance_rate,
+    log_binding_weight,
+    solve_binding_equilibrium,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
-from chemex.typing import Array
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 
 NAME = "2st_binding"
 
 TPL = ("temperature", "p_total", "l_total")
 
 
-def calculate_residuals(
-    concentrations: Array,
+@lru_cache(maxsize=100)
+def _calculate_equilibrium(
     p_total: float,
     l_total: float,
     kd: float,
-) -> Array:
-    p_free, l_free, pl = concentrations
-    return np.array(
-        [
-            l_total - l_free - pl,
-            p_total - p_free - pl,
-            kd * pl - p_free * l_free,
-        ],
+) -> BindingEquilibrium:
+    return solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(log_binding_weight(kd),),
     )
 
 
@@ -38,14 +43,39 @@ def calculate_concentrations(
     l_total: float,
     kd: float,
 ) -> dict[str, float]:
-    concentrations_start = (p_total, l_total, 0.0)
-    results = root(
-        calculate_residuals,
-        concentrations_start,
-        args=(p_total, l_total, kd),
-    )
-    p_free, l_free, pl = results["x"]
-    return {"p_free": p_free, "l_free": l_free, "pl": pl}
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd)
+    return {
+        "p_free": equilibrium.protein_free,
+        "l_free": equilibrium.ligand_free,
+        "pl": equilibrium.complexes[0],
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(
+    p_total: float,
+    l_total: float,
+    kd: float,
+    koff: float,
+) -> dict[str, float]:
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd)
+    return {
+        "kab": detailed_balance_rate(
+            koff,
+            equilibrium.log_populations[0],
+            equilibrium.log_populations[1],
+        ),
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    l_total: float,
+    kd: float,
+) -> dict[str, float]:
+    pa, pb = _calculate_equilibrium(p_total, l_total, kd).populations
+    return {"pa": pa, "pb": pb}
 
 
 def make_settings_2st_binding(conditions: Conditions) -> dict[str, ParamLocalSetting]:
@@ -65,13 +95,9 @@ def make_settings_2st_binding(conditions: Conditions) -> dict[str, ParamLocalSet
         "kd": ParamLocalSetting(
             name_setting=NameSetting("kd", "", ("temperature",)),
             value=1e-3,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
-        ),
-        "kon": ParamLocalSetting(
-            name_setting=NameSetting("kon", "", ("temperature",)),
-            expr="{koff} / max({kd}, 1e-100)",
         ),
         "p_free": ParamLocalSetting(
             name_setting=NameSetting("p_free", "", TPL),
@@ -85,9 +111,14 @@ def make_settings_2st_binding(conditions: Conditions) -> dict[str, ParamLocalSet
             name_setting=NameSetting("pl", "", TPL),
             expr=f"calc_conc({p_total}, {l_total}, {{kd}})['pl']",
         ),
+        "kon": ParamLocalSetting(
+            name_setting=NameSetting("kon", "", ("temperature",)),
+            expr="{koff} / {kd}",
+            report_only=True,
+        ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TPL),
-            expr="{kon} * {l_free}",
+            expr=f"rates({p_total}, {l_total}, {{kd}}, {{koff}})['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TPL),
@@ -95,16 +126,29 @@ def make_settings_2st_binding(conditions: Conditions) -> dict[str, ParamLocalSet
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TPL),
-            expr=f"{{p_free}} / {p_total}",
+            expr=f"populations({p_total}, {l_total}, {{kd}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TPL),
-            expr=f"{{pl}} / {p_total}",
+            expr=f"populations({p_total}, {l_total}, {{kd}})['pb']",
         ),
     }
 
 
 def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_2st_binding)
-    user_functions = {"calc_conc": calculate_concentrations}
+    user_functions = {
+        "calc_conc": calculate_concentrations,
+        "populations": calculate_populations,
+        "rates": calculate_rates,
+    }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3, 1.0e-3),
+            ("nonnegative", "nonnegative", "positive"),
+            "pa",
+            "pb",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_2st_monomer_dimer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_dimer.py
@@ -19,7 +19,11 @@ from chemex.models.kinetic._oligomerization import (
     validate_oligomerization_kd,
 )
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 from chemex.typing import Array
 
 NAME = "2st_monomer_dimer"
@@ -68,6 +72,18 @@ def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "dimer": results["x"][1]}
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(p_total: float, kd: float) -> dict[str, float]:
+    validate_oligomerization_kd(kd)
+    if p_total == 0.0:
+        return {"pa": 1.0, "pb": 0.0}
+    equilibrium = _calculate_equilibrium(p_total, kd)
+    return {
+        "pa": equilibrium.monomer_fraction,
+        "pb": 2.0 * equilibrium.oligomer_fractions[0],
+    }
 
 
 @lru_cache(maxsize=100)
@@ -126,11 +142,11 @@ def make_settings_2st_monomer_dimer(
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TP),
-            expr="pop_2st({kab}, {kba})['pa']",
+            expr=f"populations({p_total}, {{kd}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TP),
-            expr="pop_2st({kab}, {kba})['pb']",
+            expr=f"populations({p_total}, {{kd}})['pb']",
         ),
     }
 
@@ -139,7 +155,17 @@ def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_2st_monomer_dimer)
     user_functions = {
         "concentrations": calculate_concentrations,
+        "populations": calculate_populations,
         "rates": calculate_rates,
         "pop_2st": pop_2st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3),
+            ("nonnegative", "positive"),
+            "pa",
+            "pb",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_2st_monomer_tetramer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_tetramer.py
@@ -19,7 +19,11 @@ from chemex.models.kinetic._oligomerization import (
     validate_oligomerization_kd,
 )
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 from chemex.typing import Array
 
 NAME = "2st_monomer_tetramer"
@@ -68,6 +72,18 @@ def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "tetramer": results["x"][1]}
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(p_total: float, kd: float) -> dict[str, float]:
+    validate_oligomerization_kd(kd)
+    if p_total == 0.0:
+        return {"pa": 1.0, "pb": 0.0}
+    equilibrium = _calculate_equilibrium(p_total, kd)
+    return {
+        "pa": equilibrium.monomer_fraction,
+        "pb": 4.0 * equilibrium.oligomer_fractions[0],
+    }
 
 
 @lru_cache(maxsize=100)
@@ -126,11 +142,11 @@ def make_settings_2st_monomer_tetramer(
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TP),
-            expr="pop_2st({kab}, {kba})['pa']",
+            expr=f"populations({p_total}, {{kd}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TP),
-            expr="pop_2st({kab}, {kba})['pb']",
+            expr=f"populations({p_total}, {{kd}})['pb']",
         ),
     }
 
@@ -139,7 +155,17 @@ def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_2st_monomer_tetramer)
     user_functions = {
         "concentrations": calculate_concentrations,
+        "populations": calculate_populations,
         "rates": calculate_rates,
         "pop_2st": pop_2st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3),
+            ("nonnegative", "positive"),
+            "pa",
+            "pb",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_2st_monomer_trimer.py
+++ b/src/chemex/models/kinetic/settings_2st_monomer_trimer.py
@@ -19,7 +19,11 @@ from chemex.models.kinetic._oligomerization import (
     validate_oligomerization_kd,
 )
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 from chemex.typing import Array
 
 NAME = "2st_monomer_trimer"
@@ -68,6 +72,18 @@ def calculate_concentrations(p_total: float, kd: float) -> dict[str, float]:
     concentrations_start = (p_total, 0.0)
     results = root(calculate_residuals, concentrations_start, args=(p_total, kd))
     return {"monomer": results["x"][0], "trimer": results["x"][1]}
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(p_total: float, kd: float) -> dict[str, float]:
+    validate_oligomerization_kd(kd)
+    if p_total == 0.0:
+        return {"pa": 1.0, "pb": 0.0}
+    equilibrium = _calculate_equilibrium(p_total, kd)
+    return {
+        "pa": equilibrium.monomer_fraction,
+        "pb": 3.0 * equilibrium.oligomer_fractions[0],
+    }
 
 
 @lru_cache(maxsize=100)
@@ -126,11 +142,11 @@ def make_settings_2st_monomer_trimer(
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TP),
-            expr="pop_2st({kab}, {kba})['pa']",
+            expr=f"populations({p_total}, {{kd}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TP),
-            expr="pop_2st({kab}, {kba})['pb']",
+            expr=f"populations({p_total}, {{kd}})['pb']",
         ),
     }
 
@@ -139,7 +155,17 @@ def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_2st_monomer_trimer)
     user_functions = {
         "concentrations": calculate_concentrations,
+        "populations": calculate_populations,
         "rates": calculate_rates,
         "pop_2st": pop_2st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3),
+            ("nonnegative", "positive"),
+            "pa",
+            "pb",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_3st_binding_2st_partner.py
+++ b/src/chemex/models/kinetic/settings_3st_binding_2st_partner.py
@@ -2,38 +2,50 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import numpy as np
-from scipy.optimize import root
-
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._binding import (
+    MIN_POSITIVE_FLOAT,
+    BindingEquilibrium,
+    detailed_balance_rate,
+    log_binding_weight,
+    log_equilibrium_ratio,
+    solve_binding_equilibrium,
+    split_exchange_rate,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
-from chemex.typing import Array
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 
 NAME = "3st_binding_partner_2st"
 
 TPL = ("temperature", "p_total", "l_total")
 
 
-def calculate_residuals(
-    concentrations: Array,
+@lru_cache(maxsize=100)
+def _calculate_equilibrium(
     p_total: float,
     l_total: float,
     kd1: float,
     kd2: float,
     keq: float,
-) -> Array:
-    p, l1, l2, pl1, pl2 = concentrations
-    return np.array(
-        [
-            l_total - (l1 + l2 + pl1 + pl2),
-            p_total - (p + pl1 + pl2),
-            kd1 * pl1 - p * l1,
-            kd2 * pl2 - p * l2,
-            keq * l1 - l2,
-        ],
+) -> BindingEquilibrium:
+    log_keq = log_equilibrium_ratio(keq)
+    log_pl1 = log_binding_weight(kd1)
+    log_pl2 = log_keq + log_binding_weight(kd2)
+    return solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=(0.0, log_keq),
+        complex_log_weights=(
+            log_pl1,
+            log_pl2,
+        ),
+        edge_log_ratios=(log_pl2 - log_pl1,),
     )
 
 
@@ -45,13 +57,60 @@ def calculate_concentrations(
     kd2: float,
     keq: float,
 ) -> dict[str, float]:
-    concentrations_start = (p_total, l_total / 2, l_total / 2, 0.0, 0.0)
-    results = root(
-        calculate_residuals,
-        concentrations_start,
-        args=(p_total, l_total, kd1, kd2, keq),
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd1, kd2, keq)
+    l1, l2 = equilibrium.free_ligands
+    pl1, pl2 = equilibrium.complexes
+    return {
+        "p": equilibrium.protein_free,
+        "l1": l1,
+        "l2": l2,
+        "pl1": pl1,
+        "pl2": pl2,
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    l_total: float,
+    kd1: float,
+    kd2: float,
+    keq: float,
+) -> dict[str, float]:
+    pa, pb, pc = _calculate_equilibrium(
+        p_total,
+        l_total,
+        kd1,
+        kd2,
+        keq,
+    ).populations
+    return {"pa": pa, "pb": pb, "pc": pc}
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(
+    p_total: float,
+    l_total: float,
+    kd1: float,
+    kd2: float,
+    keq: float,
+    koff_ab: float,
+    koff_ac: float,
+    kex_bc: float,
+) -> dict[str, float]:
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd1, kd2, keq)
+    log_pa, log_pb, log_pc = equilibrium.log_populations
+    kbc, kcb = split_exchange_rate(
+        kex_bc,
+        0.0,
+        equilibrium.edge_log_ratios[0],
     )
-    return dict(zip(("p", "l1", "l2", "pl1", "pl2"), results["x"], strict=True))
+    return {
+        "kab": detailed_balance_rate(koff_ab, log_pa, log_pb),
+        "kac": detailed_balance_rate(koff_ac, log_pa, log_pc),
+        "kbc": kbc,
+        "kcb": kcb,
+    }
 
 
 def make_settings_3st_binding_partner_2st(
@@ -65,6 +124,10 @@ def make_settings_3st_binding_partner_2st(
     if l_total is None:
         msg = f"'l_total' must be specified to use the '{NAME}' model"
         raise ValueError(msg)
+    rates = (
+        f"rates({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq}},"
+        "{koff_ab},{koff_ac},{kex_bc})"
+    )
     return {
         "koff_ab": ParamLocalSetting(
             name_setting=NameSetting("koff_ab", "", ("temperature",)),
@@ -76,7 +139,7 @@ def make_settings_3st_binding_partner_2st(
         "kd_ab": ParamLocalSetting(
             name_setting=NameSetting("kd_ab", "", ("temperature",)),
             value=1e-3,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -90,7 +153,7 @@ def make_settings_3st_binding_partner_2st(
         "kd_ac": ParamLocalSetting(
             name_setting=NameSetting("kd_ac", "", ("temperature",)),
             value=1e-3,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -110,11 +173,13 @@ def make_settings_3st_binding_partner_2st(
         ),
         "kon_ab": ParamLocalSetting(
             name_setting=NameSetting("kon_ab", "", ("temperature",)),
-            expr="{koff_ab} / max({kd_ab}, 1e-100)",
+            expr="{koff_ab} / {kd_ab}",
+            report_only=True,
         ),
         "kon_ac": ParamLocalSetting(
             name_setting=NameSetting("kon_ac", "", ("temperature",)),
-            expr="{koff_ac} / max({kd_ac}, 1e-100)",
+            expr="{koff_ac} / {kd_ac}",
+            report_only=True,
         ),
         "l1_free": ParamLocalSetting(
             name_setting=NameSetting("l1_free", "", TPL),
@@ -134,7 +199,7 @@ def make_settings_3st_binding_partner_2st(
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TPL),
-            expr="{kon_ab} * {l1_free}",
+            expr=f"{rates}['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TPL),
@@ -142,7 +207,7 @@ def make_settings_3st_binding_partner_2st(
         ),
         "kac": ParamLocalSetting(
             name_setting=NameSetting("kac", "", TPL),
-            expr="{kon_ac} * {l2_free}",
+            expr=f"{rates}['kac']",
         ),
         "kca": ParamLocalSetting(
             name_setting=NameSetting("kca", "", TPL),
@@ -150,23 +215,23 @@ def make_settings_3st_binding_partner_2st(
         ),
         "kbc": ParamLocalSetting(
             name_setting=NameSetting("kbc", "", TPL),
-            expr="{kex_bc} * {pl2} / max({pl1} + {pl2}, 1e-100)",
+            expr=f"{rates}['kbc']",
         ),
         "kcb": ParamLocalSetting(
             name_setting=NameSetting("kcb", "", TPL),
-            expr="{kex_bc} * {pl1} / max({pl1} + {pl2}, 1e-100)",
+            expr=f"{rates}['kcb']",
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TPL),
-            expr="pop_3st({kab},{kba},{kac},{kca},{kbc},{kcb})['pa']",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TPL),
-            expr="pop_3st({kab},{kba},{kac},{kca},{kbc},{kcb})['pb']",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq}})['pb']",
         ),
         "pc": ParamLocalSetting(
             name_setting=NameSetting("pc", "", TPL),
-            expr="pop_3st({kab},{kba},{kac},{kca},{kbc},{kcb})['pc']",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq}})['pc']",
         ),
     }
 
@@ -178,6 +243,24 @@ def register() -> None:
     )
     user_functions = {
         "calc_conc": calculate_concentrations,
+        "populations": calculate_populations,
+        "rates": calculate_rates,
         "pop_3st": pop_3st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3, 1.0e-3, 1.0e-3, 1.0),
+            (
+                "nonnegative",
+                "nonnegative",
+                "positive",
+                "positive",
+                "nonnegative",
+            ),
+            "pa",
+            "pb",
+            "pc",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_3st_double_binding.py
+++ b/src/chemex/models/kinetic/settings_3st_double_binding.py
@@ -12,36 +12,43 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import numpy as np
-from scipy.optimize import root
-
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._binding import (
+    MIN_POSITIVE_FLOAT,
+    BindingEquilibrium,
+    detailed_balance_rate,
+    log_binding_weight,
+    solve_binding_equilibrium,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
-from chemex.typing import Array
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 
 NAME = "3st_double_binding"
 
 TPL = ("temperature", "p_total", "l_total")
 
 
-def calculate_residuals(
-    populations: Array,
+@lru_cache(maxsize=100)
+def _calculate_equilibrium(
     p_total: float,
     l_total: float,
     kd_ab: float,
     kd_ac: float,
-) -> Array:
-    pfree, pl1, pl2 = populations
-    lfree = l_total - p_total + pfree
-    return np.array(
-        [
-            pfree + pl1 + pl2 - p_total,
-            lfree * pfree - kd_ab * pl1,
-            lfree * pfree - kd_ac * pl2,
-        ],
+) -> BindingEquilibrium:
+    return solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(
+            log_binding_weight(kd_ab),
+            log_binding_weight(kd_ac),
+        ),
     )
 
 
@@ -52,13 +59,46 @@ def calculate_concentrations(
     kd_ab: float,
     kd_ac: float,
 ) -> dict[str, float]:
-    concentrations_start = (p_total, 0.0, 0.0)
-    results = root(
-        calculate_residuals,
-        concentrations_start,
-        args=(p_total, l_total, kd_ab, kd_ac),
-    )
-    return dict(zip(("pfree", "pl1", "pl2"), results["x"], strict=True))
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd_ab, kd_ac)
+    return {
+        "pfree": equilibrium.protein_free,
+        "lfree": equilibrium.ligand_free,
+        "pl1": equilibrium.complexes[0],
+        "pl2": equilibrium.complexes[1],
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    l_total: float,
+    kd_ab: float,
+    kd_ac: float,
+) -> dict[str, float]:
+    pa, pb, pc = _calculate_equilibrium(
+        p_total,
+        l_total,
+        kd_ab,
+        kd_ac,
+    ).populations
+    return {"pa": pa, "pb": pb, "pc": pc}
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(
+    p_total: float,
+    l_total: float,
+    kd_ab: float,
+    kd_ac: float,
+    koff_ab: float,
+    koff_ac: float,
+) -> dict[str, float]:
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd_ab, kd_ac)
+    log_pa, log_pb, log_pc = equilibrium.log_populations
+    return {
+        "kab": detailed_balance_rate(koff_ab, log_pa, log_pb),
+        "kac": detailed_balance_rate(koff_ac, log_pa, log_pc),
+    }
 
 
 def make_settings_3st_double_binding(
@@ -83,7 +123,7 @@ def make_settings_3st_double_binding(
         "kd_ab": ParamLocalSetting(
             name_setting=NameSetting("kd_ab", "", ("temperature",)),
             value=1e-3,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -97,17 +137,19 @@ def make_settings_3st_double_binding(
         "kd_ac": ParamLocalSetting(
             name_setting=NameSetting("kd_ac", "", ("temperature",)),
             value=1e-3,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
         "kon_ab": ParamLocalSetting(
             name_setting=NameSetting("kon_ab", "", ("temperature",)),
-            expr="{koff_ab} / max({kd_ab}, 1e-100)",
+            expr="{koff_ab} / {kd_ab}",
+            report_only=True,
         ),
         "kon_ac": ParamLocalSetting(
             name_setting=NameSetting("kon_ac", "", ("temperature",)),
-            expr="{koff_ac} / max({kd_ac}, 1e-100)",
+            expr="{koff_ac} / {kd_ac}",
+            report_only=True,
         ),
         "pfree": ParamLocalSetting(
             name_setting=NameSetting("pfree", "", TPL),
@@ -115,11 +157,14 @@ def make_settings_3st_double_binding(
         ),
         "l_free": ParamLocalSetting(
             name_setting=NameSetting("l_free", "", TPL),
-            expr=f"{l_total} - {p_total} + {{pfree}}",
+            expr=f"calc_conc({p_total}, {l_total}, {{kd_ab}}, {{kd_ac}})['lfree']",
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TPL),
-            expr="{kon_ab} * {l_free}",
+            expr=(
+                f"rates({p_total}, {l_total}, {{kd_ab}}, {{kd_ac}}, "
+                "{koff_ab}, {koff_ac})['kab']"
+            ),
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TPL),
@@ -127,7 +172,10 @@ def make_settings_3st_double_binding(
         ),
         "kac": ParamLocalSetting(
             name_setting=NameSetting("kac", "", TPL),
-            expr="{kon_ac} * {l_free}",
+            expr=(
+                f"rates({p_total}, {l_total}, {{kd_ab}}, {{kd_ac}}, "
+                "{koff_ab}, {koff_ac})['kac']"
+            ),
         ),
         "kca": ParamLocalSetting(
             name_setting=NameSetting("kca", "", TPL),
@@ -135,15 +183,15 @@ def make_settings_3st_double_binding(
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TPL),
-            expr="pop_3st({kab}, {kba}, {kac}, {kca}, 0.0, 0.0)['pa']",
+            expr=f"populations({p_total}, {l_total}, {{kd_ab}}, {{kd_ac}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TPL),
-            expr="pop_3st({kab}, {kba}, {kac}, {kca}, 0.0, 0.0)['pb']",
+            expr=f"populations({p_total}, {l_total}, {{kd_ab}}, {{kd_ac}})['pb']",
         ),
         "pc": ParamLocalSetting(
             name_setting=NameSetting("pc", "", TPL),
-            expr="pop_3st({kab}, {kba}, {kac}, {kca}, 0.0, 0.0)['pc']",
+            expr=f"populations({p_total}, {l_total}, {{kd_ab}}, {{kd_ac}})['pc']",
         ),
     }
 
@@ -152,6 +200,18 @@ def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_3st_double_binding)
     user_functions = {
         "calc_conc": calculate_concentrations,
+        "populations": calculate_populations,
+        "rates": calculate_rates,
         "pop_3st": pop_3st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3, 1.0e-3, 1.0e-3),
+            ("nonnegative", "nonnegative", "positive", "positive"),
+            "pa",
+            "pb",
+            "pc",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_3st_monomer_dimer_tetramer.py
+++ b/src/chemex/models/kinetic/settings_3st_monomer_dimer_tetramer.py
@@ -19,7 +19,11 @@ from chemex.models.kinetic._oligomerization import (
     validate_oligomerization_kd,
 )
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 from chemex.typing import Array
 
 NAME = "3st_monomer_dimer_tetramer"
@@ -87,6 +91,24 @@ def calculate_concentrations(
         "monomer": results["x"][0],
         "dimer": results["x"][1],
         "tetramer": results["x"][2],
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    kd1: float,
+    kd2: float,
+) -> dict[str, float]:
+    validate_oligomerization_kd(kd1)
+    validate_oligomerization_kd(kd2)
+    if p_total == 0.0:
+        return {"pa": 1.0, "pb": 0.0, "pc": 0.0}
+    equilibrium = _calculate_equilibrium(p_total, kd1, kd2)
+    return {
+        "pa": equilibrium.monomer_fraction,
+        "pb": 2.0 * equilibrium.oligomer_fractions[0],
+        "pc": 4.0 * equilibrium.oligomer_fractions[1],
     }
 
 
@@ -179,15 +201,15 @@ def make_settings_3st_monomer_dimer_tetramer(
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TP),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pa']",
+            expr=f"populations({p_total}, {{kd1}}, {{kd2}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TP),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pb']",
+            expr=f"populations({p_total}, {{kd1}}, {{kd2}})['pb']",
         ),
         "pc": ParamLocalSetting(
             name_setting=NameSetting("pc", "", TP),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pc']",
+            expr=f"populations({p_total}, {{kd1}}, {{kd2}})['pc']",
         ),
     }
 
@@ -199,7 +221,18 @@ def register() -> None:
     )
     user_functions = {
         "concentrations": calculate_concentrations,
+        "populations": calculate_populations,
         "rates": calculate_rates,
         "pop_3st": pop_3st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3, 1.0e-3),
+            ("nonnegative", "positive", "positive"),
+            "pa",
+            "pb",
+            "pc",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_3st_monomer_dimer_trimer.py
+++ b/src/chemex/models/kinetic/settings_3st_monomer_dimer_trimer.py
@@ -20,7 +20,11 @@ from chemex.models.kinetic._oligomerization import (
     validate_oligomerization_kd,
 )
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 from chemex.typing import Array
 
 NAME = "3st_monomer_dimer_trimer"
@@ -88,6 +92,24 @@ def calculate_concentrations(
         "monomer": results["x"][0],
         "dimer": results["x"][1],
         "trimer": results["x"][2],
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    kd1: float,
+    kd2: float,
+) -> dict[str, float]:
+    validate_oligomerization_kd(kd1)
+    validate_oligomerization_kd(kd2)
+    if p_total == 0.0:
+        return {"pa": 1.0, "pb": 0.0, "pc": 0.0}
+    equilibrium = _calculate_equilibrium(p_total, kd1, kd2)
+    return {
+        "pa": equilibrium.monomer_fraction,
+        "pb": 2.0 * equilibrium.oligomer_fractions[0],
+        "pc": 3.0 * equilibrium.oligomer_fractions[1],
     }
 
 
@@ -192,15 +214,15 @@ def make_settings_3st_monomer_dimer_trimer(
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TP),
-            expr="pop_3st({kab}, {kba}, {kac}, {kca}, {kbc}, {kcb})['pa']",
+            expr=f"populations({p_total}, {{kd1}}, {{kd2}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TP),
-            expr="pop_3st({kab}, {kba}, {kac}, {kca}, {kbc}, {kcb})['pb']",
+            expr=f"populations({p_total}, {{kd1}}, {{kd2}})['pb']",
         ),
         "pc": ParamLocalSetting(
             name_setting=NameSetting("pc", "", TP),
-            expr="pop_3st({kab}, {kba}, {kac}, {kca}, {kbc}, {kcb})['pc']",
+            expr=f"populations({p_total}, {{kd1}}, {{kd2}})['pc']",
         ),
     }
 
@@ -212,7 +234,18 @@ def register() -> None:
     )
     user_functions = {
         "concetrations": calculate_concentrations,
+        "populations": calculate_populations,
         "rates": calculate_rates,
         "pop_3st": pop_3st,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3, 1.0e-3),
+            ("nonnegative", "positive", "positive"),
+            "pa",
+            "pb",
+            "pc",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_4st_binding_2st_partner.py
+++ b/src/chemex/models/kinetic/settings_4st_binding_2st_partner.py
@@ -2,39 +2,52 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import numpy as np
-from scipy.optimize import root
-
 from chemex.configuration.conditions import Conditions
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._binding import (
+    MIN_POSITIVE_FLOAT,
+    BindingEquilibrium,
+    detailed_balance_rate,
+    log_binding_weight,
+    log_equilibrium_ratio,
+    solve_binding_equilibrium,
+    split_exchange_rate,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
-from chemex.typing import Array
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 
 NAME = "4st_binding_partner_2st"
 
 TPL = ("temperature", "p_total", "l_total")
 
 
-def calculate_residuals(
-    concentrations: Array,
+@lru_cache(maxsize=100)
+def _calculate_equilibrium(
     p_total: float,
     l_total: float,
     kd1: float,
     kd2: float,
     keq_l: float,
     keq_pl: float,
-) -> Array:
-    p, l1, l2, pl1, pl2, pl3 = concentrations
-    return np.array(
-        [
-            l_total - (l1 + l2 + pl1 + pl2 + pl3),
-            p_total - (p + pl1 + pl2 + pl3),
-            kd1 * pl1 - p * l1,
-            kd2 * pl2 - p * l2,
-            keq_l * l1 - l2,
-            keq_pl * pl2 - pl3,
-        ],
+) -> BindingEquilibrium:
+    log_keq_l = log_equilibrium_ratio(keq_l)
+    log_keq_pl = log_equilibrium_ratio(keq_pl)
+    log_pl1 = log_binding_weight(kd1)
+    log_pl2 = log_keq_l + log_binding_weight(kd2)
+    return solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=(0.0, log_keq_l),
+        complex_log_weights=(
+            log_pl1,
+            log_pl2,
+            log_pl2 + log_keq_pl,
+        ),
+        edge_log_ratios=(log_pl2 - log_pl1, log_keq_pl),
     )
 
 
@@ -47,13 +60,86 @@ def calculate_concentrations(
     keq_l: float,
     keq_pl: float,
 ) -> dict[str, float]:
-    concentrations_start = (p_total, l_total / 2, l_total / 2, 0.0, 0.0, 0.0)
-    results = root(
-        calculate_residuals,
-        concentrations_start,
-        args=(p_total, l_total, kd1, kd2, keq_l, keq_pl),
+    equilibrium = _calculate_equilibrium(
+        p_total,
+        l_total,
+        kd1,
+        kd2,
+        keq_l,
+        keq_pl,
     )
-    return dict(zip(("p", "l1", "l2", "pl1", "pl2", "pl3"), results["x"], strict=True))
+    l1, l2 = equilibrium.free_ligands
+    pl1, pl2, pl3 = equilibrium.complexes
+    return {
+        "p": equilibrium.protein_free,
+        "l1": l1,
+        "l2": l2,
+        "pl1": pl1,
+        "pl2": pl2,
+        "pl3": pl3,
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(
+    p_total: float,
+    l_total: float,
+    kd1: float,
+    kd2: float,
+    keq_l: float,
+    keq_pl: float,
+    koff_ab: float,
+    koff_ac: float,
+    kex_bc: float,
+    kex_cd: float,
+) -> dict[str, float]:
+    equilibrium = _calculate_equilibrium(
+        p_total,
+        l_total,
+        kd1,
+        kd2,
+        keq_l,
+        keq_pl,
+    )
+    log_pa, log_pb, log_pc, log_pd = equilibrium.log_populations
+    kbc, kcb = split_exchange_rate(
+        kex_bc,
+        0.0,
+        equilibrium.edge_log_ratios[0],
+    )
+    kcd, kdc = split_exchange_rate(
+        kex_cd,
+        0.0,
+        equilibrium.edge_log_ratios[1],
+    )
+    return {
+        "kab": detailed_balance_rate(koff_ab, log_pa, log_pb),
+        "kac": detailed_balance_rate(koff_ac, log_pa, log_pc),
+        "kbc": kbc,
+        "kcb": kcb,
+        "kcd": kcd,
+        "kdc": kdc,
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    l_total: float,
+    kd1: float,
+    kd2: float,
+    keq_l: float,
+    keq_pl: float,
+) -> dict[str, float]:
+    pa, pb, pc, pd = _calculate_equilibrium(
+        p_total,
+        l_total,
+        kd1,
+        kd2,
+        keq_l,
+        keq_pl,
+    ).populations
+    return {"pa": pa, "pb": pb, "pc": pc, "pd": pd}
 
 
 def make_settings_4st_binding_partner_2st(
@@ -67,6 +153,10 @@ def make_settings_4st_binding_partner_2st(
     if l_total is None:
         msg = f"'l_total' must be specified to use the '{NAME}' model"
         raise ValueError(msg)
+    rates = (
+        f"rates({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq_l}},"
+        "{keq_pl},{koff_ab},{koff_ac},{kex_bc},{kex_cd})"
+    )
     return {
         "koff_ab": ParamLocalSetting(
             name_setting=NameSetting("koff_ab", "", ("temperature",)),
@@ -78,7 +168,7 @@ def make_settings_4st_binding_partner_2st(
         "kd_ab": ParamLocalSetting(
             name_setting=NameSetting("kd_ab", "", ("temperature",)),
             value=1e-3,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -92,7 +182,7 @@ def make_settings_4st_binding_partner_2st(
         "kd_ac": ParamLocalSetting(
             name_setting=NameSetting("kd_ac", "", ("temperature",)),
             value=1e-3,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -126,11 +216,13 @@ def make_settings_4st_binding_partner_2st(
         ),
         "kon_ab": ParamLocalSetting(
             name_setting=NameSetting("kon_ab", "", ("temperature",)),
-            expr="{koff_ab} / max({kd_ab}, 1e-100)",
+            expr="{koff_ab} / {kd_ab}",
+            report_only=True,
         ),
         "kon_ac": ParamLocalSetting(
             name_setting=NameSetting("kon_ac", "", ("temperature",)),
-            expr="{koff_ac} / max({kd_ac}, 1e-100)",
+            expr="{koff_ac} / {kd_ac}",
+            report_only=True,
         ),
         "p_free": ParamLocalSetting(
             name_setting=NameSetting("p_free", "", TPL),
@@ -158,7 +250,7 @@ def make_settings_4st_binding_partner_2st(
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TPL),
-            expr="{kon_ab} * {l1_free}",
+            expr=f"{rates}['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TPL),
@@ -166,7 +258,7 @@ def make_settings_4st_binding_partner_2st(
         ),
         "kac": ParamLocalSetting(
             name_setting=NameSetting("kac", "", TPL),
-            expr="{kon_ac} * {l2_free}",
+            expr=f"{rates}['kac']",
         ),
         "kca": ParamLocalSetting(
             name_setting=NameSetting("kca", "", TPL),
@@ -174,35 +266,35 @@ def make_settings_4st_binding_partner_2st(
         ),
         "kbc": ParamLocalSetting(
             name_setting=NameSetting("kbc", "", TPL),
-            expr="{kex_bc} * {pl2} / max({pl1} + {pl2}, 1e-100)",
+            expr=f"{rates}['kbc']",
         ),
         "kcb": ParamLocalSetting(
             name_setting=NameSetting("kcb", "", TPL),
-            expr="{kex_bc} * {pl1} / max({pl1} + {pl2}, 1e-100)",
+            expr=f"{rates}['kcb']",
         ),
         "kcd": ParamLocalSetting(
             name_setting=NameSetting("kcd", "", TPL),
-            expr="{kex_cd} * {pl3} / max({pl2} + {pl3}, 1e-100)",
+            expr=f"{rates}['kcd']",
         ),
         "kdc": ParamLocalSetting(
             name_setting=NameSetting("kdc", "", TPL),
-            expr="{kex_cd} * {pl2} / max({pl2} + {pl3}, 1e-100)",
+            expr=f"{rates}['kdc']",
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TPL),
-            expr=f"{{p_free}} / {p_total}",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq_l}},{{keq_pl}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TPL),
-            expr=f"{{pl1}} / {p_total}",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq_l}},{{keq_pl}})['pb']",
         ),
         "pc": ParamLocalSetting(
             name_setting=NameSetting("pc", "", TPL),
-            expr=f"{{pl2}} / {p_total}",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq_l}},{{keq_pl}})['pc']",
         ),
         "pd": ParamLocalSetting(
             name_setting=NameSetting("pd", "", TPL),
-            expr=f"{{pl3}} / {p_total}",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{kd_ac}},{{keq_l}},{{keq_pl}})['pd']",
         ),
     }
 
@@ -214,5 +306,25 @@ def register() -> None:
     )
     user_functions = {
         "calc_conc": calculate_concentrations,
+        "populations": calculate_populations,
+        "rates": calculate_rates,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3, 1.0e-3, 1.0e-3, 1.0, 1.0),
+            (
+                "nonnegative",
+                "nonnegative",
+                "positive",
+                "positive",
+                "nonnegative",
+                "nonnegative",
+            ),
+            "pa",
+            "pb",
+            "pc",
+            "pd",
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_4st_binding_3_bound_states.py
+++ b/src/chemex/models/kinetic/settings_4st_binding_3_bound_states.py
@@ -2,37 +2,50 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import numpy as np
-from scipy.optimize import root
-
 from chemex.configuration.conditions import Conditions
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._binding import (
+    MIN_POSITIVE_FLOAT,
+    BindingEquilibrium,
+    detailed_balance_rate,
+    log_binding_weight,
+    log_equilibrium_ratio,
+    solve_binding_equilibrium,
+    split_exchange_rate,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
-from chemex.typing import Array
+from chemex.parameters.userfunctions import (
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 
 NAME = "4st_binding_3_bound_states"
 
 TPL = ("temperature", "p_total", "l_total")
 
 
-def calculate_residuals(
-    concentrations: Array,
+@lru_cache(maxsize=100)
+def _calculate_equilibrium(
     p_total: float,
     l_total: float,
     kd_ab: float,
     keq_bc: float,
     keq_cd: float,
-) -> Array:
-    p_, l_, pl1, pl2, pl3 = concentrations
-    return np.array(
-        [
-            l_total - (l_ + pl1 + pl2 + pl3),
-            p_total - (p_ + pl1 + pl2 + pl3),
-            kd_ab * pl1 - p_ * l_,
-            keq_bc * pl1 - pl2,
-            keq_cd * pl2 - pl3,
-        ],
+) -> BindingEquilibrium:
+    log_keq_bc = log_equilibrium_ratio(keq_bc)
+    log_keq_cd = log_equilibrium_ratio(keq_cd)
+    log_pl1 = log_binding_weight(kd_ab)
+    return solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(
+            log_pl1,
+            log_pl1 + log_keq_bc,
+            log_pl1 + log_keq_bc + log_keq_cd,
+        ),
+        edge_log_ratios=(log_keq_bc, log_keq_cd),
     )
 
 
@@ -44,14 +57,80 @@ def calculate_concentrations(
     keq_bc: float,
     keq_cd: float,
 ) -> dict[str, float]:
-    concentrations_start = (p_total, l_total, 0.0, 0.0, 0.0)
-    results = root(
-        calculate_residuals,
-        concentrations_start,
-        args=(p_total, l_total, kd_ab, keq_bc, keq_cd),
+    equilibrium = _calculate_equilibrium(
+        p_total,
+        l_total,
+        kd_ab,
+        keq_bc,
+        keq_cd,
     )
-    p_, l_, pl1, pl2, pl3 = results["x"]
-    return {"p": p_, "l": l_, "pl1": pl1, "pl2": pl2, "pl3": pl3}
+    pl1, pl2, pl3 = equilibrium.complexes
+    return {
+        "p": equilibrium.protein_free,
+        "l": equilibrium.ligand_free,
+        "pl1": pl1,
+        "pl2": pl2,
+        "pl3": pl3,
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_rates(
+    p_total: float,
+    l_total: float,
+    kd_ab: float,
+    keq_bc: float,
+    keq_cd: float,
+    koff_ab: float,
+    kex_bc: float,
+    kex_cd: float,
+) -> dict[str, float]:
+    equilibrium = _calculate_equilibrium(
+        p_total,
+        l_total,
+        kd_ab,
+        keq_bc,
+        keq_cd,
+    )
+    kbc, kcb = split_exchange_rate(
+        kex_bc,
+        0.0,
+        equilibrium.edge_log_ratios[0],
+    )
+    kcd, kdc = split_exchange_rate(
+        kex_cd,
+        0.0,
+        equilibrium.edge_log_ratios[1],
+    )
+    return {
+        "kab": detailed_balance_rate(
+            koff_ab,
+            equilibrium.log_populations[0],
+            equilibrium.log_populations[1],
+        ),
+        "kbc": kbc,
+        "kcb": kcb,
+        "kcd": kcd,
+        "kdc": kdc,
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    l_total: float,
+    kd_ab: float,
+    keq_bc: float,
+    keq_cd: float,
+) -> dict[str, float]:
+    pa, pb, pc, pd = _calculate_equilibrium(
+        p_total,
+        l_total,
+        kd_ab,
+        keq_bc,
+        keq_cd,
+    ).populations
+    return {"pa": pa, "pb": pb, "pc": pc, "pd": pd}
 
 
 def make_settings_4st_binding_3_bound_states(
@@ -65,11 +144,15 @@ def make_settings_4st_binding_3_bound_states(
     if l_total is None:
         msg = f"'l_total' must be specified to use the '{NAME}' model"
         raise ValueError(msg)
+    rates = (
+        f"rates({p_total},{l_total},{{kd_ab}},{{keq_bc}},{{keq_cd}},"
+        "{koff_ab},{kex_bc},{kex_cd})"
+    )
     return {
         "kd_app": ParamLocalSetting(
             name_setting=NameSetting("kd_app", "", ("temperature",)),
             value=1e-6,
-            min=0.0,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -114,7 +197,8 @@ def make_settings_4st_binding_3_bound_states(
         ),
         "kon_ab": ParamLocalSetting(
             name_setting=NameSetting("kon_ab", "", ("temperature",)),
-            expr="{koff_ab} / max({kd_ab}, 1e-32)",
+            expr="{koff_ab} / {kd_ab}",
+            report_only=True,
         ),
         "c_p": ParamLocalSetting(
             name_setting=NameSetting("c_p", "", TPL),
@@ -142,11 +226,11 @@ def make_settings_4st_binding_3_bound_states(
         ),
         "kd_eff": ParamLocalSetting(
             name_setting=NameSetting("kd_eff", "", TPL),
-            expr="({c_p}+{c_l}) / max({c_pl}, 1e-32)",
+            expr="{kd_app}",
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TPL),
-            expr="{kon_ab} * {c_l}",
+            expr=f"{rates}['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TPL),
@@ -154,35 +238,35 @@ def make_settings_4st_binding_3_bound_states(
         ),
         "kbc": ParamLocalSetting(
             name_setting=NameSetting("kbc", "", TPL),
-            expr="{keq_bc}*{kex_bc}/(1.0+{keq_bc})",
+            expr=f"{rates}['kbc']",
         ),
         "kcb": ParamLocalSetting(
             name_setting=NameSetting("kcb", "", TPL),
-            expr="{kex_bc}/(1.0+{keq_bc})",
+            expr=f"{rates}['kcb']",
         ),
         "kcd": ParamLocalSetting(
             name_setting=NameSetting("kcd", "", TPL),
-            expr="{keq_cd}*{kex_cd}/(1.0+{keq_cd})",
+            expr=f"{rates}['kcd']",
         ),
         "kdc": ParamLocalSetting(
             name_setting=NameSetting("kdc", "", TPL),
-            expr="{kex_cd}/(1.0+{keq_cd})",
+            expr=f"{rates}['kdc']",
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TPL),
-            expr=f"{{c_p}} / {p_total}",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{keq_bc}},{{keq_cd}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TPL),
-            expr=f"{{c_pl1}} / {p_total}",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{keq_bc}},{{keq_cd}})['pb']",
         ),
         "pc": ParamLocalSetting(
             name_setting=NameSetting("pc", "", TPL),
-            expr=f"{{c_pl2}} / {p_total}",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{keq_bc}},{{keq_cd}})['pc']",
         ),
         "pd": ParamLocalSetting(
             name_setting=NameSetting("pd", "", TPL),
-            expr=f"{{c_pl3}} / {p_total}",
+            expr=f"populations({p_total},{l_total},{{kd_ab}},{{keq_bc}},{{keq_cd}})['pd']",
         ),
     }
 
@@ -194,5 +278,24 @@ def register() -> None:
     )
     user_functions = {
         "concentrations": calculate_concentrations,
+        "populations": calculate_populations,
+        "rates": calculate_rates,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    function_linearization_registry.register(
+        NAME,
+        population_linearizations(
+            (1.0e-3, 1.0e-3, 1.0e-3, 1.0, 1.0),
+            (
+                "nonnegative",
+                "nonnegative",
+                "positive",
+                "nonnegative",
+                "nonnegative",
+            ),
+            "pa",
+            "pb",
+            "pc",
+            "pd",
+        ),
+    )

--- a/src/chemex/optimize/deterministic_uncertainty.py
+++ b/src/chemex/optimize/deterministic_uncertainty.py
@@ -21,6 +21,7 @@ from chemex.optimize.direct_trf import (
 from chemex.optimize.grouped_direct_trf import FitPartitionProof
 from chemex.optimize.uncertainty import (
     CompiledConstraintLinearizationCapabilities,
+    FunctionFiniteDifferenceCapability,
     MissingFunctionLinearizationCapability,
     OperationTerminal,
     ParameterUnit,
@@ -39,6 +40,7 @@ from chemex.parameters.parameterization import (
     ActiveParameterization,
     ParameterRole,
 )
+from chemex.parameters.userfunctions import function_linearization_registry
 
 
 class InterpretationCompleteness(StrEnum):
@@ -68,6 +70,32 @@ class ProfiledGridBasis:
 
 
 type DeterministicUncertaintyBasis = ContinuousTrfBasis | ProfiledGridBasis
+
+
+def compile_model_constraint_linearization_capabilities(
+    parameterization: ActiveParameterization,
+    output_scope: tuple[str, ...],
+) -> CompiledConstraintLinearizationCapabilities:
+    """Compile only the model-owned scientific-function derivative policies."""
+    capabilities = tuple(
+        FunctionFiniteDifferenceCapability(
+            function_id=item.function_id,
+            component=item.component,
+            argument_scales=item.argument_scales,
+            output_scale=item.output_scale,
+            argument_domains=item.argument_domains,
+            relative_steps=True,
+            normalized_population_components=item.normalized_population_components,
+        )
+        for item in function_linearization_registry.get(
+            parameterization.binder.model_name
+        )
+    )
+    return compile_constraint_linearization_capabilities(
+        parameterization,
+        output_scope,
+        capabilities,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -409,20 +437,18 @@ def _resolve_inputs(
     unsupported: list[str] = []
     for param_id in propagation_candidates:
         try:
-            compile_constraint_linearization_capabilities(
+            compile_model_constraint_linearization_capabilities(
                 parameterization,
                 (param_id,),
-                (),
             )
         except MissingFunctionLinearizationCapability:
             unsupported.append(param_id)
         else:
             supported.append(param_id)
     constrained_scope = tuple(supported)
-    compiled_capabilities = compile_constraint_linearization_capabilities(
+    compiled_capabilities = compile_model_constraint_linearization_capabilities(
         parameterization,
         constrained_scope,
-        (),
     )
     return _ResolvedUncertaintyInputs(
         policy,

--- a/src/chemex/optimize/helper.py
+++ b/src/chemex/optimize/helper.py
@@ -116,6 +116,7 @@ def _write_files(
     parameter_values: Mapping[str, float],
     parameterization: ActiveParameterization,
     fitted_ids: tuple[str, ...] = (),
+    report_only_values: Mapping[str, float] | None = None,
 ) -> None:
     """Write the results of the fit to output files."""
     print_writing_results(path)
@@ -127,6 +128,7 @@ def _write_files(
         parameterization=parameterization,
         fitted_ids=fitted_ids,
         deterministic_uncertainty=deterministic_uncertainty,
+        report_only_values=report_only_values,
     )
     experiments.write(path)
     uncertainty_interrupted = (
@@ -193,6 +195,7 @@ def _write_simulation_files(
     parameter_model: SealedParameterModel,
     parameter_values: Mapping[str, float],
     parameterization: ActiveParameterization,
+    report_only_values: Mapping[str, float] | None = None,
 ) -> None:
     """Write the results of the simulation to output files."""
     print_writing_results(path)
@@ -202,6 +205,7 @@ def _write_simulation_files(
         parameter_model=parameter_model,
         parameter_values=parameter_values,
         parameterization=parameterization,
+        report_only_values=report_only_values,
     )
     experiments.write(path)
 
@@ -237,6 +241,7 @@ def execute_post_fit(
     parameter_values: Mapping[str, float],
     parameterization: ActiveParameterization,
     fitted_ids: tuple[str, ...] = (),
+    report_only_values: Mapping[str, float] | None = None,
 ) -> None:
     _write_files(
         experiments,
@@ -249,6 +254,7 @@ def execute_post_fit(
         parameter_values=parameter_values,
         parameterization=parameterization,
         fitted_ids=fitted_ids,
+        report_only_values=report_only_values,
     )
     uncertainty_interrupted = (
         deterministic_uncertainty is not None
@@ -266,6 +272,7 @@ def execute_simulation(
     parameter_model: SealedParameterModel,
     parameterization: ActiveParameterization,
     plot: bool = False,
+    report_only_values: Mapping[str, float] | None = None,
 ) -> None:
     validate_relaxation_state(parameterization, parameter_values)
     experiments.prepare_for_simulation(parameter_values)
@@ -276,6 +283,7 @@ def execute_simulation(
             parameter_model=parameter_model,
             parameter_values=parameter_values,
             parameterization=parameterization,
+            report_only_values=report_only_values,
         )
         if plot:
             _write_simulation_plots(experiments, path)

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -532,6 +532,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
                 parameter_model=parameter_model,
                 parameter_values=result.resolved_values,
                 parameterization=parameterization,
+                report_only_values=session.resolve_report_only_values(),
             )
         except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
             _propagate_output_failure(error, path)
@@ -691,6 +692,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
                 parameter_values=result.resolved_values,
                 parameterization=parameterization,
                 fitted_ids=problem.controlled_ids,
+                report_only_values=session.resolve_report_only_values(),
             )
         except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
             if uncertainty_interrupted:
@@ -715,6 +717,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
             parameter_values=result.resolved_values,
             parameterization=parameterization,
             fitted_ids=problem.controlled_ids,
+            report_only_values=session.resolve_report_only_values(),
         )
     except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
         if uncertainty_interrupted:

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -17,7 +17,7 @@ import inspect
 import json
 import math
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass, field, fields, is_dataclass
+from dataclasses import dataclass, field, fields, is_dataclass, replace
 from enum import StrEnum
 from itertools import pairwise
 from numbers import Real
@@ -60,8 +60,8 @@ from chemex.parameters.parameterization import (
 from chemex.typing import Array
 
 _SCHEMA_VERSION = 2
-_RESIDUAL_LINEARIZATION_VERSION = "accepted-residual-jacobian-v2"
-_CONSTRAINT_LINEARIZATION_VERSION = "constraint-forward-chain-v1"
+_RESIDUAL_LINEARIZATION_VERSION = "accepted-residual-jacobian-v3"
+_CONSTRAINT_LINEARIZATION_VERSION = "constraint-forward-chain-v2"
 _COVARIANCE_VERSION = "column-equilibrated-full-rank-svd-factor-gram-v5"
 _FACTOR_VERSION = "column-equilibrated-svd-factor-gram-v4"
 _REDUCTION_VERSION = "fixed-pairwise-binary64-v1"
@@ -337,6 +337,9 @@ class FunctionFiniteDifferenceCapability:
     component: str | None
     argument_scales: tuple[float, ...]
     output_scale: float
+    argument_domains: tuple[Literal["unbounded", "nonnegative", "positive"], ...] = ()
+    relative_steps: bool = False
+    normalized_population_components: tuple[str, ...] = ()
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -345,17 +348,39 @@ class FunctionFiniteDifferenceCapability:
             for index, value in enumerate(self.argument_scales)
         )
         output_scale = _finite(self.output_scale, name="function output scale")
+        domains = self.argument_domains or ("unbounded",) * len(scales)
+        population_components = tuple(self.normalized_population_components)
         if (
             not self.function_id
             or not scales
             or any(value <= 0.0 for value in scales)
             or output_scale <= 0.0
+            or len(domains) != len(scales)
+            or any(
+                domain not in {"unbounded", "nonnegative", "positive"}
+                for domain in domains
+            )
         ):
             raise UncertaintyConstructionError(
                 "Function finite-difference scales must be positive and explicit"
             )
+        if population_components and (
+            len(population_components) < 2
+            or len(set(population_components)) != len(population_components)
+            or self.component not in population_components
+        ):
+            raise UncertaintyConstructionError(
+                "Normalized population components must be distinct and include "
+                "the capability component"
+            )
         object.__setattr__(self, "argument_scales", scales)
         object.__setattr__(self, "output_scale", output_scale)
+        object.__setattr__(self, "argument_domains", tuple(domains))
+        object.__setattr__(
+            self,
+            "normalized_population_components",
+            population_components,
+        )
         object.__setattr__(
             self,
             "identity",
@@ -366,6 +391,9 @@ class FunctionFiniteDifferenceCapability:
                     self.component,
                     _vector_tokens(scales),
                     _float_token(output_scale),
+                    tuple(domains),
+                    self.relative_steps,
+                    population_components,
                     _CONSTRAINT_LINEARIZATION_VERSION,
                 ),
             ),
@@ -3930,6 +3958,28 @@ def _max_norm(values: Sequence[float]) -> float:
     return max((abs(value) for value in values), default=0.0)
 
 
+def _normalized_three_point_weights(
+    first_displacement: float,
+    second_displacement: float,
+) -> tuple[tuple[float, float, float], float]:
+    """Return derivative weights in a local dimensionless coordinate.
+
+    The displacements must be finite, nonzero, and distinct.  The returned scale
+    converts the derivative with respect to the normalized coordinate back to
+    the original parameter units.
+    """
+    coordinate_scale = max(abs(first_displacement), abs(second_displacement))
+    first_offset = first_displacement / coordinate_scale
+    second_offset = second_displacement / coordinate_scale
+
+    # Raw subnormal displacement products can underflow even when the derivative
+    # is representable.  Their normalized counterparts remain order one.
+    first_weight = -second_offset / (first_offset * (first_offset - second_offset))
+    center_weight = -(first_offset + second_offset) / (first_offset * second_offset)
+    second_weight = -first_offset / (second_offset * (second_offset - first_offset))
+    return (first_weight, center_weight, second_weight), coordinate_scale
+
+
 def _three_point_derivative(
     first: Sequence[float],
     center: Sequence[float],
@@ -3937,24 +3987,21 @@ def _three_point_derivative(
     first_displacement: float,
     second_displacement: float,
 ) -> tuple[float, ...]:
-    first_coefficient = -second_displacement / (
-        first_displacement * (first_displacement - second_displacement)
+    weights, coordinate_scale = _normalized_three_point_weights(
+        first_displacement,
+        second_displacement,
     )
-    center_coefficient = -(first_displacement + second_displacement) / (
-        first_displacement * second_displacement
-    )
-    second_coefficient = -first_displacement / (
-        second_displacement * (second_displacement - first_displacement)
-    )
+    first_weight, center_weight, second_weight = weights
     result = tuple(
         _finite(
             _pairwise_sum(
                 (
-                    first_coefficient * left,
-                    center_coefficient * middle,
-                    second_coefficient * right,
+                    first_weight * left,
+                    center_weight * middle,
+                    second_weight * right,
                 )
-            ),
+            )
+            / coordinate_scale,
             name="finite-difference derivative",
         )
         for left, middle, right in zip(first, center, second, strict=True)
@@ -4197,11 +4244,22 @@ def _assess_stencil(
         *(_max_norm(result) for result in results),
     )
     minimum_displacement = min(abs(item) for item in displacements)
+    # Form the ratio first so epsilon times a subnormal function scale cannot
+    # underflow when the final roundoff allowance is representable.
     roundoff = (
-        policy.roundoff_multiplier * _EPSILON * function_scale / minimum_displacement
+        policy.roundoff_multiplier * _EPSILON * (function_scale / minimum_displacement)
     )
     threshold = policy.relative_step_tolerance * derivative_scale + roundoff
-    return discrepancy, derivative_scale, roundoff, discrepancy <= threshold
+    reliability_quantities = (
+        discrepancy,
+        derivative_scale,
+        roundoff,
+        threshold,
+    )
+    reliable = all(math.isfinite(value) for value in reliability_quantities) and (
+        discrepancy <= threshold
+    )
+    return discrepancy, derivative_scale, roundoff, reliable
 
 
 def _linearize_residual_column(
@@ -5826,99 +5884,122 @@ def _scientific_function_partial(
     policy: UncertaintyPolicy,
 ) -> tuple[float, FunctionPartialDiagnostic]:
     center = arguments[argument_index]
-    nominal = _NOMINAL_STEP_FACTOR * capability.argument_scales[argument_index]
+    scale = capability.argument_scales[argument_index]
+    nominal = _NOMINAL_STEP_FACTOR * (
+        abs(center) if capability.relative_steps and center != 0.0 else scale
+    )
+    nominal = max(nominal, math.ulp(center))
+    domain = capability.argument_domains[argument_index]
+    lower = 0.0 if domain in {"nonnegative", "positive"} else -math.inf
+    orientations = _column_orientations(center, lower, math.inf)
     base = (_scientific_function_output(expression, function, arguments),)
     trajectory: list[object] = []
-    for attempt, step in enumerate(
-        _step_candidates(nominal, math.inf, policy),
-        start=1,
-    ):
-        trial_arguments: list[tuple[float, ...]] = []
-        displacements: list[float] = []
-        represented = {center}
-        for multiplier in (-2.0, -1.0, 1.0, 2.0):
-            updated = center + multiplier * step
-            if not math.isfinite(updated) or updated in represented:
-                break
-            represented.add(updated)
-            trial = list(arguments)
-            trial[argument_index] = updated
-            trial_arguments.append(tuple(trial))
-            displacements.append(updated - center)
-        if len(trial_arguments) != 4:
-            trajectory.append((_float_token(step), "not_distinct"))
-            continue
-        try:
-            results = tuple(
-                (_scientific_function_output(expression, function, trial),)
-                for trial in trial_arguments
+    attempt = 0
+    for orientation, maximum in orientations:
+        for step in _step_candidates(nominal, maximum, policy):
+            attempt += 1
+            multipliers = (
+                (-2.0, -1.0, 1.0, 2.0)
+                if orientation == "centered"
+                else (
+                    (1.0, 2.0, 4.0)
+                    if orientation == "one_sided_positive"
+                    else (-1.0, -2.0, -4.0)
+                )
             )
-        except (ArithmeticError, FloatingPointError, TypeError, ValueError):
-            trajectory.append((_float_token(step), "domain_failure"))
-            continue
-        fine, coarse = _stencil_estimates(
-            "centered",
-            results,
-            base,
-            displacements,
-        )
-        discrepancy, derivative_scale, roundoff, reliable = _assess_stencil(
-            fine,
-            coarse,
-            results,
-            base,
-            displacements,
-            policy,
-            capability.output_scale,
-        )
-        trajectory.append(
-            (
-                _float_token(step),
-                tuple(_float_token(item) for item in displacements),
-                _float_token(discrepancy),
-                _float_token(derivative_scale),
-                _float_token(roundoff),
-                reliable,
+            trial_arguments: list[tuple[float, ...]] = []
+            displacements: list[float] = []
+            represented = {center}
+            for multiplier in multipliers:
+                updated = center + multiplier * step
+                if (
+                    not math.isfinite(updated)
+                    or updated in represented
+                    or (domain == "positive" and updated <= 0.0)
+                    or (domain == "nonnegative" and updated < 0.0)
+                ):
+                    break
+                represented.add(updated)
+                trial = list(arguments)
+                trial[argument_index] = updated
+                trial_arguments.append(tuple(trial))
+                displacements.append(updated - center)
+            if len(trial_arguments) != len(multipliers):
+                trajectory.append(
+                    (orientation, _float_token(step), "not_distinct_or_outside_domain")
+                )
+                continue
+            try:
+                results = tuple(
+                    (_scientific_function_output(expression, function, trial),)
+                    for trial in trial_arguments
+                )
+            except (ArithmeticError, FloatingPointError, TypeError, ValueError):
+                trajectory.append((orientation, _float_token(step), "domain_failure"))
+                continue
+            fine, coarse = _stencil_estimates(
+                orientation,
+                results,
+                base,
+                displacements,
             )
-        )
-        if reliable:
-            fingerprint = _identity(
-                "scientific-function-partial-trajectory", trajectory
+            discrepancy, derivative_scale, roundoff, reliable = _assess_stencil(
+                fine,
+                coarse,
+                results,
+                base,
+                displacements,
+                policy,
+                capability.output_scale,
             )
-            return (
-                fine[0],
-                FunctionPartialDiagnostic(
-                    capability.identity,
-                    expression.function_id,
-                    expression.component,
-                    argument_index,
-                    "centered_two_scale_numerical",
+            trajectory.append(
+                (
+                    orientation,
+                    _float_token(step),
+                    tuple(_float_token(item) for item in displacements),
+                    _float_token(discrepancy),
+                    _float_token(derivative_scale),
+                    _float_token(roundoff),
+                    reliable,
+                )
+            )
+            if reliable:
+                fingerprint = _identity(
+                    "scientific-function-partial-trajectory", trajectory
+                )
+                return (
                     fine[0],
-                    coarse[0],
-                    tuple(displacements),
-                    discrepancy,
-                    derivative_scale,
-                    roundoff,
-                    attempt,
-                    fingerprint,
-                    (
-                        ClaimAssessment(
-                            "FUNCTION_PARTIAL_RELIABILITY",
-                            ClaimState.SATISFIED,
+                    FunctionPartialDiagnostic(
+                        capability.identity,
+                        expression.function_id,
+                        expression.component,
+                        argument_index,
+                        f"{orientation}_two_scale_numerical",
+                        fine[0],
+                        coarse[0],
+                        tuple(displacements),
+                        discrepancy,
+                        derivative_scale,
+                        roundoff,
+                        attempt,
+                        fingerprint,
+                        (
+                            ClaimAssessment(
+                                "FUNCTION_PARTIAL_RELIABILITY",
+                                ClaimState.SATISFIED,
+                            ),
                         ),
                     ),
-                ),
-            )
+                )
     fingerprint = _identity("scientific-function-partial-trajectory", trajectory)
     if trajectory and all(
-        isinstance(item, tuple) and len(item) == 2 and item[1] == "not_distinct"
+        isinstance(item, tuple) and item[-1] == "not_distinct_or_outside_domain"
         for item in trajectory
     ):
         category = "function_partial_representation_loss"
     elif trajectory and all(
         isinstance(item, tuple)
-        and len(item) == 2
-        and item[1] in {"not_distinct", "domain_failure"}
+        and item[-1] in {"not_distinct_or_outside_domain", "domain_failure"}
         for item in trajectory
     ):
         category = "function_partial_active_domain_failure"
@@ -5934,6 +6015,169 @@ def _scientific_function_partial(
             "exhausted_declared_larger_step_extent",
         ),
     )
+
+
+def _normalization_complement_diagnostic(
+    expression: FunctionExpression,
+    capability: FunctionFiniteDifferenceCapability,
+    argument_index: int,
+    dependent_component: str,
+    independent_components: tuple[str, ...],
+    estimate: float,
+    source_diagnostics: tuple[FunctionPartialDiagnostic, ...],
+) -> FunctionPartialDiagnostic:
+    """Record the numerical evidence behind one normalization complement."""
+    companion_estimates = tuple(
+        diagnostic.companion_estimate for diagnostic in source_diagnostics
+    )
+    if any(value is None for value in companion_estimates):
+        raise UncertaintyConstructionError(
+            "Numerical population partial lacks its companion estimate"
+        )
+    companion_estimate = _finite(
+        -math.fsum(value for value in companion_estimates if value is not None),
+        name="normalized population complement companion derivative",
+    )
+    discrepancy = abs(estimate - companion_estimate)
+    derivative_scale = max(
+        abs(estimate),
+        *(diagnostic.derivative_scale for diagnostic in source_diagnostics),
+    )
+    roundoff_allowance = _finite(
+        math.fsum(diagnostic.roundoff_allowance for diagnostic in source_diagnostics),
+        name="normalized population complement roundoff allowance",
+    )
+    represented_displacements = tuple(
+        sorted(
+            {
+                displacement
+                for diagnostic in source_diagnostics
+                for displacement in diagnostic.represented_displacements
+            }
+        )
+    )
+    trajectory_fingerprint = _identity(
+        "normalized-population-partial-trajectory",
+        (
+            capability.identity,
+            dependent_component,
+            argument_index,
+            tuple(diagnostic.identity for diagnostic in source_diagnostics),
+        ),
+    )
+    return FunctionPartialDiagnostic(
+        capability.identity,
+        expression.function_id,
+        dependent_component,
+        argument_index,
+        "normalized_population_complement",
+        estimate,
+        companion_estimate,
+        represented_displacements,
+        discrepancy,
+        derivative_scale,
+        roundoff_allowance,
+        sum(diagnostic.attempt_count for diagnostic in source_diagnostics),
+        trajectory_fingerprint,
+        (
+            ClaimAssessment(
+                "FUNCTION_PARTIAL_RELIABILITY",
+                ClaimState.SATISFIED,
+            ),
+            ClaimAssessment(
+                "NORMALIZED_POPULATION_GRADIENT",
+                ClaimState.SATISFIED,
+                (
+                    f"d{dependent_component} = -sum("
+                    + ", ".join(f"d{component}" for component in independent_components)
+                    + ")"
+                ),
+            ),
+        ),
+    )
+
+
+def _normalized_population_partial(
+    expression: FunctionExpression,
+    function: Callable[..., object],
+    arguments: tuple[float, ...],
+    argument_index: int,
+    capability: FunctionFiniteDifferenceCapability,
+    policy: UncertaintyPolicy,
+) -> tuple[float, FunctionPartialDiagnostic]:
+    """Differentiate one component of a model-owned normalized population vector.
+
+    The largest population is reconstructed from the other gradients because its
+    scalar value is the component most likely to round to exactly one.  Central
+    population values continue to come directly from the scientific function.
+    """
+    components = capability.normalized_population_components
+    requested_component = expression.component
+    if requested_component not in components:
+        raise UncertaintyConstructionError(
+            "Normalized population capability does not include its output component"
+        )
+    component_expressions = {
+        component: FunctionExpression(
+            expression.function_id,
+            expression.arguments,
+            component,
+        )
+        for component in components
+    }
+    component_capabilities = {
+        component: replace(capability, component=component) for component in components
+    }
+    population_values = {
+        component: _scientific_function_output(
+            component_expression,
+            function,
+            arguments,
+        )
+        for component, component_expression in component_expressions.items()
+    }
+    dependent_component = max(components, key=population_values.__getitem__)
+    if requested_component != dependent_component:
+        return _scientific_function_partial(
+            expression,
+            function,
+            arguments,
+            argument_index,
+            component_capabilities[requested_component],
+            policy,
+        )
+
+    independent_components = tuple(
+        component for component in components if component != dependent_component
+    )
+    independent_partials = tuple(
+        _scientific_function_partial(
+            component_expressions[component],
+            function,
+            arguments,
+            argument_index,
+            component_capabilities[component],
+            policy,
+        )
+        for component in independent_components
+    )
+    estimate = _finite(
+        -math.fsum(partial for partial, _diagnostic in independent_partials),
+        name="normalized population complement derivative",
+    )
+    source_diagnostics = tuple(
+        diagnostic for _partial, diagnostic in independent_partials
+    )
+    diagnostic = _normalization_complement_diagnostic(
+        expression,
+        capability,
+        argument_index,
+        dependent_component,
+        independent_components,
+        estimate,
+        source_diagnostics,
+    )
+    return estimate, diagnostic
 
 
 def _analytic_function_partials(
@@ -6031,8 +6275,18 @@ def _differentiate_function(
                 f"Scientific function {expression.function_id!r} capability has the "
                 "wrong arity"
             )
-        partial_results = tuple(
-            _scientific_function_partial(
+        active_indices = tuple(
+            index
+            for index, argument in enumerate(arguments)
+            if any(component != 0.0 for component in argument.gradient)
+        )
+        partial_function = (
+            _normalized_population_partial
+            if capability.normalized_population_components
+            else _scientific_function_partial
+        )
+        partial_results = {
+            index: partial_function(
                 expression,
                 function,
                 argument_values,
@@ -6040,10 +6294,13 @@ def _differentiate_function(
                 capability,
                 policy,
             )
+            for index in active_indices
+        }
+        partials = tuple(
+            partial_results[index][0] if index in partial_results else 0.0
             for index in range(len(arguments))
         )
-        partials = tuple(item[0] for item in partial_results)
-        diagnostics = tuple(item[1] for item in partial_results)
+        diagnostics = tuple(partial_results[index][1] for index in active_indices)
     else:
         partials, diagnostics = _analytic_function_partials(
             expression,

--- a/src/chemex/parameters/factory.py
+++ b/src/chemex/parameters/factory.py
@@ -71,6 +71,7 @@ def _build_parameters(
             max=setting.max,
             vary=setting.vary,
             expr=expression,
+            report_only=setting.report_only,
         )
 
     return name_map, parameters
@@ -237,6 +238,7 @@ class ParameterFactory:
                 model_owned=param_id in model_owned_ids and bool(parameter.expr),
                 requires_independent=not bool(parameter.expr),
                 fits_by_default=param_id in default_fit_ids,
+                report_only=parameter.report_only,
             )
             target.setdefault(param_id, []).append(contribution)
 

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -146,6 +146,7 @@ class ParameterDeclarationContribution:
     model_owned: bool = False
     requires_independent: bool = False
     fits_by_default: bool = False
+    report_only: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -163,6 +164,7 @@ class ParameterDeclaration:
     model_owned: bool = False
     requires_independent: bool = False
     fits_by_default: bool = False
+    report_only: bool = False
 
 
 def baseline_parameter_role(declaration: ParameterDeclaration) -> ParameterRole:
@@ -222,6 +224,7 @@ class SealedParameterDeclarations(Mapping[str, ParameterDeclaration]):
                         item.model_owned,
                         item.requires_independent,
                         item.fits_by_default,
+                        item.report_only,
                     )
                     for item in items
                 ),
@@ -267,6 +270,13 @@ def seal_parameter_declarations(
         supports_estimation = any(item.supports_estimation for item in contributed)
         requires_independent = any(item.requires_independent for item in contributed)
         fits_by_default = any(item.fits_by_default for item in contributed)
+        report_only_values = {item.report_only for item in contributed}
+        if len(report_only_values) > 1:
+            raise IncompatibleParameterizationInputError(
+                "Contributors disagree on report-only derivation semantics",
+                param_id=definition.param_id,
+            )
+        report_only = report_only_values.pop()
         expression = expressions[0] if expressions else ""
         model_owned = any(
             item.model_owned and item.model_expression.strip() == expression
@@ -280,6 +290,7 @@ def seal_parameter_declarations(
                 model_owned,
                 requires_independent,
                 fits_by_default,
+                report_only,
             )
         )
     return SealedParameterDeclarations(tuple(items))
@@ -1921,8 +1932,11 @@ def build_initial_analysis_values(
 ) -> Mapping[str, float]:
     """Natively fill missing model-derived revision-zero configuration values."""
     configuration = parameter_model.configuration
+    deferred_ids = deferred_derived_ids(parameter_model)
     missing_ids = tuple(
-        config.param_id for config in configuration if config.effective_value is None
+        config.param_id
+        for config in configuration
+        if config.effective_value is None and config.param_id not in deferred_ids
     )
     for param_id in missing_ids:
         if not parameter_model.declarations[param_id].model_expression:
@@ -1940,13 +1954,14 @@ def build_initial_analysis_values(
             (config.param_id, config.effective_value)
             for config in configuration
             if config.effective_value is not None
+            and config.param_id not in deferred_ids
         ),
     )
     parameterization = _compile_active_parameterization_from_rules(
         parameter_model,
         bootstrap_snapshot,
         (),
-        set(parameter_model.declarations),
+        set(parameter_model.declarations) - set(deferred_ids),
         initialize_missing=True,
     )
     resolved = parameterization.resolve(
@@ -1960,7 +1975,26 @@ def build_initial_analysis_values(
                 else config.effective_value
             )
             for config in configuration
+            if config.param_id not in deferred_ids
         }
+    )
+
+
+def deferred_derived_ids(
+    parameter_model: SealedParameterModel,
+) -> tuple[str, ...]:
+    """Keep public report-only derivations out of central materialization."""
+    return report_only_derived_ids(parameter_model)
+
+
+def report_only_derived_ids(
+    parameter_model: SealedParameterModel,
+) -> tuple[str, ...]:
+    """Return model-owned outputs resolved only when explicitly needed."""
+    return tuple(
+        declaration.param_id
+        for declaration in parameter_model.declarations.values()
+        if declaration.report_only
     )
 
 

--- a/src/chemex/parameters/setting.py
+++ b/src/chemex/parameters/setting.py
@@ -69,6 +69,7 @@ class ParamLocalSetting:
         vary: bool = False,
         expr: str = "",
         supports_estimation: bool = False,
+        report_only: bool = False,
     ) -> None:
         self.__expr: ExpressionSetting = ExpressionSetting(_RE_NAMES)
         self.name_setting = name_setting
@@ -77,6 +78,7 @@ class ParamLocalSetting:
         self.max = max
         self.vary = vary
         self.supports_estimation = supports_estimation
+        self.report_only = report_only
         self.expr = expr
 
     @property
@@ -103,6 +105,7 @@ class ParamSetting:
         vary: bool = False,
         expr: str = "",
         brute_step: float | None = None,
+        report_only: bool = False,
     ) -> None:
         self.__expr: ExpressionSetting = ExpressionSetting(_RE_IDS)
         self.param_name = param_name
@@ -113,6 +116,7 @@ class ParamSetting:
         self.vary = vary
         self.expr = expr
         self.brute_step = brute_step
+        self.report_only = report_only
 
     @property
     def expr(self) -> str:

--- a/src/chemex/parameters/userfunctions.py
+++ b/src/chemex/parameters/userfunctions.py
@@ -1,13 +1,56 @@
-"""Registry for functions available to scientific constraint expressions."""
+"""Registries for functions used by scientific constraint expressions."""
 
+import math
 from collections.abc import Callable
-from typing import Any, ClassVar
+from dataclasses import dataclass
+from typing import Any, ClassVar, Literal
 
 from chemex.configuration.conditions import Conditions
 from chemex.parameters.setting import ParamLocalSetting
 
 SettingsType = dict[str, ParamLocalSetting]
 SettingMakerType = Callable[[Conditions], SettingsType]
+
+type FunctionArgumentDomain = Literal["unbounded", "nonnegative", "positive"]
+_MINIMUM_POSITIVE_FLOAT = math.ulp(0.0)
+
+
+@dataclass(frozen=True, slots=True)
+class NumericalFunctionLinearization:
+    """Model-owned numerical derivative policy for one function component."""
+
+    function_id: str
+    component: str | None
+    argument_scales: tuple[float, ...]
+    argument_domains: tuple[FunctionArgumentDomain, ...]
+    output_scale: float = 1.0
+    normalized_population_components: tuple[str, ...] = ()
+
+
+def population_linearizations(
+    argument_scales: tuple[float, ...],
+    argument_domains: tuple[FunctionArgumentDomain, ...],
+    *components: str,
+) -> tuple[NumericalFunctionLinearization, ...]:
+    """Build coupled derivative policies for one normalized population vector."""
+    population_components = tuple(components)
+    if len(population_components) < 2 or len(set(population_components)) != len(
+        population_components
+    ):
+        raise ValueError("Normalized populations require distinct components")
+    # Let each population's sampled magnitude set its roundoff scale.  A unit
+    # floor would overwhelm informative subnormal components.
+    return tuple(
+        NumericalFunctionLinearization(
+            function_id="populations",
+            component=component,
+            argument_scales=argument_scales,
+            argument_domains=argument_domains,
+            output_scale=_MINIMUM_POSITIVE_FLOAT,
+            normalized_population_components=population_components,
+        )
+        for component in population_components
+    )
 
 
 class Registry:
@@ -26,3 +69,22 @@ class Registry:
 
 
 user_function_registry = Registry()
+
+
+class LinearizationRegistry:
+    """Registry for explicitly approved model-owned function derivatives."""
+
+    _items: ClassVar[dict[str, tuple[NumericalFunctionLinearization, ...]]] = {}
+
+    def register(
+        self,
+        name: str,
+        capabilities: tuple[NumericalFunctionLinearization, ...],
+    ) -> None:
+        self._items[name] = capabilities
+
+    def get(self, name: str) -> tuple[NumericalFunctionLinearization, ...]:
+        return self._items.get(name, ())
+
+
+function_linearization_registry = LinearizationRegistry()

--- a/src/chemex/parameters/values.py
+++ b/src/chemex/parameters/values.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import math
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from numbers import Real
 from threading import RLock
@@ -154,6 +154,7 @@ class AnalysisValues:
         configuration: SealedConfiguration,
         *,
         _native_initial_values: Mapping[str, float] | None = None,
+        _deferred_derived_ids: Sequence[str] = (),
     ) -> None:
         """Initialize revision zero from immutable configured effective values."""
         with self._lock:
@@ -162,15 +163,25 @@ class AnalysisValues:
                 raise RuntimeError(msg)
 
             configured_ids = tuple(config.param_id for config in configuration)
-            if (
-                _native_initial_values is not None
-                and tuple(_native_initial_values) != configured_ids
+            deferred_ids = frozenset(_deferred_derived_ids)
+            if _native_initial_values is not None and tuple(
+                _native_initial_values
+            ) != tuple(
+                param_id for param_id in configured_ids if param_id not in deferred_ids
             ):
-                msg = "Native initial values do not exactly cover configuration IDs"
+                msg = (
+                    "Native initial values do not exactly cover materialized "
+                    "configuration IDs"
+                )
+                raise ValueError(msg)
+            if deferred_ids - set(configured_ids):
+                msg = "Deferred derived IDs are invalid for this configuration"
                 raise ValueError(msg)
 
             items: list[tuple[str, float]] = []
             for config in configuration:
+                if config.param_id in deferred_ids:
+                    continue
                 value = (
                     config.effective_value
                     if _native_initial_values is None

--- a/src/chemex/printers/parameters.py
+++ b/src/chemex/printers/parameters.py
@@ -278,21 +278,27 @@ def classify_parameters(
     parameter_values: Mapping[str, float],
     parameterization: ActiveParameterization,
     fitted_ids: tuple[str, ...],
+    report_only_values: Mapping[str, float] | None = None,
 ) -> ClassifiedParameters:
+    optional_values = {} if report_only_values is None else report_only_values
+    included_ids = set(parameterization.scope_ids) | set(optional_values)
     parameters = {
         parameter_name_from_definition(definition): ReportParameter(
             definition.param_id,
             parameter_name_from_definition(definition),
-            parameter_values[definition.param_id],
+            optional_values[definition.param_id]
+            if definition.param_id in optional_values
+            else parameter_values[definition.param_id],
         )
         for definition in parameter_model.definitions
-        if definition.param_id in parameterization.scope_ids
+        if definition.param_id in included_ids
     }
     fitted_id_set = set(fitted_ids)
     constrained = {
         pname: param
         for pname, param in parameters.items()
-        if parameterization.role(param.param_id) is ParameterRole.DERIVED
+        if parameter_model.declarations[param.param_id].report_only
+        or parameterization.role(param.param_id) is ParameterRole.DERIVED
     }
     fitted = {
         pname: param
@@ -322,6 +328,7 @@ def write_parameters(
     parameterization: ActiveParameterization,
     fitted_ids: tuple[str, ...] = (),
     deterministic_uncertainty: DeterministicUncertainty | None = None,
+    report_only_values: Mapping[str, float] | None = None,
 ) -> None:
     """Write the model parameter values and their uncertainties to a file."""
     path_par = path / "Parameters"
@@ -331,6 +338,7 @@ def write_parameters(
         parameter_values,
         parameterization,
         fitted_ids,
+        report_only_values,
     )
     names = {
         definition.param_id: parameter_name_from_definition(definition)
@@ -340,6 +348,16 @@ def write_parameters(
         item.target_id: _replace_parameter_ids(item.expression_text, names)
         for item in parameterization.program.constraints
     }
+    constraint_expressions.update(
+        {
+            declaration.param_id: _replace_parameter_ids(
+                declaration.model_expression,
+                names,
+            )
+            for declaration in parameter_model.declarations.values()
+            if declaration.report_only
+        }
+    )
 
     write_file(
         classified_parameters.fitted,

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Protocol
 
 from chemex.configuration.method_plan import MethodPlan, RoleAction
@@ -16,9 +17,12 @@ from chemex.parameters.database import (
 from chemex.parameters.factory import ParameterFactory
 from chemex.parameters.parameterization import (
     ActiveParameterization,
+    NonFiniteParameterValueError,
     build_initial_analysis_values,
     compile_active_parameterization,
     compile_active_parameterization_from_actions,
+    deferred_derived_ids,
+    report_only_derived_ids,
 )
 from chemex.parameters.values import AnalysisValues
 from chemex.runtime.execution import ExecutionSettings
@@ -97,13 +101,17 @@ class AnalysisSession:
                     self.model.spec.identity,
                     model_free_configuration,
                     _native_initial_values=model_free_initial_values,
+                    _deferred_derived_ids=deferred_derived_ids(
+                        model_free_parameter_model
+                    ),
                 )
                 model_free_snapshot = model_free_values.snapshot()
                 model_free_parameterization = compile_active_parameterization(
                     model_free_parameter_model,
                     model_free_snapshot,
                     Method(),
-                    set(model_free_parameter_model.declarations),
+                    set(model_free_parameter_model.declarations)
+                    - set(report_only_derived_ids(model_free_parameter_model)),
                 )
                 resolved_model_free_values = model_free_parameterization.resolve(
                     model_free_parameterization.frame_from_snapshot(model_free_snapshot)
@@ -131,6 +139,7 @@ class AnalysisSession:
                 model_identity,
                 configuration,
                 _native_initial_values=initial_values,
+                _deferred_derived_ids=deferred_derived_ids(parameter_model),
             )
         except Exception as error:  # noqa: BLE001 - checkpoint-1 isolation boundary
             self.parameter_factory.disable_native_candidate(error)
@@ -192,6 +201,29 @@ class AnalysisSession:
         parameterization = self.compile_parameterization(Method(), required_ids)
         frame = parameterization.frame_from_snapshot(self.analysis_values.snapshot())
         return parameterization.resolve(frame)
+
+    def resolve_report_only_values(self) -> Mapping[str, float]:
+        """Resolve representable report-only outputs without blocking analysis."""
+        parameter_model = self.parameter_factory.sealed_parameter_model
+        if parameter_model is None:
+            raise RuntimeError("Native parameter model is unavailable")
+        snapshot = self.analysis_values.snapshot()
+        values: dict[str, float] = {}
+        for param_id in report_only_derived_ids(parameter_model):
+            try:
+                parameterization = compile_active_parameterization(
+                    parameter_model,
+                    snapshot,
+                    Method(),
+                    {param_id},
+                )
+                resolved = parameterization.resolve(
+                    parameterization.frame_from_snapshot(snapshot)
+                )
+            except NonFiniteParameterValueError:
+                continue
+            values[param_id] = resolved[param_id]
+        return MappingProxyType(values)
 
 
 def ensure_plugins_registered() -> None:

--- a/tests/models/kinetic/test_binding_equilibrium.py
+++ b/tests/models/kinetic/test_binding_equilibrium.py
@@ -1,0 +1,333 @@
+"""Independent numerical qualifications for finite-pool binding equilibrium."""
+
+from __future__ import annotations
+
+import math
+import sys
+from decimal import Decimal, localcontext
+
+import pytest
+
+from chemex.models.kinetic._binding import (
+    log_binding_weight,
+    log_equilibrium_ratio,
+    solve_binding_equilibrium,
+    split_exchange_rate,
+)
+
+
+def _decimal_one_site(
+    p_total: float,
+    l_total: float,
+    kd: float,
+) -> tuple[float, float, float]:
+    """Return an independent stable high-precision physical solution."""
+    values = tuple(Decimal.from_float(value) for value in (p_total, l_total, kd))
+    exponent_span = max(value.adjusted() for value in values) - min(
+        value.adjusted() for value in values
+    )
+    with localcontext() as context:
+        context.prec = exponent_span + 100
+        protein, ligand, dissociation = values
+        total = protein + ligand + dissociation
+        discriminant = (total * total - Decimal(4) * protein * ligand).sqrt()
+        bound = Decimal(2) * protein * ligand / (total + discriminant)
+        return float(protein - bound), float(ligand - bound), float(bound)
+
+
+@pytest.mark.parametrize(
+    ("p_total", "l_total", "kd"),
+    (
+        (1.0e-3, 1.0e-3, 1.0e-300),
+        (1.0e-100, 1.0e-100, 1.0e-300),
+        (1.0e-9, 2.0e-3, 1.0e-50),
+        (2.0e-3, 1.0e-9, 1.0e-50),
+        (1.0e-12, 2.0e-12, 3.0e-12),
+        (1.0e-3, 2.0e-3, 1.0e6),
+    ),
+)
+def test_one_site_binding_matches_high_precision_physical_root(
+    p_total: float,
+    l_total: float,
+    kd: float,
+) -> None:
+    equilibrium = solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(log_binding_weight(kd),),
+    )
+    expected = _decimal_one_site(p_total, l_total, kd)
+
+    assert equilibrium.protein_free == pytest.approx(expected[0], rel=2.0e-14, abs=0.0)
+    assert equilibrium.ligand_free == pytest.approx(expected[1], rel=2.0e-14, abs=0.0)
+    assert equilibrium.bound_total == pytest.approx(expected[2], rel=2.0e-14, abs=0.0)
+    assert math.fsum((equilibrium.protein_free, equilibrium.bound_total)) == (
+        pytest.approx(p_total, rel=2.0e-15, abs=0.0)
+    )
+    assert math.fsum((equilibrium.ligand_free, equilibrium.bound_total)) == (
+        pytest.approx(l_total, rel=2.0e-15, abs=0.0)
+    )
+    assert math.fsum(equilibrium.populations) == pytest.approx(1.0, rel=2.0e-15)
+
+
+@pytest.mark.parametrize(
+    ("p_total", "l_total", "kd"),
+    (
+        (1.0e-320, 1.0e308, 1.0e308),
+        (1.0e-3, math.nextafter(1.0e-3, math.inf), 1.0e-300),
+    ),
+    ids=("extreme-asymmetric-totals", "adjacent-nearly-equal-totals"),
+)
+def test_finite_pool_binding_preserves_decisive_input_information(
+    p_total: float,
+    l_total: float,
+    kd: float,
+) -> None:
+    expected = _decimal_one_site(p_total, l_total, kd)
+    equilibrium = solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(log_binding_weight(kd),),
+    )
+
+    assert equilibrium.protein_free == pytest.approx(
+        expected[0], rel=2.0e-13, abs=math.nextafter(0.0, 1.0)
+    )
+    assert equilibrium.ligand_free == pytest.approx(
+        expected[1], rel=2.0e-13, abs=math.nextafter(0.0, 1.0)
+    )
+    assert equilibrium.bound_total == pytest.approx(
+        expected[2], rel=2.0e-13, abs=math.nextafter(0.0, 1.0)
+    )
+
+
+def test_population_survives_dimensional_complex_underflow() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+    equilibrium = solve_binding_equilibrium(
+        1.0e-3,
+        2.0e-3,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(
+            log_binding_weight(minimum),
+            log_binding_weight(1.0),
+        ),
+    )
+
+    assert equilibrium.complexes[1] == 0.0
+    assert equilibrium.populations[2] == minimum
+    assert math.fsum(equilibrium.populations) == 1.0
+    assert equilibrium.log_populations[2] > -math.inf
+
+
+@pytest.mark.parametrize(
+    ("total_rate", "ratio", "expected"),
+    (
+        (10.0, 0.0, (0.0, 10.0)),
+        (10.0, 1.0, (5.0, 5.0)),
+        (1.0, math.nextafter(0.0, 1.0), (math.nextafter(0.0, 1.0), 1.0)),
+        (1.0, sys.float_info.max, (1.0, 1.0 / sys.float_info.max)),
+    ),
+)
+def test_exchange_rate_split_preserves_boundaries_and_ratio(
+    total_rate: float,
+    ratio: float,
+    expected: tuple[float, float],
+) -> None:
+    forward, reverse = split_exchange_rate(
+        total_rate,
+        0.0,
+        log_equilibrium_ratio(ratio),
+    )
+
+    assert forward == pytest.approx(expected[0], rel=2.0e-15, abs=0.0)
+    assert reverse == pytest.approx(expected[1], rel=3.0e-14, abs=0.0)
+    assert forward + reverse == pytest.approx(total_rate, rel=2.0e-15)
+    if ratio > 0.0:
+        assert forward / reverse == pytest.approx(ratio, rel=3.0e-14, abs=0.0)
+
+
+@pytest.mark.parametrize(
+    ("total_rate", "ratio"),
+    (
+        (0.5, math.nextafter(0.0, 1.0)),
+        (math.nextafter(0.0, 1.0), 1.0),
+    ),
+)
+def test_exchange_rate_split_rejects_positive_unrepresentable_direction(
+    total_rate: float,
+    ratio: float,
+) -> None:
+    with pytest.raises(ValueError, match="below binary64 representability"):
+        split_exchange_rate(
+            total_rate,
+            0.0,
+            log_equilibrium_ratio(ratio),
+        )
+
+
+def test_alternative_bound_modes_use_normalized_equilibrium_weights() -> None:
+    kd_ab = 4.0e-4
+    kd_ac = 1.3e-3
+    equilibrium = solve_binding_equilibrium(
+        8.0e-4,
+        2.3e-3,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(
+            log_binding_weight(kd_ab),
+            log_binding_weight(kd_ac),
+        ),
+    )
+    pl1, pl2 = equilibrium.complexes
+
+    assert pl1 / pl2 == pytest.approx(kd_ac / kd_ab, rel=2.0e-15)
+    assert kd_ab * pl1 == pytest.approx(
+        equilibrium.protein_free * equilibrium.ligand_free,
+        rel=2.0e-14,
+    )
+    assert kd_ac * pl2 == pytest.approx(
+        equilibrium.protein_free * equilibrium.ligand_free,
+        rel=2.0e-14,
+    )
+
+
+@pytest.mark.parametrize(
+    ("free_weights", "complex_weights"),
+    (
+        ((1.0,), (1.0 / 4.0e-4, 1.0 / 1.3e-3)),
+        ((1.0, 2.5), (1.0 / 4.0e-4, 2.5 / 1.3e-3)),
+        (
+            (1.0, 2.5),
+            (1.0 / 4.0e-4, 2.5 / 1.3e-3, 2.5 * 1.7 / 1.3e-3),
+        ),
+        (
+            (1.0,),
+            (
+                1.0 / 3.1e-3,
+                2.5 / 3.1e-3,
+                2.5 * 1.7 / 3.1e-3,
+            ),
+        ),
+    ),
+    ids=(
+        "alternative-complexes",
+        "partner-conformers",
+        "partner-conformers-three-complexes",
+        "three-bound-conformers",
+    ),
+)
+def test_multi_species_binding_matches_independent_effective_kd_matrix(
+    free_weights: tuple[float, ...],
+    complex_weights: tuple[float, ...],
+) -> None:
+    p_total = 8.0e-4
+    l_total = 2.3e-3
+    with localcontext() as context:
+        context.prec = 100
+        free_total = sum(Decimal(str(value)) for value in free_weights)
+        complex_total = sum(Decimal(str(value)) for value in complex_weights)
+        kd_app = float(free_total / complex_total)
+    expected_p, expected_l, expected_bound = _decimal_one_site(
+        p_total,
+        l_total,
+        kd_app,
+    )
+    equilibrium = solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=tuple(math.log(value) for value in free_weights),
+        complex_log_weights=tuple(math.log(value) for value in complex_weights),
+    )
+
+    assert equilibrium.protein_free == pytest.approx(expected_p, rel=3.0e-14)
+    assert equilibrium.ligand_free == pytest.approx(expected_l, rel=3.0e-14)
+    assert equilibrium.bound_total == pytest.approx(expected_bound, rel=3.0e-14)
+    for concentration, weight in zip(
+        equilibrium.free_ligands,
+        free_weights,
+        strict=True,
+    ):
+        assert concentration == pytest.approx(
+            expected_l * weight / math.fsum(free_weights),
+            rel=3.0e-14,
+        )
+    for concentration, weight in zip(
+        equilibrium.complexes,
+        complex_weights,
+        strict=True,
+    ):
+        assert concentration == pytest.approx(
+            expected_bound * weight / math.fsum(complex_weights),
+            rel=3.0e-14,
+        )
+
+
+def test_zero_equilibrium_weight_removes_only_that_species() -> None:
+    equilibrium = solve_binding_equilibrium(
+        8.0e-4,
+        2.3e-3,
+        free_ligand_log_weights=(0.0, log_equilibrium_ratio(0.0)),
+        complex_log_weights=(
+            log_binding_weight(4.0e-4),
+            log_equilibrium_ratio(0.0) + log_binding_weight(1.3e-3),
+        ),
+    )
+
+    assert equilibrium.free_ligands[1] == 0.0
+    assert equilibrium.complexes[1] == 0.0
+    assert equilibrium.populations[2] == 0.0
+    assert equilibrium.populations[0] + equilibrium.populations[1] == (
+        pytest.approx(1.0)
+    )
+
+
+def test_zero_ligand_preserves_the_unbound_protein_population() -> None:
+    equilibrium = solve_binding_equilibrium(
+        8.0e-4,
+        0.0,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(log_binding_weight(1.0e-3),),
+    )
+
+    assert equilibrium.protein_free == 8.0e-4
+    assert equilibrium.ligand_free == 0.0
+    assert equilibrium.bound_total == 0.0
+    assert equilibrium.free_ligands == (0.0,)
+    assert equilibrium.complexes == (0.0,)
+    assert equilibrium.populations == (1.0, 0.0)
+
+
+@pytest.mark.parametrize("kd", (0.0, -1.0, math.inf, -math.inf, math.nan))
+def test_binding_kd_must_be_finite_and_strictly_positive(kd: float) -> None:
+    with pytest.raises(ValueError, match="KD must be finite and strictly positive"):
+        log_binding_weight(kd)
+
+
+@pytest.mark.parametrize("p_total", (0.0, -1.0, math.inf, math.nan))
+def test_binding_protein_total_must_be_finite_and_strictly_positive(
+    p_total: float,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="P_total must be finite and strictly positive",
+    ):
+        solve_binding_equilibrium(
+            p_total,
+            1.0e-3,
+            free_ligand_log_weights=(0.0,),
+            complex_log_weights=(log_binding_weight(1.0e-3),),
+        )
+
+
+@pytest.mark.parametrize("l_total", (-1.0, math.inf, math.nan))
+def test_binding_ligand_total_must_be_finite_and_non_negative(
+    l_total: float,
+) -> None:
+    with pytest.raises(ValueError, match="L_total must be finite and non-negative"):
+        solve_binding_equilibrium(
+            1.0e-3,
+            l_total,
+            free_ligand_log_weights=(0.0,),
+            complex_log_weights=(log_binding_weight(1.0e-3),),
+        )

--- a/tests/models/kinetic/test_binding_models.py
+++ b/tests/models/kinetic/test_binding_models.py
@@ -1,0 +1,968 @@
+"""Association-equilibrium authority across finite-pool binding models."""
+
+from __future__ import annotations
+
+import math
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Method
+from chemex.configuration.parameters import DefaultSetting
+from chemex.models.factory import model_factory
+from chemex.nmr.basis import Basis
+from chemex.optimize.deterministic_uncertainty import (
+    compile_model_constraint_linearization_capabilities,
+)
+from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import (
+    ConstraintDomainError,
+    NonFiniteParameterValueError,
+)
+from chemex.parameters.sealed import InvalidConfigurationError
+from chemex.parameters.spin_system import SpinSystem
+from chemex.printers.parameters import write_parameters
+from chemex.runtime import AnalysisSession
+
+
+def _prepare_model(
+    model_name: str,
+    p_total: float,
+    l_total: float,
+    defaults: Mapping[str, float | DefaultSetting],
+) -> tuple[AnalysisSession, dict[str, str]]:
+    conditions = Conditions(
+        h_larmor_frq=600.0,
+        temperature=25.0,
+        p_total=p_total,
+        l_total=l_total,
+    )
+    session = AnalysisSession.create()
+    session.set_model(model_name)
+    basis = Basis(type="iz", spin_system="nh", model=session.model.spec)
+    spin_system = SpinSystem.from_name("G23N-HN")
+    settings = model_factory.create(model_name, conditions)
+    local_ids = {
+        name: setting.name_setting.get_param_name(spin_system, conditions).id_
+        for name, setting in settings.items()
+    }
+    config = SimpleNamespace(
+        conditions=conditions,
+        to_be_fitted=SimpleNamespace(rates=[], model_free=[]),
+    )
+    session.parameter_factory.create_parameters(
+        config,  # ty: ignore[invalid-argument-type]
+        basis=basis,
+        spin_system=spin_system,
+    )
+    session.parameters.set_defaults(
+        [
+            (
+                ParamName.from_section(name),
+                value if isinstance(value, DefaultSetting) else DefaultSetting(value),
+            )
+            for name, value in defaults.items()
+        ],
+    )
+    assert session.parameter_factory.try_seal_definitions(), repr(
+        session.parameter_factory.native_construction_error,
+    )
+    return session, local_ids
+
+
+def _construct_and_resolve(
+    model_name: str,
+    p_total: float,
+    l_total: float,
+    defaults: Mapping[str, float | DefaultSetting],
+) -> dict[str, float]:
+    session, local_ids = _prepare_model(model_name, p_total, l_total, defaults)
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error,
+    )
+    resolved = session.resolve_current_values(set(local_ids.values()))
+    return {name: resolved[param_id] for name, param_id in local_ids.items()}
+
+
+@pytest.mark.parametrize(
+    ("model_name", "population_names", "defaults"),
+    (
+        ("2st_binding", ("pa", "pb"), {}),
+        ("3st_double_binding", ("pa", "pb", "pc"), {}),
+        ("3st_binding_partner_2st", ("pa", "pb", "pc"), {}),
+        ("4st_binding_partner_2st", ("pa", "pb", "pc", "pd"), {}),
+        (
+            "4st_binding_3_bound_states",
+            ("pa", "pb", "pc", "pd", "kd_eff"),
+            {},
+        ),
+    ),
+)
+def test_binding_population_outputs_have_production_uncertainty_capabilities(
+    model_name: str,
+    population_names: tuple[str, ...],
+    defaults: Mapping[str, float],
+) -> None:
+    session, local_ids = _prepare_model(
+        model_name,
+        1.0e-3,
+        2.0e-3,
+        defaults,
+    )
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    output_ids = tuple(local_ids[name] for name in population_names)
+    parameterization = session.compile_parameterization(Method(), set(output_ids))
+
+    compiled = compile_model_constraint_linearization_capabilities(
+        parameterization,
+        output_ids,
+    )
+
+    assert compiled.output_scope == output_ids
+    expected_components = tuple(
+        component for component in population_names if component != "kd_eff"
+    )
+    population_capabilities = tuple(
+        capability
+        for capability in compiled.capabilities
+        if capability.component in expected_components
+    )
+    assert {capability.component for capability in population_capabilities} == set(
+        expected_components
+    )
+    assert all(
+        capability.normalized_population_components == expected_components
+        for capability in population_capabilities
+    )
+
+
+@pytest.mark.parametrize(
+    ("p_total", "l_total", "expected_p_free"),
+    (
+        (1.0e-100, 1.0e-100, 1.0e-200),
+        (1.0e-3, 1.0e-3, math.sqrt(1.0e-303)),
+    ),
+)
+def test_2st_binding_resolves_audited_strong_binding_cases(
+    p_total: float,
+    l_total: float,
+    expected_p_free: float,
+) -> None:
+    values = _construct_and_resolve(
+        "2st_binding",
+        p_total,
+        l_total,
+        {"kd": 1.0e-300, "koff": 0.0},
+    )
+
+    assert values["p_free"] == pytest.approx(expected_p_free, rel=2.0e-14, abs=0.0)
+    assert values["l_free"] == pytest.approx(expected_p_free, rel=2.0e-14, abs=0.0)
+    assert values["pl"] > 0.999999999999 * p_total
+    assert values["p_free"] + values["pl"] == pytest.approx(
+        p_total, rel=2.0e-15, abs=0.0
+    )
+    assert values["l_free"] + values["pl"] == pytest.approx(
+        l_total, rel=2.0e-15, abs=0.0
+    )
+    assert values["pa"] == pytest.approx(
+        values["p_free"] / p_total, rel=5.0e-14, abs=0.0
+    )
+    assert values["pb"] == pytest.approx(values["pl"] / p_total, rel=2.0e-14, abs=0.0)
+    assert values["kab"] == 0.0
+    assert values["kba"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "kd",
+    (1.0e-31, 1.0e-32, 1.0e-50, 1.0e-100, 1.0e-300),
+)
+def test_2st_binding_preserves_literal_positive_kd_below_legacy_floor(
+    kd: float,
+) -> None:
+    values = _construct_and_resolve(
+        "2st_binding",
+        1.0e-3,
+        2.0e-3,
+        {"kd": kd, "koff": kd},
+    )
+
+    assert values["kd"] == kd
+    assert values["kon"] == pytest.approx(1.0)
+    assert values["kab"] == pytest.approx(values["l_free"])
+    assert values["pa"] * values["kab"] == pytest.approx(
+        values["pb"] * values["kba"],
+        rel=2.0e-12,
+        abs=math.nextafter(0.0, 1.0),
+    )
+
+
+def test_2st_binding_zero_ligand_is_unbound() -> None:
+    values = _construct_and_resolve(
+        "2st_binding",
+        1.0e-3,
+        0.0,
+        {"kd": 1.0e-6, "koff": 100.0},
+    )
+
+    assert values["p_free"] == 1.0e-3
+    assert values["l_free"] == 0.0
+    assert values["pl"] == 0.0
+    assert values["kab"] == 0.0
+    assert values["kba"] == 100.0
+    assert values["pa"] == 1.0
+    assert values["pb"] == 0.0
+
+
+def test_unrepresentable_public_kon_does_not_block_finite_tagged_dynamics() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+    session, local_ids = _prepare_model(
+        "2st_binding",
+        1.0e-300,
+        1.0e-300,
+        {"kd": minimum, "koff": 1.0},
+    )
+
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    dynamics = {local_ids[name] for name in ("pa", "pb", "kab", "kba")}
+    resolved = session.resolve_current_values(dynamics)
+    assert resolved[local_ids["kab"]] == pytest.approx(4.5e11, rel=2.0e-2)
+    assert resolved[local_ids["kba"]] == 1.0
+    assert resolved[local_ids["pa"]] + resolved[local_ids["pb"]] == 1.0
+
+    with pytest.raises(NonFiniteParameterValueError):
+        session.resolve_current_values({local_ids["kon"]})
+
+    assert session.resolve_report_only_values() == {}
+
+
+def test_supplied_unrepresentable_report_only_kon_remains_deferred() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+    session, local_ids = _prepare_model(
+        "2st_binding",
+        1.0e-300,
+        1.0e-300,
+        {"kd": minimum, "koff": 1.0, "kon": 1.0},
+    )
+
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    snapshot = session.analysis_values.snapshot()
+    assert local_ids["kon"] not in snapshot
+    dynamics = {local_ids[name] for name in ("pa", "pb", "kab", "kba")}
+    parameterization = session.compile_parameterization(Method(), dynamics)
+    assert local_ids["kon"] not in parameterization.scope_ids
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+    assert all(math.isfinite(resolved[param_id]) for param_id in dynamics)
+    assert session.resolve_report_only_values() == {}
+
+    with pytest.raises(NonFiniteParameterValueError):
+        session.resolve_current_values({local_ids["kon"]})
+
+
+def test_representable_public_kon_remains_serialized_at_report_time(
+    tmp_path: Path,
+) -> None:
+    session, local_ids = _prepare_model(
+        "2st_binding",
+        1.0e-3,
+        2.0e-3,
+        {"kd": 2.0e-6, "koff": 40.0, "kon": 1.0},
+    )
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    assert local_ids["kon"] not in session.analysis_values.snapshot()
+    dynamics = {local_ids[name] for name in ("pa", "pb", "kab", "kba")}
+    parameterization = session.compile_parameterization(Method(), dynamics)
+    assert local_ids["kon"] not in parameterization.scope_ids
+    resolved = parameterization.resolve(
+        parameterization.frame_from_snapshot(session.analysis_values.snapshot())
+    )
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    assert resolved[local_ids["kab"]] == pytest.approx(
+        resolved[local_ids["pb"]]
+        * resolved[local_ids["kba"]]
+        / resolved[local_ids["pa"]]
+    )
+    assert session.resolve_report_only_values()[local_ids["kon"]] == 2.0e7
+
+    write_parameters(
+        tmp_path,
+        parameter_model=parameter_model,
+        parameter_values=resolved,
+        parameterization=parameterization,
+        report_only_values=session.resolve_report_only_values(),
+    )
+
+    constrained = (tmp_path / "Parameters" / "constrained.toml").read_text()
+    assert "KON" in constrained
+    assert "2.00000e+07" in constrained
+    assert "[KOFF, T->25.0C] / [KD, T->25.0C]" in constrained
+
+
+def test_2st_binding_zero_kd_is_rejected_by_default_bounds() -> None:
+    session, _ = _prepare_model(
+        "2st_binding",
+        1.0e-3,
+        2.0e-3,
+        {"kd": 0.0},
+    )
+
+    assert not session.try_build_analysis_values()
+    assert isinstance(
+        session.parameter_factory.native_construction_error,
+        InvalidConfigurationError,
+    )
+
+
+def test_2st_binding_zero_kd_override_reaches_runtime_domain_authority() -> None:
+    session, _ = _prepare_model(
+        "2st_binding",
+        1.0e-3,
+        2.0e-3,
+        {"kd": DefaultSetting(0.0, min=0.0, max=1.0)},
+    )
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "KD must be finite and strictly positive" in str(error.__cause__)
+
+
+def test_category_a_binding_rejects_zero_protein_total() -> None:
+    session, _ = _prepare_model(
+        "2st_binding",
+        0.0,
+        2.0e-3,
+        {"kd": 1.0e-6, "koff": 100.0},
+    )
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "P_total must be finite and strictly positive" in str(error.__cause__)
+
+
+@pytest.mark.parametrize(
+    ("koff_ab", "koff_ac"),
+    ((0.0, 0.0), (0.0, 130.0), (80.0, 0.0), (80.0, 130.0)),
+)
+def test_double_binding_populations_are_invariant_to_branch_disconnection(
+    koff_ab: float,
+    koff_ac: float,
+) -> None:
+    p_total = 8.0e-4
+    values = _construct_and_resolve(
+        "3st_double_binding",
+        p_total,
+        2.3e-3,
+        {
+            "koff_ab": koff_ab,
+            "kd_ab": 4.0e-4,
+            "koff_ac": koff_ac,
+            "kd_ac": 1.3e-3,
+        },
+    )
+
+    assert values["pa"] + values["pb"] + values["pc"] == pytest.approx(1.0)
+    assert values["pa"] == pytest.approx(values["pfree"] / p_total)
+    assert all(values[name] > 0.0 for name in ("pa", "pb", "pc"))
+    assert values["kd_ab"] * values["pb"] == pytest.approx(
+        values["pfree"] * values["l_free"] / p_total,
+        rel=2.0e-14,
+    )
+    assert values["kd_ac"] * values["pc"] == pytest.approx(
+        values["pfree"] * values["l_free"] / p_total,
+        rel=2.0e-14,
+    )
+    assert values["pa"] * values["kab"] == pytest.approx(values["pb"] * values["kba"])
+    assert values["pa"] * values["kac"] == pytest.approx(values["pc"] * values["kca"])
+
+
+def test_double_binding_strong_limit_retains_both_alternative_complexes() -> None:
+    values = _construct_and_resolve(
+        "3st_double_binding",
+        1.0e-3,
+        1.0e-3,
+        {
+            "koff_ab": 0.0,
+            "kd_ab": 1.0e-300,
+            "koff_ac": 0.0,
+            "kd_ac": 1.0e-300,
+        },
+    )
+
+    assert values["pfree"] == pytest.approx(math.sqrt(5.0e-304), rel=5.0e-14, abs=0.0)
+    assert values["l_free"] == pytest.approx(values["pfree"], rel=5.0e-14, abs=0.0)
+    assert values["pb"] == pytest.approx(0.5, rel=2.0e-14)
+    assert values["pc"] == pytest.approx(0.5, rel=2.0e-14)
+    assert values["pa"] > 0.0
+
+
+@pytest.mark.parametrize("kd_name", ("kd_ab", "kd_ac"))
+def test_double_binding_zero_kd_is_rejected_at_metadata_and_runtime(
+    kd_name: str,
+) -> None:
+    session, _ = _prepare_model(
+        "3st_double_binding",
+        1.0e-3,
+        2.0e-3,
+        {kd_name: 0.0},
+    )
+    assert not session.try_build_analysis_values()
+    assert isinstance(
+        session.parameter_factory.native_construction_error,
+        InvalidConfigurationError,
+    )
+
+    overridden, _ = _prepare_model(
+        "3st_double_binding",
+        1.0e-3,
+        2.0e-3,
+        {kd_name: DefaultSetting(0.0, min=0.0, max=1.0)},
+    )
+    assert not overridden.try_build_analysis_values()
+    error = overridden.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "KD must be finite and strictly positive" in str(error.__cause__)
+
+
+@pytest.mark.parametrize(
+    ("koff_ab", "koff_ac", "kex_bc"),
+    (
+        (0.0, 0.0, 0.0),
+        (80.0, 0.0, 0.0),
+        (0.0, 130.0, 0.0),
+        (0.0, 0.0, 700.0),
+        (80.0, 130.0, 0.0),
+        (80.0, 0.0, 700.0),
+        (0.0, 130.0, 700.0),
+        (80.0, 130.0, 700.0),
+    ),
+)
+def test_partner_binding_populations_are_invariant_to_every_kinetic_scale(
+    koff_ab: float,
+    koff_ac: float,
+    kex_bc: float,
+) -> None:
+    p_total = 8.0e-4
+    values = _construct_and_resolve(
+        "3st_binding_partner_2st",
+        p_total,
+        2.3e-3,
+        {
+            "koff_ab": koff_ab,
+            "kd_ab": 4.0e-4,
+            "koff_ac": koff_ac,
+            "kd_ac": 1.3e-3,
+            "keq": 2.5,
+            "kex_bc": kex_bc,
+        },
+    )
+
+    assert values["pa"] + values["pb"] + values["pc"] == pytest.approx(1.0)
+    assert values["pa"] == pytest.approx(1.0 - values["pb"] - values["pc"])
+    assert values["pb"] == pytest.approx(values["pl1"] / p_total)
+    assert values["pc"] == pytest.approx(values["pl2"] / p_total)
+    assert values["l2_free"] == pytest.approx(2.5 * values["l1_free"])
+    p_free = p_total * values["pa"]
+    assert 4.0e-4 * values["pl1"] == pytest.approx(
+        p_free * values["l1_free"], rel=2.0e-14
+    )
+    assert 1.3e-3 * values["pl2"] == pytest.approx(
+        p_free * values["l2_free"], rel=2.0e-14
+    )
+    assert values["pa"] * values["kab"] == pytest.approx(values["pb"] * values["kba"])
+    assert values["pa"] * values["kac"] == pytest.approx(values["pc"] * values["kca"])
+    assert values["pb"] * values["kbc"] == pytest.approx(values["pc"] * values["kcb"])
+
+
+def test_partner_binding_zero_keq_removes_second_conformer_without_a_floor() -> None:
+    values = _construct_and_resolve(
+        "3st_binding_partner_2st",
+        8.0e-4,
+        2.3e-3,
+        {
+            "koff_ab": 80.0,
+            "kd_ab": 4.0e-4,
+            "koff_ac": 130.0,
+            "kd_ac": 1.3e-3,
+            "keq": 0.0,
+            "kex_bc": 700.0,
+        },
+    )
+
+    assert values["l2_free"] == 0.0
+    assert values["pl2"] == 0.0
+    assert values["pc"] == 0.0
+    assert values["kac"] == 0.0
+    assert values["kbc"] == 0.0
+    assert values["kcb"] == 700.0
+    assert values["pa"] + values["pb"] == pytest.approx(1.0)
+
+
+def test_partner_binding_zero_ligand_retains_parameter_defined_rate_splitting() -> None:
+    values = _construct_and_resolve(
+        "3st_binding_partner_2st",
+        8.0e-4,
+        0.0,
+        {
+            "koff_ab": 80.0,
+            "kd_ab": 4.0e-4,
+            "koff_ac": 130.0,
+            "kd_ac": 1.3e-3,
+            "keq": 2.5,
+            "kex_bc": 700.0,
+        },
+    )
+
+    assert values["l1_free"] == 0.0
+    assert values["l2_free"] == 0.0
+    assert values["pl1"] == 0.0
+    assert values["pl2"] == 0.0
+    assert (values["pa"], values["pb"], values["pc"]) == (1.0, 0.0, 0.0)
+    assert values["kab"] == 0.0
+    assert values["kac"] == 0.0
+    assert values["kbc"] + values["kcb"] == pytest.approx(700.0)
+    assert values["kbc"] / values["kcb"] == pytest.approx(2.5 * 4.0e-4 / 1.3e-3)
+
+
+@pytest.mark.parametrize("edge_mask", range(16))
+def test_four_state_partner_populations_ignore_all_edge_scale_patterns(
+    edge_mask: int,
+) -> None:
+    p_total = 8.0e-4
+    scales = (80.0, 130.0, 700.0, 900.0)
+    koff_ab, koff_ac, kex_bc, kex_cd = (
+        scale if edge_mask & (1 << index) else 0.0 for index, scale in enumerate(scales)
+    )
+    values = _construct_and_resolve(
+        "4st_binding_partner_2st",
+        p_total,
+        2.3e-3,
+        {
+            "koff_ab": koff_ab,
+            "kd_ab": 4.0e-4,
+            "koff_ac": koff_ac,
+            "kd_ac": 1.3e-3,
+            "keq_l": 2.5,
+            "keq_pl": 1.7,
+            "kex_bc": kex_bc,
+            "kex_cd": kex_cd,
+        },
+    )
+
+    assert sum(values[name] for name in ("pa", "pb", "pc", "pd")) == (
+        pytest.approx(1.0)
+    )
+    assert values["pa"] == pytest.approx(values["p_free"] / p_total)
+    assert values["pb"] == pytest.approx(values["pl1"] / p_total)
+    assert values["pc"] == pytest.approx(values["pl2"] / p_total)
+    assert values["pd"] == pytest.approx(values["pl3"] / p_total)
+    assert values["l2_free"] == pytest.approx(2.5 * values["l1_free"])
+    assert values["pl3"] == pytest.approx(1.7 * values["pl2"])
+    assert 4.0e-4 * values["pl1"] == pytest.approx(
+        values["p_free"] * values["l1_free"], rel=2.0e-14
+    )
+    assert 1.3e-3 * values["pl2"] == pytest.approx(
+        values["p_free"] * values["l2_free"], rel=2.0e-14
+    )
+
+
+def test_four_state_partner_strong_binding_is_non_negative_and_conservative() -> None:
+    p_total = 1.0e-3
+    l_total = 1.0e-3
+    values = _construct_and_resolve(
+        "4st_binding_partner_2st",
+        p_total,
+        l_total,
+        {
+            "koff_ab": 0.0,
+            "kd_ab": 1.0e-300,
+            "koff_ac": 0.0,
+            "kd_ac": 1.0e-300,
+            "keq_l": 2.5,
+            "keq_pl": 1.7,
+            "kex_bc": 0.0,
+            "kex_cd": 0.0,
+        },
+    )
+
+    concentrations = (
+        values["p_free"],
+        values["l1_free"],
+        values["l2_free"],
+        values["pl1"],
+        values["pl2"],
+        values["pl3"],
+    )
+    assert all(math.isfinite(value) and value >= 0.0 for value in concentrations)
+    assert values["p_free"] + values["pl1"] + values["pl2"] + values["pl3"] == (
+        pytest.approx(p_total, rel=2.0e-15, abs=0.0)
+    )
+    assert (
+        values["l1_free"]
+        + values["l2_free"]
+        + values["pl1"]
+        + values["pl2"]
+        + values["pl3"]
+    ) == pytest.approx(l_total, rel=2.0e-15, abs=0.0)
+
+
+@pytest.mark.parametrize(("keq_l", "keq_pl"), ((0.0, 1.7), (2.5, 0.0)))
+def test_four_state_partner_zero_equilibrium_ratio_removes_exact_state_weights(
+    keq_l: float,
+    keq_pl: float,
+) -> None:
+    values = _construct_and_resolve(
+        "4st_binding_partner_2st",
+        8.0e-4,
+        2.3e-3,
+        {
+            "koff_ab": 80.0,
+            "kd_ab": 4.0e-4,
+            "koff_ac": 130.0,
+            "kd_ac": 1.3e-3,
+            "keq_l": keq_l,
+            "keq_pl": keq_pl,
+            "kex_bc": 700.0,
+            "kex_cd": 900.0,
+        },
+    )
+
+    if keq_l == 0.0:
+        assert values["l2_free"] == 0.0
+        assert values["pl2"] == 0.0
+        assert values["pl3"] == 0.0
+        assert values["kbc"] == 0.0
+        assert values["kcb"] == 700.0
+    if keq_pl == 0.0:
+        assert values["pl3"] == 0.0
+        assert values["kcd"] == 0.0
+        assert values["kdc"] == 900.0
+
+
+@pytest.mark.parametrize("edge_mask", range(8))
+def test_three_bound_state_populations_ignore_all_kinetic_scale_patterns(
+    edge_mask: int,
+) -> None:
+    p_total = 8.0e-4
+    scales = (80.0, 700.0, 900.0)
+    koff_ab, kex_bc, kex_cd = (
+        scale if edge_mask & (1 << index) else 0.0 for index, scale in enumerate(scales)
+    )
+    values = _construct_and_resolve(
+        "4st_binding_3_bound_states",
+        p_total,
+        2.3e-3,
+        {
+            "kd_app": 4.0e-4,
+            "koff_ab": koff_ab,
+            "kex_bc": kex_bc,
+            "keq_bc": 2.5,
+            "kex_cd": kex_cd,
+            "keq_cd": 1.7,
+        },
+    )
+
+    populations = tuple(values[name] for name in ("pa", "pb", "pc", "pd"))
+    assert sum(populations) == pytest.approx(1.0)
+    assert values["pa"] == pytest.approx(values["c_p"] / p_total)
+    assert values["pb"] == pytest.approx(values["c_pl1"] / p_total)
+    assert values["pc"] == pytest.approx(values["c_pl2"] / p_total)
+    assert values["pd"] == pytest.approx(values["c_pl3"] / p_total)
+    assert values["c_pl2"] == pytest.approx(2.5 * values["c_pl1"])
+    assert values["c_pl3"] == pytest.approx(1.7 * values["c_pl2"])
+    assert values["kd_ab"] == pytest.approx(4.0e-4 * (1.0 + 2.5 + 2.5 * 1.7))
+    assert values["kd_ab"] * values["c_pl1"] == pytest.approx(
+        values["c_p"] * values["c_l"], rel=2.0e-14
+    )
+    assert values["kd_eff"] == values["kd_app"]
+
+
+def test_three_bound_state_strong_binding_is_non_negative_and_conservative() -> None:
+    p_total = 1.0e-3
+    l_total = 1.0e-3
+    values = _construct_and_resolve(
+        "4st_binding_3_bound_states",
+        p_total,
+        l_total,
+        {
+            "kd_app": 1.0e-300,
+            "koff_ab": 0.0,
+            "kex_bc": 0.0,
+            "keq_bc": 2.5,
+            "kex_cd": 0.0,
+            "keq_cd": 1.7,
+        },
+    )
+
+    concentrations = tuple(
+        values[name] for name in ("c_p", "c_l", "c_pl1", "c_pl2", "c_pl3")
+    )
+    assert all(math.isfinite(value) and value >= 0.0 for value in concentrations)
+    assert values["c_p"] + values["c_pl"] == pytest.approx(
+        p_total, rel=2.0e-15, abs=0.0
+    )
+    assert values["c_l"] + values["c_pl"] == pytest.approx(
+        l_total, rel=2.0e-15, abs=0.0
+    )
+    assert values["kd_eff"] == 1.0e-300
+
+
+@pytest.mark.parametrize(("keq_bc", "keq_cd"), ((0.0, 1.7), (2.5, 0.0)))
+def test_three_bound_state_zero_equilibrium_ratios_remove_exact_states(
+    keq_bc: float,
+    keq_cd: float,
+) -> None:
+    values = _construct_and_resolve(
+        "4st_binding_3_bound_states",
+        8.0e-4,
+        2.3e-3,
+        {
+            "kd_app": 4.0e-4,
+            "koff_ab": 80.0,
+            "kex_bc": 700.0,
+            "keq_bc": keq_bc,
+            "kex_cd": 900.0,
+            "keq_cd": keq_cd,
+        },
+    )
+
+    if keq_bc == 0.0:
+        assert values["c_pl2"] == 0.0
+        assert values["c_pl3"] == 0.0
+        assert values["kbc"] == 0.0
+        assert values["kcb"] == 700.0
+    if keq_cd == 0.0:
+        assert values["c_pl3"] == 0.0
+        assert values["kcd"] == 0.0
+        assert values["kdc"] == 900.0
+
+
+def test_three_bound_state_zero_kd_app_is_rejected_at_metadata_and_runtime() -> None:
+    session, _ = _prepare_model(
+        "4st_binding_3_bound_states",
+        1.0e-3,
+        2.0e-3,
+        {"kd_app": 0.0},
+    )
+    assert not session.try_build_analysis_values()
+    assert isinstance(
+        session.parameter_factory.native_construction_error,
+        InvalidConfigurationError,
+    )
+
+    overridden, _ = _prepare_model(
+        "4st_binding_3_bound_states",
+        1.0e-3,
+        2.0e-3,
+        {"kd_app": DefaultSetting(0.0, min=0.0, max=1.0)},
+    )
+    assert not overridden.try_build_analysis_values()
+    error = overridden.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "KD must be finite and strictly positive" in str(error.__cause__)
+
+
+CATEGORY_A_BINDING_MODELS = (
+    "2st_binding",
+    "3st_double_binding",
+    "3st_binding_partner_2st",
+    "4st_binding_partner_2st",
+    "4st_binding_3_bound_states",
+)
+
+
+@pytest.mark.parametrize("model_name", CATEGORY_A_BINDING_MODELS)
+def test_every_category_a_binding_model_rejects_zero_protein_total(
+    model_name: str,
+) -> None:
+    defaults = _zero_rate_defaults(
+        model_name,
+        "kd_app" if model_name == "4st_binding_3_bound_states" else "kd",
+        1.0e-6,
+    )
+    if model_name != "2st_binding" and "kd" in defaults:
+        defaults.pop("kd")
+    session, _ = _prepare_model(model_name, 0.0, 2.0e-3, defaults)
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "P_total must be finite and strictly positive" in str(error.__cause__)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "defaults"),
+    (
+        ("2st_binding", {"kd": 1.0e-6, "koff": 100.0}),
+        (
+            "3st_double_binding",
+            {
+                "kd_ab": 1.0e-6,
+                "kd_ac": 2.0e-6,
+                "koff_ab": 100.0,
+                "koff_ac": 120.0,
+            },
+        ),
+        (
+            "3st_binding_partner_2st",
+            {
+                "kd_ab": 1.0e-6,
+                "kd_ac": 2.0e-6,
+                "koff_ab": 100.0,
+                "koff_ac": 120.0,
+                "keq": 2.5,
+                "kex_bc": 700.0,
+            },
+        ),
+        (
+            "4st_binding_partner_2st",
+            {
+                "kd_ab": 1.0e-6,
+                "kd_ac": 2.0e-6,
+                "koff_ab": 100.0,
+                "koff_ac": 120.0,
+                "keq_l": 2.5,
+                "keq_pl": 1.7,
+                "kex_bc": 700.0,
+                "kex_cd": 900.0,
+            },
+        ),
+        (
+            "4st_binding_3_bound_states",
+            {
+                "kd_app": 1.0e-6,
+                "koff_ab": 100.0,
+                "keq_bc": 2.5,
+                "keq_cd": 1.7,
+                "kex_bc": 700.0,
+                "kex_cd": 900.0,
+            },
+        ),
+    ),
+)
+def test_every_category_a_binding_model_accepts_zero_ligand(
+    model_name: str,
+    defaults: dict[str, float],
+) -> None:
+    values = _construct_and_resolve(model_name, 1.0e-3, 0.0, defaults)
+    populations = tuple(
+        values[name] for name in ("pa", "pb", "pc", "pd") if name in values
+    )
+
+    assert populations[0] == 1.0
+    assert all(population == 0.0 for population in populations[1:])
+
+
+KD_CASES = (
+    ("2st_binding", "kd"),
+    ("3st_double_binding", "kd_ab"),
+    ("3st_double_binding", "kd_ac"),
+    ("3st_binding_partner_2st", "kd_ab"),
+    ("3st_binding_partner_2st", "kd_ac"),
+    ("4st_binding_partner_2st", "kd_ab"),
+    ("4st_binding_partner_2st", "kd_ac"),
+    ("4st_binding_3_bound_states", "kd_app"),
+)
+
+
+def _zero_rate_defaults(model_name: str, kd_name: str, kd: float) -> dict[str, float]:
+    defaults: dict[str, float] = {kd_name: kd}
+    if model_name == "2st_binding":
+        return {**defaults, "koff": 0.0}
+    if model_name == "3st_double_binding":
+        return {
+            "kd_ab": 1.0e-6,
+            "kd_ac": 2.0e-6,
+            "koff_ab": 0.0,
+            "koff_ac": 0.0,
+            **defaults,
+        }
+    if model_name == "3st_binding_partner_2st":
+        return {
+            "kd_ab": 1.0e-6,
+            "kd_ac": 2.0e-6,
+            "koff_ab": 0.0,
+            "koff_ac": 0.0,
+            "keq": 2.5,
+            "kex_bc": 0.0,
+            **defaults,
+        }
+    if model_name == "4st_binding_partner_2st":
+        return {
+            "kd_ab": 1.0e-6,
+            "kd_ac": 2.0e-6,
+            "koff_ab": 0.0,
+            "koff_ac": 0.0,
+            "keq_l": 2.5,
+            "keq_pl": 1.7,
+            "kex_bc": 0.0,
+            "kex_cd": 0.0,
+            **defaults,
+        }
+    return {
+        "kd_app": kd,
+        "koff_ab": 0.0,
+        "keq_bc": 2.5,
+        "keq_cd": 1.7,
+        "kex_bc": 0.0,
+        "kex_cd": 0.0,
+    }
+
+
+@pytest.mark.parametrize(("model_name", "kd_name"), KD_CASES)
+@pytest.mark.parametrize(
+    "kd",
+    (1.0e-31, 1.0e-32, 1.0e-50, 1.0e-100, sys.float_info.min, math.nextafter(0.0, 1.0)),
+)
+def test_every_binding_kd_preserves_positive_values_below_legacy_floors(
+    model_name: str,
+    kd_name: str,
+    kd: float,
+) -> None:
+    values = _construct_and_resolve(
+        model_name,
+        1.0e-3,
+        2.0e-3,
+        _zero_rate_defaults(model_name, kd_name, kd),
+    )
+
+    assert values[kd_name] == kd
+    assert all(math.isfinite(value) and value >= 0.0 for value in values.values())
+    populations = tuple(
+        values[name] for name in ("pa", "pb", "pc", "pd") if name in values
+    )
+    assert sum(populations) == pytest.approx(1.0, rel=2.0e-14)
+
+
+@pytest.mark.parametrize(("model_name", "kd_name"), KD_CASES)
+def test_every_binding_kd_rejects_zero_even_with_a_bounds_override(
+    model_name: str,
+    kd_name: str,
+) -> None:
+    defaults = _zero_rate_defaults(model_name, kd_name, 1.0e-6)
+    defaults[kd_name] = DefaultSetting(0.0, min=0.0, max=1.0)  # ty: ignore[invalid-assignment]
+    session, _ = _prepare_model(model_name, 1.0e-3, 2.0e-3, defaults)
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "KD must be finite and strictly positive" in str(error.__cause__)

--- a/tests/models/kinetic/test_oligomerization_models.py
+++ b/tests/models/kinetic/test_oligomerization_models.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Method
 from chemex.configuration.parameters import DefaultSetting
 from chemex.models.factory import model_factory
 from chemex.models.kinetic import (
@@ -19,6 +20,9 @@ from chemex.models.kinetic import (
     settings_3st_monomer_dimer_trimer as dimer_trimer_model,
 )
 from chemex.nmr.basis import Basis
+from chemex.optimize.deterministic_uncertainty import (
+    compile_model_constraint_linearization_capabilities,
+)
 from chemex.parameters.name import ParamName
 from chemex.parameters.parameterization import ConstraintDomainError
 from chemex.parameters.sealed import InvalidConfigurationError
@@ -91,6 +95,47 @@ def _construct_and_resolve(
         name_map,
         local_ids,
         {name: resolved[param_id] for name, param_id in local_ids.items()},
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "population_names"),
+    (
+        ("2st_monomer_dimer", ("pa", "pb")),
+        ("2st_monomer_trimer", ("pa", "pb")),
+        ("2st_monomer_tetramer", ("pa", "pb")),
+        ("3st_monomer_dimer_trimer", ("pa", "pb", "pc")),
+        ("3st_monomer_dimer_tetramer", ("pa", "pb", "pc")),
+    ),
+)
+def test_oligomer_population_outputs_have_production_uncertainty_capabilities(
+    model_name: str,
+    population_names: tuple[str, ...],
+) -> None:
+    session, _name_map, local_ids = _prepare_model(model_name, 1.0e-3, {})
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    output_ids = tuple(local_ids[name] for name in population_names)
+    parameterization = session.compile_parameterization(Method(), set(output_ids))
+
+    compiled = compile_model_constraint_linearization_capabilities(
+        parameterization,
+        output_ids,
+    )
+
+    assert compiled.output_scope == output_ids
+    population_capabilities = tuple(
+        capability
+        for capability in compiled.capabilities
+        if capability.component in population_names
+    )
+    assert {capability.component for capability in population_capabilities} == set(
+        population_names
+    )
+    assert all(
+        capability.normalized_population_components == population_names
+        for capability in population_capabilities
     )
 
 
@@ -687,14 +732,66 @@ def test_monomer_trimer_rejects_upward_rounded_subminimum_forward_rate() -> None
     assert "below binary64 representability" in str(error.__cause__)
 
 
-def test_zero_koff_retains_exact_zero_forward_rate_policy() -> None:
+@pytest.mark.parametrize(
+    ("model_name", "oligomer", "stoichiometry"),
+    (
+        ("2st_monomer_dimer", "dimer", 2.0),
+        ("2st_monomer_trimer", "trimer", 3.0),
+        ("2st_monomer_tetramer", "tetramer", 4.0),
+    ),
+)
+def test_direct_zero_koff_freezes_exchange_without_erasing_equilibrium_species(
+    model_name: str,
+    oligomer: str,
+    stoichiometry: float,
+) -> None:
+    p_total = 1.0e-3
     _, _, values = _construct_and_resolve(
-        "2st_monomer_dimer",
-        1e-3,
-        {"kd": math.nextafter(0.0, 1.0), "koff": 0.0},
+        model_name,
+        p_total,
+        {"kd": 1.0e-6, "koff": 0.0},
     )
 
     assert values["kab"] == 0.0
     assert values["kba"] == 0.0
-    assert values["pa"] == 1.0
-    assert values["pb"] == 0.0
+    assert values["pa"] == pytest.approx(values["c_monomer"] / p_total)
+    assert values["pb"] == pytest.approx(
+        stoichiometry * values[f"c_{oligomer}"] / p_total
+    )
+    assert values["pa"] > 0.0
+    assert values["pb"] > 0.0
+
+
+@pytest.mark.parametrize(
+    ("model_name", "higher", "higher_stoichiometry"),
+    (
+        ("3st_monomer_dimer_trimer", "trimer", 3.0),
+        ("3st_monomer_dimer_tetramer", "tetramer", 4.0),
+    ),
+)
+@pytest.mark.parametrize(
+    ("koff1", "koff2"),
+    ((0.0, 0.0), (0.0, 150.0), (90.0, 0.0), (90.0, 150.0)),
+)
+def test_sequential_populations_are_invariant_to_every_koff_disconnection(
+    model_name: str,
+    higher: str,
+    higher_stoichiometry: float,
+    koff1: float,
+    koff2: float,
+) -> None:
+    p_total = 1.0e-3
+    _, _, values = _construct_and_resolve(
+        model_name,
+        p_total,
+        {"kd1": 1.0e-6, "kd2": 2.0e-6, "koff1": koff1, "koff2": koff2},
+    )
+
+    assert values["pa"] == pytest.approx(values["c_monomer"] / p_total)
+    assert values["pb"] == pytest.approx(2.0 * values["c_dimer"] / p_total)
+    assert values["pc"] == pytest.approx(
+        higher_stoichiometry * values[f"c_{higher}"] / p_total
+    )
+    assert values["pa"] > 0.0
+    assert values["pb"] > 0.0
+    assert values["pc"] > 0.0

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -129,6 +129,9 @@ class StubSession:
     def resolve_current_values(self, _required_ids: set[str]) -> dict[str, float]:
         return {}
 
+    def resolve_report_only_values(self) -> dict[str, float]:
+        return {"__REPORT_ONLY": 1.0}
+
     def compile_parameterization(
         self,
         _method: Method,
@@ -517,6 +520,7 @@ def test_run_uses_explicit_session_for_simulation_flow(
         parameter_model: object,
         parameterization: object,
         plot: bool = False,
+        report_only_values: object = None,
     ) -> None:
         recorded["simulation"] = (
             experiments_arg,
@@ -525,6 +529,7 @@ def test_run_uses_explicit_session_for_simulation_flow(
             parameter_model,
             parameterization,
             plot,
+            report_only_values,
         )
 
     monkeypatch.setattr(chemex_module, "build_experiments", fake_build_experiments)
@@ -544,6 +549,7 @@ def test_run_uses_explicit_session_for_simulation_flow(
     assert simulation[3] is session.parameter_factory.sealed_parameter_model
     assert isinstance(simulation[4], StubParameterization)
     assert simulation[5] is True
+    assert simulation[6] == {"__REPORT_ONLY": 1.0}
 
 
 def test_main_bootstraps_plugins_for_non_run_commands(

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -29,6 +29,9 @@ PARAMETERS = EXAMPLE / "Parameters/parameters.toml"
 OLIGOMERIZATION_EXAMPLE = ROOT / "examples/Experiments/CPMG_15N_IP"
 OLIGOMERIZATION_DATA = OLIGOMERIZATION_EXAMPLE / "Data/500MHz"
 OLIGOMERIZATION_PARAMETERS = OLIGOMERIZATION_EXAMPLE / "Parameters/parameters.toml"
+BINDING_EXAMPLE = ROOT / "examples/Combinations/2stBinding"
+BINDING_DATA = BINDING_EXAMPLE / "Data/CEST_10Hz_10P_1"
+BINDING_PARAMETERS = BINDING_EXAMPLE / "Parameters/params.toml"
 
 
 def _entry_commands() -> tuple[tuple[str, ...], ...]:
@@ -271,6 +274,59 @@ path = "{OLIGOMERIZATION_DATA.as_posix()}"
     assert "Parameter configuration is invalid" in completed.stderr
     assert str(zero_kd) in completed.stderr
     assert "KD must be finite and strictly positive" in completed.stderr
+    assert "unexpected internal error" not in combined
+    assert TRACEBACK_HEADER not in combined
+
+
+@pytest.mark.parametrize("command", _entry_commands())
+def test_cli_reports_zero_binding_protein_total_as_parameter_error(
+    command: tuple[str, ...],
+    tmp_path: Path,
+) -> None:
+    experiment = tmp_path / "binding.toml"
+    experiment.write_text(
+        f"""
+[experiment]
+name = "cest_15n"
+time_t1 = 0.4
+carrier = 121.32188326
+b1_frq = 10.4
+
+[conditions]
+h_larmor_frq = 800.0
+p_total = 0.0
+l_total = 55.2e-6
+
+[data]
+path = "{BINDING_DATA.as_posix()}"
+error = "scatter"
+
+[data.profiles]
+480N = "480N-HN.out"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    completed = _run(
+        command,
+        "simulate",
+        "-e",
+        str(experiment),
+        "-p",
+        str(BINDING_PARAMETERS),
+        "-o",
+        str(tmp_path / "output"),
+        "-d",
+        "2st_binding",
+        "--plot",
+        "nothing",
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode == 1
+    assert "Parameter configuration is invalid" in completed.stderr
+    assert str(BINDING_PARAMETERS) in completed.stderr
+    assert "P_total must be finite and strictly positive" in completed.stderr
     assert "unexpected internal error" not in combined
     assert TRACEBACK_HEADER not in combined
 

--- a/tests/test_native_binding_uncertainty.py
+++ b/tests/test_native_binding_uncertainty.py
@@ -1,8 +1,9 @@
-"""Product regressions for retained Direct-TRF Jacobians in 2st binding fits."""
+"""Product regressions for retained Direct-TRF Jacobians in binding fits."""
 
 from __future__ import annotations
 
 import math
+import sys
 import tomllib
 from pathlib import Path
 from unittest.mock import patch
@@ -11,8 +12,30 @@ import pytest
 
 from chemex.chemex import run
 from chemex.cli import build_parser
+from chemex.configuration.methods import Method, Selection, read_method_plan
+from chemex.configuration.parameters import read_defaults
+from chemex.evaluation.native import EvaluationEngine, EvaluationFrame, EvaluationResult
+from chemex.experiments.builder import build_experiments
+from chemex.optimize import direct_trf as direct_trf_module
 from chemex.optimize import native_deterministic as native_deterministic_module
-from chemex.optimize.deterministic_uncertainty import DeterministicUncertainty
+from chemex.optimize.deterministic_uncertainty import (
+    AcceptedDeterministicFitFacts,
+    ContinuousTrfBasis,
+    DeterministicUncertainty,
+    derive_deterministic_uncertainty,
+)
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    DirectTrfInvocation,
+    FinalResidualJacobianEvidence,
+    OptimizationProblem,
+    ResidualJacobianSource,
+    execute_direct_trf,
+)
+from chemex.optimize.grouped_direct_trf import FitDecomposition
+from chemex.parameters.parameterization import ActiveParameterization
+from chemex.parameters.sealed import parameter_name_from_definition
+from chemex.parameters.spin_system import SpinSystem
 from chemex.runtime import AnalysisSession
 
 ROOT = Path(__file__).parent.parent
@@ -150,6 +173,472 @@ ROLES = [
     return path
 
 
+def _write_extreme_binding_experiment(path: Path) -> Path:
+    data_path = path.with_name("shift-data.txt")
+    data_path.write_text(
+        "486N-HN 121.34550 0.01\n487N-HN 120.00000 0.01\n",
+        encoding="utf-8",
+    )
+    path.write_text(
+        f"""[experiment]
+name = "shift_15n_sq"
+
+[conditions]
+h_larmor_frq = 800.0
+p_total = 1e-300
+l_total = 1e-300
+
+[data]
+path = "{data_path}"
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _qualification_anchor_with_unit_residual_jacobian(
+    problem: OptimizationProblem,
+    parameterization: ActiveParameterization,
+    engine: EvaluationEngine,
+) -> AcceptedFitResult:
+    """Build exact accepted-point evidence while isolating constraint propagation."""
+    vector = problem.start
+    frame = EvaluationFrame.from_lifecycle_frame(
+        parameterization,
+        problem.lifecycle_frame(vector, parameterization),
+    )
+    evaluation = engine.new_evaluator().evaluate(frame)
+    assert isinstance(evaluation, EvaluationResult)
+    residuals = tuple(float(value) for value in evaluation.residuals)
+    retained_jacobian = FinalResidualJacobianEvidence(
+        ResidualJacobianSource.SCIPY_FINAL_2_POINT,
+        problem.controlled_ids,
+        vector,
+        residuals,
+        (len(residuals), len(problem.controlled_ids)),
+        tuple(
+            tuple(
+                1.0 if row_index == column_index else 0.0
+                for column_index in range(len(problem.controlled_ids))
+            )
+            for row_index, _residual in enumerate(residuals)
+        ),
+    )
+    occurrence_identity = "exact-binding-boundary-qualification-occurrence"
+    return AcceptedFitResult(
+        occurrence_identity,
+        problem.identity,
+        "exact-binding-boundary-qualification-invocation",
+        "exact-binding-boundary-qualification-execution",
+        "exact-binding-boundary-qualification-materialization",
+        problem.parameterization_identity,
+        problem.evaluator_parameterization_identity,
+        problem.source_snapshot.occurrence_identity,
+        problem.source_snapshot.revision,
+        problem.controlled_ids,
+        vector,
+        math.fsum(value * value for value in residuals),
+        evaluation,
+        problem.controlled_ids,
+        tuple(zip(problem.controlled_ids, vector, strict=True)),
+        "exact-binding-boundary-qualification-origin",
+        final_residual_jacobian=retained_jacobian,
+        occurrence_witness=direct_trf_module._mint_accepted_occurrence_witness(
+            occurrence_identity
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "model_name",
+        "fitted_names",
+        "population_names",
+        "parameter_values",
+        "kd_value",
+    ),
+    (
+        (
+            "2st_binding",
+            ("KD",),
+            ("PA", "PB"),
+            "KOFF = 0.0\nKD = 5e-324",
+            math.nextafter(0.0, 1.0),
+        ),
+        (
+            "3st_double_binding",
+            ("KD_AB",),
+            ("PA", "PB", "PC"),
+            "KOFF_AB = 0.0\nKOFF_AC = 0.0\nKD_AB = 5e-324\nKD_AC = 1e-6",
+            math.nextafter(0.0, 1.0),
+        ),
+        (
+            "4st_binding_3_bound_states",
+            ("KD_APP", "KEQ_BC"),
+            ("PA", "PB", "PC", "PD"),
+            (
+                "KOFF_AB = 0.0\nKEX_BC = 0.0\nKEX_CD = 0.0\n"
+                "KD_APP = 2.2250738585072014e-308\nKEQ_BC = 0.0\nKEQ_CD = 1.0"
+            ),
+            sys.float_info.min,
+        ),
+    ),
+    ids=("simple-binding", "three-state-binding", "four-state-binding"),
+)
+def test_boundary_association_population_uncertainties_are_reportable(
+    tmp_path: Path,
+    model_name: str,
+    fitted_names: tuple[str, ...],
+    population_names: tuple[str, ...],
+    parameter_values: str,
+    kd_value: float,
+) -> None:
+    experiment = _write_extreme_binding_experiment(tmp_path / "experiment.toml")
+    experiment.write_text(
+        experiment.read_text(encoding="utf-8")
+        .replace("p_total = 1e-300", "p_total = 1e-3")
+        .replace("l_total = 1e-300", "l_total = 2e-3"),
+        encoding="utf-8",
+    )
+    parameters = tmp_path / "parameters.toml"
+    parameters.write_text(
+        f"[GLOBAL]\nR1_A = 1.5\nR2_A = 4.7\n{parameter_values}\n",
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+    session.set_model(model_name)
+    experiments = build_experiments(
+        [experiment],
+        Selection(include="*", exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([parameters]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    configuration = session.parameter_factory.sealed_configuration
+    assert parameter_model is not None
+    assert configuration is not None
+    population_ids = {
+        definition.name: definition.param_id
+        for definition in parameter_model.definitions
+        if definition.name in population_names
+    }
+    assert set(population_ids) == set(population_names)
+    required_ids = experiments.param_ids | set(population_ids.values())
+    baseline = session.compile_parameterization(Method(), required_ids)
+    fitted_ids = {
+        definition.param_id
+        for definition in parameter_model.definitions
+        if definition.name in fitted_names
+    }
+    assert len(fitted_ids) == len(fitted_names)
+    fixed_names = sorted(
+        {
+            parameter_name_from_definition(parameter_model.definitions[param_id]).name
+            for param_id in baseline.independent_ids
+            if param_id not in fitted_ids
+        }
+    )
+    parameterization = session.compile_parameterization(
+        Method(fit=fitted_names, fix=fixed_names),
+        required_ids,
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    start_by_name = {
+        parameter_model.definitions[param_id].name: value
+        for param_id, value in zip(
+            problem.controlled_ids,
+            problem.start,
+            strict=True,
+        )
+    }
+    assert start_by_name[fitted_names[0]] == kd_value
+    accepted = _qualification_anchor_with_unit_residual_jacobian(
+        problem,
+        parameterization,
+        engine,
+    )
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    uncertainty = derive_deterministic_uncertainty(
+        AcceptedDeterministicFitFacts(
+            accepted,
+            problem,
+            parameterization,
+            engine,
+            ContinuousTrfBasis(decomposition.partition_proof),
+            "exact-binding-boundary-output-qualification",
+        )
+    )
+
+    conclusions = {
+        name: uncertainty.parameter(param_id)
+        for name, param_id in population_ids.items()
+    }
+    assert all(
+        conclusion is not None
+        and conclusion.reportable
+        and conclusion.standard_error is not None
+        and math.isfinite(conclusion.standard_error)
+        for conclusion in conclusions.values()
+    ), (
+        {
+            name: (
+                None
+                if conclusion is None
+                else (
+                    conclusion.reportable,
+                    conclusion.standard_error,
+                    conclusion.unavailable_kind,
+                )
+            )
+            for name, conclusion in conclusions.items()
+        },
+        ()
+        if uncertainty.root_evidence is None
+        else tuple(
+            (failure.category, failure.message)
+            for failure in uncertainty.root_evidence.failures
+        ),
+        None
+        if uncertainty.root_evidence is None
+        else (
+            uncertainty.root_evidence.constraint_jacobian is not None,
+            uncertainty.root_evidence.constrained_propagation is not None,
+            uncertainty.root_evidence.constrained_marginal_errors is not None,
+            uncertainty.root_evidence.constrained_correlations is not None,
+        ),
+    )
+    assert uncertainty.root_evidence is not None
+    constraint_jacobian = uncertainty.root_evidence.constraint_jacobian
+    assert constraint_jacobian is not None
+    gradients = {
+        parameter_model.definitions[param_id].name: row
+        for param_id, row in zip(
+            constraint_jacobian.output_ids,
+            constraint_jacobian.matrix,
+            strict=True,
+        )
+        if param_id in population_ids.values()
+    }
+    kd_column = next(
+        index
+        for index, param_id in enumerate(problem.controlled_ids)
+        if parameter_model.definitions[param_id].name == fitted_names[0]
+    )
+    assert gradients["PA"][kd_column] == pytest.approx(
+        1.0e3,
+        rel=2.0e-7,
+        abs=0.0,
+    )
+    assert gradients["PB"][kd_column] != 0.0
+    for column in range(len(problem.controlled_ids)):
+        column_gradients = tuple(gradient[column] for gradient in gradients.values())
+        assert math.fsum(column_gradients) == pytest.approx(
+            0.0,
+            abs=4.0 * math.ulp(max(map(abs, column_gradients))),
+        )
+    assert any(
+        diagnostic.component == "pb"
+        and diagnostic.method == "normalized_population_complement"
+        for diagnostic in constraint_jacobian.function_partial_diagnostics
+    )
+
+
+def test_unrepresentable_kon_does_not_block_simulation_or_fixed_fit_setup(
+    tmp_path: Path,
+) -> None:
+    experiment = _write_extreme_binding_experiment(tmp_path / "experiment.toml")
+    parameters = tmp_path / "parameters.toml"
+    parameters.write_text(
+        PARAMETERS.read_text(encoding="utf-8")
+        .replace("KOFF = 50.0", "KOFF = 1.0")
+        .replace("KD = 2.3E-6", "KD = 5e-324\nKON = 1.0"),
+        encoding="utf-8",
+    )
+    method = tmp_path / "method.toml"
+    method.write_text(
+        """FORMAT_VERSION = 2
+
+[STEP]
+INCLUDE = [486]
+ROLES = [
+  { FIT = ["CS_A"] },
+  { FIX = ["KD", "KOFF"] },
+]
+""",
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "Simulation"
+    run(
+        build_parser().parse_args(
+            [
+                "simulate",
+                "-e",
+                str(experiment),
+                "-p",
+                str(parameters),
+                "-d",
+                "2st_binding",
+                "-o",
+                str(output),
+                "--plot",
+                "nothing",
+            ]
+        ),
+        session=AnalysisSession.create(),
+    )
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "KAB" in constrained
+    assert "KON" not in constrained
+
+    fit_session = AnalysisSession.create()
+    fit_session.set_model("2st_binding")
+    experiments = build_experiments(
+        [experiment],
+        Selection(include=[SpinSystem.from_name("486N-HN")], exclude=None),
+        session=fit_session,
+    )
+    fit_session.parameters.set_defaults(read_defaults([parameters]))
+    assert fit_session.try_build_analysis_values(), repr(
+        fit_session.parameter_factory.native_construction_error
+    )
+    plan = read_method_plan([method])
+    parameterization = fit_session.compile_parameterization_from_actions(
+        plan.effective_role_actions()["STEP"],
+        experiments.param_ids,
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = fit_session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        fit_session.analysis_values.snapshot(),
+    )
+    assert any(param_id.startswith("__KAB") for param_id in problem.commit_scope)
+    assert all(not param_id.startswith("__KON") for param_id in problem.commit_scope)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "fitted_name", "population_names"),
+    (
+        ("2st_monomer_dimer", "KD", ("PA", "PB")),
+        ("3st_monomer_dimer_trimer", "KD1", ("PA", "PB", "PC")),
+        ("3st_double_binding", "KD_AB", ("PA", "PB", "PC")),
+        ("3st_binding_partner_2st", "KD_AB", ("PA", "PB", "PC")),
+        (
+            "4st_binding_3_bound_states",
+            "KD_APP",
+            ("PA", "PB", "PC", "PD", "KD_EFF"),
+        ),
+    ),
+)
+def test_association_population_uncertainties_are_reportable_in_structured_output(
+    tmp_path: Path,
+    model_name: str,
+    fitted_name: str,
+    population_names: tuple[str, ...],
+) -> None:
+    experiment = _write_extreme_binding_experiment(tmp_path / "experiment.toml")
+    experiment.write_text(
+        experiment.read_text(encoding="utf-8")
+        .replace("p_total = 1e-300", "p_total = 1e-3")
+        .replace("l_total = 1e-300", "l_total = 2e-3"),
+        encoding="utf-8",
+    )
+    session = AnalysisSession.create()
+    session.set_model(model_name)
+    experiments = build_experiments(
+        [experiment],
+        Selection(include="*", exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults([PARAMETERS]))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    configuration = session.parameter_factory.sealed_configuration
+    assert parameter_model is not None
+    assert configuration is not None
+    requested_ids = {
+        definition.param_id
+        for definition in parameter_model.definitions
+        if definition.name in population_names
+    }
+    required_ids = experiments.param_ids | requested_ids
+    baseline = session.compile_parameterization(Method(), required_ids)
+    fitted_ids = {
+        definition.param_id
+        for definition in parameter_model.definitions
+        if definition.name == fitted_name
+    }
+    assert len(fitted_ids) == 1
+    fixed_names = sorted(
+        {
+            parameter_name_from_definition(parameter_model.definitions[param_id]).name
+            for param_id in baseline.independent_ids
+            if param_id not in fitted_ids
+        }
+    )
+    parameterization = session.compile_parameterization(
+        Method(fit=[fitted_name], fix=fixed_names),
+        required_ids,
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    outcome = execute_direct_trf(
+        problem,
+        DirectTrfInvocation.for_problem(problem, objective_request_budget=100),
+        parameterization,
+        engine,
+    )
+    accepted = outcome.accepted_result
+    assert accepted is not None
+    decomposition = FitDecomposition.from_root(problem, parameterization, engine)
+    uncertainty = derive_deterministic_uncertainty(
+        AcceptedDeterministicFitFacts(
+            accepted,
+            problem,
+            parameterization,
+            engine,
+            ContinuousTrfBasis(decomposition.partition_proof),
+            "association-population-uncertainty-test",
+        )
+    )
+    output_ids = tuple(
+        param_id for param_id in parameterization.scope_ids if param_id in requested_ids
+    )
+
+    assert {
+        parameter_model.definitions[param_id].name for param_id in output_ids
+    } == set(population_names)
+    assert all(
+        (conclusion := uncertainty.parameter(param_id)) is not None
+        and conclusion.reportable
+        and conclusion.standard_error is not None
+        and math.isfinite(conclusion.standard_error)
+        for param_id in output_ids
+    )
+
+
 def _assert_representative_profiles_are_shipped() -> None:
     """Fail clearly if a selected residue's stable N profile disappears."""
 
@@ -213,6 +702,26 @@ FIX = ["KD"]
     fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
     assert "KD" in fitted
     assert "Jacobian unavailable" not in fitted
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    population_ids = tuple(
+        definition.param_id
+        for definition in parameter_model.definitions
+        if definition.name in {"PA", "PB"}
+        and uncertainty.parameter(definition.param_id) is not None
+    )
+    assert population_ids
+    assert all(
+        uncertainty.parameter(param_id).reportable for param_id in population_ids
+    )
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    population_lines = tuple(
+        line for line in constrained.splitlines() if line.startswith(('"PA,', '"PB,'))
+    )
+    assert len(population_lines) == len(population_ids)
+    assert all("# ±" in line for line in population_lines)
 
 
 def test_representative_binding_step2_reports_boundary_warning_with_retained_jacobian(

--- a/tests/test_native_uncertainty.py
+++ b/tests/test_native_uncertainty.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 import dataclasses
 import json
 import math
+import sys
+from collections.abc import Callable
+from decimal import Decimal, localcontext
 from pathlib import Path
 from typing import cast
 from unittest.mock import patch
@@ -28,6 +31,18 @@ from chemex.evaluation.native import (
     EvaluationResult,
 )
 from chemex.experiments.builder import build_experiments
+from chemex.models.kinetic.settings_2st_binding import (
+    calculate_populations as calculate_binding_populations,
+)
+from chemex.models.kinetic.settings_2st_monomer_dimer import (
+    calculate_populations as calculate_dimer_populations,
+)
+from chemex.models.kinetic.settings_3st_double_binding import (
+    calculate_populations as calculate_double_binding_populations,
+)
+from chemex.models.kinetic.settings_4st_binding_3_bound_states import (
+    calculate_populations as calculate_four_state_binding_populations,
+)
 from chemex.optimize import uncertainty as uncertainty_module
 from chemex.optimize.deterministic_uncertainty import (
     AcceptedDeterministicFitFacts,
@@ -71,6 +86,7 @@ from chemex.parameters.parameterization import (
     ReferenceExpression,
 )
 from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.userfunctions import FunctionArgumentDomain
 from chemex.printers.parameters import uncertainty_unavailable_reason
 from chemex.runtime import AnalysisSession
 from chemex.typing import Array
@@ -126,6 +142,88 @@ def _analytic_pa_kab_alternative(kab: float, kba: float) -> float:
 
 def _analytic_pa_kba(kab: float, kba: float) -> float:
     return kab / (kab + kba) ** 2
+
+
+def _nonnegative_identity(value: float) -> float:
+    return value
+
+
+def _decimal_forward_derivative(
+    function: Callable[[Decimal], Decimal],
+    center: float,
+) -> float:
+    """Return an independent high-precision one-sided three-point derivative."""
+    with localcontext() as context:
+        context.prec = 800
+        center_decimal = Decimal.from_float(center)
+        step = Decimal.from_float(math.ulp(center))
+        first = center_decimal + step
+        second = center_decimal + 2 * step
+        first_displacement = first - center_decimal
+        second_displacement = second - center_decimal
+        first_weight = -second_displacement / (
+            first_displacement * (first_displacement - second_displacement)
+        )
+        center_weight = -(first_displacement + second_displacement) / (
+            first_displacement * second_displacement
+        )
+        second_weight = -first_displacement / (
+            second_displacement * (second_displacement - first_displacement)
+        )
+        derivative = (
+            first_weight * function(first)
+            + center_weight * function(center_decimal)
+            + second_weight * function(second)
+        )
+    return float(derivative)
+
+
+def _normalized_population_capability(
+    argument_scales: tuple[float, ...],
+    argument_domains: tuple[FunctionArgumentDomain, ...],
+    components: tuple[str, ...],
+) -> FunctionFiniteDifferenceCapability:
+    return FunctionFiniteDifferenceCapability(
+        function_id="populations",
+        component=components[0],
+        argument_scales=argument_scales,
+        output_scale=math.nextafter(0.0, 1.0),
+        argument_domains=argument_domains,
+        relative_steps=True,
+        normalized_population_components=components,
+    )
+
+
+def _coupled_population_partials(
+    function: Callable[..., object],
+    arguments: tuple[float, ...],
+    argument_index: int,
+    capability: FunctionFiniteDifferenceCapability,
+) -> tuple[tuple[float, ...], tuple[uncertainty_module.FunctionPartialDiagnostic, ...]]:
+    components = capability.normalized_population_components
+    results = tuple(
+        uncertainty_module._normalized_population_partial(
+            FunctionExpression("populations", (), component),
+            function,
+            arguments,
+            argument_index,
+            dataclasses.replace(capability, component=component),
+            _qualification_policy("__INPUT"),
+        )
+        for component in components
+    )
+    return (
+        tuple(derivative for derivative, _diagnostic in results),
+        tuple(diagnostic for _derivative, diagnostic in results),
+    )
+
+
+def _assert_normalized_population_gradient(derivatives: tuple[float, ...]) -> None:
+    assert all(math.isfinite(value) for value in derivatives)
+    assert math.fsum(derivatives) == pytest.approx(
+        0.0,
+        abs=4.0 * math.ulp(max(map(abs, derivatives))),
+    )
 
 
 def _accepted_relaxation_fit(
@@ -1432,6 +1530,363 @@ def test_scientific_constraint_requires_and_uses_declared_numerical_capability()
     assert all(
         item.method == "versioned_analytic_partial"
         for item in analytic_evidence.constraint_jacobian.function_partial_diagnostics
+    )
+
+
+def test_scientific_function_capability_uses_one_sided_stencil_at_zero_domain() -> None:
+    capability = FunctionFiniteDifferenceCapability(
+        function_id="nonnegative_identity",
+        component=None,
+        argument_scales=(1.0,),
+        output_scale=1.0,
+        argument_domains=("nonnegative",),
+        relative_steps=True,
+    )
+
+    derivative, diagnostic = uncertainty_module._scientific_function_partial(
+        FunctionExpression("nonnegative_identity", (), None),
+        _nonnegative_identity,
+        (0.0,),
+        0,
+        capability,
+        _qualification_policy("__X"),
+    )
+
+    assert derivative == pytest.approx(1.0, rel=1.0e-12)
+    assert diagnostic.method == "one_sided_positive_two_scale_numerical"
+    assert all(
+        displacement > 0.0 for displacement in diagnostic.represented_displacements
+    )
+
+
+@pytest.mark.parametrize(
+    "center",
+    (
+        1.0e-6,
+        sys.float_info.min,
+        math.nextafter(0.0, 1.0),
+        math.nextafter(math.nextafter(0.0, 1.0), math.inf),
+    ),
+    ids=("ordinary", "minimum-normal", "minimum-subnormal", "above-boundary"),
+)
+def test_positive_domain_scientific_partial_handles_subnormal_scales(
+    center: float,
+) -> None:
+    capability = FunctionFiniteDifferenceCapability(
+        function_id="positive_identity",
+        component=None,
+        argument_scales=(1.0,),
+        output_scale=math.nextafter(0.0, 1.0),
+        argument_domains=("positive",),
+        relative_steps=True,
+    )
+
+    derivative, diagnostic = uncertainty_module._scientific_function_partial(
+        FunctionExpression("positive_identity", (), None),
+        _nonnegative_identity,
+        (center,),
+        0,
+        capability,
+        _qualification_policy("__KD"),
+    )
+
+    assert math.isfinite(derivative)
+    # Subnormal stencil points carry quantized displacements, so the derivative
+    # is qualified to a tighter-than-nanounit relative error, not exact rounding.
+    assert derivative == pytest.approx(1.0, rel=1.0e-9, abs=0.0)
+    assert all(
+        center + displacement > 0.0
+        for displacement in diagnostic.represented_displacements
+    )
+
+
+def test_subnormal_three_point_stencil_has_finite_normalized_weights() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+
+    weights, coordinate_scale = uncertainty_module._normalized_three_point_weights(
+        minimum,
+        2.0 * minimum,
+    )
+
+    assert coordinate_scale == 2.0 * minimum
+    assert all(math.isfinite(weight) for weight in weights)
+
+
+def test_shared_three_point_arithmetic_has_residual_provenance() -> None:
+    assert (
+        uncertainty_module._RESIDUAL_LINEARIZATION_VERSION
+        == "accepted-residual-jacobian-v3"
+    )
+
+
+@pytest.mark.parametrize(
+    "kd",
+    (sys.float_info.min, math.nextafter(0.0, 1.0)),
+    ids=("minimum-normal", "minimum-subnormal"),
+)
+def test_extreme_binding_population_uncertainty_partial_matches_decimal_difference(
+    kd: float,
+) -> None:
+    p_total = 1.0e-3
+    l_total = 2.0e-3
+    capability = FunctionFiniteDifferenceCapability(
+        function_id="populations",
+        component="pa",
+        argument_scales=(1.0e-3, 1.0e-3, 1.0e-3),
+        output_scale=math.nextafter(0.0, 1.0),
+        argument_domains=("nonnegative", "nonnegative", "positive"),
+        relative_steps=True,
+    )
+
+    derivative, _diagnostic = uncertainty_module._scientific_function_partial(
+        FunctionExpression("populations", (), "pa"),
+        calculate_binding_populations,
+        (p_total, l_total, kd),
+        2,
+        capability,
+        _qualification_policy("__KD"),
+    )
+
+    protein = Decimal.from_float(p_total)
+    ligand = Decimal.from_float(l_total)
+
+    def decimal_population(kd: Decimal) -> Decimal:
+        total = protein + ligand + kd
+        discriminant = (total * total - Decimal(4) * protein * ligand).sqrt()
+        bound = Decimal(2) * protein * ligand / (total + discriminant)
+        return (protein - bound) / protein
+
+    expected = _decimal_forward_derivative(decimal_population, kd)
+    assert math.isfinite(derivative)
+    assert derivative == pytest.approx(expected, rel=5.0e-9, abs=0.0)
+
+
+@pytest.mark.parametrize(
+    "kd",
+    (
+        sys.float_info.min,
+        math.nextafter(0.0, 1.0),
+        math.nextafter(math.nextafter(0.0, 1.0), math.inf),
+    ),
+    ids=("minimum-normal", "minimum-subnormal", "subnormal-successor"),
+)
+def test_simple_binding_population_gradient_uses_normalization_at_kd_boundary(
+    kd: float,
+) -> None:
+    capability = _normalized_population_capability(
+        (1.0e-3, 1.0e-3, 1.0e-3),
+        ("nonnegative", "nonnegative", "positive"),
+        ("pa", "pb"),
+    )
+
+    derivatives, diagnostics = _coupled_population_partials(
+        calculate_binding_populations,
+        (1.0e-3, 2.0e-3, kd),
+        2,
+        capability,
+    )
+
+    dpa_dkd, dpb_dkd = derivatives
+    _assert_normalized_population_gradient(derivatives)
+    assert dpa_dkd == pytest.approx(1.0e3, rel=2.0e-7, abs=0.0)
+    assert dpb_dkd == pytest.approx(-dpa_dkd, rel=2.0e-15, abs=0.0)
+    assert {item.component: item.method for item in diagnostics}["pb"] == (
+        "normalized_population_complement"
+    )
+
+
+def test_three_state_binding_population_gradient_sums_to_zero_at_boundary() -> None:
+    capability = _normalized_population_capability(
+        (1.0e-3, 1.0e-3, 1.0e-3, 1.0e-3),
+        ("nonnegative", "nonnegative", "positive", "positive"),
+        ("pa", "pb", "pc"),
+    )
+
+    derivatives, diagnostics = _coupled_population_partials(
+        calculate_double_binding_populations,
+        (1.0e-3, 2.0e-3, math.nextafter(0.0, 1.0), 1.0e-6),
+        2,
+        capability,
+    )
+
+    _assert_normalized_population_gradient(derivatives)
+    complement = next(
+        item
+        for item in diagnostics
+        if item.method == "normalized_population_complement"
+    )
+    assert complement.component == "pb"
+    assert derivatives[1] != 0.0
+
+
+def test_four_state_binding_population_gradient_sums_to_zero_at_boundary() -> None:
+    capability = _normalized_population_capability(
+        (1.0e-3, 1.0e-3, 1.0e-3, 1.0, 1.0),
+        ("nonnegative", "nonnegative", "positive", "nonnegative", "nonnegative"),
+        ("pa", "pb", "pc", "pd"),
+    )
+
+    derivatives, diagnostics = _coupled_population_partials(
+        calculate_four_state_binding_populations,
+        (1.0e-3, 2.0e-3, sys.float_info.min, 0.0, 1.0),
+        3,
+        capability,
+    )
+
+    _assert_normalized_population_gradient(derivatives)
+    complement = next(
+        item
+        for item in diagnostics
+        if item.method == "normalized_population_complement"
+    )
+    assert complement.component == "pb"
+    assert derivatives[1] != 0.0
+
+
+def test_coupled_population_partial_matches_scalar_partial_in_ordinary_domain() -> None:
+    arguments = (1.0e-3, 2.0e-3, 2.0e-6)
+    coupled_capability = _normalized_population_capability(
+        (1.0e-3, 1.0e-3, 1.0e-3),
+        ("nonnegative", "nonnegative", "positive"),
+        ("pa", "pb"),
+    )
+    scalar_capability = dataclasses.replace(
+        coupled_capability,
+        component="pb",
+        output_scale=1.0,
+        normalized_population_components=(),
+    )
+
+    derivatives, _diagnostics = _coupled_population_partials(
+        calculate_binding_populations,
+        arguments,
+        2,
+        coupled_capability,
+    )
+    scalar_dpb, _diagnostic = uncertainty_module._scientific_function_partial(
+        FunctionExpression("populations", (), "pb"),
+        calculate_binding_populations,
+        arguments,
+        2,
+        scalar_capability,
+        _qualification_policy("__KD"),
+    )
+
+    protein = Decimal.from_float(arguments[0])
+    ligand = Decimal.from_float(arguments[1])
+
+    def decimal_population(kd: Decimal) -> Decimal:
+        total = protein + ligand + kd
+        discriminant = (total * total - Decimal(4) * protein * ligand).sqrt()
+        bound = Decimal(2) * protein * ligand / (total + discriminant)
+        return (protein - bound) / protein
+
+    independent_dpa = _decimal_forward_derivative(decimal_population, arguments[2])
+    assert derivatives[0] == pytest.approx(independent_dpa, rel=5.0e-9, abs=0.0)
+    assert derivatives[1] == pytest.approx(-independent_dpa, rel=5.0e-9, abs=0.0)
+    assert derivatives[1] == pytest.approx(scalar_dpb, rel=2.0e-6, abs=0.0)
+
+
+def test_nonfinite_roundoff_allowance_cannot_certify_scalar_population_plateau() -> (
+    None
+):
+    capability = FunctionFiniteDifferenceCapability(
+        function_id="populations",
+        component="pb",
+        argument_scales=(1.0e-3, 1.0e-3, 1.0e-3),
+        output_scale=1.0,
+        argument_domains=("nonnegative", "nonnegative", "positive"),
+        relative_steps=True,
+    )
+
+    with pytest.raises(
+        uncertainty_module.FunctionPartialFailure,
+        match="No reliable numerical partial",
+    ):
+        uncertainty_module._scientific_function_partial(
+            FunctionExpression("populations", (), "pb"),
+            calculate_binding_populations,
+            (1.0e-3, 2.0e-3, math.nextafter(0.0, 1.0)),
+            2,
+            capability,
+            _qualification_policy("__KD"),
+        )
+
+
+def test_boundary_gradient_invariant_rejects_zeroed_dependent_component() -> None:
+    capability = _normalized_population_capability(
+        (1.0e-3, 1.0e-3, 1.0e-3),
+        ("nonnegative", "nonnegative", "positive"),
+        ("pa", "pb"),
+    )
+    derivatives, _diagnostics = _coupled_population_partials(
+        calculate_binding_populations,
+        (1.0e-3, 2.0e-3, math.nextafter(0.0, 1.0)),
+        2,
+        capability,
+    )
+    forced_zero_dependent = (derivatives[0], 0.0)
+
+    with pytest.raises(AssertionError):
+        _assert_normalized_population_gradient(forced_zero_dependent)
+
+
+def test_subnormal_oligomer_partial_fails_closed_when_stencil_is_unresolved() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+    p_total = 1.0e308
+    capability = FunctionFiniteDifferenceCapability(
+        function_id="populations",
+        component="pa",
+        argument_scales=(1.0e-3, 1.0e-3),
+        output_scale=math.nextafter(0.0, 1.0),
+        argument_domains=("nonnegative", "positive"),
+        relative_steps=True,
+    )
+
+    protein = Decimal.from_float(p_total)
+
+    def decimal_population(kd: Decimal) -> Decimal:
+        return Decimal(2) / (Decimal(1) + (Decimal(1) + 8 * protein / kd).sqrt())
+
+    expected = _decimal_forward_derivative(decimal_population, minimum)
+    assert math.isfinite(expected) and expected != 0.0
+    with pytest.raises(
+        uncertainty_module.FunctionPartialFailure,
+        match="No reliable numerical partial",
+    ):
+        uncertainty_module._scientific_function_partial(
+            FunctionExpression("populations", (), "pa"),
+            calculate_dimer_populations,
+            (p_total, minimum),
+            1,
+            capability,
+            _qualification_policy("__KD"),
+        )
+
+
+def test_zero_ligand_population_uncertainty_uses_nonnegative_stencil() -> None:
+    capability = FunctionFiniteDifferenceCapability(
+        function_id="populations",
+        component="pb",
+        argument_scales=(1.0e-3, 1.0e-3, 1.0e-3),
+        output_scale=math.nextafter(0.0, 1.0),
+        argument_domains=("nonnegative", "nonnegative", "positive"),
+        relative_steps=True,
+    )
+
+    derivative, diagnostic = uncertainty_module._scientific_function_partial(
+        FunctionExpression("populations", (), "pb"),
+        calculate_binding_populations,
+        (1.0e-3, 0.0, 1.0e-6),
+        1,
+        capability,
+        _qualification_policy("__L_TOTAL"),
+    )
+
+    assert math.isfinite(derivative)
+    assert diagnostic.method == "one_sided_positive_two_scale_numerical"
+    assert all(
+        displacement >= 0.0 for displacement in diagnostic.represented_displacements
     )
 
 

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -61,6 +61,7 @@ from chemex.parameters.parameterization import (
     SealedParameterDeclarations,
     SealedParameterModel,
     UnsupportedConstraintExpressionError,
+    build_initial_analysis_values,
     compile_active_parameterization,
     compile_active_parameterization_from_actions,
     seal_parameter_declarations,
@@ -1960,6 +1961,62 @@ def test_non_finite_derived_value_has_its_own_failure_category() -> None:
 
     assert raised.value.code == "non_finite"
     assert raised.value.context["param_id"] == "__B"
+
+
+def test_required_expression_keeps_report_only_derived_intermediate() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration(
+            "__REPORT",
+            False,
+            "__A * 2.0",
+            model_owned=True,
+            report_only=True,
+        ),
+        ParameterDeclaration(
+            "__REQUIRED",
+            False,
+            "__REPORT + 1.0",
+            model_owned=True,
+        ),
+    )
+    parameter_model, snapshot = _native_fixture(
+        declarations,
+        values={"__A": 2.0, "__REPORT": -1.0, "__REQUIRED": -1.0},
+    )
+
+    parameterization = compile_active_parameterization(
+        parameter_model,
+        snapshot,
+        Method(),
+        {"__REQUIRED"},
+    )
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+
+    assert "__REPORT" in parameterization.scope_ids
+    assert resolved["__REPORT"] == 4.0
+    assert resolved["__REQUIRED"] == 5.0
+
+
+def test_non_report_only_non_finite_model_derivation_still_fails_eagerly() -> None:
+    declarations = (
+        ParameterDeclaration("__A", False),
+        ParameterDeclaration(
+            "__DERIVED",
+            False,
+            "__A * __A",
+            model_owned=True,
+        ),
+    )
+    parameter_model, _snapshot = _native_fixture(
+        declarations,
+        values={"__A": 1.0e308, "__DERIVED": 1.0},
+    )
+
+    with pytest.raises(NonFiniteParameterValueError) as raised:
+        build_initial_analysis_values(parameter_model)
+
+    assert raised.value.context["param_id"] == "__DERIVED"
 
 
 def test_unknown_model_dependency_is_incomplete_dependency_failure() -> None:

--- a/tests/test_standard_parameter_bounds.py
+++ b/tests/test_standard_parameter_bounds.py
@@ -73,6 +73,13 @@ def test_approved_kinetic_family_domains_apply_only_to_independent_settings() ->
         "3st_monomer_dimer_trimer",
         "3st_monomer_dimer_tetramer",
     }
+    strict_binding_models = {
+        "2st_binding",
+        "3st_double_binding",
+        "3st_binding_partner_2st",
+        "4st_binding_partner_2st",
+        "4st_binding_3_bound_states",
+    }
 
     for model_name in sorted(model_factory.set):
         for local_name, setting in model_factory.create(
@@ -84,7 +91,10 @@ def test_approved_kinetic_family_domains_apply_only_to_independent_settings() ->
                 expected = (0.0, 1.0e6)
             elif local_name in approved_equilibria:
                 expected = expected_domains["keq"]
-            elif model_name in oligomerization_models and local_name.startswith("kd"):
+            elif (
+                model_name in oligomerization_models | strict_binding_models
+                and local_name.startswith("kd")
+            ):
                 expected = (math.nextafter(0.0, 1.0), 1.0)
             else:
                 family = next(


### PR DESCRIPTION
## Summary

This change establishes one scientific authority for Category-A association models:

- equilibrium parameters and mass balances determine species composition;
- kinetic parameters determine tagged-magnetization exchange dynamics.

It also replaces fragile binding equilibrium calculations with a validated shared solver and closes the numerical/uncertainty edge cases required to make that authority reliable across the supported binary64 domain.

## Association population authority

The following models now use canonical equilibrium composition for reported populations:

### Oligomerization

- `2st_monomer_dimer`
- `2st_monomer_trimer`
- `2st_monomer_tetramer`
- `3st_monomer_dimer_trimer`
- `3st_monomer_dimer_tetramer`

### Binding

- `2st_binding`
- `3st_double_binding`
- `3st_binding_partner_2st`
- `4st_binding_partner_2st`
- `4st_binding_3_bound_states`

Where a complete equilibrium authority exists, zero kinetic scales now freeze exchange without erasing equilibrium species or renormalizing populations onto connected kinetic components.

Generic `pop_2st` / `pop_3st` semantics remain unchanged for genuinely kinetic-authority models.

## Binding equilibrium solver

A private shared finite-pool authority now handles the Category-A binding family.

It:

- solves the one-ligand finite-pool equilibrium through a stable physical reduction;
- validates protein and ligand conservation;
- validates equilibrium laws and population normalization;
- preserves near-stoichiometric and extreme asymmetric information;
- keeps dimensionless populations authoritative even when a dimensional concentration underflows;
- exposes canonical equilibrium edge ratios for rate construction.

Unchecked multidimensional concentration-space root solving is removed from these Category-A binding models.

## Binding KD domain

Binding dissociation constants used for reversible association now follow the same policy established for oligomerization:

- every finite `KD > 0` retains literal semantics;
- exact zero is rejected;
- no hidden `1e-100` / `1e-32` effective KD floors remain in the Category-A models.

Zero dimensionless equilibrium ratios remain valid where they intentionally remove an equilibrium state.

`L_TOTAL=0` remains a valid ligand-free boundary.

Binding `P_TOTAL=0` is rejected through the normal parameter-configuration error path because normalized protein-state populations are undefined.

## Tagged rates

Tagged association and interconversion rates use equilibrium ratios and checked log-domain construction where necessary.

This avoids false failure from intermediates such as:

`KOFF / KD`

or large population ratios when the final tagged rate remains representable.

Positive mathematically unrepresentable rates fail explicitly rather than being clipped or silently converted to structural zero.

Exact kinetic zero remains supported.

## Public KON compatibility

Public binding derived outputs such as:

- `KON`
- `KON_AB`
- `KON_AC`

are retained.

They are now explicitly report-only when they are not required by model dynamics.

This means an unrepresentable report-only KON no longer invalidates an otherwise representable simulation or fit.

- representable KON values still serialize normally;
- stale supplied report-only values do not override KD/KOFF authority;
- unrepresentable values are omitted during ordinary reporting;
- explicit resolution remains fail-closed with `NonFiniteParameterValueError`.

This is opt-in behavior; ordinary derived parameters retain previous eager semantics.

## KD_EFF correction

`4st_binding_3_bound_states.KD_EFF` previously reported a dimensionless free-to-bound ratio under a KD-like name.

It now reports the actual apparent dissociation constant represented by the model and is equivalent to authoritative `KD_APP`.

The public parameter identity is retained.

## Numerical uncertainty

Canonical equilibrium population functions now expose model-owned linearization capabilities for deterministic uncertainty propagation.

The implementation supports:

- scale-adaptive finite differences;
- positive/non-negative domains;
- one-sided boundary stencils;
- subnormal-safe normalized finite-difference coordinates;
- fail-closed reliability checks;
- normalized-population gradient coupling.

For a normalized population vector:

`Σ p_i = 1`

so:

`Σ dp_i = 0`.

When a dominant population saturates numerically to 0 or 1, its derivative is reconstructed from the other population derivatives rather than falsely treating the binary64 plateau as a physical zero gradient.

Central population values remain sourced directly from equilibrium; only derivative construction uses the normalization invariant.

## Robustness

Independent high-precision checks cover:

- weak and mixed binding;
- ligand and protein excess;
- strong binding;
- tiny total concentrations;
- adjacent floating-point total concentrations;
- extreme asymmetric totals;
- minimum-normal and minimum-subnormal KD values;
- dimensional concentration underflow with representable population;
- rate-splitting representability boundaries;
- zero kinetic scales;
- zero equilibrium ratios.

The candidate corrects several cases where the previous unchecked root solver returned inaccurate or negative concentrations.

## Ordinary compatibility

Ordinary positive-domain population changes are at floating-point rounding scale where the old implementation was already scientifically correct.

Larger differences in some legacy binding concentration calculations were independently verified as corrections to the previous poorly scaled multidimensional root solution.

Public parameter names, scopes, identities, and ordinary workflows are retained except for the intentional scientific correction to `KD_EFF`.

## Uncertainty and execution paths

The audited candidate verifies the same equilibrium authority through:

- direct parameter resolution;
- fixed and varying parameters;
- native deterministic fitting;
- deterministic constrained uncertainty;
- MCMC;
- resampling;
- output serialization.

Scientifically important PA/PB/PC/PD outputs have explicit finite/reportable uncertainty qualifications.

## Deferred Category-C models

This PR intentionally does not change:

- `3st_binding_cs`
- `3st_binding_if`

Those models currently mix macrostate equilibrium information with directional kinetic parameters that implicitly encode an internal conformer equilibrium.

They require a separate public parameterization decision and remain the next association-model pass.

## Other exclusions

This PR does not change:

- Eyring models;
- generic 3/4/5/6-state topology semantics;
- generic `pop_2st` / `pop_3st`;
- `.mf`, `.rs`, `.tc` modifiers;
- aliases/catalog;
- statistics;
- unrelated experiment implementations.

## Validation

Final audited candidate:

- complete kinetic models: 632 passed
- affected uncertainty/fitting group: 261 passed
- final full suite: 1,971 passed
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- full binding/oligomerization numerical matrices
- MCMC/resampling regression
- shipped binding simulation validation
- repository graph refresh

Independent audit and repeated closure reviews ultimately concluded:

- Standards: PASS
- Specification: PASS
- Numerical robustness: PASS
- Compatibility: PASS
- Readability: PASS
- `PASS — 0 closure findings`
- `READY TO COMMIT THE AUDITED DIFF`