### PR TITLE
fix: separate binding equilibrium from exchange kinetics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- `3st_binding_cs` and `3st_binding_if` now use equilibrium parameters and mass
+  balances as the sole population authority, independently of tagged kinetic
+  scales. This is a breaking independent-parameter change: conformational
+  selection replaces `KAB`/`KBA` with `KEQ_AB = KAB / KBA` and
+  `KEX_AB = KAB + KBA`; induced fit replaces `KBC`/`KCB` with
+  `KEQ_BC = KBC / KCB` and `KEX_BC = KBC + KCB`. Directional rates remain
+  derived outputs. A legacy `(0,0)` pair determines `KEX = 0` but leaves KEQ
+  ambiguous and is rejected with migration guidance. Induced fit supports exact
+  `KEQ_BC = 0`; conformational selection rejects exact `KEQ_AB = 0`. Migration
+  diagnostics are scoped by parameter identity, reject unrepresentable ratio or
+  sum advice instead of printing false zero/infinity, and show explicit bound
+  override syntax when an exact replacement exceeds the new `1e6` safety bound.
+  MCMC initialization now preserves valid exact-zero nonnegative coordinates.
+  Representable report-only intrinsic KD and KON outputs participate in the same
+  deterministic uncertainty propagation as the final parameter report.
 - Category-A association models now use one equilibrium-composition authority
   for reported populations and tagged detailed-balance rates. Exact-zero kinetic
   scales therefore freeze exchange without erasing equilibrium species. Binding
@@ -47,10 +62,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   unrepresentable report-only value is omitted. Positive directional exchange
   rates that cannot be represented in binary64 are rejected instead of being
   silently rounded to structural zero. Canonical association-population
-  constraints now carry deterministic propagated uncertainties.
-  `3st_binding_cs` and `3st_binding_if` retain their existing parameterizations
-  pending a separate equilibrium-authority pass; generic kinetic models are
-  unchanged.
+  constraints now carry deterministic propagated uncertainties. Generic kinetic
+  models are unchanged.
 - Oligomerization models now retain literal semantics for every finite positive
   `KD`, including sub-`1e-32` values; the hidden `1e-32` effective-KD floor has
   been removed, so affected results can change materially. Exact `KD = 0` is now

--- a/src/chemex/configuration/method_validation.py
+++ b/src/chemex/configuration/method_validation.py
@@ -25,6 +25,10 @@ from chemex.configuration.method_plan import (
     SourceRef,
     UnaryExpression,
 )
+from chemex.models.kinetic._binding_migration import (
+    binding_rate_migration,
+    legacy_binding_migration_message,
+)
 from chemex.parameters.name import ParamName, matches_parameter_index_selector
 from chemex.parameters.parameterization import (
     ParameterRole,
@@ -175,6 +179,76 @@ def _references(expression: ConstraintExpression) -> Iterator[ParameterSelector]
     elif isinstance(expression, BinaryExpression):
         yield from _references(expression.left)
         yield from _references(expression.right)
+
+
+def _action_selectors(
+    action: FitAction | FixAction | ConstrainAction,
+) -> Iterator[tuple[ParameterSelector, SourceRef]]:
+    if isinstance(action, (FitAction, FixAction)):
+        for selector in action.selectors:
+            yield selector, _source(selector, action.source)
+        return
+    for constraint in action.constraints:
+        yield constraint.target, constraint.source
+        for selector in _references(constraint.expression):
+            yield selector, _source(selector, constraint.source)
+
+
+def _method_selectors(
+    plan: MethodPlan,
+) -> Iterator[tuple[ParameterSelector, SourceRef]]:
+    for step in plan.steps:
+        for action in step.role_actions:
+            yield from _action_selectors(action)
+        search = step.search
+        if isinstance(search, GridSearch):
+            for axis in search.axes:
+                yield axis.selector, _source(axis.selector, axis.source)
+        elif isinstance(search, DeSearch):
+            for coordinate in search.coordinates:
+                yield (
+                    coordinate.selector,
+                    _source(coordinate.selector, coordinate.source),
+                )
+
+
+def _validate_legacy_binding_selectors(
+    plan: MethodPlan,
+    model: SealedParameterModel,
+) -> None:
+    migration = binding_rate_migration(model.model_name)
+    if migration is None:
+        return
+    selectors = tuple(_method_selectors(plan))
+    grouped: dict[str, tuple[ParamName, set[str], SourceRef]] = {}
+    for selector, source in selectors:
+        name = selector.name.upper()
+        if name not in migration.legacy_names | migration.replacement_names:
+            continue
+        parsed = _selector_name(selector)
+        scope = ParamName("", parsed.spin_system, parsed.conditions)
+        _stored_scope, names, _stored_source = grouped.setdefault(
+            scope.id_,
+            (scope, set(), source),
+        )
+        names.add(name)
+    affected = tuple(
+        (scope, names, source)
+        for scope, names, source in grouped.values()
+        if migration.legacy_names & names
+    )
+    if not affected:
+        return
+    messages = tuple(
+        legacy_binding_migration_message(migration, names, scope=scope)
+        for scope, names, _source in affected
+    )
+    source = affected[0][2]
+    first_legacy_name = sorted(migration.legacy_names & affected[0][1])[0]
+    raise MethodFormatError(
+        f"{first_legacy_name} is a derived output. " + "\n".join(messages),
+        source,
+    )
 
 
 def _check_bounds(
@@ -458,6 +532,7 @@ def resolve_de_coordinates(
 
 
 def validate_method_plan(plan: MethodPlan, model: SealedParameterModel) -> None:
+    _validate_legacy_binding_selectors(plan, model)
     baseline = {
         param_id: baseline_parameter_role(declaration)
         for param_id, declaration in model.declarations.items()

--- a/src/chemex/models/kinetic/_binding.py
+++ b/src/chemex/models/kinetic/_binding.py
@@ -24,10 +24,12 @@ class BindingEquilibrium:
     protein_free: float
     ligand_free: float
     bound_total: float
+    free_proteins: tuple[float, ...]
     free_ligands: tuple[float, ...]
     complexes: tuple[float, ...]
     populations: tuple[float, ...]
     log_populations: tuple[float, ...]
+    free_protein_log_fractions: tuple[float, ...]
     free_ligand_log_fractions: tuple[float, ...]
     complex_log_fractions: tuple[float, ...]
     edge_log_ratios: tuple[float, ...]
@@ -141,6 +143,15 @@ def log_equilibrium_ratio(ratio: float) -> float:
     return -math.inf if ratio == 0.0 else math.log(ratio)
 
 
+def report_only_positive_log_value(log_value: float) -> float:
+    """Return a positive report value or a non-finite typed-value sentinel."""
+    if math.isnan(log_value) or log_value < _LOG_MIN_POSITIVE_FLOAT:
+        return math.nan
+    if log_value > _LOG_MAX_FLOAT:
+        return math.inf
+    return math.exp(log_value)
+
+
 def _logsumexp(values: tuple[float, ...]) -> float:
     maximum = max(values)
     if maximum == -math.inf:
@@ -213,8 +224,15 @@ def _distribute(total: float, fractions: tuple[float, ...]) -> tuple[float, ...]
     correction = total - math.fsum(concentrations)
     largest = max(range(len(concentrations)), key=concentrations.__getitem__)
     concentrations[largest] += correction
+    # A subnormal macro pool may be representable even when none of its exact
+    # species shares are.  Preserve the pool mass in one concrete value while
+    # the accompanying log fractions retain the equilibrium composition.
+    correction_tolerance = max(
+        _BALANCE_TOLERANCE * total,
+        len(fractions) * MIN_POSITIVE_FLOAT,
+    )
     if (
-        abs(correction) > _BALANCE_TOLERANCE * total
+        abs(correction) > correction_tolerance
         or concentrations[largest] < 0.0
         or not math.isfinite(concentrations[largest])
     ):
@@ -319,6 +337,7 @@ def _validate_concentration_domain(equilibrium: BindingEquilibrium) -> None:
         equilibrium.protein_free,
         equilibrium.ligand_free,
         equilibrium.bound_total,
+        *equilibrium.free_proteins,
         *equilibrium.free_ligands,
         *equilibrium.complexes,
         *equilibrium.populations,
@@ -349,16 +368,25 @@ def _validate_mass_balance(
     ):
         msg = "Binding equilibrium violated ligand mass conservation"
         raise RuntimeError(msg)
-    if not math.isclose(
-        math.fsum(equilibrium.free_ligands),
-        equilibrium.ligand_free,
-        rel_tol=_BALANCE_TOLERANCE,
-        abs_tol=MIN_POSITIVE_FLOAT,
-    ) or not math.isclose(
-        math.fsum(equilibrium.complexes),
-        equilibrium.bound_total,
-        rel_tol=_BALANCE_TOLERANCE,
-        abs_tol=MIN_POSITIVE_FLOAT,
+    if (
+        not math.isclose(
+            math.fsum(equilibrium.free_proteins),
+            equilibrium.protein_free,
+            rel_tol=_BALANCE_TOLERANCE,
+            abs_tol=MIN_POSITIVE_FLOAT,
+        )
+        or not math.isclose(
+            math.fsum(equilibrium.free_ligands),
+            equilibrium.ligand_free,
+            rel_tol=_BALANCE_TOLERANCE,
+            abs_tol=MIN_POSITIVE_FLOAT,
+        )
+        or not math.isclose(
+            math.fsum(equilibrium.complexes),
+            equilibrium.bound_total,
+            rel_tol=_BALANCE_TOLERANCE,
+            abs_tol=MIN_POSITIVE_FLOAT,
+        )
     ):
         msg = "Binding equilibrium species do not conserve their pools"
         raise RuntimeError(msg)
@@ -396,7 +424,7 @@ def _validate_populations(
         msg = "Binding equilibrium populations do not match their log authority"
         raise RuntimeError(msg)
     log_p_total = math.log(p_total)
-    species = (equilibrium.protein_free, *equilibrium.complexes)
+    species = (*equilibrium.free_proteins, *equilibrium.complexes)
     for concentration, log_population in zip(
         species,
         equilibrium.log_populations,
@@ -452,20 +480,30 @@ def _validate_species_distribution(
 
 def _validate_equilibrium(
     equilibrium: BindingEquilibrium,
-    p_total: float,
-    l_total: float,
+    *,
+    protein_total: float,
+    ligand_total: float,
     log_protein_free: float,
     log_ligand_free: float,
     log_bound: float,
+    free_protein_log_weights: tuple[float, ...],
     free_ligand_log_weights: tuple[float, ...],
     complex_log_weights: tuple[float, ...],
+    free_protein_fractions: tuple[float, ...],
     free_ligand_fractions: tuple[float, ...],
     complex_fractions: tuple[float, ...],
 ) -> None:
     _validate_concentration_domain(equilibrium)
-    _validate_mass_balance(equilibrium, p_total, l_total)
-    _validate_populations(equilibrium, p_total)
-    if l_total > 0.0:
+    _validate_mass_balance(equilibrium, protein_total, ligand_total)
+    _validate_populations(equilibrium, protein_total)
+    _validate_species_distribution(
+        equilibrium.free_proteins,
+        equilibrium.protein_free,
+        free_protein_log_weights,
+        free_protein_fractions,
+        description="free-protein species",
+    )
+    if ligand_total > 0.0:
         log_residual = (
             log_protein_free + log_ligand_free - log_bound - equilibrium.log_apparent_kd
         )
@@ -500,54 +538,56 @@ def solve_binding_equilibrium(
     p_total: float,
     l_total: float,
     *,
+    free_protein_log_weights: tuple[float, ...] = (0.0,),
     free_ligand_log_weights: tuple[float, ...],
     complex_log_weights: tuple[float, ...],
     edge_log_ratios: tuple[float, ...] = (),
 ) -> BindingEquilibrium:
     """Solve one finite ligand pool and distribute its free and bound species."""
     validate_binding_totals(p_total, l_total)
+    _validate_log_weights(free_protein_log_weights, description="free-protein")
     _validate_log_weights(free_ligand_log_weights, description="free-ligand")
     _validate_log_weights(complex_log_weights, description="complex")
     if any(math.isnan(ratio) or ratio == math.inf for ratio in edge_log_ratios):
         msg = "Binding edge equilibrium ratios must be finite or exact-zero"
         raise ValueError(msg)
 
+    protein_fractions = _normalized_weights(free_protein_log_weights)
     free_fractions = _normalized_weights(free_ligand_log_weights)
     complex_fractions = _normalized_weights(complex_log_weights)
+    protein_log_fractions = _normalized_log_weights(free_protein_log_weights)
     free_log_fractions = _normalized_log_weights(free_ligand_log_weights)
     complex_log_fractions = _normalized_log_weights(complex_log_weights)
+    log_protein_weight = _logsumexp(free_protein_log_weights)
     log_free_weight = _logsumexp(free_ligand_log_weights)
     log_complex_weight = _logsumexp(complex_log_weights)
-    log_apparent_kd = log_free_weight - log_complex_weight
+    log_apparent_kd = log_protein_weight + log_free_weight - log_complex_weight
 
     if l_total == 0.0:
-        return BindingEquilibrium(
-            protein_free=p_total,
-            ligand_free=0.0,
-            bound_total=0.0,
-            free_ligands=tuple(0.0 for _ in free_fractions),
-            complexes=tuple(0.0 for _ in complex_fractions),
-            populations=(1.0, *(0.0 for _ in complex_fractions)),
-            log_populations=(0.0, *(-math.inf for _ in complex_fractions)),
-            free_ligand_log_fractions=free_log_fractions,
-            complex_log_fractions=complex_log_fractions,
-            edge_log_ratios=edge_log_ratios,
-            log_apparent_kd=log_apparent_kd,
-        )
-
-    (
-        protein_free,
-        ligand_free,
-        bound_total,
-        log_protein_free,
-        log_ligand_free,
-        log_bound,
-    ) = _finite_pool_totals(p_total, l_total, log_apparent_kd)
+        protein_free = p_total
+        ligand_free = bound_total = 0.0
+        log_protein_free = math.log(p_total)
+        log_ligand_free = log_bound = -math.inf
+    else:
+        (
+            protein_free,
+            ligand_free,
+            bound_total,
+            log_protein_free,
+            log_ligand_free,
+            log_bound,
+        ) = _finite_pool_totals(p_total, l_total, log_apparent_kd)
+    free_proteins = _distribute(protein_free, protein_fractions)
     free_ligands = _distribute(ligand_free, free_fractions)
     complexes = _distribute(bound_total, complex_fractions)
     log_p_total = math.log(p_total)
     raw_log_populations = (
-        log_protein_free - log_p_total,
+        *(
+            -math.inf
+            if log_weight == -math.inf
+            else log_protein_free + log_weight - log_protein_weight - log_p_total
+            for log_weight in free_protein_log_weights
+        ),
         *(
             -math.inf
             if log_weight == -math.inf
@@ -567,10 +607,12 @@ def solve_binding_equilibrium(
         protein_free=protein_free,
         ligand_free=ligand_free,
         bound_total=bound_total,
+        free_proteins=free_proteins,
         free_ligands=free_ligands,
         complexes=complexes,
         populations=populations,
         log_populations=log_populations,
+        free_protein_log_fractions=protein_log_fractions,
         free_ligand_log_fractions=free_log_fractions,
         complex_log_fractions=complex_log_fractions,
         edge_log_ratios=edge_log_ratios,
@@ -578,14 +620,16 @@ def solve_binding_equilibrium(
     )
     _validate_equilibrium(
         equilibrium,
-        p_total,
-        l_total,
-        log_protein_free,
-        log_ligand_free,
-        log_bound,
-        free_ligand_log_weights,
-        complex_log_weights,
-        free_fractions,
-        complex_fractions,
+        protein_total=p_total,
+        ligand_total=l_total,
+        log_protein_free=log_protein_free,
+        log_ligand_free=log_ligand_free,
+        log_bound=log_bound,
+        free_protein_log_weights=free_protein_log_weights,
+        free_ligand_log_weights=free_ligand_log_weights,
+        complex_log_weights=complex_log_weights,
+        free_protein_fractions=protein_fractions,
+        free_ligand_fractions=free_fractions,
+        complex_fractions=complex_fractions,
     )
     return equilibrium

--- a/src/chemex/models/kinetic/_binding_migration.py
+++ b/src/chemex/models/kinetic/_binding_migration.py
@@ -1,0 +1,294 @@
+"""Migration diagnostics for the two directional-rate Category-C models."""
+
+from __future__ import annotations
+
+import math
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import TYPE_CHECKING, Literal
+
+from chemex.exceptions import ChemExError
+from chemex.parameters.name import ParamName
+
+if TYPE_CHECKING:
+    from chemex.configuration.parameters import DefaultType
+
+
+@dataclass(frozen=True, slots=True)
+class BindingRateMigration:
+    """One model's complete breaking directional-rate migration policy."""
+
+    model_name: str
+    forward_name: str
+    reverse_name: str
+    equilibrium_name: str
+    exchange_name: str
+    equilibrium_lower_bound: float
+    equilibrium_upper_bound: float = 1.0e6
+    exchange_lower_bound: float = 0.0
+    exchange_upper_bound: float = 1.0e6
+
+    @property
+    def equilibrium_allows_zero(self) -> bool:
+        return self.equilibrium_lower_bound == 0.0
+
+    @property
+    def legacy_names(self) -> frozenset[str]:
+        return frozenset((self.forward_name, self.reverse_name))
+
+    @property
+    def replacement_names(self) -> frozenset[str]:
+        return frozenset((self.equilibrium_name, self.exchange_name))
+
+
+_MIN_POSITIVE_FLOAT = math.ulp(0.0)
+_LOG_MIN_POSITIVE_FLOAT = math.log(_MIN_POSITIVE_FLOAT)
+_LOG_MAX_FLOAT = math.log(sys.float_info.max)
+
+# The declaration is deliberately close to the top: a maintainer can read each
+# old pair, replacement pair, and zero policy without following parser code.
+_MIGRATIONS = {
+    "3st_binding_cs": BindingRateMigration(
+        model_name="3st_binding_cs",
+        forward_name="KAB",
+        reverse_name="KBA",
+        equilibrium_name="KEQ_AB",
+        exchange_name="KEX_AB",
+        equilibrium_lower_bound=_MIN_POSITIVE_FLOAT,
+    ),
+    "3st_binding_if": BindingRateMigration(
+        model_name="3st_binding_if",
+        forward_name="KBC",
+        reverse_name="KCB",
+        equilibrium_name="KEQ_BC",
+        exchange_name="KEX_BC",
+        equilibrium_lower_bound=0.0,
+    ),
+}
+
+
+class LegacyBindingParameterError(ChemExError, ValueError):
+    """A Category-C input uses directional rates that are now derived outputs."""
+
+    def __init__(self, model_name: str, explanation: str) -> None:
+        super().__init__(explanation)
+        self.model_name = model_name
+        self.explanation = explanation
+
+
+type _UnrepresentableKind = Literal["below_minimum", "above_maximum"]
+
+
+@dataclass(frozen=True, slots=True)
+class _ConvertedLegacyValue:
+    value: float | None
+    unrepresentable: _UnrepresentableKind | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _LegacyRatePairConversion:
+    equilibrium: _ConvertedLegacyValue
+    exchange: _ConvertedLegacyValue
+
+
+def binding_rate_migration(model_name: str) -> BindingRateMigration | None:
+    return _MIGRATIONS.get(model_name)
+
+
+def _convert_legacy_rate_pair(
+    forward: float,
+    reverse: float,
+) -> _LegacyRatePairConversion:
+    """Classify exact positive legacy relationships before formatting advice."""
+    log_ratio = math.log(forward) - math.log(reverse)
+    if log_ratio < _LOG_MIN_POSITIVE_FLOAT:
+        equilibrium = _ConvertedLegacyValue(None, "below_minimum")
+    elif log_ratio > _LOG_MAX_FLOAT:
+        equilibrium = _ConvertedLegacyValue(None, "above_maximum")
+    else:
+        ratio = forward / reverse
+        if ratio == 0.0:
+            equilibrium = _ConvertedLegacyValue(None, "below_minimum")
+        elif not math.isfinite(ratio):
+            equilibrium = _ConvertedLegacyValue(None, "above_maximum")
+        else:
+            equilibrium = _ConvertedLegacyValue(ratio)
+
+    exact_sum = Fraction.from_float(forward) + Fraction.from_float(reverse)
+    exchange = (
+        _ConvertedLegacyValue(None, "above_maximum")
+        if exact_sum > Fraction.from_float(sys.float_info.max)
+        else _ConvertedLegacyValue(float(exact_sum))
+    )
+    return _LegacyRatePairConversion(equilibrium=equilibrium, exchange=exchange)
+
+
+def _scope_label(scope: ParamName | None) -> str:
+    return "[GLOBAL]" if scope is None or not scope else str(scope)
+
+
+def _bound_override_guidance(
+    migration: BindingRateMigration,
+    conversion: _LegacyRatePairConversion,
+) -> str:
+    guidance: list[str] = []
+    replacements = (
+        (
+            migration.equilibrium_name,
+            conversion.equilibrium.value,
+            migration.equilibrium_lower_bound,
+            migration.equilibrium_upper_bound,
+        ),
+        (
+            migration.exchange_name,
+            conversion.exchange.value,
+            migration.exchange_lower_bound,
+            migration.exchange_upper_bound,
+        ),
+    )
+    for name, value, lower, upper in replacements:
+        if value is not None and not lower <= value <= upper:
+            guidance.append(
+                f"{name} = {value!r} lies outside the new default bound "
+                f"[{lower!r}, {upper!r}]. Override it explicitly in the parameter "
+                f"file with {name} = [{value!r}, {lower!r}, {value!r}]."
+            )
+    return " ".join(guidance)
+
+
+def _conversion_guidance(
+    migration: BindingRateMigration,
+    conversion: _LegacyRatePairConversion,
+) -> str:
+    equilibrium = conversion.equilibrium
+    if equilibrium.value is not None:
+        equilibrium_text = f"{migration.equilibrium_name} = {equilibrium.value!r}"
+    elif equilibrium.unrepresentable == "below_minimum":
+        equilibrium_text = (
+            f"the equivalent {migration.equilibrium_name} is below minimum positive "
+            "binary64 representability and requires manual model/parameter "
+            "reconsideration"
+        )
+    else:
+        equilibrium_text = (
+            f"the equivalent {migration.equilibrium_name} exceeds maximum finite "
+            "binary64 representability and requires manual model/parameter "
+            "reconsideration"
+        )
+
+    exchange = conversion.exchange
+    exchange_text = (
+        f"{migration.exchange_name} = {exchange.value!r}"
+        if exchange.value is not None
+        else (
+            f"the equivalent {migration.exchange_name} exceeds maximum finite "
+            "binary64 representability and requires manual model/parameter "
+            "reconsideration"
+        )
+    )
+    bounds = _bound_override_guidance(migration, conversion)
+    suffix = f" {bounds}" if bounds else ""
+    return f"Use replacement values {equilibrium_text}; {exchange_text}.{suffix}"
+
+
+def legacy_binding_migration_message(
+    migration: BindingRateMigration,
+    supplied_names: set[str],
+    values: Mapping[str, float] | None = None,
+    *,
+    scope: ParamName | None = None,
+) -> str:
+    old = migration.legacy_names & supplied_names
+    new = migration.replacement_names & supplied_names
+    prefix = (
+        f"Scope {_scope_label(scope)}: model '{migration.model_name}' no longer "
+        f"accepts {migration.forward_name}/{migration.reverse_name} as independent "
+        "inputs; the directional rates are derived outputs. "
+    )
+    formulas = (
+        f"{migration.equilibrium_name} = {migration.forward_name} / "
+        f"{migration.reverse_name}; {migration.exchange_name} = "
+        f"{migration.forward_name} + {migration.reverse_name}."
+    )
+    if new:
+        return (
+            prefix + "The old and new parameterizations cannot be combined. " + formulas
+        )
+    if len(old) == 1:
+        missing = next(iter(migration.legacy_names - old))
+        return (
+            prefix
+            + f"The legacy pair is incomplete: {missing} is also needed to reconstruct "
+            f"{migration.equilibrium_name}/{migration.exchange_name}. " + formulas
+        )
+    if values is None:
+        return prefix + "Replace the legacy pair using: " + formulas
+
+    forward = values[migration.forward_name]
+    reverse = values[migration.reverse_name]
+    if not math.isfinite(forward) or not math.isfinite(reverse):
+        return prefix + "Legacy directional rates must be finite. " + formulas
+    if forward < 0.0 or reverse < 0.0:
+        return prefix + "Legacy directional rates must be non-negative. " + formulas
+    if forward == 0.0 and reverse == 0.0:
+        return (
+            prefix
+            + f"{migration.exchange_name} = 0; {migration.equilibrium_name} cannot be "
+            "inferred from (0,0), so choose the equilibrium ratio explicitly."
+        )
+    if reverse == 0.0:
+        return (
+            prefix
+            + f"A finite {migration.equilibrium_name} cannot be reconstructed when "
+            f"{migration.forward_name} > 0 and {migration.reverse_name} = 0."
+        )
+    if forward == 0.0:
+        if not migration.equilibrium_allows_zero:
+            return (
+                prefix + f"The legacy pair gives {migration.equilibrium_name} = 0, but "
+                f"{migration.model_name} requires finite positive "
+                f"{migration.equilibrium_name}; choose it explicitly."
+            )
+        conversion = _LegacyRatePairConversion(
+            equilibrium=_ConvertedLegacyValue(0.0),
+            exchange=_ConvertedLegacyValue(reverse),
+        )
+    else:
+        conversion = _convert_legacy_rate_pair(forward, reverse)
+    return prefix + _conversion_guidance(migration, conversion)
+
+
+def validate_legacy_binding_defaults(
+    model_name: str,
+    defaults: Sequence[DefaultType],
+) -> None:
+    migration = binding_rate_migration(model_name)
+    if migration is None:
+        return
+
+    grouped: dict[str, tuple[ParamName, dict[str, float]]] = {}
+    for name, setting in defaults:
+        if name.name not in migration.legacy_names | migration.replacement_names:
+            continue
+        scope = ParamName("", name.spin_system, name.conditions)
+        _existing_scope, supplied = grouped.setdefault(scope.id_, (scope, {}))
+        supplied[name.name] = setting.value
+
+    messages: list[str] = []
+    for scope, supplied in grouped.values():
+        supplied_names = set(supplied)
+        if not migration.legacy_names & supplied_names:
+            continue
+        values = supplied if migration.legacy_names <= supplied_names else None
+        messages.append(
+            legacy_binding_migration_message(
+                migration,
+                supplied_names,
+                values,
+                scope=scope,
+            )
+        )
+    if messages:
+        raise LegacyBindingParameterError(model_name, "\n".join(messages))

--- a/src/chemex/models/kinetic/settings_3st_binding_cs.py
+++ b/src/chemex/models/kinetic/settings_3st_binding_cs.py
@@ -1,38 +1,56 @@
+"""Three-state conformational-selection binding equilibrium and kinetics."""
+
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 
-import numpy as np
-from scipy.optimize import root
-
 from chemex.configuration.conditions import Conditions
-from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._binding import (
+    MIN_POSITIVE_FLOAT,
+    BindingEquilibrium,
+    detailed_balance_rate,
+    log_binding_weight,
+    report_only_positive_log_value,
+    solve_binding_equilibrium,
+    split_exchange_rate,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
-from chemex.typing import Array
+from chemex.parameters.userfunctions import (
+    NumericalFunctionLinearization,
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 
 NAME = "3st_binding_cs"
-
 TPL = ("temperature", "p_total", "l_total")
 
 
-def calculate_residuals(
-    concentrations: Array,
+def _log_keq_ab(keq_ab: float) -> float:
+    if not math.isfinite(keq_ab) or keq_ab <= 0.0:
+        msg = "3st_binding_cs KEQ_AB must be finite and strictly positive"
+        raise ValueError(msg)
+    return math.log(keq_ab)
+
+
+@lru_cache(maxsize=100)
+def _calculate_equilibrium(
     p_total: float,
     l_total: float,
-    kab: float,
-    kba: float,
-    kd_bc: float,
-) -> Array:
-    p1, p2, pl, l_ = concentrations
-    return np.array(
-        [
-            p_total - p1 - p2 - pl,
-            l_total - l_ - pl,
-            kab * p1 - kba * p2,
-            kd_bc * pl - p2 * l_,
-        ],
+    kd_app: float,
+    keq_ab: float,
+) -> BindingEquilibrium:
+    log_keq_ab = _log_keq_ab(keq_ab)
+    log_apo_weight = math.log1p(keq_ab)
+    return solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_protein_log_weights=(0.0, log_keq_ab),
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(log_binding_weight(kd_app) + log_apo_weight,),
+        edge_log_ratios=(log_keq_ab,),
     )
 
 
@@ -40,20 +58,94 @@ def calculate_residuals(
 def calculate_concentrations(
     p_total: float,
     l_total: float,
-    kab: float,
-    kba: float,
-    kd_bc: float,
+    kd_app: float,
+    keq_ab: float,
 ) -> dict[str, float]:
-    p1 = p2 = 0.5 * (p_total - 0.5 * l_total)
-    pl = l_ = 0.5 * l_total
-    concentrations_start = (p1, p2, pl, l_)
-    results = root(
-        calculate_residuals,
-        concentrations_start,
-        args=(p_total, l_total, kab, kba, kd_bc),
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd_app, keq_ab)
+    a, b = equilibrium.free_proteins
+    return {
+        "a": a,
+        "b": b,
+        "c": equilibrium.complexes[0],
+        "l": equilibrium.ligand_free,
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+    keq_ab: float,
+) -> dict[str, float]:
+    pa, pb, pc = _calculate_equilibrium(p_total, l_total, kd_app, keq_ab).populations
+    return {"pa": pa, "pb": pb, "pc": pc}
+
+
+@lru_cache(maxsize=100)
+def calculate_conformational_rates(
+    kex_ab: float,
+    keq_ab: float,
+) -> dict[str, float]:
+    kab, kba = split_exchange_rate(kex_ab, 0.0, _log_keq_ab(keq_ab))
+    return {"kab": kab, "kba": kba}
+
+
+@lru_cache(maxsize=100)
+def calculate_binding_rates(
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+    keq_ab: float,
+    koff_bc: float,
+) -> dict[str, float]:
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd_app, keq_ab)
+    return {
+        "kbc": detailed_balance_rate(
+            koff_bc,
+            equilibrium.log_populations[1],
+            equilibrium.log_populations[2],
+        ),
+        "kcb": koff_bc,
+    }
+
+
+def calculate_rates(
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+    keq_ab: float,
+    kex_ab: float,
+    koff_bc: float,
+) -> dict[str, float]:
+    return calculate_conformational_rates(kex_ab, keq_ab) | calculate_binding_rates(
+        p_total, l_total, kd_app, keq_ab, koff_bc
     )
-    p1, p2, pl, l_ = results["x"]
-    return {"p1": p1, "p2": p2, "pl": pl, "l": l_}
+
+
+def calculate_intrinsic_kd(kd_app: float, keq_ab: float) -> float:
+    """Return KD_BC without silently flooring a positive unrepresentable value."""
+    log_value = math.log(kd_app) + _log_keq_ab(keq_ab) - math.log1p(keq_ab)
+    return report_only_positive_log_value(log_value)
+
+
+def calculate_kon(koff_bc: float, kd_app: float, keq_ab: float) -> float:
+    if koff_bc == 0.0:
+        return 0.0
+    log_kd_bc = math.log(kd_app) + _log_keq_ab(keq_ab) - math.log1p(keq_ab)
+    return report_only_positive_log_value(math.log(koff_bc) - log_kd_bc)
+
+
+def calculate_intrinsic_values(kd_app: float, keq_ab: float) -> dict[str, float]:
+    return {"kd": calculate_intrinsic_kd(kd_app, keq_ab)}
+
+
+def calculate_kon_values(
+    koff_bc: float,
+    kd_app: float,
+    keq_ab: float,
+) -> dict[str, float]:
+    return {"kon": calculate_kon(koff_bc, kd_app, keq_ab)}
 
 
 def make_settings_3st_binding_cs(
@@ -67,22 +159,17 @@ def make_settings_3st_binding_cs(
     if l_total is None:
         msg = f"'l_total' must be specified to use the '{NAME}' model"
         raise ValueError(msg)
-    concentrations_string = (
-        f"concentrations({p_total}, {l_total}, {{kab}}, {{kba}}, {{kd_bc}})"
+    equilibrium = f"equilibrium({p_total},{l_total},{{kd_app}},{{keq_ab}})"
+    conformational_rates = "conformational_rates({kex_ab},{keq_ab})"
+    binding_rates = (
+        f"binding_rates({p_total},{l_total},{{kd_app}},{{keq_ab}},{{koff_bc}})"
     )
     return {
-        "kab": ParamLocalSetting(
-            name_setting=NameSetting("kab", "", ("temperature",)),
-            value=100.0,
-            min=0.0,
-            max=1.0e6,
-            vary=True,
-        ),
-        "kba": ParamLocalSetting(
-            name_setting=NameSetting("kba", "", ("temperature",)),
-            value=100.0,
-            min=0.0,
-            max=1.0e6,
+        "kd_app": ParamLocalSetting(
+            name_setting=NameSetting("kd_app", "", ("temperature",)),
+            value=1.0e-6,
+            min=MIN_POSITIVE_FLOAT,
+            max=1.0,
             vary=True,
         ),
         "koff_bc": ParamLocalSetting(
@@ -92,52 +179,127 @@ def make_settings_3st_binding_cs(
             max=1.0e6,
             vary=True,
         ),
-        "kd_app": ParamLocalSetting(
-            name_setting=NameSetting("kd_app", "", ("temperature",)),
-            value=1e-6,
-            min=0.0,
-            max=1.0,
+        "keq_ab": ParamLocalSetting(
+            name_setting=NameSetting("keq_ab", "", ("temperature",)),
+            value=1.0,
+            min=MIN_POSITIVE_FLOAT,
+            max=1.0e6,
             vary=True,
+        ),
+        "kex_ab": ParamLocalSetting(
+            name_setting=NameSetting("kex_ab", "", ("temperature",)),
+            value=200.0,
+            min=0.0,
+            max=1.0e6,
+            vary=True,
+        ),
+        "kab": ParamLocalSetting(
+            name_setting=NameSetting("kab", "", ("temperature",)),
+            expr=f"{conformational_rates}['kab']",
+        ),
+        "kba": ParamLocalSetting(
+            name_setting=NameSetting("kba", "", ("temperature",)),
+            expr=f"{conformational_rates}['kba']",
         ),
         "kd_bc": ParamLocalSetting(
             name_setting=NameSetting("kd_bc", "", ("temperature",)),
-            expr="{kd_app} * {kab} / max({kab} + {kba}, 1e-16)",
+            expr="intrinsic_values({kd_app},{keq_ab})['kd']",
+            report_only=True,
         ),
         "kon_bc": ParamLocalSetting(
             name_setting=NameSetting("kon_bc", "", ("temperature",)),
-            expr="{koff_bc} / max({kd_bc}, 1e-16)",
+            expr="kon_values({koff_bc},{kd_app},{keq_ab})['kon']",
+            report_only=True,
         ),
         "c_l": ParamLocalSetting(
             name_setting=NameSetting("c_l", "", TPL),
-            expr=f"{concentrations_string}['l']",
+            expr=f"{equilibrium}['l']",
         ),
         "kbc": ParamLocalSetting(
             name_setting=NameSetting("kbc", "", TPL),
-            expr="{kon_bc} * {c_l}",
+            expr=f"{binding_rates}['kbc']",
         ),
         "kcb": ParamLocalSetting(
             name_setting=NameSetting("kcb", "", TPL),
-            expr="{koff_bc}",
+            expr=f"{binding_rates}['kcb']",
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TPL),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pa']",
+            expr=f"populations({p_total},{l_total},{{kd_app}},{{keq_ab}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TPL),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pb']",
+            expr=f"populations({p_total},{l_total},{{kd_app}},{{keq_ab}})['pb']",
         ),
         "pc": ParamLocalSetting(
             name_setting=NameSetting("pc", "", TPL),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pc']",
+            expr=f"populations({p_total},{l_total},{{kd_app}},{{keq_ab}})['pc']",
         ),
     }
 
 
 def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_3st_binding_cs)
-    user_functions = {
-        "concentrations": calculate_concentrations,
-        "pop_3st": pop_3st,
-    }
-    user_function_registry.register(name=NAME, user_functions=user_functions)
+    user_function_registry.register(
+        name=NAME,
+        user_functions={
+            "equilibrium": calculate_concentrations,
+            "populations": calculate_populations,
+            "conformational_rates": calculate_conformational_rates,
+            "binding_rates": calculate_binding_rates,
+            "intrinsic_values": calculate_intrinsic_values,
+            "kon_values": calculate_kon_values,
+        },
+    )
+    function_linearization_registry.register(
+        NAME,
+        (
+            *population_linearizations(
+                (1.0e-3, 1.0e-3, 1.0e-3, 1.0),
+                ("nonnegative", "nonnegative", "positive", "positive"),
+                "pa",
+                "pb",
+                "pc",
+            ),
+            NumericalFunctionLinearization(
+                "conformational_rates",
+                "kab",
+                (200.0, 1.0),
+                ("nonnegative", "positive"),
+                output_scale=MIN_POSITIVE_FLOAT,
+            ),
+            NumericalFunctionLinearization(
+                "conformational_rates",
+                "kba",
+                (200.0, 1.0),
+                ("nonnegative", "positive"),
+                output_scale=MIN_POSITIVE_FLOAT,
+            ),
+            NumericalFunctionLinearization(
+                "binding_rates",
+                "kbc",
+                (1.0e-3, 1.0e-3, 1.0e-3, 1.0, 100.0),
+                ("nonnegative", "nonnegative", "positive", "positive", "nonnegative"),
+                output_scale=MIN_POSITIVE_FLOAT,
+            ),
+            NumericalFunctionLinearization(
+                "binding_rates",
+                "kcb",
+                (1.0e-3, 1.0e-3, 1.0e-3, 1.0, 100.0),
+                ("nonnegative", "nonnegative", "positive", "positive", "nonnegative"),
+                output_scale=MIN_POSITIVE_FLOAT,
+            ),
+            NumericalFunctionLinearization(
+                "intrinsic_values",
+                "kd",
+                (1.0e-3, 1.0),
+                ("positive", "positive"),
+            ),
+            NumericalFunctionLinearization(
+                "kon_values",
+                "kon",
+                (100.0, 1.0e-3, 1.0),
+                ("nonnegative", "positive", "positive"),
+            ),
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_3st_binding_if.py
+++ b/src/chemex/models/kinetic/settings_3st_binding_if.py
@@ -1,38 +1,53 @@
+"""Three-state induced-fit binding equilibrium and kinetics."""
+
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 
-import numpy as np
-from scipy.optimize import root
-
 from chemex.configuration.conditions import Conditions
-from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._binding import (
+    MIN_POSITIVE_FLOAT,
+    BindingEquilibrium,
+    detailed_balance_rate,
+    log_binding_weight,
+    log_equilibrium_ratio,
+    report_only_positive_log_value,
+    solve_binding_equilibrium,
+    split_exchange_rate,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
-from chemex.typing import Array
+from chemex.parameters.userfunctions import (
+    NumericalFunctionLinearization,
+    function_linearization_registry,
+    population_linearizations,
+    user_function_registry,
+)
 
 NAME = "3st_binding_if"
-
 TPL = ("temperature", "p_total", "l_total")
 
 
-def calculate_residuals(
-    populations: Array,
+@lru_cache(maxsize=100)
+def _calculate_equilibrium(
     p_total: float,
     l_total: float,
-    kd_ab: float,
-    kbc: float,
-    kcb: float,
-) -> Array:
-    p_, pl1, pl2, l_ = populations
-    return np.array(
-        [
-            p_ + pl1 + pl2 - p_total,
-            l_ + pl1 + pl2 - l_total,
-            l_ * p_ - kd_ab * pl1,
-            kbc * pl1 - kcb * pl2,
-        ],
+    kd_app: float,
+    keq_bc: float,
+) -> BindingEquilibrium:
+    log_keq_bc = log_equilibrium_ratio(keq_bc)
+    log_bound_partition = math.log1p(keq_bc)
+    log_first_complex = log_binding_weight(kd_app) - log_bound_partition
+    return solve_binding_equilibrium(
+        p_total,
+        l_total,
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(
+            log_first_complex,
+            -math.inf if log_keq_bc == -math.inf else log_first_complex + log_keq_bc,
+        ),
+        edge_log_ratios=(log_keq_bc,),
     )
 
 
@@ -40,20 +55,91 @@ def calculate_residuals(
 def calculate_concentrations(
     p_total: float,
     l_total: float,
-    kd_ab: float,
-    kbc: float,
-    kcb: float,
+    kd_app: float,
+    keq_bc: float,
 ) -> dict[str, float]:
-    p_ = p_total - 0.5 * l_total
-    pl1 = pl2 = 0.5 * (p_total - p_)
-    l_ = 0.5 * l_total
-    concentrations_start = (p_, pl1, pl2, l_)
-    results = root(
-        calculate_residuals,
-        concentrations_start,
-        args=(p_total, l_total, kd_ab, kbc, kcb),
-    )
-    return dict(zip(("p", "pl1", "pl2", "l"), results["x"], strict=True))
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd_app, keq_bc)
+    return {
+        "a": equilibrium.free_proteins[0],
+        "b": equilibrium.complexes[0],
+        "c": equilibrium.complexes[1],
+        "l": equilibrium.ligand_free,
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations(
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+    keq_bc: float,
+) -> dict[str, float]:
+    pa, pb, pc = _calculate_equilibrium(p_total, l_total, kd_app, keq_bc).populations
+    return {"pa": pa, "pb": pb, "pc": pc}
+
+
+@lru_cache(maxsize=100)
+def calculate_conformational_rates(
+    kex_bc: float,
+    keq_bc: float,
+) -> dict[str, float]:
+    kbc, kcb = split_exchange_rate(kex_bc, 0.0, log_equilibrium_ratio(keq_bc))
+    return {"kbc": kbc, "kcb": kcb}
+
+
+@lru_cache(maxsize=100)
+def calculate_binding_rates(
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+    keq_bc: float,
+    koff_ab: float,
+) -> dict[str, float]:
+    equilibrium = _calculate_equilibrium(p_total, l_total, kd_app, keq_bc)
+    return {
+        "kab": detailed_balance_rate(
+            koff_ab,
+            equilibrium.log_populations[0],
+            equilibrium.log_populations[1],
+        ),
+        "kba": koff_ab,
+    }
+
+
+def calculate_rates(
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+    keq_bc: float,
+    kex_bc: float,
+    koff_ab: float,
+) -> dict[str, float]:
+    return calculate_binding_rates(
+        p_total, l_total, kd_app, keq_bc, koff_ab
+    ) | calculate_conformational_rates(kex_bc, keq_bc)
+
+
+def calculate_intrinsic_kd(kd_app: float, keq_bc: float) -> float:
+    return report_only_positive_log_value(math.log(kd_app) + math.log1p(keq_bc))
+
+
+def calculate_kon(koff_ab: float, kd_app: float, keq_bc: float) -> float:
+    if koff_ab == 0.0:
+        return 0.0
+    log_kd_ab = math.log(kd_app) + math.log1p(keq_bc)
+    return report_only_positive_log_value(math.log(koff_ab) - log_kd_ab)
+
+
+def calculate_intrinsic_values(kd_app: float, keq_bc: float) -> dict[str, float]:
+    return {"kd": calculate_intrinsic_kd(kd_app, keq_bc)}
+
+
+def calculate_kon_values(
+    koff_ab: float,
+    kd_app: float,
+    keq_bc: float,
+) -> dict[str, float]:
+    return {"kon": calculate_kon(koff_ab, kd_app, keq_bc)}
 
 
 def make_settings_3st_induced_fit(
@@ -67,11 +153,16 @@ def make_settings_3st_induced_fit(
     if l_total is None:
         msg = f"'l_total' must be specified to use the '{NAME}' model"
         raise ValueError(msg)
+    equilibrium = f"equilibrium({p_total},{l_total},{{kd_app}},{{keq_bc}})"
+    binding_rates = (
+        f"binding_rates({p_total},{l_total},{{kd_app}},{{keq_bc}},{{koff_ab}})"
+    )
+    conformational_rates = "conformational_rates({kex_bc},{keq_bc})"
     return {
         "kd_app": ParamLocalSetting(
             name_setting=NameSetting("kd_app", "", ("temperature",)),
-            value=1e-3,
-            min=0.0,
+            value=1.0e-3,
+            min=MIN_POSITIVE_FLOAT,
             max=1.0,
             vary=True,
         ),
@@ -82,59 +173,139 @@ def make_settings_3st_induced_fit(
             max=1.0e6,
             vary=True,
         ),
-        "kbc": ParamLocalSetting(
-            name_setting=NameSetting("kbc", "", ("temperature",)),
-            value=100.0,
+        "keq_bc": ParamLocalSetting(
+            name_setting=NameSetting("keq_bc", "", ("temperature",)),
+            value=1.0,
             min=0.0,
             max=1.0e6,
             vary=True,
+        ),
+        "kex_bc": ParamLocalSetting(
+            name_setting=NameSetting("kex_bc", "", ("temperature",)),
+            value=200.0,
+            min=0.0,
+            max=1.0e6,
+            vary=True,
+        ),
+        "kbc": ParamLocalSetting(
+            name_setting=NameSetting("kbc", "", ("temperature",)),
+            expr=f"{conformational_rates}['kbc']",
         ),
         "kcb": ParamLocalSetting(
             name_setting=NameSetting("kcb", "", ("temperature",)),
-            value=100.0,
-            min=0.0,
-            max=1.0e6,
-            vary=True,
+            expr=f"{conformational_rates}['kcb']",
         ),
         "kd_ab": ParamLocalSetting(
             name_setting=NameSetting("kd_ab", "", ("temperature",)),
-            expr="{kd_app} * (1 + {kbc} / {kcb})",
+            expr="intrinsic_values({kd_app},{keq_bc})['kd']",
+            report_only=True,
         ),
         "kon_ab": ParamLocalSetting(
             name_setting=NameSetting("kon_ab", "", ("temperature",)),
-            expr="{koff_ab} / max({kd_ab}, 1e-100)",
+            expr="kon_values({koff_ab},{kd_app},{keq_bc})['kon']",
+            report_only=True,
         ),
         "c_l": ParamLocalSetting(
             name_setting=NameSetting("c_l", "", TPL),
-            expr=(f"calc_conc({p_total},{l_total},{{kd_ab}},{{kbc}},{{kcb}})['l']"),
+            expr=f"{equilibrium}['l']",
         ),
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TPL),
-            expr="{kon_ab} * {c_l}",
+            expr=f"{binding_rates}['kab']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TPL),
-            expr="{koff_ab}",
+            expr=f"{binding_rates}['kba']",
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TPL),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pa']",
+            expr=f"populations({p_total},{l_total},{{kd_app}},{{keq_bc}})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TPL),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pb']",
+            expr=f"populations({p_total},{l_total},{{kd_app}},{{keq_bc}})['pb']",
         ),
         "pc": ParamLocalSetting(
             name_setting=NameSetting("pc", "", TPL),
-            expr="pop_3st({kab}, {kba}, 0.0, 0.0, {kbc}, {kcb})['pc']",
+            expr=f"populations({p_total},{l_total},{{kd_app}},{{keq_bc}})['pc']",
         ),
     }
 
 
 def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_3st_induced_fit)
-    user_functions = {
-        "calc_conc": calculate_concentrations,
-        "pop_3st": pop_3st,
-    }
-    user_function_registry.register(name=NAME, user_functions=user_functions)
+    user_function_registry.register(
+        name=NAME,
+        user_functions={
+            "equilibrium": calculate_concentrations,
+            "populations": calculate_populations,
+            "conformational_rates": calculate_conformational_rates,
+            "binding_rates": calculate_binding_rates,
+            "intrinsic_values": calculate_intrinsic_values,
+            "kon_values": calculate_kon_values,
+        },
+    )
+    function_linearization_registry.register(
+        NAME,
+        (
+            *population_linearizations(
+                (1.0e-3, 1.0e-3, 1.0e-3, 1.0),
+                ("nonnegative", "nonnegative", "positive", "nonnegative"),
+                "pa",
+                "pb",
+                "pc",
+            ),
+            NumericalFunctionLinearization(
+                "conformational_rates",
+                "kbc",
+                (200.0, 1.0),
+                ("nonnegative", "nonnegative"),
+                output_scale=MIN_POSITIVE_FLOAT,
+            ),
+            NumericalFunctionLinearization(
+                "conformational_rates",
+                "kcb",
+                (200.0, 1.0),
+                ("nonnegative", "nonnegative"),
+                output_scale=MIN_POSITIVE_FLOAT,
+            ),
+            NumericalFunctionLinearization(
+                "binding_rates",
+                "kab",
+                (1.0e-3, 1.0e-3, 1.0e-3, 1.0, 100.0),
+                (
+                    "nonnegative",
+                    "nonnegative",
+                    "positive",
+                    "nonnegative",
+                    "nonnegative",
+                ),
+                output_scale=MIN_POSITIVE_FLOAT,
+            ),
+            NumericalFunctionLinearization(
+                "binding_rates",
+                "kba",
+                (1.0e-3, 1.0e-3, 1.0e-3, 1.0, 100.0),
+                (
+                    "nonnegative",
+                    "nonnegative",
+                    "positive",
+                    "nonnegative",
+                    "nonnegative",
+                ),
+                output_scale=MIN_POSITIVE_FLOAT,
+            ),
+            NumericalFunctionLinearization(
+                "intrinsic_values",
+                "kd",
+                (1.0e-3, 1.0),
+                ("positive", "nonnegative"),
+            ),
+            NumericalFunctionLinearization(
+                "kon_values",
+                "kon",
+                (100.0, 1.0e-3, 1.0),
+                ("nonnegative", "positive", "nonnegative"),
+            ),
+        ),
+    )

--- a/src/chemex/optimize/deterministic_uncertainty.py
+++ b/src/chemex/optimize/deterministic_uncertainty.py
@@ -9,6 +9,7 @@ conclusions associated with one exact accepted deterministic fit.
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 
@@ -39,6 +40,7 @@ from chemex.optimize.uncertainty import (
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     ParameterRole,
+    ReportableParameterSet,
 )
 from chemex.parameters.userfunctions import function_linearization_registry
 
@@ -108,6 +110,7 @@ class AcceptedDeterministicFitFacts:
     engine: EvaluationEngine = field(repr=False, compare=False)
     basis: DeterministicUncertaintyBasis
     resolved_environment_identity: str
+    reportable_parameters: ReportableParameterSet | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -316,6 +319,8 @@ class _ResolvedUncertaintyInputs:
     constrained_scope: tuple[str, ...]
     compiled_capabilities: CompiledConstraintLinearizationCapabilities
     unsupported_constrained_ids: tuple[str, ...]
+    constraint_parameterization: ActiveParameterization
+    constraint_values: Mapping[str, float]
 
     @property
     def parameter_ids(self) -> tuple[str, ...]:
@@ -381,7 +386,15 @@ def _resolve_inputs(
     facts: AcceptedDeterministicFitFacts,
 ) -> _ResolvedUncertaintyInputs:
     problem = facts.problem
-    parameterization = facts.parameterization
+    reportable = facts.reportable_parameters
+    parameterization = (
+        facts.parameterization if reportable is None else reportable.parameterization
+    )
+    constraint_values: Mapping[str, float] = (
+        facts.accepted.evaluation_result.resolved_values
+        if reportable is None
+        else reportable.values
+    )
     policy = UncertaintyPolicy(
         calibration_identity="native-product-local-covariance-numerics-v2",
         numerical_compatibility_requirement=(
@@ -455,6 +468,8 @@ def _resolve_inputs(
         constrained_scope,
         compiled_capabilities,
         tuple(unsupported),
+        parameterization,
+        constraint_values,
     )
 
 
@@ -655,6 +670,8 @@ def derive_deterministic_uncertainty(
                 (param_id, 1.0) for param_id in inputs.constrained_scope
             ),
             compiled_constraint_linearization=inputs.compiled_capabilities,
+            constraint_parameterization=inputs.constraint_parameterization,
+            constraint_values=inputs.constraint_values,
             resolved_environment_identity=facts.resolved_environment_identity,
         )
     except KeyboardInterrupt:

--- a/src/chemex/optimize/native_deterministic.py
+++ b/src/chemex/optimize/native_deterministic.py
@@ -521,6 +521,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
         if continuity_snapshot is not None and run_info is not None:
             run_info.publish_restart(continuity_snapshot)
         _materialize_evaluation(experiments, result)
+        reportable_parameters = session.resolve_reportable_parameters(parameterization)
         try:
             execute_post_fit(
                 experiments,
@@ -532,7 +533,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
                 parameter_model=parameter_model,
                 parameter_values=result.resolved_values,
                 parameterization=parameterization,
-                report_only_values=session.resolve_report_only_values(),
+                report_only_values=reportable_parameters.report_only_values,
             )
         except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
             _propagate_output_failure(error, path)
@@ -631,6 +632,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
     if accepted is None:
         raise RuntimeError("Committed native fit lacks its accepted result")
     result = accepted.evaluation_result
+    reportable_parameters = session.resolve_reportable_parameters(parameterization)
     uncertainty_facts = AcceptedDeterministicFitFacts(
         accepted,
         problem,
@@ -642,6 +644,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
             else ContinuousTrfBasis(decomposition.partition_proof)
         ),
         resolved_environment_identity,
+        reportable_parameters,
     )
     try:
         deterministic_uncertainty = derive_deterministic_uncertainty(uncertainty_facts)
@@ -692,7 +695,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
                 parameter_values=result.resolved_values,
                 parameterization=parameterization,
                 fitted_ids=problem.controlled_ids,
-                report_only_values=session.resolve_report_only_values(),
+                report_only_values=reportable_parameters.report_only_values,
             )
         except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
             if uncertainty_interrupted:
@@ -717,7 +720,7 @@ def run_native_deterministic(  # noqa: C901 - closed Direct/GRID/DE product disp
             parameter_values=result.resolved_values,
             parameterization=parameterization,
             fitted_ids=problem.controlled_ids,
-            report_only_values=session.resolve_report_only_values(),
+            report_only_values=reportable_parameters.report_only_values,
         )
     except (Exception, KeyboardInterrupt) as error:  # noqa: BLE001
         if uncertainty_interrupted:

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -55,6 +55,7 @@ _INITIALIZATION_VERSION = "bounded-latin-hypercube-v1"
 _PRODUCT_INITIALIZATION_VERSION = "accepted-point-jitter-v1"
 _PROPOSAL_VERSION = "emcee-stretch-v1"
 _MAX_U64 = (1 << 64) - 1
+_MAX_INITIALIZATION_ATTEMPTS = 64
 _EMCEE_MONITOR_INTEGRATED_TIME = emcee.autocorr.integrated_time
 
 
@@ -178,6 +179,10 @@ class BackendTransitionEvidenceKind(StrEnum):
 
 class McmcExecutionError(RuntimeError):
     """Raised internally when native evaluation cannot produce log density."""
+
+
+class McmcInitializationError(McmcExecutionError):
+    """Raised when bounded retries cannot construct a finite-density ensemble."""
 
 
 class _McmcCancelled(RuntimeError):
@@ -570,12 +575,6 @@ def build_accepted_point_ensemble(
             "Accepted-point MCMC initialization requires a finite accepted vector "
             "inside finite strictly ordered bounds"
         )
-    interior_lower = np.nextafter(lower, upper)
-    interior_upper = np.nextafter(upper, lower)
-    if not np.all(interior_lower < interior_upper):
-        raise McmcConstructionError(
-            "Accepted-point MCMC initialization has no representable open interval"
-        )
     scale = np.maximum.reduce(
         (
             np.abs(center) * 1.0e-4,
@@ -585,10 +584,13 @@ def build_accepted_point_ensemble(
     )
     rng = np.random.Generator(np.random.PCG64(rng_seed))
     positions = center + rng.standard_normal((walker_count, center.size)) * scale
-    positions = np.clip(positions, interior_lower, interior_upper)
-    if not np.all((positions > lower) & (positions < upper)):
+    # Declared parameter bounds are inclusive. In particular, an exact lower-bound
+    # zero is valid for nonnegative parameters; replacing it with the minimum
+    # positive float can create a scientifically unevaluable coupled state.
+    positions = np.clip(positions, lower, upper)
+    if not np.all((positions >= lower) & (positions <= upper)):
         raise McmcConstructionError(
-            "Accepted-point MCMC initialization reached a closed bound"
+            "Accepted-point MCMC initialization exceeded its declared bounds"
         )
     return tuple(tuple(float(value) for value in row) for row in positions)
 
@@ -927,7 +929,7 @@ class McmcAcceptedAnchor:
 
 @dataclass(frozen=True, slots=True)
 class McmcPlan:
-    """One accepted-result MCMC request with all choices frozen pre-run."""
+    """One accepted-result MCMC request with first candidates frozen pre-run."""
 
     accepted: AcceptedFitResult = field(repr=False, compare=False)
     source_problem: OptimizationProblem = field(repr=False, compare=False)
@@ -1132,6 +1134,70 @@ class McmcPlan:
             policy,
             tuple(coordinate_units),
         )
+
+
+def _initialization_candidate(
+    plan: McmcPlan,
+    walker_index: int,
+    attempt: int,
+) -> tuple[float, ...]:
+    """Return one deterministic bounded candidate; attempt zero is the plan seed."""
+    if attempt == 0:
+        return plan.initial_ensemble[walker_index]
+    retry_seed = _derive_seed(
+        plan.policy.initialization_seed,
+        "mcmc-initialization-retry",
+        f"{walker_index}:{attempt}",
+    )
+    if plan.policy.initialization is InitializationKind.ACCEPTED_POINT_JITTER:
+        return build_accepted_point_ensemble(
+            plan.accepted.vector,
+            plan.lower_bounds,
+            plan.upper_bounds,
+            walkers=1,
+            seed=retry_seed,
+        )[0]
+    return build_bounded_latin_hypercube(
+        plan.lower_bounds,
+        plan.upper_bounds,
+        walkers=1,
+        seed=retry_seed,
+    )[0]
+
+
+def _initialization_attempts_for_positions(
+    plan: McmcPlan,
+    positions: tuple[tuple[float, ...], ...],
+) -> tuple[int, ...] | None:
+    """Recover each deterministic retry ordinal from an initialized ensemble."""
+    if len(positions) != plan.policy.walkers:
+        return None
+    attempts: list[int] = []
+    for walker_index, position in enumerate(positions):
+        for attempt in range(_MAX_INITIALIZATION_ATTEMPTS + 1):
+            if position == _initialization_candidate(plan, walker_index, attempt):
+                attempts.append(attempt)
+                break
+        else:
+            return None
+    return tuple(attempts)
+
+
+def _maximum_objective_request_count(plan: McmcPlan) -> int:
+    return (
+        plan.policy.objective_request_budget
+        + plan.policy.walkers * _MAX_INITIALIZATION_ATTEMPTS
+    )
+
+
+def _completed_objective_request_count(
+    plan: McmcPlan,
+    initial_positions: tuple[tuple[float, ...], ...],
+) -> int | None:
+    attempts = _initialization_attempts_for_positions(plan, initial_positions)
+    if attempts is None:
+        return None
+    return plan.policy.objective_request_budget + sum(attempts)
 
 
 def _finite_state_scalar(value: object, *, name: str) -> float:
@@ -1918,9 +1984,13 @@ class McmcEvidence:
             raise McmcConstructionError(
                 "MCMC evidence must preserve a contiguous prefix of complete states"
             )
-        if states[0].positions != self.plan.initial_ensemble:
+        expected_requests = _completed_objective_request_count(
+            self.plan,
+            states[0].positions,
+        )
+        if expected_requests is None:
             raise McmcConstructionError(
-                "MCMC evidence initial state differs from its frozen plan"
+                "MCMC evidence initial state is not a deterministic plan candidate"
             )
         for state in states:
             if len(state.positions) != self.plan.policy.walkers or any(
@@ -1948,9 +2018,14 @@ class McmcEvidence:
             )
         if (
             self.objective_request_count < len(states[0].positions)
-            or self.objective_request_count > self.plan.policy.objective_request_budget
+            or self.objective_request_count
+            > _maximum_objective_request_count(self.plan)
             or self.evaluation_request_count < 0
             or self.evaluation_request_count > self.objective_request_count
+            or (
+                self.lifecycle is McmcEvidenceLifecycle.COMPLETED
+                and self.objective_request_count != expected_requests
+            )
         ):
             raise McmcConstructionError("MCMC request accounting is inconsistent")
         if self.backend_transition_evidence is not None:
@@ -2296,13 +2371,8 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
             None,
         )
     if (
-        raw_capture.objective_request_count > plan.policy.objective_request_budget
+        raw_capture.objective_request_count > _maximum_objective_request_count(plan)
         or raw_capture.evaluation_request_count > raw_capture.objective_request_count
-        or (
-            raw_capture.terminal is McmcOperationTerminal.COMPLETED
-            and raw_capture.objective_request_count
-            != plan.policy.objective_request_budget
-        )
     ):
         return McmcChainValidation(
             raw_capture.identity,
@@ -2339,18 +2409,37 @@ def validate_raw_mcmc_capture(  # noqa: C901 - state/walker validation boundary
                 )
             )
             break
-        if state.ordinal == 0 and state.positions != plan.initial_ensemble:
-            failures.append(
-                McmcValidationFailure(
-                    0,
-                    0,
-                    "initial_ensemble_mismatch",
-                    "raw MCMC initial state differs from its frozen construction",
-                )
+        if state.ordinal == 0:
+            expected_requests = _completed_objective_request_count(
+                plan,
+                state.positions,
             )
-            break
+            if expected_requests is None:
+                failures.append(
+                    McmcValidationFailure(
+                        0,
+                        0,
+                        "initial_ensemble_mismatch",
+                        "raw MCMC initial state is not a deterministic plan candidate",
+                    )
+                )
+                break
+            if (
+                raw_capture.terminal is McmcOperationTerminal.COMPLETED
+                and raw_capture.objective_request_count != expected_requests
+            ):
+                failures.append(
+                    McmcValidationFailure(
+                        0,
+                        0,
+                        "request_accounting_mismatch",
+                        "raw MCMC request accounting differs from its initialized "
+                        "ensemble",
+                    )
+                )
+                break
         positions = np.asarray(state.positions, dtype=np.float64)
-        outside = np.any((positions <= lower) | (positions >= upper), axis=1)
+        outside = np.any((positions < lower) | (positions > upper), axis=1)
         if np.any(outside):
             walker = int(np.flatnonzero(outside)[0])
             failures.append(
@@ -3736,8 +3825,8 @@ class _LogDensityKernel:
         if (
             candidate.shape != (self._context.dimension,)
             or not np.all(np.isfinite(candidate))
-            or np.any(candidate <= np.asarray(self._context.lower_bounds))
-            or np.any(candidate >= np.asarray(self._context.upper_bounds))
+            or np.any(candidate < np.asarray(self._context.lower_bounds))
+            or np.any(candidate > np.asarray(self._context.upper_bounds))
         ):
             return _LogDensityResult(-np.inf, False)
         try:
@@ -3771,6 +3860,15 @@ class _LogDensityKernel:
             -0.5 * canonical_chi_square(outcome.residuals),
             True,
         )
+
+
+@dataclass(frozen=True, slots=True)
+class _InitializedEnsemble:
+    """Finite native densities and the exact deterministic candidates that own them."""
+
+    positions: tuple[tuple[float, ...], ...]
+    log_densities: tuple[float, ...]
+    attempts: tuple[int, ...]
 
 
 class _LogDensityAccounting:
@@ -3808,6 +3906,9 @@ class _SerialLogDensityEvaluator:
             raise
         self._accounting.record_evaluations(int(result.evaluated))
         return result.value
+
+    def evaluate_many(self, vectors: Iterable[Array]) -> list[float]:
+        return [self(vector) for vector in vectors]
 
 
 @dataclass(frozen=True, slots=True)
@@ -3925,6 +4026,43 @@ class _McmcProcessPool:
                 )
         return [receipt.result.value for receipt in receipts if receipt.result]
 
+    def evaluate_many(self, vectors: Iterable[Array]) -> list[float]:
+        return self.map(_process_log_density, vectors)
+
+
+def _initialize_finite_density_walkers(
+    plan: McmcPlan,
+    evaluator: _SerialLogDensityEvaluator | _McmcProcessPool,
+) -> _InitializedEnsemble:
+    """Accept only bounded, resolvable walkers with finite native log density."""
+    positions = list(plan.initial_ensemble)
+    log_densities = evaluator.evaluate_many(np.asarray(positions, dtype=np.float64))
+    attempts = [0] * plan.policy.walkers
+    for walker_index, value in enumerate(log_densities):
+        if math.isfinite(value):
+            continue
+        for attempt in range(1, _MAX_INITIALIZATION_ATTEMPTS + 1):
+            candidate = _initialization_candidate(plan, walker_index, attempt)
+            [candidate_density] = evaluator.evaluate_many((np.asarray(candidate),))
+            if math.isfinite(candidate_density):
+                positions[walker_index] = candidate
+                log_densities[walker_index] = candidate_density
+                attempts[walker_index] = attempt
+                break
+        else:
+            candidate_count = _MAX_INITIALIZATION_ATTEMPTS + 1
+            raise McmcInitializationError(
+                "MCMC initialization found no parameter-and-density-feasible "
+                f"initial point for walker {walker_index} after "
+                f"{_MAX_INITIALIZATION_ATTEMPTS} retries "
+                f"({candidate_count} candidates evaluated)"
+            )
+    return _InitializedEnsemble(
+        positions=tuple(positions),
+        log_densities=tuple(log_densities),
+        attempts=tuple(attempts),
+    )
+
 
 class _RecordingStretchMove(emcee.moves.StretchMove):
     """Capture the backend's exact per-transition acceptance mask."""
@@ -3970,7 +4108,7 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
     plan.validate_integrity(accepted)
     signal = CancellationToken() if cancellation is None else cancellation
     worker_context = _McmcWorkerContext.from_plan(plan)
-    accounting = _LogDensityAccounting(plan.policy.objective_request_budget)
+    accounting = _LogDensityAccounting(_maximum_objective_request_count(plan))
     backend_observation = _mint_backend_execution_observation(
         plan,
         backend_implementation_identity="emcee-stretch-backend-v1",
@@ -4013,24 +4151,27 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
                 if execution_settings.is_parallel
                 else None
             )
-            log_density = (
-                _SerialLogDensityEvaluator(worker_context, accounting)
-                if pool is None
-                else _process_log_density
-            )
-            checkpoint(McmcExecutionStage.BEFORE_INITIALIZATION)
-            initial = np.asarray(plan.initial_ensemble, dtype=np.float64)
-            checkpoint(McmcExecutionStage.INITIALIZING)
-            initial_values = (
-                [log_density(row) for row in initial]
-                if pool is None
-                else pool.map(_process_log_density, initial)
-            )
-            initial_log_density = np.asarray(initial_values, dtype=np.float64)
-            if not np.all(np.isfinite(initial_log_density)):
-                raise McmcExecutionError(
-                    "MCMC initial ensemble has unavailable native log density"
+            if pool is None:
+                serial_evaluator = _SerialLogDensityEvaluator(
+                    worker_context,
+                    accounting,
                 )
+                density_evaluator = serial_evaluator
+                log_density = serial_evaluator
+            else:
+                density_evaluator = pool
+                log_density = _process_log_density
+            checkpoint(McmcExecutionStage.BEFORE_INITIALIZATION)
+            checkpoint(McmcExecutionStage.INITIALIZING)
+            initialized = _initialize_finite_density_walkers(
+                plan,
+                density_evaluator,
+            )
+            initial = np.asarray(initialized.positions, dtype=np.float64)
+            initial_log_density = np.asarray(
+                initialized.log_densities,
+                dtype=np.float64,
+            )
             initialization_outcome = McmcInitializationOutcome.COMPLETED
             states.append(_ensemble_state(0, initial, initial_log_density))
             checkpoint(McmcExecutionStage.AFTER_INITIALIZATION)
@@ -4077,7 +4218,10 @@ def execute_mcmc_evidence(  # noqa: C901 - checkpointed lifecycle boundary
                 if state_observer is not None:
                     state_observer(state)
                 checkpoint(McmcExecutionStage.AFTER_COMPLETE_STATE)
-        if accounting.objective_request_count != plan.policy.objective_request_budget:
+        expected_objective_requests = plan.policy.objective_request_budget + sum(
+            initialized.attempts
+        )
+        if accounting.objective_request_count != expected_objective_requests:
             raise McmcExecutionError(
                 "MCMC backend request count differs from the frozen budget"
             )

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -2277,6 +2277,9 @@ class ConstraintJacobianEvidence:
     source_capabilities: CompiledConstraintLinearizationCapabilities = field(
         repr=False, compare=False, metadata={"record": False}, kw_only=True
     )
+    source_values: Mapping[str, float] = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -2299,8 +2302,6 @@ class ConstraintJacobianEvidence:
             self.accepted_evaluation_identity
             != self.accepted_anchor.evaluation_result.identity
             or self.problem_identity != self.accepted_anchor.problem_identity
-            or self.parameterization_identity
-            != self.accepted_anchor.parameterization_identity
             or self.controlled_ids != self.accepted_anchor.controlled_ids
             or len(set(self.output_ids)) != len(self.output_ids)
             or len(self.output_units) != len(self.output_ids)
@@ -2331,6 +2332,7 @@ class ConstraintJacobianEvidence:
             self.source_capabilities,
             self.output_ids,
             None,
+            self.source_values,
         )
         if (
             failure is not None
@@ -2576,6 +2578,12 @@ class UncertaintyEvidence:
     source_capabilities: CompiledConstraintLinearizationCapabilities = field(
         repr=False, compare=False, metadata={"record": False}, kw_only=True
     )
+    source_constraint_parameterization: ActiveParameterization = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
+    source_constraint_values: Mapping[str, float] = field(
+        repr=False, compare=False, metadata={"record": False}, kw_only=True
+    )
     identity: str = field(init=False)
 
     def __post_init__(self) -> None:  # noqa: C901 - complete bundle integrity chain
@@ -2591,6 +2599,7 @@ class UncertaintyEvidence:
                 self.accepted_anchor.occurrence_identity,
                 self.source_problem.identity,
                 self.source_parameterization.identity,
+                self.source_constraint_parameterization.identity,
                 self.source_engine.plan.identity,
                 self.source_policy.identity,
                 self.requested_output_scope,
@@ -2603,6 +2612,10 @@ class UncertaintyEvidence:
             self.request_identity != expected_request
             or self.policy_identity != self.source_policy.identity
             or self.source_capabilities.output_scope != self.requested_output_scope
+            or self.source_capabilities.parameterization_identity
+            != self.source_constraint_parameterization.identity
+            or self.source_capabilities.constraint_program_identity
+            != self.source_constraint_parameterization.program.fingerprint
             or len(self.requested_output_units) != len(self.requested_output_scope)
             or len(self.requested_output_scales) != len(self.requested_output_scope)
         ):
@@ -6517,6 +6530,7 @@ def _constraint_rows(
     compiled_capabilities: CompiledConstraintLinearizationCapabilities,
     output_scope: tuple[str, ...],
     cancellation_probe: Callable[[], OperationTerminal | None] | None,
+    resolved_values: Mapping[str, float] | None = None,
 ) -> tuple[
     tuple[tuple[float, ...], ...] | None,
     tuple[tuple[str, ...], ...] | None,
@@ -6528,7 +6542,11 @@ def _constraint_rows(
         constraint.target_id: constraint
         for constraint in parameterization.program.constraints
     }
-    resolved = accepted.evaluation_result.resolved_values
+    resolved = (
+        accepted.evaluation_result.resolved_values
+        if resolved_values is None
+        else resolved_values
+    )
     rows: list[tuple[float, ...]] = []
     dependencies: list[tuple[str, ...]] = []
     diagnostics: dict[str, FunctionPartialDiagnostic] = {}
@@ -6626,6 +6644,7 @@ def _linearize_constraints(
     output_scales: tuple[float, ...],
     request_identity: str,
     cancellation_probe: Callable[[], OperationTerminal | None] | None,
+    constraint_values: Mapping[str, float],
 ) -> tuple[ConstraintJacobianEvidence | None, EvidenceFailure | None]:
     if not output_scope:
         return None, None
@@ -6644,6 +6663,7 @@ def _linearize_constraints(
         compiled_capabilities,
         output_scope,
         cancellation_probe,
+        constraint_values,
     )
     if (
         row_failure is not None
@@ -6684,6 +6704,7 @@ def _linearize_constraints(
             source_parameterization=parameterization,
             source_policy=policy,
             source_capabilities=compiled_capabilities,
+            source_values=constraint_values,
         ),
         None,
     )
@@ -7284,6 +7305,7 @@ def _derive_constraint_branch(  # noqa: C901 - ordered cancellation phase ledger
     covariance: CovarianceEvidence | None,
     resolved_environment_identity: str,
     cancellation_probe: Callable[[], OperationTerminal | None] | None,
+    constraint_values: Mapping[str, float],
 ) -> _ConstraintBranch:
     if not output_scope:
         return _ConstraintBranch((), (), None, None, None, None)
@@ -7317,6 +7339,7 @@ def _derive_constraint_branch(  # noqa: C901 - ordered cancellation phase ledger
             output_scales=output_scales,
             request_identity=constraint_request,
             cancellation_probe=cancellation_probe,
+            constraint_values=constraint_values,
         )
     except DerivationTermination as termination:
         constraint_terminal = termination.terminal
@@ -7518,6 +7541,8 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
     compiled_constraint_linearization: (
         CompiledConstraintLinearizationCapabilities | None
     ) = None,
+    constraint_parameterization: ActiveParameterization | None = None,
+    constraint_values: Mapping[str, float] | None = None,
     cancellation_probe: Callable[[], OperationTerminal | None] | None = None,
     resolved_environment_identity: str,
 ) -> UncertaintyEvidence:
@@ -7532,9 +7557,19 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             "occurrence"
         )
     output_scope = tuple(constrained_scope)
+    output_parameterization = (
+        parameterization
+        if constraint_parameterization is None
+        else constraint_parameterization
+    )
+    output_values = (
+        accepted.evaluation_result.resolved_values
+        if constraint_values is None
+        else constraint_values
+    )
     compiled_capabilities = (
         compile_constraint_linearization_capabilities(
-            parameterization,
+            output_parameterization,
             (),
             (),
         )
@@ -7542,9 +7577,10 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
         else compiled_constraint_linearization
     )
     if compiled_capabilities is None or (
-        compiled_capabilities.parameterization_identity != parameterization.identity
+        compiled_capabilities.parameterization_identity
+        != output_parameterization.identity
         or compiled_capabilities.constraint_program_identity
-        != parameterization.program.fingerprint
+        != output_parameterization.program.fingerprint
         or compiled_capabilities.output_scope != output_scope
     ):
         raise UncertaintyConstructionError(
@@ -7576,6 +7612,7 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             accepted.occurrence_identity,
             problem.identity,
             parameterization.identity,
+            output_parameterization.identity,
             engine.plan.identity,
             policy.identity,
             output_scope,
@@ -7625,6 +7662,8 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
             source_engine=engine,
             source_policy=policy,
             source_capabilities=compiled_capabilities,
+            source_constraint_parameterization=output_parameterization,
+            source_constraint_values=output_values,
         )
 
     initial_terminal = _cancellation_terminal(cancellation_probe)
@@ -7716,7 +7755,7 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
     constraint_branch = _derive_constraint_branch(
         accepted,
         problem=problem,
-        parameterization=parameterization,
+        parameterization=output_parameterization,
         policy=policy,
         compiled_capabilities=compiled_capabilities,
         request_identity=request_identity,
@@ -7726,6 +7765,7 @@ def derive_uncertainty_evidence(  # noqa: C901 - fail-closed phase orchestration
         covariance=covariance_branch.covariance,
         resolved_environment_identity=resolved_environment_identity,
         cancellation_probe=cancellation_probe,
+        constraint_values=output_values,
     )
 
     combined_operations = covariance_branch.operations + constraint_branch.operations

--- a/src/chemex/parameters/database.py
+++ b/src/chemex/parameters/database.py
@@ -14,6 +14,7 @@ from chemex.messages import (
     print_warning_negative_jch,
     print_warning_positive_jnh,
 )
+from chemex.models.kinetic._binding_migration import validate_legacy_binding_defaults
 from chemex.parameters.name import ParamName
 from chemex.parameters.setting import Parameters, ParamSetting
 from chemex.typing import Array
@@ -544,6 +545,7 @@ class ParameterStore:
 
         """
         self._ensure_configuration_open()
+        validate_legacy_binding_defaults(self.model.name, defaults)
         if self._defaults_applied:
             msg = "Parameter defaults have already been applied"
             raise RuntimeError(msg)

--- a/src/chemex/parameters/parameterization.py
+++ b/src/chemex/parameters/parameterization.py
@@ -910,6 +910,21 @@ class ActiveParameterization:
 
 
 @dataclass(frozen=True, slots=True)
+class ReportableParameterSet:
+    """The finite derived values selected once for uncertainty and output."""
+
+    parameterization: ActiveParameterization
+    values: ResolvedParameterValues
+    report_only_ids: tuple[str, ...]
+
+    @property
+    def report_only_values(self) -> Mapping[str, float]:
+        return MappingProxyType(
+            {param_id: self.values[param_id] for param_id in self.report_only_ids}
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class _RoleRule:
     role: ParameterRole
     selector: str
@@ -1924,6 +1939,124 @@ def compile_active_parameterization_from_actions(
         rules,
         required_ids,
         require_active_rule_matches=False,
+    )
+
+
+def extend_parameterization_for_report_only_outputs(
+    parameter_model: SealedParameterModel,
+    snapshot: AnalysisValuesSnapshot,
+    parameterization: ActiveParameterization,
+    report_only_ids: Sequence[str],
+) -> ActiveParameterization:
+    """Add finite model-owned report constraints without changing fit roles."""
+    requested = tuple(dict.fromkeys(report_only_ids))
+    if not requested:
+        return ActiveParameterization(
+            parameterization.program,
+            parameterization.binder,
+            snapshot.occurrence_identity,
+            snapshot.revision,
+            tuple(
+                (param_id, parameterization.role(param_id))
+                for param_id in parameterization.scope_ids
+            ),
+        )
+    if (
+        parameterization.program.parameter_model_identity != parameter_model.identity
+        or snapshot.model_identity != parameter_model.model_identity
+        or snapshot.definitions_identity != parameter_model.definitions.identity
+        or snapshot.configuration_identity != parameter_model.configuration.identity
+    ):
+        raise IncompatibleParameterizationInputError(
+            "Report outputs do not belong to the active parameter model"
+        )
+
+    active = set(parameterization.scope_ids)
+    constraints = {
+        constraint.target_id: constraint
+        for constraint in parameterization.program.constraints
+    }
+    for param_id in requested:
+        declaration = parameter_model.declarations[param_id]
+        if not declaration.report_only or not declaration.model_expression:
+            raise ParameterizationError(
+                "Report extension accepts only model-owned report-only derivations",
+                param_id=param_id,
+            )
+        expression = _parse_expression(
+            declaration.model_expression,
+            definitions=parameter_model.definitions,
+            binder=parameterization.binder,
+            target_id=param_id,
+            model_owned=True,
+        )
+        dependencies = _dependencies(expression)
+        missing = set(dependencies) - active
+        if missing:
+            raise IncompleteParameterDependenciesError(
+                "Report-only derivation depends on the inactive parameter scope",
+                target_id=param_id,
+                param_ids=tuple(sorted(missing)),
+            )
+        constraints[param_id] = CompiledConstraint(
+            param_id,
+            expression,
+            dependencies,
+            "model",
+            declaration.model_expression,
+        )
+        active.add(param_id)
+
+    definition_order = {
+        definition.param_id: position
+        for position, definition in enumerate(parameter_model.definitions)
+    }
+    scope_ids = tuple(
+        definition.param_id
+        for definition in parameter_model.definitions
+        if definition.param_id in active
+    )
+    roles = tuple(
+        (
+            param_id,
+            ParameterRole.DERIVED
+            if param_id in requested
+            else parameterization.role(param_id),
+        )
+        for param_id in scope_ids
+    )
+    independent_ids = tuple(
+        param_id
+        for param_id, role in roles
+        if role in (ParameterRole.FIT, ParameterRole.FIX)
+    )
+    derived_ids = tuple(
+        param_id for param_id, role in roles if role is ParameterRole.DERIVED
+    )
+    evaluation_order = _topological_order(
+        derived_ids,
+        constraints,
+        definition_order,
+    )
+    program = ConstraintProgram(
+        parameter_model_identity=parameter_model.identity,
+        model_identity=parameter_model.model_identity,
+        definitions_identity=snapshot.definitions_identity,
+        configuration_identity=snapshot.configuration_identity,
+        function_binder_identity=parameterization.binder.identity,
+        scope_ids=scope_ids,
+        independent_ids=independent_ids,
+        derived_ids=derived_ids,
+        constraints=tuple(constraints[param_id] for param_id in derived_ids),
+        evaluation_order=evaluation_order,
+        relaxation_domains=parameterization.program.relaxation_domains,
+    )
+    return ActiveParameterization(
+        program,
+        parameterization.binder,
+        snapshot.occurrence_identity,
+        snapshot.revision,
+        roles,
     )
 
 

--- a/src/chemex/runtime/session.py
+++ b/src/chemex/runtime/session.py
@@ -18,10 +18,12 @@ from chemex.parameters.factory import ParameterFactory
 from chemex.parameters.parameterization import (
     ActiveParameterization,
     NonFiniteParameterValueError,
+    ReportableParameterSet,
     build_initial_analysis_values,
     compile_active_parameterization,
     compile_active_parameterization_from_actions,
     deferred_derived_ids,
+    extend_parameterization_for_report_only_outputs,
     report_only_derived_ids,
 )
 from chemex.parameters.values import AnalysisValues
@@ -224,6 +226,31 @@ class AnalysisSession:
                 continue
             values[param_id] = resolved[param_id]
         return MappingProxyType(values)
+
+    def resolve_reportable_parameters(
+        self,
+        parameterization: ActiveParameterization,
+    ) -> ReportableParameterSet:
+        """Select once the finite report-only outputs used by uncertainty and output."""
+        parameter_model = self.parameter_factory.sealed_parameter_model
+        if parameter_model is None:
+            raise RuntimeError("Native parameter model is unavailable")
+        snapshot = self.analysis_values.snapshot()
+        report_only_values = self.resolve_report_only_values()
+        reporting_parameterization = extend_parameterization_for_report_only_outputs(
+            parameter_model,
+            snapshot,
+            parameterization,
+            tuple(report_only_values),
+        )
+        resolved = reporting_parameterization.resolve(
+            reporting_parameterization.frame_from_snapshot(snapshot)
+        )
+        return ReportableParameterSet(
+            reporting_parameterization,
+            resolved,
+            tuple(report_only_values),
+        )
 
 
 def ensure_plugins_registered() -> None:

--- a/tests/models/kinetic/test_binding_equilibrium.py
+++ b/tests/models/kinetic/test_binding_equilibrium.py
@@ -192,6 +192,28 @@ def test_alternative_bound_modes_use_normalized_equilibrium_weights() -> None:
     )
 
 
+def test_free_protein_conformers_contribute_to_apparent_equilibrium() -> None:
+    equilibrium = solve_binding_equilibrium(
+        8.0e-4,
+        2.3e-3,
+        free_protein_log_weights=(0.0, math.log(2.5)),
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(math.log(3.5 / 4.0e-4),),
+    )
+    free_a, free_b = equilibrium.free_proteins
+
+    assert free_b / free_a == pytest.approx(2.5, rel=2.0e-15)
+    assert equilibrium.log_apparent_kd == pytest.approx(math.log(4.0e-4))
+    assert equilibrium.populations == pytest.approx(
+        tuple(
+            concentration / 8.0e-4
+            for concentration in (*equilibrium.free_proteins, *equilibrium.complexes)
+        ),
+        rel=2.0e-15,
+        abs=0.0,
+    )
+
+
 @pytest.mark.parametrize(
     ("free_weights", "complex_weights"),
     (
@@ -293,9 +315,26 @@ def test_zero_ligand_preserves_the_unbound_protein_population() -> None:
     assert equilibrium.protein_free == 8.0e-4
     assert equilibrium.ligand_free == 0.0
     assert equilibrium.bound_total == 0.0
+    assert equilibrium.free_proteins == (8.0e-4,)
     assert equilibrium.free_ligands == (0.0,)
     assert equilibrium.complexes == (0.0,)
     assert equilibrium.populations == (1.0, 0.0)
+
+
+def test_zero_ligand_distributes_a_free_protein_conformational_equilibrium() -> None:
+    equilibrium = solve_binding_equilibrium(
+        8.0e-4,
+        0.0,
+        free_protein_log_weights=(0.0, math.log(3.0)),
+        free_ligand_log_weights=(0.0,),
+        complex_log_weights=(math.log(4.0 / 1.0e-3),),
+    )
+
+    assert equilibrium.free_proteins == pytest.approx((2.0e-4, 6.0e-4))
+    assert equilibrium.populations == pytest.approx((0.25, 0.75, 0.0))
+    assert equilibrium.log_populations == pytest.approx(
+        (math.log(0.25), math.log(0.75), -math.inf)
+    )
 
 
 @pytest.mark.parametrize("kd", (0.0, -1.0, math.inf, -math.inf, math.nan))

--- a/tests/models/kinetic/test_binding_models.py
+++ b/tests/models/kinetic/test_binding_models.py
@@ -94,6 +94,8 @@ def _construct_and_resolve(
         ("2st_binding", ("pa", "pb"), {}),
         ("3st_double_binding", ("pa", "pb", "pc"), {}),
         ("3st_binding_partner_2st", ("pa", "pb", "pc"), {}),
+        ("3st_binding_cs", ("pa", "pb", "pc"), {}),
+        ("3st_binding_if", ("pa", "pb", "pc"), {}),
         ("4st_binding_partner_2st", ("pa", "pb", "pc", "pd"), {}),
         (
             "4st_binding_3_bound_states",

--- a/tests/models/kinetic/test_category_c_binding_models.py
+++ b/tests/models/kinetic/test_category_c_binding_models.py
@@ -1,0 +1,1069 @@
+"""Equilibrium-authoritative qualifications for Category-C binding models."""
+
+from __future__ import annotations
+
+import math
+import sys
+from decimal import Decimal, localcontext
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from scipy.linalg import expm
+
+from chemex.chemex import run
+from chemex.cli import build_parser
+from chemex.configuration.methods import Method, Selection, read_method_plan
+from chemex.configuration.parameters import DefaultSetting, read_defaults
+from chemex.experiments.builder import build_experiments
+from chemex.models.kinetic import settings_3st_binding_cs as cs
+from chemex.models.kinetic import settings_3st_binding_if as induced_fit
+from chemex.models.kinetic._binding_migration import (
+    LegacyBindingParameterError,
+    validate_legacy_binding_defaults,
+)
+from chemex.optimize import uncertainty as uncertainty_module
+from chemex.optimize.native_deterministic import run_native_deterministic
+from chemex.parameters.parameterization import (
+    ConstraintDomainError,
+    NonFiniteParameterValueError,
+    ParameterRole,
+)
+from chemex.parameters.sealed import (
+    InvalidConfigurationError,
+    parameter_name_from_definition,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.runtime import AnalysisSession
+from tests.models.kinetic.test_binding_models import _prepare_model
+
+BINDING_EXAMPLE = Path(__file__).parents[3] / "examples/Combinations/2stBinding"
+BINDING_CPMG = BINDING_EXAMPLE / "Experiments/cpmg_13p.toml"
+BINDING_PARAMETERS = BINDING_EXAMPLE / "Parameters/params.toml"
+
+
+def _write_execution_fixture(
+    directory: Path,
+    model_name: str,
+) -> tuple[Path, tuple[Path, ...], Path, Path]:
+    if model_name == "3st_binding_cs":
+        kinetic_values = "KOFF_BC = 80.0\nKEQ_AB = 3.0\nKEX_AB = 250.0"
+        fitted_kinetics = '"KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB"'
+    else:
+        kinetic_values = "KOFF_AB = 80.0\nKEQ_BC = 3.0\nKEX_BC = 250.0"
+        fitted_kinetics = '"KD_APP", "KOFF_AB", "KEQ_BC", "KEX_BC"'
+    parameters = directory / "parameters.toml"
+    parameters.write_text(
+        f"""[GLOBAL]
+R1_A = 1.5
+R2_A = 4.7
+KD_APP = [2e-4, 1e-8, 1.0]
+{kinetic_values}
+""",
+        encoding="utf-8",
+    )
+    method = directory / "method.toml"
+    method.write_text(
+        f"""FORMAT_VERSION = 2
+
+[STEP]
+INCLUDE = ["486"]
+ROLES = [
+  {{ FIX = ["R2_A", "R2_B", "R2_C", "DW_AB", "DW_AC"] }},
+  {{ FIT = [{fitted_kinetics}] }},
+]
+STATISTICS = {{ MC = {{ REPLICATES = 1, SEED = 731 }}, BS = {{ REPLICATES = 1, SEED = 732 }}, MCMC = {{ STEPS = 2, BURN = 0, SEED = 733 }} }}
+""",
+        encoding="utf-8",
+    )
+    return BINDING_CPMG, (BINDING_PARAMETERS, parameters), method, directory / "Output"
+
+
+def _parameter_output_line(output: str, name: str) -> str:
+    matches = [
+        line
+        for line in output.splitlines()
+        if line.startswith((f"{name} ", f'"{name},'))
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _output_value(line: str) -> float:
+    return float(line.split("=", 1)[1].split("#", 1)[0])
+
+
+def _output_unavailable_reason(line: str) -> str:
+    marker = "error unavailable: "
+    assert marker in line
+    return line.split(marker, 1)[1].split(";", 1)[0]
+
+
+@pytest.mark.parametrize("kex_ab", (300.0, 1.0e-10, 1.0e-50, 0.0))
+@pytest.mark.parametrize("koff_bc", (75.0, 1.0e-50, 0.0))
+def test_cs_equilibrium_is_independent_of_every_kinetic_scale(
+    kex_ab: float,
+    koff_bc: float,
+) -> None:
+    concentrations = cs.calculate_concentrations(5.0e-4, 8.0e-4, 8.0e-4, 2.0)
+    populations = cs.calculate_populations(5.0e-4, 8.0e-4, 8.0e-4, 2.0)
+    rates = cs.calculate_rates(
+        5.0e-4,
+        8.0e-4,
+        8.0e-4,
+        2.0,
+        kex_ab,
+        koff_bc,
+    )
+
+    assert concentrations == pytest.approx(
+        {
+            "a": 9.605091023733683e-05,
+            "b": 1.9210182047467366e-04,
+            "c": 2.118472692879895e-04,
+            "l": 5.881527307120105e-04,
+        },
+        rel=3.0e-14,
+    )
+    assert populations == pytest.approx(
+        {
+            "pa": 0.19210182047467367,
+            "pb": 0.38420364094934734,
+            "pc": 0.42369453857597894,
+        },
+        rel=3.0e-14,
+    )
+    assert rates["kab"] + rates["kba"] == pytest.approx(kex_ab)
+    if kex_ab == 0.0:
+        assert rates["kab"] == rates["kba"] == 0.0
+    if koff_bc == 0.0:
+        assert rates["kbc"] == rates["kcb"] == 0.0
+    assert populations["pa"] * rates["kab"] == pytest.approx(
+        populations["pb"] * rates["kba"], rel=3.0e-14, abs=math.ulp(0.0)
+    )
+    assert populations["pb"] * rates["kbc"] == pytest.approx(
+        populations["pc"] * rates["kcb"], rel=3.0e-14, abs=math.ulp(0.0)
+    )
+
+
+@pytest.mark.parametrize("kex_bc", (300.0, 1.0e-10, 1.0e-50, 0.0))
+@pytest.mark.parametrize("koff_ab", (75.0, 1.0e-50, 0.0))
+def test_if_equilibrium_is_independent_of_every_kinetic_scale(
+    kex_bc: float,
+    koff_ab: float,
+) -> None:
+    concentrations = induced_fit.calculate_concentrations(5.0e-4, 8.0e-4, 8.0e-4, 2.0)
+    populations = induced_fit.calculate_populations(5.0e-4, 8.0e-4, 8.0e-4, 2.0)
+    rates = induced_fit.calculate_rates(
+        5.0e-4,
+        8.0e-4,
+        8.0e-4,
+        2.0,
+        kex_bc,
+        koff_ab,
+    )
+
+    assert concentrations == pytest.approx(
+        {
+            "a": 2.881527307120105e-04,
+            "b": 7.061575642932983e-05,
+            "c": 1.4123151285865966e-04,
+            "l": 5.881527307120105e-04,
+        },
+        rel=3.0e-14,
+    )
+    assert populations == pytest.approx(
+        {
+            "pa": 0.5763054614240212,
+            "pb": 0.14123151285865965,
+            "pc": 0.2824630257173193,
+        },
+        rel=3.0e-14,
+    )
+    assert rates["kbc"] + rates["kcb"] == pytest.approx(kex_bc)
+    if kex_bc == 0.0:
+        assert rates["kbc"] == rates["kcb"] == 0.0
+    if koff_ab == 0.0:
+        assert rates["kab"] == rates["kba"] == 0.0
+    assert populations["pa"] * rates["kab"] == pytest.approx(
+        populations["pb"] * rates["kba"], rel=3.0e-14, abs=math.ulp(0.0)
+    )
+    assert populations["pb"] * rates["kbc"] == pytest.approx(
+        populations["pc"] * rates["kcb"], rel=3.0e-14, abs=math.ulp(0.0)
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "defaults", "message"),
+    (
+        (
+            "3st_binding_cs",
+            {"KAB": 30.0, "KBA": 270.0},
+            "KEQ_AB = 0.1111111111111111; KEX_AB = 300.0",
+        ),
+        (
+            "3st_binding_if",
+            {"KBC": 30.0, "KCB": 270.0},
+            "KEQ_BC = 0.1111111111111111; KEX_BC = 300.0",
+        ),
+        (
+            "3st_binding_cs",
+            {"KAB": 30.0},
+            "pair is incomplete",
+        ),
+        (
+            "3st_binding_if",
+            {"KBC": 0.0, "KCB": 0.0},
+            "KEX_BC = 0; KEQ_BC cannot be inferred",
+        ),
+        (
+            "3st_binding_if",
+            {"KBC": 30.0, "KCB": 0.0},
+            "finite KEQ_BC cannot be reconstructed",
+        ),
+        (
+            "3st_binding_if",
+            {"KBC": 0.0, "KCB": 30.0},
+            "KEQ_BC = 0.0; KEX_BC = 30.0",
+        ),
+        (
+            "3st_binding_cs",
+            {"KAB": 0.0, "KBA": 30.0},
+            "3st_binding_cs requires finite positive KEQ_AB",
+        ),
+        (
+            "3st_binding_cs",
+            {"KAB": 30.0, "KBA": 270.0, "KEQ_AB": 0.1},
+            "old and new parameterizations cannot be combined",
+        ),
+    ),
+)
+def test_legacy_directional_parameter_defaults_are_rejected_with_migration(
+    model_name: str,
+    defaults: dict[str, float],
+    message: str,
+) -> None:
+    with pytest.raises(LegacyBindingParameterError, match=message):
+        _prepare_model(model_name, 1.0e-3, 2.0e-3, defaults)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "rates", "expected", "forbidden"),
+    (
+        (
+            "3st_binding_if",
+            (math.ulp(0.0), sys.float_info.max),
+            "equivalent KEQ_BC is below minimum positive binary64",
+            "KEQ_BC = 0.0",
+        ),
+        (
+            "3st_binding_if",
+            (sys.float_info.max, math.ulp(0.0)),
+            "equivalent KEQ_BC exceeds maximum finite binary64",
+            "KEQ_BC = inf",
+        ),
+        (
+            "3st_binding_if",
+            (sys.float_info.max, sys.float_info.max),
+            "equivalent KEX_BC exceeds maximum finite binary64",
+            "KEX_BC = inf",
+        ),
+        (
+            "3st_binding_if",
+            (sys.float_info.min, 1.0),
+            f"KEQ_BC = {sys.float_info.min!r}",
+            "outside binary64 representability",
+        ),
+    ),
+)
+def test_legacy_migration_never_invents_unrepresentable_values(
+    model_name: str,
+    rates: tuple[float, float],
+    expected: str,
+    forbidden: str,
+) -> None:
+    with pytest.raises(LegacyBindingParameterError) as error:
+        _prepare_model(
+            model_name,
+            1.0e-3,
+            2.0e-3,
+            {"KBC": rates[0], "KCB": rates[1]},
+        )
+
+    assert expected in str(error.value)
+    assert forbidden not in str(error.value)
+
+
+@pytest.mark.parametrize(
+    ("rates", "expected"),
+    (
+        (
+            (999_999.0, 0.5),
+            "KEQ_BC = [1999998.0, 0.0, 1999998.0]",
+        ),
+        (
+            (600_000.0, 600_000.0),
+            "KEX_BC = [1200000.0, 0.0, 1200000.0]",
+        ),
+    ),
+)
+def test_legacy_migration_explains_explicit_default_bound_override(
+    rates: tuple[float, float],
+    expected: str,
+) -> None:
+    with pytest.raises(
+        LegacyBindingParameterError, match="outside the new default"
+    ) as error:
+        _prepare_model(
+            "3st_binding_if",
+            1.0e-3,
+            2.0e-3,
+            {"KBC": rates[0], "KCB": rates[1]},
+        )
+
+    assert expected in str(error.value)
+
+
+def test_legacy_rate_pairs_are_diagnosed_per_normalized_condition_scope(
+    tmp_path: Path,
+) -> None:
+    scoped = tmp_path / "scoped.toml"
+    scoped.write_text(
+        """[GLOBAL]
+"kab, T->25.0C" = 30.0
+"kba, T->35.0C" = 270.0
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(LegacyBindingParameterError) as error:
+        validate_legacy_binding_defaults(
+            "3st_binding_cs",
+            read_defaults([scoped]),
+        )
+
+    message = str(error.value)
+    assert "T->25.0C" in message and "KBA is also needed" in message
+    assert "T->35.0C" in message and "KAB is also needed" in message
+    assert "KEQ_AB = 0.1111111111111111" not in message
+
+
+def test_complete_legacy_pairs_are_converted_independently_per_temperature(
+    tmp_path: Path,
+) -> None:
+    scoped = tmp_path / "serialized-constrained.toml"
+    scoped.write_text(
+        """[GLOBAL]
+"KBC, T->25.0C" = 30.0
+"KCB, T->25.0C" = 270.0
+"KBC, T->35.0C" = 50.0
+"KCB, T->35.0C" = 50.0
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(LegacyBindingParameterError) as error:
+        validate_legacy_binding_defaults(
+            "3st_binding_if",
+            read_defaults([scoped]),
+        )
+
+    message = str(error.value)
+    assert "T->25.0C" in message and "KEQ_BC = 0.1111111111111111" in message
+    assert "T->35.0C" in message and "KEQ_BC = 1.0" in message
+
+
+@pytest.mark.parametrize(
+    ("model_name", "method_entry", "legacy_name"),
+    (
+        ("3st_binding_cs", 'FIT = ["KAB"]', "KAB"),
+        ("3st_binding_cs", 'FIX = ["KBA"]', "KBA"),
+        ("3st_binding_if", 'CONSTRAINTS = ["[KBC] = [KEX_BC]"]', "KBC"),
+        ("3st_binding_if", 'CONSTRAINTS = ["[KEQ_BC] = [KCB]"]', "KCB"),
+        ("3st_binding_if", 'GRID = ["[KCB] = lin(1.0, 2.0, 2)"]', "KCB"),
+        (
+            "3st_binding_cs",
+            '[STEP.SEARCH.DE]\nSEED = 19\nCOORDINATES = ["[KAB] = lin(1, 2)"]',
+            "KAB",
+        ),
+    ),
+)
+def test_legacy_directional_method_roles_are_rejected_with_migration(
+    tmp_path,
+    model_name: str,
+    method_entry: str,
+    legacy_name: str,
+) -> None:
+    session, _ = _prepare_model(model_name, 1.0e-3, 2.0e-3, {})
+    assert session.try_build_analysis_values()
+    method_path = tmp_path / "method.toml"
+    version = "FORMAT_VERSION = 2\n" if "SEARCH.DE" in method_entry else ""
+    method_path.write_text(
+        f"{version}[STEP]\n{method_entry}\n",
+        encoding="utf-8",
+    )
+    plan = read_method_plan([method_path])
+
+    with pytest.raises(ValueError, match=f"{legacy_name} is a derived output"):
+        session.validate_method_plan(plan)
+
+
+def test_stale_constrained_parameter_file_is_rejected_before_defaults_apply(
+    tmp_path: Path,
+) -> None:
+    stale = tmp_path / "constrained.toml"
+    stale.write_text("[GLOBAL]\nKAB = 30.0\nKBA = 270.0\n", encoding="utf-8")
+    session, _ = _prepare_model("3st_binding_cs", 1.0e-3, 2.0e-3, {})
+
+    with pytest.raises(
+        LegacyBindingParameterError,
+        match=r"KEQ_AB = 0\.1111111111111111; KEX_AB = 300\.0",
+    ):
+        session.parameters.set_defaults(read_defaults([stale]))
+
+
+def test_old_and_new_method_syntax_has_no_precedence(tmp_path: Path) -> None:
+    session, _ = _prepare_model("3st_binding_if", 1.0e-3, 2.0e-3, {})
+    assert session.try_build_analysis_values()
+    method_path = tmp_path / "method.toml"
+    method_path.write_text(
+        '[STEP]\nFIT = ["KBC", "KEQ_BC"]\n',
+        encoding="utf-8",
+    )
+    plan = read_method_plan([method_path])
+
+    with pytest.raises(
+        ValueError, match="old and new parameterizations cannot be combined"
+    ):
+        session.validate_method_plan(plan)
+
+
+def test_legacy_method_selectors_are_diagnosed_per_condition_scope(
+    tmp_path: Path,
+) -> None:
+    session, _ = _prepare_model("3st_binding_cs", 1.0e-3, 2.0e-3, {})
+    assert session.try_build_analysis_values()
+    method_path = tmp_path / "method.toml"
+    method_path.write_text(
+        '[STEP]\nFIT = ["KAB, T->25.0C", "KBA, T->35.0C"]\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as error:
+        session.validate_method_plan(read_method_plan([method_path]))
+
+    message = str(error.value)
+    assert "T->25.0C" in message and "KBA is also needed" in message
+    assert "T->35.0C" in message and "KAB is also needed" in message
+
+
+ORDINARY_CASES = (
+    ("balanced", 1.0e-3, 2.0e-3, 1.0e-3, 100.0, 100.0, 75.0),
+    ("biased", 1.0e-3, 2.0e-3, 2.0e-4, 900.0, 10.0, 33.0),
+    ("slow", 5.0e-4, 8.0e-4, 8.0e-4, 1.0e-4, 2.0e-4, 0.03),
+    ("fast", 5.0e-4, 8.0e-4, 8.0e-4, 4.0e5, 2.0e5, 3.0e5),
+    ("weak", 2.0e-4, 3.0e-4, 0.7, 40.0, 160.0, 12.0),
+    ("strong", 2.0e-4, 3.0e-4, 1.0e-12, 40.0, 160.0, 12.0),
+    ("depletion", 1.0e-3, 8.0e-4, 1.0e-7, 30.0, 270.0, 45.0),
+)
+
+
+def _decimal_macrostate(
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+) -> tuple[float, float, float]:
+    with localcontext() as context:
+        context.prec = 100
+        protein, ligand, kd = (
+            Decimal.from_float(value) for value in (p_total, l_total, kd_app)
+        )
+        total = protein + ligand + kd
+        discriminant = (total * total - Decimal(4) * protein * ligand).sqrt()
+        bound = Decimal(2) * protein * ligand / (total + discriminant)
+        return float(protein - bound), float(ligand - bound), float(bound)
+
+
+@pytest.mark.parametrize(
+    ("_case", "p_total", "l_total", "kd_app", "legacy_kab", "legacy_kba", "koff_bc"),
+    ORDINARY_CASES,
+)
+def test_cs_positive_legacy_parameterization_round_trips_to_equilibrium_authority(
+    _case: str,
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+    legacy_kab: float,
+    legacy_kba: float,
+    koff_bc: float,
+) -> None:
+    keq_ab = legacy_kab / legacy_kba
+    kex_ab = legacy_kab + legacy_kba
+    expected_unbound, expected_ligand, expected_bound = _decimal_macrostate(
+        p_total, l_total, kd_app
+    )
+    expected_a = expected_unbound / (1.0 + keq_ab)
+    expected_b = expected_unbound - expected_a
+    kd_bc = kd_app * keq_ab / (1.0 + keq_ab)
+    expected_kbc = koff_bc * expected_ligand / kd_bc
+
+    concentrations = cs.calculate_concentrations(p_total, l_total, kd_app, keq_ab)
+    populations = cs.calculate_populations(p_total, l_total, kd_app, keq_ab)
+    rates = cs.calculate_rates(p_total, l_total, kd_app, keq_ab, kex_ab, koff_bc)
+
+    assert concentrations == pytest.approx(
+        {"a": expected_a, "b": expected_b, "c": expected_bound, "l": expected_ligand},
+        rel=4.0e-14,
+        abs=math.ulp(0.0),
+    )
+    assert populations == pytest.approx(
+        {
+            "pa": expected_a / p_total,
+            "pb": expected_b / p_total,
+            "pc": expected_bound / p_total,
+        },
+        rel=4.0e-14,
+        abs=math.ulp(0.0),
+    )
+    assert rates == pytest.approx(
+        {
+            "kab": legacy_kab,
+            "kba": legacy_kba,
+            "kbc": expected_kbc,
+            "kcb": koff_bc,
+        },
+        rel=5.0e-14,
+        abs=math.ulp(0.0),
+    )
+    assert cs.calculate_intrinsic_kd(kd_app, keq_ab) == pytest.approx(kd_bc)
+    assert cs.calculate_kon(koff_bc, kd_app, keq_ab) == pytest.approx(koff_bc / kd_bc)
+
+
+@pytest.mark.parametrize(
+    ("_case", "p_total", "l_total", "kd_app", "legacy_kbc", "legacy_kcb", "koff_ab"),
+    ORDINARY_CASES,
+)
+def test_if_positive_legacy_parameterization_round_trips_to_equilibrium_authority(
+    _case: str,
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+    legacy_kbc: float,
+    legacy_kcb: float,
+    koff_ab: float,
+) -> None:
+    keq_bc = legacy_kbc / legacy_kcb
+    kex_bc = legacy_kbc + legacy_kcb
+    expected_free, expected_ligand, expected_bound = _decimal_macrostate(
+        p_total, l_total, kd_app
+    )
+    expected_b = expected_bound / (1.0 + keq_bc)
+    expected_c = expected_bound - expected_b
+    kd_ab = kd_app * (1.0 + keq_bc)
+    expected_kab = koff_ab * expected_ligand / kd_ab
+
+    concentrations = induced_fit.calculate_concentrations(
+        p_total, l_total, kd_app, keq_bc
+    )
+    populations = induced_fit.calculate_populations(p_total, l_total, kd_app, keq_bc)
+    rates = induced_fit.calculate_rates(
+        p_total, l_total, kd_app, keq_bc, kex_bc, koff_ab
+    )
+
+    assert concentrations == pytest.approx(
+        {"a": expected_free, "b": expected_b, "c": expected_c, "l": expected_ligand},
+        rel=4.0e-14,
+        abs=math.ulp(0.0),
+    )
+    assert populations == pytest.approx(
+        {
+            "pa": expected_free / p_total,
+            "pb": expected_b / p_total,
+            "pc": expected_c / p_total,
+        },
+        rel=4.0e-14,
+        abs=math.ulp(0.0),
+    )
+    assert rates == pytest.approx(
+        {
+            "kab": expected_kab,
+            "kba": koff_ab,
+            "kbc": legacy_kbc,
+            "kcb": legacy_kcb,
+        },
+        rel=5.0e-14,
+        abs=math.ulp(0.0),
+    )
+    assert induced_fit.calculate_intrinsic_kd(kd_app, keq_bc) == pytest.approx(kd_ab)
+    assert induced_fit.calculate_kon(koff_ab, kd_app, keq_bc) == pytest.approx(
+        koff_ab / kd_ab
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "expected"),
+    (
+        (
+            cs,
+            (0.8331367642181426, 0.13577169691101548, 0.031091538870841925),
+        ),
+        (
+            induced_fit,
+            (0.9060016771131519, 0.08542529780633287, 0.008573025080515152),
+        ),
+    ),
+)
+def test_balanced_legacy_rates_preserve_a_frozen_propagated_observable(
+    module,
+    expected: tuple[float, float, float],
+) -> None:
+    rates = module.calculate_rates(1.0e-3, 2.0e-3, 1.0e-3, 1.0, 200.0, 75.0)
+    kab, kba, kbc, kcb = (rates[name] for name in ("kab", "kba", "kbc", "kcb"))
+    generator = np.array(
+        (
+            (-kab, kba, 0.0),
+            (kab, -kba - kbc, kcb),
+            (0.0, kbc, -kcb),
+        )
+    )
+    propagated = expm(0.002 * generator) @ np.array((1.0, 0.0, 0.0))
+
+    assert propagated == pytest.approx(expected, rel=2.0e-15, abs=0.0)
+
+
+def test_cs_zero_ligand_retains_the_apo_equilibrium() -> None:
+    concentrations = cs.calculate_concentrations(8.0e-4, 0.0, 4.0e-4, 3.0)
+    populations = cs.calculate_populations(8.0e-4, 0.0, 4.0e-4, 3.0)
+    rates = cs.calculate_rates(8.0e-4, 0.0, 4.0e-4, 3.0, 700.0, 80.0)
+
+    assert concentrations == pytest.approx(
+        {"a": 2.0e-4, "b": 6.0e-4, "c": 0.0, "l": 0.0}
+    )
+    assert populations == pytest.approx({"pa": 0.25, "pb": 0.75, "pc": 0.0})
+    assert rates == pytest.approx({"kab": 525.0, "kba": 175.0, "kbc": 0.0, "kcb": 80.0})
+
+
+def test_cs_minimum_positive_keq_retains_a_positive_forward_rate() -> None:
+    minimum_positive = math.ulp(0.0)
+    rates = cs.calculate_conformational_rates(1.0, minimum_positive)
+
+    assert rates["kab"] == minimum_positive
+    assert rates["kba"] > 0.0
+    assert math.fsum(rates.values()) == 1.0
+
+
+def test_if_zero_ligand_is_entirely_free_and_zero_keq_removes_c() -> None:
+    zero_ligand = induced_fit.calculate_populations(8.0e-4, 0.0, 4.0e-4, 3.0)
+    zero_ligand_rates = induced_fit.calculate_rates(
+        8.0e-4, 0.0, 4.0e-4, 3.0, 700.0, 80.0
+    )
+    populations = induced_fit.calculate_populations(8.0e-4, 2.3e-3, 4.0e-4, 0.0)
+    rates = induced_fit.calculate_rates(8.0e-4, 2.3e-3, 4.0e-4, 0.0, 700.0, 80.0)
+
+    assert zero_ligand == {"pa": 1.0, "pb": 0.0, "pc": 0.0}
+    assert zero_ligand_rates["kab"] == 0.0
+    assert populations["pc"] == 0.0
+    assert rates["kbc"] == 0.0
+    assert rates["kcb"] == 700.0
+    assert induced_fit.calculate_intrinsic_kd(4.0e-4, 0.0) == pytest.approx(4.0e-4)
+
+
+@pytest.mark.parametrize("model_name", ("3st_binding_cs", "3st_binding_if"))
+def test_category_c_public_independent_parameters_exclude_directional_rates(
+    model_name: str,
+) -> None:
+    session, local_ids = _prepare_model(model_name, 1.0e-3, 2.0e-3, {})
+    assert session.try_build_analysis_values()
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    independent = {
+        parameter_model.definitions[param_id].name
+        for param_id, declaration in parameter_model.declarations.items()
+        if declaration.requires_independent
+    }
+    expected = (
+        {"KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB"}
+        if model_name == "3st_binding_cs"
+        else {"KD_APP", "KOFF_AB", "KEQ_BC", "KEX_BC"}
+    )
+
+    assert expected <= independent
+    assert {"KAB", "KBA", "KBC", "KCB"}.isdisjoint(independent - expected)
+    resolved = session.resolve_current_values(
+        {local_ids[name] for name in ("kab", "kba", "kbc", "kcb", "pa", "pb", "pc")}
+    )
+    assert all(math.isfinite(value) for value in resolved.values())
+
+
+@pytest.mark.parametrize(
+    ("module", "keq"),
+    ((cs, math.ulp(0.0)), (cs, 1.0e6), (induced_fit, 0.0), (induced_fit, 1.0e6)),
+)
+@pytest.mark.parametrize(
+    ("p_total", "l_total", "kd_app"),
+    (
+        (1.0e-300, 2.0e-300, math.ulp(0.0)),
+        (1.0e-3, 1.0e-3, 1.0e-100),
+        (1.0e-9, 2.0e-3, 1.0),
+        (2.0e-3, 1.0e-9, 1.0e-31),
+    ),
+)
+def test_category_c_extreme_equilibria_are_nonnegative_and_conservative(
+    module,
+    keq: float,
+    p_total: float,
+    l_total: float,
+    kd_app: float,
+) -> None:
+    concentrations = module.calculate_concentrations(p_total, l_total, kd_app, keq)
+    populations = module.calculate_populations(p_total, l_total, kd_app, keq)
+
+    assert all(
+        math.isfinite(value) and value >= 0.0 for value in concentrations.values()
+    )
+    assert math.fsum(populations.values()) == pytest.approx(1.0, rel=3.0e-14)
+    assert math.fsum(concentrations[name] for name in ("a", "b", "c")) == (
+        pytest.approx(p_total, rel=3.0e-14, abs=math.ulp(0.0))
+    )
+    bound_names = ("c",) if module is cs else ("b", "c")
+    assert concentrations["l"] + math.fsum(
+        concentrations[name] for name in bound_names
+    ) == (pytest.approx(l_total, rel=3.0e-14, abs=math.ulp(0.0)))
+
+
+def test_cs_zero_keq_is_rejected_at_metadata_and_runtime() -> None:
+    session, _ = _prepare_model("3st_binding_cs", 1.0e-3, 2.0e-3, {"keq_ab": 0.0})
+    assert not session.try_build_analysis_values()
+    assert isinstance(
+        session.parameter_factory.native_construction_error, InvalidConfigurationError
+    )
+
+    overridden, _ = _prepare_model(
+        "3st_binding_cs",
+        1.0e-3,
+        2.0e-3,
+        {"keq_ab": DefaultSetting(0.0, min=0.0, max=1.0e6)},
+    )
+    assert not overridden.try_build_analysis_values()
+    assert isinstance(
+        overridden.parameter_factory.native_construction_error, ConstraintDomainError
+    )
+
+
+@pytest.mark.parametrize("model_name", ("3st_binding_cs", "3st_binding_if"))
+def test_category_c_zero_kd_and_zero_protein_are_rejected(model_name: str) -> None:
+    zero_kd, _ = _prepare_model(model_name, 1.0e-3, 2.0e-3, {"kd_app": 0.0})
+    assert not zero_kd.try_build_analysis_values()
+    assert isinstance(
+        zero_kd.parameter_factory.native_construction_error, InvalidConfigurationError
+    )
+
+    zero_protein, _ = _prepare_model(model_name, 0.0, 2.0e-3, {})
+    assert not zero_protein.try_build_analysis_values()
+    assert isinstance(
+        zero_protein.parameter_factory.native_construction_error, ConstraintDomainError
+    )
+
+
+def test_unrepresentable_cs_intrinsic_reports_do_not_block_tagged_dynamics() -> None:
+    session, local_ids = _prepare_model(
+        "3st_binding_cs",
+        1.0e-300,
+        2.0e-300,
+        {
+            "kd_app": math.ulp(0.0),
+            "keq_ab": math.ulp(0.0),
+            "kex_ab": 0.0,
+            "koff_bc": 0.0,
+        },
+    )
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    dynamics = {
+        local_ids[name] for name in ("pa", "pb", "pc", "kab", "kba", "kbc", "kcb")
+    }
+    assert all(
+        math.isfinite(value)
+        for value in session.resolve_current_values(dynamics).values()
+    )
+    reports = session.resolve_report_only_values()
+    assert local_ids["kd_bc"] not in reports
+    assert reports[local_ids["kon_bc"]] == 0.0
+    with pytest.raises(NonFiniteParameterValueError):
+        session.resolve_current_values({local_ids["kd_bc"]})
+
+
+def test_unrepresentable_if_kon_does_not_block_finite_tagged_dynamics() -> None:
+    session, local_ids = _prepare_model(
+        "3st_binding_if",
+        1.0e-300,
+        2.0e-300,
+        {
+            "kd_app": math.ulp(0.0),
+            "keq_bc": 0.0,
+            "kex_bc": 0.0,
+            "koff_ab": 1.0,
+        },
+    )
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    rates = session.resolve_current_values(
+        {local_ids[name] for name in ("kab", "kba", "kbc", "kcb")}
+    )
+    assert all(math.isfinite(value) for value in rates.values())
+    reports = session.resolve_report_only_values()
+    assert local_ids["kon_ab"] not in reports
+    assert reports[local_ids["kd_ab"]] == math.ulp(0.0)
+    with pytest.raises(NonFiniteParameterValueError):
+        session.resolve_current_values({local_ids["kon_ab"]})
+
+
+def test_unrepresentable_if_intrinsic_kd_is_report_only() -> None:
+    maximum = sys.float_info.max
+    session, local_ids = _prepare_model(
+        "3st_binding_if",
+        1.0e-3,
+        2.0e-3,
+        {
+            "kd_app": DefaultSetting(maximum, min=math.ulp(0.0), max=maximum),
+            "keq_bc": DefaultSetting(maximum, min=0.0, max=maximum),
+            "kex_bc": 0.0,
+            "koff_ab": 0.0,
+        },
+    )
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    populations = session.resolve_current_values(
+        {local_ids[name] for name in ("pa", "pb", "pc")}
+    )
+    assert all(math.isfinite(value) for value in populations.values())
+    reports = session.resolve_report_only_values()
+    assert local_ids["kd_ab"] not in reports
+    assert reports[local_ids["kon_ab"]] == 0.0
+    with pytest.raises(NonFiniteParameterValueError):
+        session.resolve_current_values({local_ids["kd_ab"]})
+
+
+@pytest.mark.parametrize("model_name", ("3st_binding_cs", "3st_binding_if"))
+@pytest.mark.filterwarnings("ignore:invalid value encountered in divide:RuntimeWarning")
+def test_category_c_parameterization_executes_fit_mcmc_and_resampling(
+    tmp_path: Path,
+    model_name: str,
+) -> None:
+    experiment, parameter_files, method, output = _write_execution_fixture(
+        tmp_path,
+        model_name,
+    )
+    args = build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            str(experiment),
+            "-p",
+            *(str(path) for path in parameter_files),
+            "-m",
+            str(method),
+            "-d",
+            model_name,
+            "-o",
+            str(output),
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+        ]
+    )
+
+    session = AnalysisSession.create()
+    run(args, session=session)
+
+    fitted = (output / "Parameters" / "fitted.toml").read_text(encoding="utf-8")
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "KD_APP" in fitted
+    assert all(name not in fitted for name in ("KAB", "KBA", "KBC", "KCB"))
+    assert all(name in constrained for name in ("KAB", "KBA", "KBC", "KCB"))
+    report_only_names = (
+        ("KD_BC", "KON_BC") if model_name == "3st_binding_cs" else ("KD_AB", "KON_AB")
+    )
+    directional_name = "KAB" if model_name == "3st_binding_cs" else "KBC"
+    for name in (*report_only_names, directional_name, "PA"):
+        line = _parameter_output_line(constrained, name)
+        assert math.isfinite(_output_value(line))
+        assert "# ±" in line
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    kex_name = "KEX_AB" if model_name == "3st_binding_cs" else "KEX_BC"
+    [kex_id] = [
+        definition.param_id
+        for definition in parameter_model.definitions
+        if definition.name == kex_name
+    ]
+    fitted_kex = session.analysis_values.snapshot()[kex_id]
+    assert math.isfinite(fitted_kex) and fitted_kex >= 0.0
+    if model_name == "3st_binding_if":
+        # Three repeated native runs were bitwise stable. Keep six significant
+        # digits while allowing conservative solver/platform variation.
+        assert fitted_kex == pytest.approx(
+            2.6051568671104906e-10,
+            abs=0.0,
+            rel=1.0e-6,
+        )
+    assert (output / "Statistics" / "MonteCarlo" / "summary.toml").is_file()
+    assert (output / "Statistics" / "Bootstrap" / "summary.toml").is_file()
+    assert (output / "Statistics" / "MCMC" / "summary.toml").is_file()
+    restart = output / "run_info" / "restart.toml"
+    restart_defaults = read_defaults([restart])
+    validate_legacy_binding_defaults(model_name, restart_defaults)
+    restart_names = {name.name for name, _setting in restart_defaults}
+    new_names = (
+        {"KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB"}
+        if model_name == "3st_binding_cs"
+        else {"KD_APP", "KOFF_AB", "KEQ_BC", "KEX_BC"}
+    )
+    legacy_names = {"KAB", "KBA"} if model_name == "3st_binding_cs" else {"KBC", "KCB"}
+    assert new_names <= restart_names
+    assert restart_names.isdisjoint(legacy_names)
+
+    reloaded_output = tmp_path / "Reloaded"
+    reload_args = build_parser().parse_args(
+        [
+            "simulate",
+            "-e",
+            str(experiment),
+            "-p",
+            str(restart),
+            "-d",
+            model_name,
+            "-o",
+            str(reloaded_output),
+            "--plot",
+            "nothing",
+        ]
+    )
+    run(reload_args, session=AnalysisSession.create())
+    assert (reloaded_output / "Parameters" / "constrained.toml").is_file()
+
+    with pytest.raises(LegacyBindingParameterError, match="derived outputs"):
+        validate_legacy_binding_defaults(
+            model_name,
+            read_defaults([output / "Parameters" / "constrained.toml"]),
+        )
+
+
+@pytest.mark.parametrize("model_name", ("3st_binding_cs", "3st_binding_if"))
+def test_category_c_no_variable_output_uses_reportable_parameter_set(
+    tmp_path: Path,
+    model_name: str,
+) -> None:
+    experiment_path, parameter_files, _method, output = _write_execution_fixture(
+        tmp_path,
+        model_name,
+    )
+    session = AnalysisSession.create()
+    session.set_model(model_name)
+    experiments = build_experiments(
+        [experiment_path],
+        Selection(include=[SpinSystem.from_name("486N-HN")], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults(read_defaults(parameter_files))
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    baseline = session.compile_parameterization(Method(), experiments.param_ids)
+    fixed_names = sorted(
+        {
+            parameter_name_from_definition(parameter_model.definitions[param_id]).name
+            for param_id in baseline.independent_ids
+        }
+    )
+    parameterization = session.compile_parameterization(
+        Method(fix=fixed_names),
+        experiments.param_ids,
+    )
+    assert all(
+        parameterization.role(param_id) is not ParameterRole.FIT
+        for param_id in parameterization.independent_ids
+    )
+
+    fit = run_native_deterministic(
+        experiments,
+        output,
+        "nothing",
+        session=session,
+        parameterization=parameterization,
+    )
+
+    assert fit is None
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    report_only_names = (
+        ("KD_BC", "KON_BC") if model_name == "3st_binding_cs" else ("KD_AB", "KON_AB")
+    )
+    for name in (*report_only_names, "PA"):
+        line = _parameter_output_line(constrained, name)
+        assert math.isfinite(_output_value(line))
+        assert "# ±" not in line
+        assert "error unavailable" not in line
+
+
+def test_category_c_report_only_output_explains_unavailable_uncertainty(
+    tmp_path: Path,
+) -> None:
+    experiment, parameter_files, method, output = _write_execution_fixture(
+        tmp_path,
+        "3st_binding_cs",
+    )
+    method.write_text(
+        method.read_text(encoding="utf-8").split("STATISTICS", 1)[0],
+        encoding="utf-8",
+    )
+    original_svd = uncertainty_module.svd
+
+    def rank_deficient_svd(*args, **kwargs):
+        left, singular, right = original_svd(*args, **kwargs)
+        singular = np.array(singular, copy=True)
+        singular[-1] = 0.0
+        return left, singular, right
+
+    args = build_parser().parse_args(
+        [
+            "fit",
+            "-e",
+            str(experiment),
+            "-p",
+            *(str(path) for path in parameter_files),
+            "-m",
+            str(method),
+            "-d",
+            "3st_binding_cs",
+            "-o",
+            str(output),
+            "--plot",
+            "nothing",
+            "--workers",
+            "1",
+        ]
+    )
+
+    with patch("chemex.optimize.uncertainty.svd", side_effect=rank_deficient_svd):
+        run(args, session=AnalysisSession.create())
+
+    constrained = (output / "Parameters" / "constrained.toml").read_text(
+        encoding="utf-8"
+    )
+    for name in ("KD_BC", "KON_BC"):
+        line = _parameter_output_line(constrained, name)
+        assert math.isfinite(_output_value(line))
+        assert _output_unavailable_reason(line) == (
+            "constrained propagation unavailable"
+        )

--- a/tests/models/kinetic/test_category_c_binding_models.py
+++ b/tests/models/kinetic/test_category_c_binding_models.py
@@ -905,15 +905,13 @@ def test_category_c_parameterization_executes_fit_mcmc_and_resampling(
         if definition.name == kex_name
     ]
     fitted_kex = session.analysis_values.snapshot()[kex_id]
-    assert math.isfinite(fitted_kex) and fitted_kex >= 0.0
+    assert math.isfinite(fitted_kex)
     if model_name == "3st_binding_if":
-        # Three repeated native runs were bitwise stable. Keep six significant
-        # digits while allowing conservative solver/platform variation.
-        assert fitted_kex == pytest.approx(
-            2.6051568671104906e-10,
-            abs=0.0,
-            rel=1.0e-6,
-        )
+        # This fitted boundary coordinate varies slightly across platforms. The
+        # invariant is positive near-zero exchange; state-0 tests cover exact zero.
+        assert 0.0 < fitted_kex <= 1.0e-9
+    else:
+        assert fitted_kex >= 0.0
     assert (output / "Statistics" / "MonteCarlo" / "summary.toml").is_file()
     assert (output / "Statistics" / "Bootstrap" / "summary.toml").is_file()
     assert (output / "Statistics" / "MCMC" / "summary.toml").is_file()

--- a/tests/test_analysis_session.py
+++ b/tests/test_analysis_session.py
@@ -92,7 +92,11 @@ class StubParameterFactory:
         self.seal_definition_calls = 0
         self.seal_configuration_calls = 0
         self.native_sealing_succeeds = True
-        self.sealed_parameter_model = SimpleNamespace(declarations={}, definitions=())
+        self.sealed_parameter_model = SimpleNamespace(
+            model_name="2st",
+            declarations={},
+            definitions=(),
+        )
 
     def clear_cache(self) -> None:
         self.clear_calls += 1

--- a/tests/test_native_binding_uncertainty.py
+++ b/tests/test_native_binding_uncertainty.py
@@ -33,6 +33,13 @@ from chemex.optimize.direct_trf import (
     execute_direct_trf,
 )
 from chemex.optimize.grouped_direct_trf import FitDecomposition
+from chemex.optimize.native_mcmc import (
+    McmcOperationTerminal,
+    McmcPlan,
+    execute_mcmc_evidence,
+    resolve_product_mcmc_policy,
+)
+from chemex.optimize.uncertainty import ParameterUnit
 from chemex.parameters.parameterization import ActiveParameterization
 from chemex.parameters.sealed import parameter_name_from_definition
 from chemex.parameters.spin_system import SpinSystem
@@ -249,11 +256,48 @@ def _qualification_anchor_with_unit_residual_jacobian(
     )
 
 
+def _assert_minimum_category_c_uncertainty_is_qualified_or_fail_closed(
+    uncertainty: DeterministicUncertainty,
+    output_ids: dict[str, str],
+    fitted_names: tuple[str, ...],
+    population_ids: dict[str, str],
+) -> None:
+    conclusions = {
+        name: uncertainty.parameter(param_id) for name, param_id in output_ids.items()
+    }
+    assert all(
+        conclusions[name] is not None
+        and conclusions[name].reportable
+        and conclusions[name].standard_error is not None
+        and math.isfinite(conclusions[name].standard_error)
+        and conclusions[name].standard_error > 0.0
+        for name in fitted_names
+    )
+    for name in population_ids:
+        conclusion = conclusions[name]
+        assert conclusion is not None
+        if conclusion.reportable:
+            assert conclusion.standard_error is not None
+            assert math.isfinite(conclusion.standard_error)
+            assert conclusion.standard_error > 0.0
+        else:
+            assert conclusion.standard_error is None
+            assert conclusion.unavailable_kind is not None
+    assert uncertainty.root_evidence is not None
+    constraint_jacobian = uncertainty.root_evidence.constraint_jacobian
+    if constraint_jacobian is not None:
+        assert all(
+            math.isfinite(coefficient)
+            for gradient in constraint_jacobian.gradient_by_target.values()
+            for coefficient in gradient
+        )
+
+
 @pytest.mark.parametrize(
     (
         "model_name",
         "fitted_names",
-        "population_names",
+        "output_names",
         "parameter_values",
         "kd_value",
     ),
@@ -273,6 +317,140 @@ def _qualification_anchor_with_unit_residual_jacobian(
             math.nextafter(0.0, 1.0),
         ),
         (
+            "3st_binding_cs",
+            ("KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB"),
+            (
+                "KD_APP",
+                "KOFF_BC",
+                "KEQ_AB",
+                "KEX_AB",
+                "KAB",
+                "KBA",
+                "KD_BC",
+                "KBC",
+                "KCB",
+                "PA",
+                "PB",
+                "PC",
+            ),
+            ("KOFF_BC = 0.0\nKEX_AB = 0.0\nKEQ_AB = 1.0\nKD_APP = 1e-6"),
+            1.0e-6,
+        ),
+        (
+            "3st_binding_cs",
+            ("KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB"),
+            (
+                "KD_APP",
+                "KOFF_BC",
+                "KEQ_AB",
+                "KEX_AB",
+                "KAB",
+                "KBA",
+                "KD_BC",
+                "KBC",
+                "KCB",
+                "PA",
+                "PB",
+                "PC",
+            ),
+            ("KOFF_BC = 100.0\nKEX_AB = 1e-10\nKEQ_AB = 1.0\nKD_APP = 1e-6"),
+            1.0e-6,
+        ),
+        (
+            "3st_binding_cs",
+            ("KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB"),
+            (
+                "KD_APP",
+                "KOFF_BC",
+                "KEQ_AB",
+                "KEX_AB",
+                "KAB",
+                "KBA",
+                "KD_BC",
+                "KBC",
+                "KCB",
+                "PA",
+                "PB",
+                "PC",
+            ),
+            ("KOFF_BC = 80.0\nKEX_AB = 250.0\nKEQ_AB = 3.0\nKD_APP = 2e-4"),
+            2.0e-4,
+        ),
+        (
+            "3st_binding_if",
+            ("KD_APP", "KOFF_AB", "KEQ_BC", "KEX_BC"),
+            (
+                "KD_APP",
+                "KOFF_AB",
+                "KEQ_BC",
+                "KEX_BC",
+                "KBC",
+                "KCB",
+                "KD_AB",
+                "KAB",
+                "KBA",
+                "PA",
+                "PB",
+                "PC",
+            ),
+            ("KOFF_AB = 0.0\nKEX_BC = 200.0\nKEQ_BC = 0.0\nKD_APP = 1e-6"),
+            1.0e-6,
+        ),
+        (
+            "3st_binding_if",
+            ("KD_APP", "KOFF_AB", "KEQ_BC", "KEX_BC"),
+            (
+                "KD_APP",
+                "KOFF_AB",
+                "KEQ_BC",
+                "KEX_BC",
+                "KBC",
+                "KCB",
+                "KD_AB",
+                "KAB",
+                "KBA",
+                "PA",
+                "PB",
+                "PC",
+            ),
+            ("KOFF_AB = 80.0\nKEX_BC = 250.0\nKEQ_BC = 3.0\nKD_APP = 2e-4"),
+            2.0e-4,
+        ),
+        (
+            "3st_binding_if",
+            ("KD_APP", "KOFF_AB", "KEQ_BC", "KEX_BC"),
+            (
+                "KD_APP",
+                "KOFF_AB",
+                "KEQ_BC",
+                "KEX_BC",
+                "KBC",
+                "KCB",
+                "KD_AB",
+                "KAB",
+                "KBA",
+                "PA",
+                "PB",
+                "PC",
+            ),
+            ("KOFF_AB = 100.0\nKEX_BC = 0.0\nKEQ_BC = 1.0\nKD_APP = 1e-6"),
+            1.0e-6,
+        ),
+        (
+            "3st_binding_cs",
+            ("KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB"),
+            ("KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB", "PA", "PB", "PC"),
+            ("KOFF_BC = 0.0\nKEX_AB = 0.0\nKEQ_AB = 1.0\nKD_APP = 5e-324"),
+            math.nextafter(0.0, 1.0),
+        ),
+        (
+            "3st_binding_cs",
+            ("KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB"),
+            ("KD_APP", "KOFF_BC", "KEQ_AB", "KEX_AB", "PA", "PB", "PC"),
+            ("KOFF_BC = 0.0\nKEX_AB = 0.0\nKEQ_AB = 5e-324\nKD_APP = 1e-3"),
+            1.0e-3,
+        ),
+        (
             "4st_binding_3_bound_states",
             ("KD_APP", "KEQ_BC"),
             ("PA", "PB", "PC", "PD"),
@@ -283,13 +461,25 @@ def _qualification_anchor_with_unit_residual_jacobian(
             sys.float_info.min,
         ),
     ),
-    ids=("simple-binding", "three-state-binding", "four-state-binding"),
+    ids=(
+        "simple-binding",
+        "three-state-binding",
+        "conformational-selection-zero-kex",
+        "conformational-selection-near-zero-kex",
+        "conformational-selection-interior",
+        "induced-fit-zero-keq",
+        "induced-fit-interior",
+        "induced-fit-zero-kex",
+        "conformational-selection-minimum-kd-app",
+        "conformational-selection-minimum-keq",
+        "four-state-binding",
+    ),
 )
-def test_boundary_association_population_uncertainties_are_reportable(
+def test_boundary_association_uncertainties_are_qualified(
     tmp_path: Path,
     model_name: str,
     fitted_names: tuple[str, ...],
-    population_names: tuple[str, ...],
+    output_names: tuple[str, ...],
     parameter_values: str,
     kd_value: float,
 ) -> None:
@@ -300,6 +490,13 @@ def test_boundary_association_population_uncertainties_are_reportable(
         .replace("l_total = 1e-300", "l_total = 2e-3"),
         encoding="utf-8",
     )
+    if model_name in {"3st_binding_cs", "3st_binding_if"}:
+        data_path = experiment.with_name("shift-data.txt")
+        data_path.write_text(
+            data_path.read_text(encoding="utf-8")
+            + "488N-HN 119.50000 0.01\n489N-HN 118.75000 0.01\n",
+            encoding="utf-8",
+        )
     parameters = tmp_path / "parameters.toml"
     parameters.write_text(
         f"[GLOBAL]\nR1_A = 1.5\nR2_A = 4.7\n{parameter_values}\n",
@@ -320,13 +517,18 @@ def test_boundary_association_population_uncertainties_are_reportable(
     configuration = session.parameter_factory.sealed_configuration
     assert parameter_model is not None
     assert configuration is not None
-    population_ids = {
+    output_ids = {
         definition.name: definition.param_id
         for definition in parameter_model.definitions
-        if definition.name in population_names
+        if definition.name in output_names
     }
-    assert set(population_ids) == set(population_names)
-    required_ids = experiments.param_ids | set(population_ids.values())
+    assert set(output_ids) == set(output_names)
+    population_ids = {
+        name: param_id
+        for name, param_id in output_ids.items()
+        if name in {"PA", "PB", "PC", "PD"}
+    }
+    required_ids = experiments.param_ids | set(output_ids.values())
     baseline = session.compile_parameterization(Method(), required_ids)
     fitted_ids = {
         definition.param_id
@@ -361,11 +563,76 @@ def test_boundary_association_population_uncertainties_are_reportable(
         )
     }
     assert start_by_name[fitted_names[0]] == kd_value
+    if "KEQ_AB = 5e-324" in parameter_values:
+        assert start_by_name["KEQ_AB"] == math.nextafter(0.0, 1.0)
     accepted = _qualification_anchor_with_unit_residual_jacobian(
         problem,
         parameterization,
         engine,
     )
+    mcmc_kex_name = (
+        "KEX_AB"
+        if model_name == "3st_binding_cs"
+        and "KEQ_AB = 1.0\nKD_APP = 1e-6" in parameter_values
+        else "KEX_BC"
+        if model_name == "3st_binding_if" and "KEX_BC = 0.0" in parameter_values
+        else None
+    )
+    if mcmc_kex_name is not None:
+        mcmc_accepted = AcceptedFitResult.for_qualification(
+            occurrence_identity="category-c-boundary-mcmc-occurrence",
+            problem_identity=problem.identity,
+            invocation_identity="category-c-boundary-mcmc-invocation",
+            execution_identity="category-c-boundary-mcmc-execution",
+            materialization_identity="category-c-boundary-mcmc-materialization",
+            parameterization_identity=parameterization.identity,
+            evaluator_parameterization_identity=parameterization.evaluator_identity,
+            source_occurrence_identity=problem.source_snapshot.occurrence_identity,
+            source_revision=problem.source_snapshot.revision,
+            controlled_ids=problem.controlled_ids,
+            vector=problem.start,
+            chi_square=accepted.chi_square,
+            evaluation_result=accepted.evaluation_result,
+            commit_scope=problem.commit_scope,
+            commit_items=accepted.evaluation_result.resolved_values.ordered_items(),
+            origin_context_identity="category-c-boundary-mcmc-origin",
+        )
+        mcmc_plan = McmcPlan.for_accepted(
+            mcmc_accepted,
+            source_problem=problem,
+            parameterization=parameterization,
+            source_engine=engine,
+            policy=resolve_product_mcmc_policy(
+                dimension=len(problem.controlled_ids),
+                walkers=10,
+                steps=2,
+                root_seed=733,
+            ),
+            coordinate_units=tuple(
+                (param_id, ParameterUnit.UNSPECIFIED)
+                for param_id in problem.controlled_ids
+            ),
+        )
+        [kex_index] = [
+            index
+            for index, param_id in enumerate(problem.controlled_ids)
+            if parameter_model.definitions[param_id].name == mcmc_kex_name
+        ]
+        expected_kex = 1.0e-10 if "KEX_AB = 1e-10" in parameter_values else 0.0
+        assert problem.start[kex_index] == expected_kex
+        if expected_kex == 0.0:
+            assert any(row[kex_index] == 0.0 for row in mcmc_plan.initial_ensemble)
+        mcmc_operation = execute_mcmc_evidence(mcmc_accepted, mcmc_plan)
+        assert mcmc_operation.terminal is McmcOperationTerminal.COMPLETED, (
+            mcmc_operation.failure_message
+        )
+        assert mcmc_operation.evidence is not None
+        initial_state = mcmc_operation.evidence.states[0]
+        assert all(math.isfinite(value) for value in initial_state.log_densities)
+        if expected_kex == 0.0:
+            assert any(
+                position[kex_index] == 0.0 for position in initial_state.positions
+            )
     decomposition = FitDecomposition.from_root(problem, parameterization, engine)
     uncertainty = derive_deterministic_uncertainty(
         AcceptedDeterministicFitFacts(
@@ -379,9 +646,19 @@ def test_boundary_association_population_uncertainties_are_reportable(
     )
 
     conclusions = {
-        name: uncertainty.parameter(param_id)
-        for name, param_id in population_ids.items()
+        name: uncertainty.parameter(param_id) for name, param_id in output_ids.items()
     }
+    minimum_category_c_boundary = (
+        kd_value == math.nextafter(0.0, 1.0) or "KEQ_AB = 5e-324" in parameter_values
+    ) and model_name == "3st_binding_cs"
+    if minimum_category_c_boundary:
+        _assert_minimum_category_c_uncertainty_is_qualified_or_fail_closed(
+            uncertainty,
+            output_ids,
+            fitted_names,
+            population_ids,
+        )
+        return
     assert all(
         conclusion is not None
         and conclusion.reportable
@@ -415,6 +692,10 @@ def test_boundary_association_population_uncertainties_are_reportable(
             uncertainty.root_evidence.constrained_marginal_errors is not None,
             uncertainty.root_evidence.constrained_correlations is not None,
         ),
+        ()
+        if uncertainty.root_evidence is None
+        or uncertainty.root_evidence.constrained_marginal_errors is None
+        else tuple(uncertainty.root_evidence.constrained_marginal_errors.entries),
     )
     assert uncertainty.root_evidence is not None
     constraint_jacobian = uncertainty.root_evidence.constraint_jacobian
@@ -433,11 +714,15 @@ def test_boundary_association_population_uncertainties_are_reportable(
         for index, param_id in enumerate(problem.controlled_ids)
         if parameter_model.definitions[param_id].name == fitted_names[0]
     )
-    assert gradients["PA"][kd_column] == pytest.approx(
-        1.0e3,
-        rel=2.0e-7,
-        abs=0.0,
-    )
+    if model_name in {"3st_binding_cs", "3st_binding_if"}:
+        assert math.isfinite(gradients["PA"][kd_column])
+        assert gradients["PA"][kd_column] > 0.0
+    else:
+        assert gradients["PA"][kd_column] == pytest.approx(
+            1.0e3,
+            rel=2.0e-7,
+            abs=0.0,
+        )
     assert gradients["PB"][kd_column] != 0.0
     for column in range(len(problem.controlled_ids)):
         column_gradients = tuple(gradient[column] for gradient in gradients.values())
@@ -445,8 +730,13 @@ def test_boundary_association_population_uncertainties_are_reportable(
             0.0,
             abs=4.0 * math.ulp(max(map(abs, column_gradients))),
         )
+    complement_components = (
+        {"pa", "pb", "pc"}
+        if model_name in {"3st_binding_cs", "3st_binding_if"}
+        else {"pb"}
+    )
     assert any(
-        diagnostic.component == "pb"
+        diagnostic.component in complement_components
         and diagnostic.method == "normalized_population_complement"
         for diagnostic in constraint_jacobian.function_partial_diagnostics
     )
@@ -636,7 +926,10 @@ def test_association_population_uncertainties_are_reportable_in_structured_outpu
         and conclusion.standard_error is not None
         and math.isfinite(conclusion.standard_error)
         for param_id in output_ids
-    )
+    ), {
+        parameter_model.definitions[param_id].name: uncertainty.parameter(param_id)
+        for param_id in output_ids
+    }
 
 
 def _assert_representative_profiles_are_shipped() -> None:

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -112,12 +112,16 @@ class _LinearPulseSequence:
         evaluation_observer: Any | None = None,
         evaluation_barrier: Any | None = None,
         fail_outside_pid: int | None = None,
+        maximum_available_a: float | None = None,
+        exact_available_a: float | None = None,
         *,
         source_pid: int | None = None,
     ) -> None:
         self._evaluation_observer = evaluation_observer
         self._evaluation_barrier = evaluation_barrier
         self._fail_outside_pid = fail_outside_pid
+        self._maximum_available_a = maximum_available_a
+        self._exact_available_a = exact_available_a
         self._source_pid = os.getpid() if source_pid is None else source_pid
         self._barrier_used = False
 
@@ -126,6 +130,8 @@ class _LinearPulseSequence:
             self._evaluation_observer,
             self._evaluation_barrier,
             self._fail_outside_pid,
+            self._maximum_available_a,
+            self._exact_available_a,
             source_pid=self._source_pid,
         )
 
@@ -147,7 +153,12 @@ class _LinearPulseSequence:
             )
         if self._fail_outside_pid is not None and os.getpid() != self._fail_outside_pid:
             raise RuntimeError("worker kernel failure")
-        return spectrometer.values["a"] + spectrometer.values["b"] * np.asarray(
+        a = spectrometer.values["a"]
+        if (
+            self._maximum_available_a is not None and a > self._maximum_available_a
+        ) or (self._exact_available_a is not None and a != self._exact_available_a):
+            return np.full_like(data.metadata, np.nan, dtype=np.float64)
+        return a + spectrometer.values["b"] * np.asarray(
             data.metadata,
             dtype=np.float64,
         )
@@ -173,9 +184,12 @@ def test_linear_pulse_sequence_deepcopy_preserves_source_process_identity(
 def _native_context(
     *,
     fit_b: bool = True,
+    accepted_a: float = 1.0,
     evaluation_observer: Any | None = None,
     evaluation_barrier: Any | None = None,
     fail_outside_pid: int | None = None,
+    maximum_available_a: float | None = None,
+    exact_available_a: float | None = None,
 ) -> tuple[
     AcceptedFitResult,
     OptimizationProblem,
@@ -227,6 +241,8 @@ def _native_context(
                 evaluation_observer,
                 evaluation_barrier,
                 fail_outside_pid,
+                maximum_available_a,
+                exact_available_a,
             ),
         ),
         {"a": "A", "b": "B"},
@@ -240,7 +256,7 @@ def _native_context(
     start = (0.5, 1.5) if fit_b else (0.5,)
     lower = (0.0, 1.0) if fit_b else (0.0,)
     upper = (2.0, 3.0) if fit_b else (2.0,)
-    accepted_vector = (1.0, 2.0) if fit_b else (1.0,)
+    accepted_vector = (accepted_a, 2.0) if fit_b else (accepted_a,)
     problem = OptimizationProblem(
         engine.plan.identity,
         parameterization.identity,
@@ -705,6 +721,98 @@ def test_product_initial_ensemble_is_seeded_accepted_point_jitter() -> None:
         (1.0, 2.0),
         atol=2.0e-4,
     )
+
+
+def test_accepted_point_jitter_preserves_a_valid_exact_zero_lower_bound() -> None:
+    positions = np.asarray(
+        build_accepted_point_ensemble(
+            (0.0,),
+            (0.0,),
+            (1.0,),
+            walkers=16,
+            seed=733,
+        )
+    )
+
+    assert np.all(positions >= 0.0)
+    assert np.all(positions <= 1.0)
+    assert np.any(positions == 0.0)
+    assert not np.any(positions == np.nextafter(0.0, 1.0))
+
+
+def test_mcmc_executes_from_an_accepted_point_on_an_exact_zero_bound() -> None:
+    accepted, problem, parameterization, engine = _native_context(accepted_a=0.0)
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=problem,
+        parameterization=parameterization,
+        source_engine=engine,
+        policy=resolve_product_mcmc_policy(
+            dimension=2,
+            walkers=8,
+            steps=3,
+            root_seed=612,
+        ),
+        coordinate_units=(
+            ("A", ParameterUnit.DIMENSIONLESS),
+            ("B", ParameterUnit.DIMENSIONLESS),
+        ),
+    )
+
+    operation = execute_mcmc_evidence(accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    assert any(row[0] == 0.0 for row in plan.initial_ensemble)
+    assert all(
+        np.isfinite(value) for value in operation.evidence.states[0].log_densities
+    )
+
+
+def test_initialization_retries_parameter_resolvable_walkers_without_density() -> None:
+    accepted, plan = _plan_context(maximum_available_a=1.0)
+    assert any(row[0] > 1.0 for row in plan.initial_ensemble)
+
+    operation = execute_mcmc_evidence(accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    initial_state = operation.evidence.states[0]
+    assert initial_state.positions != plan.initial_ensemble
+    assert all(position[0] <= 1.0 for position in initial_state.positions)
+    assert all(np.isfinite(value) for value in initial_state.log_densities)
+    assert operation.raw_capture is not None
+    attempts = native_mcmc._initialization_attempts_for_positions(
+        plan,
+        initial_state.positions,
+    )
+    assert attempts is not None and sum(attempts) > 0
+    assert operation.raw_capture.objective_request_count == (
+        plan.policy.objective_request_budget + sum(attempts)
+    )
+
+
+def test_initialization_density_retry_exhaustion_is_bounded_and_typed() -> None:
+    accepted, plan = _plan_context(exact_available_a=1.0)
+
+    first = execute_mcmc_evidence(accepted, plan)
+    second = execute_mcmc_evidence(accepted, plan)
+
+    for operation in (first, second):
+        assert operation.terminal is McmcOperationTerminal.FAILED
+        assert isinstance(operation.failure, native_mcmc.McmcInitializationError)
+        assert operation.failure_message == (
+            "MCMC initialization found no parameter-and-density-feasible initial "
+            "point for walker 0 after 64 retries (65 candidates evaluated)"
+        )
+        assert operation.raw_capture is not None
+        assert operation.raw_capture.objective_request_count == (
+            plan.policy.walkers + native_mcmc._MAX_INITIALIZATION_ATTEMPTS
+        )
+        assert operation.raw_capture.evaluation_request_count == (
+            operation.raw_capture.objective_request_count
+        )
+    assert first.failure_message == second.failure_message
 
 
 def test_product_policy_initializes_from_exact_accepted_fit() -> None:
@@ -1594,7 +1702,7 @@ def test_capture_qualification_rejects_validly_encoded_state_corruption(
     state = source.states[1]
     positions = [list(row) for row in state.positions]
     if corruption == "bounds":
-        positions[0][0] = plan.upper_bounds[0]
+        positions[0][0] = float(np.nextafter(plan.upper_bounds[0], np.inf))
         expected_category = "state_outside_frozen_bounds"
     else:
         positions = [row[:-1] for row in positions]
@@ -1687,11 +1795,15 @@ def _plan_context(
     evaluation_observer: Any | None = None,
     evaluation_barrier: Any | None = None,
     fail_outside_pid: int | None = None,
+    maximum_available_a: float | None = None,
+    exact_available_a: float | None = None,
 ) -> tuple[AcceptedFitResult, McmcPlan]:
     accepted, problem, parameterization, engine = _native_context(
         evaluation_observer=evaluation_observer,
         evaluation_barrier=evaluation_barrier,
         fail_outside_pid=fail_outside_pid,
+        maximum_available_a=maximum_available_a,
+        exact_available_a=exact_available_a,
     )
     return accepted, McmcPlan.for_accepted(
         accepted,

--- a/tests/test_standard_parameter_bounds.py
+++ b/tests/test_standard_parameter_bounds.py
@@ -77,6 +77,8 @@ def test_approved_kinetic_family_domains_apply_only_to_independent_settings() ->
         "2st_binding",
         "3st_double_binding",
         "3st_binding_partner_2st",
+        "3st_binding_cs",
+        "3st_binding_if",
         "4st_binding_partner_2st",
         "4st_binding_3_bound_states",
     }
@@ -89,7 +91,11 @@ def test_approved_kinetic_family_domains_apply_only_to_independent_settings() ->
                 continue
             if local_name in direct_rates:
                 expected = (0.0, 1.0e6)
-            elif local_name in approved_equilibria:
+            elif model_name == "3st_binding_cs" and local_name == "keq_ab":
+                expected = (math.nextafter(0.0, 1.0), 1.0e6)
+            elif (
+                model_name == "3st_binding_if" and local_name == "keq_bc"
+            ) or local_name in approved_equilibria:
                 expected = expected_domains["keq"]
             elif (
                 model_name in oligomerization_models | strict_binding_models
@@ -231,10 +237,20 @@ def test_approved_standard_spin_family_domains(extension: str) -> None:
             "3st_binding_cs",
             "",
             {
-                "KAB": (0.0, 1.0e6),
-                "KBA": (0.0, 1.0e6),
+                "KEQ_AB": (math.nextafter(0.0, 1.0), 1.0e6),
+                "KEX_AB": (0.0, 1.0e6),
                 "KOFF_BC": (0.0, 1.0e6),
-                "KD_APP": (0.0, 1.0),
+                "KD_APP": (math.nextafter(0.0, 1.0), 1.0),
+            },
+        ),
+        (
+            "3st_binding_if",
+            "",
+            {
+                "KEQ_BC": (0.0, 1.0e6),
+                "KEX_BC": (0.0, 1.0e6),
+                "KOFF_AB": (0.0, 1.0e6),
+                "KD_APP": (math.nextafter(0.0, 1.0), 1.0),
             },
         ),
     ),

--- a/website/docs/user_guide/fitting/kinetic_models.md
+++ b/website/docs/user_guide/fitting/kinetic_models.md
@@ -18,6 +18,8 @@ The kinetic model (specified with the `-d` or `--model` option) defines the type
 | `3st_eyring_fork`   | Fork B ↔ A ↔ C Eyring model for temperature-dependent studies                   |
 | `4st_eyring`        | 4-state exchange model for temperature-dependent studies                        |
 | `2st_binding`       | 2-state exchange model for ligand binding studies                               |
+| `3st_binding_cs`    | 3-state conformational-selection ligand binding model                           |
+| `3st_binding_if`    | 3-state induced-fit ligand binding model                                         |
 | `4st_hd`            | 4-state exchange model for simultaneous normal and H/D solvent exchange studies |
 
 In these models, each state in the exchange process is represented with a unique
@@ -35,6 +37,116 @@ For any kinetic model, you can add the `.rs` suffix to make the kinetic paramete
 :::note
 For any kinetic model, you can add the `.mf` suffix to create a model that fits model-free parameters directly (e.g., `TAUC_A`, `S2_A`), rather than individual relaxation parameters (e.g., `R1_A`, `R2_A`). For an example, see `CEST_15N_TR/` under `Examples/Experiments/`.
 :::
+
+## Three-State Association Models
+
+The `3st_binding_cs` and `3st_binding_if` models separate equilibrium
+composition from tagged-magnetization exchange speed. In both models,
+`KD_APP` and the equilibrium ratio determine `PA`, `PB`, and `PC`; changing a
+`KEX` or `KOFF` value does not change those populations.
+
+All independent association parameters are scoped by temperature. `KD_APP` is
+in M, `KOFF_*` and `KEX_*` are in s⁻¹, and `KEQ_*` is dimensionless. The upper
+bounds shown below are broad safety defaults rather than scientific priors;
+parameter files can override them using the normal explicit-bound syntax.
+
+### Conformational selection: `3st_binding_cs`
+
+The reaction scheme is
+
+```text
+A ⇌ B
+    B + L ⇌ C
+```
+
+where A is apo conformer 1, B is the apo binding-competent conformer, and C is
+the bound complex. The independent parameters are:
+
+| Parameter | Meaning | Default | Default bounds |
+| --- | --- | ---: | ---: |
+| `KD_APP` | apparent dissociation constant against total unbound protein | `1e-6` M | `(0, 1.0]` M |
+| `KOFF_BC` | tagged B←C dissociation-rate scale | `100.0` s⁻¹ | `[0, 1e6]` s⁻¹ |
+| `KEQ_AB` | apo equilibrium ratio `B / A` | `1.0` | `(0, 1e6]` |
+| `KEX_AB` | total tagged A↔B exchange scale | `200.0` s⁻¹ | `[0, 1e6]` s⁻¹ |
+
+Writing `q = KEQ_AB` and `U = A + B`, the apo distribution is
+`A = U / (1 + q)` and `B = U q / (1 + q)`. The apparent equilibrium definition
+is `KD_APP = U L / C`, so the intrinsic binding constant is
+`KD_BC = KD_APP q / (1 + q)`. Directional conformational rates are
+`KAB = KEX_AB q / (1 + q)` and `KBA = KEX_AB / (1 + q)`. The tagged binding
+edge uses `KCB = KOFF_BC` and detailed balance, `PB KBC = PC KCB`.
+
+`KEX_AB = 0` sets both A↔B tagged rates to zero without changing the apo
+equilibrium. `KOFF_BC = 0` freezes both tagged binding directions without
+changing composition. `L_TOTAL = 0` retains the A/B apo distribution and makes
+the tagged association rate zero. `KD_APP = 0`, `KEQ_AB = 0`, and
+`P_TOTAL = 0` are rejected; exact-zero `KEQ_AB` is incompatible with this
+finite reversible apparent-binding parameterization.
+
+`KAB`, `KBA`, `KD_BC`, `KON_BC`, `C_L`, `KBC`, `KCB`, `PA`, `PB`, and `PC`
+remain public derived outputs. `KD_BC` and `KON_BC` are report-only, so an
+unrepresentable intrinsic value cannot block otherwise finite tagged dynamics.
+When representable, these report-only values are included in normal parameter
+output with propagated deterministic uncertainty when its registered derivative
+qualifies; otherwise the output gives the explicit uncertainty-unavailable reason.
+
+### Induced fit: `3st_binding_if`
+
+The reaction scheme is
+
+```text
+A + L ⇌ B ⇌ C
+```
+
+where A is free protein, B is the first bound complex, and C is the rearranged
+bound complex. The independent parameters are:
+
+| Parameter | Meaning | Default | Default bounds |
+| --- | --- | ---: | ---: |
+| `KD_APP` | apparent dissociation constant against total bound protein | `1e-3` M | `(0, 1.0]` M |
+| `KOFF_AB` | tagged A←B dissociation-rate scale | `100.0` s⁻¹ | `[0, 1e6]` s⁻¹ |
+| `KEQ_BC` | bound-state equilibrium ratio `C / B` | `1.0` | `[0, 1e6]` |
+| `KEX_BC` | total tagged B↔C exchange scale | `200.0` s⁻¹ | `[0, 1e6]` s⁻¹ |
+
+Writing `q = KEQ_BC`, the apparent equilibrium definition is
+`KD_APP = A L / (B + C)`, with `B:C = 1:q`; therefore
+`KD_AB = KD_APP (1 + q)`. Directional conformational rates are
+`KBC = KEX_BC q / (1 + q)` and `KCB = KEX_BC / (1 + q)`. The tagged binding
+edge uses `KBA = KOFF_AB` and detailed balance, `PA KAB = PB KBA`.
+
+`KEX_BC = 0` and `KOFF_AB = 0` freeze their respective tagged edges without
+changing composition. `KEQ_BC = 0` is supported exactly: C has zero equilibrium
+weight, `KBC = 0`, `KCB = KEX_BC`, and `KD_AB = KD_APP`. `L_TOTAL = 0` puts all
+protein in free A and makes the tagged association rate zero. `KD_APP = 0` and
+`P_TOTAL = 0` are rejected.
+
+`KBC`, `KCB`, `KD_AB`, `KON_AB`, `C_L`, `KAB`, `KBA`, `PA`, `PB`, and `PC`
+remain public derived outputs. `KD_AB` and `KON_AB` are report-only, with the same
+representability and uncertainty-reporting policy as `KD_BC` and `KON_BC` above.
+
+### Migrating directional-rate inputs
+
+Directional rates remain available as outputs but can no longer be supplied as
+independent parameter values, Method Plan roles, constraints, or grid targets.
+For `3st_binding_cs`, replace a positive legacy pair using
+`KEQ_AB = KAB / KBA` and `KEX_AB = KAB + KBA`. For `3st_binding_if`, use
+`KEQ_BC = KBC / KCB` and `KEX_BC = KBC + KCB`.
+
+A legacy `(0, 0)` pair determines only `KEX = 0`; its equilibrium ratio is
+ambiguous and must be chosen explicitly. For induced fit, `KBC = 0` with
+`KCB > 0` maps exactly to `KEQ_BC = 0` and `KEX_BC = KCB`. A positive forward
+rate with a zero reverse rate would require an infinite equilibrium ratio and
+cannot be migrated to the finite parameter domain. Conformational selection
+also rejects a legacy `KAB = 0` mapping because `KEQ_AB` must be positive.
+
+The migration diagnostic prints a numerical replacement only when the exact
+positive ratio and sum are representable in binary64. If either result is outside
+that domain, it asks for manual model/parameter reconsideration instead of
+printing a false zero or infinity. A representable replacement can still exceed
+the new broad default upper bound of `1e6`. In that case keep the exact migrated
+value and override the bound explicitly with the normal three-value parameter
+syntax, for example `KEX_BC = [1200000.0, 0.0, 1200000.0]`; for positive CS
+`KEQ_AB`, use a positive lower bound such as `5e-324`.
 
 ## Temperature-Dependent Eyring Models
 


### PR DESCRIPTION
## Summary

This completes the association-equilibrium authority work for the two deferred three-state binding mechanisms:

- `3st_binding_cs` — conformational selection
- `3st_binding_if` — induced fit

The models now separate thermodynamic composition from kinetic exchange speed:

- equilibrium parameters determine species populations;
- kinetic parameters determine tagged-magnetization transfer rates.

This removes the previous dependence of equilibrium composition on directional kinetic-rate ratios and gives exact, well-defined zero-exchange semantics.

## Public parameterization

### Conformational selection

Previously independent:

- `KAB`
- `KBA`

Now independent:

- `KEQ_AB`
- `KEX_AB`

with:

`KEQ_AB = B / A`

`KEX_AB = KAB + KBA`

and derived rates:

`KAB = KEX_AB × KEQ_AB / (1 + KEQ_AB)`

`KBA = KEX_AB / (1 + KEQ_AB)`.

`KD_APP` and `KOFF_BC` remain independent.

The intrinsic binding relation is:

`KD_BC = KD_APP × KEQ_AB / (1 + KEQ_AB)`.

### Induced fit

Previously independent:

- `KBC`
- `KCB`

Now independent:

- `KEQ_BC`
- `KEX_BC`

with:

`KEQ_BC = C / B`

`KEX_BC = KBC + KCB`

and derived rates:

`KBC = KEX_BC × KEQ_BC / (1 + KEQ_BC)`

`KCB = KEX_BC / (1 + KEQ_BC)`.

`KD_APP` and `KOFF_AB` remain independent.

The intrinsic binding relation is:

`KD_AB = KD_APP × (1 + KEQ_BC)`.

The existing model names are retained.

## Equilibrium authority

Both models now use the same validated finite-pool equilibrium authority introduced for the other association models.

The solver was generalized to support multiple equilibrium free-protein states while preserving the previous single-free-state behavior.

Populations now follow:

equilibrium inputs
→ canonical finite-pool composition
→ PA/PB/PC
→ tagged rates

rather than a second kinetic `pop_3st` calculation.

For fixed thermodynamics, changing:

- KEX;
- KOFF;

therefore no longer changes equilibrium populations.

## Zero semantics

### Both models

`KEX = 0` is valid:

- both directional conformational rates become exactly zero;
- equilibrium composition remains defined.

`KOFF = 0` is valid:

- the tagged binding edge freezes;
- equilibrium populations remain unchanged.

`KD_APP = 0` is rejected.

`L_TOTAL = 0` remains valid.

`P_TOTAL = 0` is rejected because normalized protein-state populations are undefined.

### Conformational selection

`KEQ_AB` must remain strictly positive.

Exact `KEQ_AB = 0` would imply a zero intrinsic reversible binding KD for finite `KD_APP`, so that boundary is outside this model's finite reversible parameterization.

### Induced fit

Exact `KEQ_BC = 0` is valid:

- `PC = 0`;
- `KBC = 0`;
- `KCB = KEX_BC`;
- `KD_AB = KD_APP`.

No equilibrium-ratio floor is used.

## Tagged rates and detailed balance

Conformational rates use the checked KEQ/KEX splitting authority.

Binding association rates are derived from canonical equilibrium populations and the reverse KOFF rate through detailed balance, avoiding potentially unrepresentable intermediate KON values.

Every positive reversible edge satisfies equilibrium detailed balance.

Positive mathematical rates that cannot be represented in binary64 fail explicitly instead of silently becoming structural zero.

## Report-only compatibility outputs

The legacy directional names remain public derived outputs:

### CS

- `KAB`
- `KBA`

### IF

- `KBC`
- `KCB`

Intrinsic binding quantities also remain available:

### CS

- `KD_BC`
- `KON_BC`

### IF

- `KD_AB`
- `KON_AB`

Intrinsic KD/KON values are report-only when not required by dynamics.

Representable report-only values receive deterministic propagated uncertainty when qualified.

Unrepresentable values:

- do not block finite model dynamics;
- are omitted from ordinary reporting;
- remain fail-closed on explicit resolution.

## Migration of existing parameter files

This is an intentional breaking change to the independent parameterization of these two models.

Legacy directional inputs are rejected with model-specific migration guidance rather than being silently ignored or automatically transformed.

### CS

For a finite positive legacy pair:

`KEQ_AB = KAB / KBA`

`KEX_AB = KAB + KBA`.

### IF

For a finite positive legacy pair:

`KEQ_BC = KBC / KCB`

`KEX_BC = KBC + KCB`.

The migration diagnostics handle:

- partial legacy pairs;
- scoped parameter IDs;
- `(0,0)` ambiguity;
- unsupported infinite-ratio cases;
- IF exact zero-forward mapping;
- old/new syntax conflicts;
- values outside the new default KEQ/KEX bounds;
- binary64-unrepresentable ratio or sum results.

Migration conversions are classified before formatting, so diagnostics never manufacture false `0.0` or `inf` replacement values.

No nonlinear aliases or dual parameterization were introduced.

## MCMC boundary robustness

MCMC initialization now uses a generic feasibility rule:

an initial walker must:

1. satisfy declared parameter bounds;
2. resolve native parameters;
3. have finite native log density.

Density-unavailable walkers are deterministically regenerated up to a bounded retry limit.

This supports legal exact-zero and near-zero exchange boundaries without weakening fail-closed rate representability checks.

The implementation is generic and contains no Category-C or binding-specific MCMC logic.

Accepted state-0 densities are reused rather than recomputed.

## Restart and output

Generated `run_info/restart.toml` files use only the new independent KEQ/KEX authority and reload successfully through the supported production path.

Generated constrained output retains:

- directional compatibility rates;
- intrinsic KD/KON;
- equilibrium populations;

with propagated uncertainties where qualified and explicit unavailable-reason diagnostics otherwise.

## Ordinary compatibility

Positive-domain legacy directional pairs were transformed to KEQ/KEX and reconstructed across fixtures covering:

- balanced and strongly biased equilibria;
- slow and fast exchange;
- weak and strong binding;
- ligand depletion.

Concentrations, populations, rates, and representative propagated observables agree within binary64/root-solver precision.

Differences from the old multidimensional concentration root in difficult strongly bound free-species cases were independently verified against high-precision equilibrium references and are corrections to the previous root accuracy.

## Numerical robustness

Coverage includes:

- minimum-positive KD;
- minimum-positive CS KEQ;
- exact-zero IF KEQ;
- KEQ up to the default upper domain;
- strong and weak binding;
- tiny and asymmetric totals;
- near-stoichiometric totals;
- zero ligand;
- zero KEX;
- zero KOFF;
- directional-rate representability boundaries.

There are no hidden KD/KEQ floors and no unchecked multidimensional binding roots.

## Readability

Readability was treated as a release requirement.

The final implementation keeps the scientific flow explicit:

### CS

KEQ_AB
→ apo composition

KD_APP
→ binding equilibrium

canonical equilibrium
→ populations

KEX_AB
→ KAB/KBA

KOFF_BC + equilibrium
→ KBC/KCB

### IF

KD_APP + KEQ_BC
→ bound composition

canonical equilibrium
→ populations

KEX_BC
→ KBC/KCB

KOFF_AB + equilibrium
→ KAB/KBA

Migration policy is isolated and declarative.

Binding validation uses keyword-only scientific arguments.

MCMC feasibility is implemented through one generic, linear initialization path.

Independent audit concluded:

`READABILITY PASS`.

## Documentation

Current documentation now includes:

- state assignments and reaction schemes;
- KEQ orientations;
- KEX formulas;
- apparent/intrinsic KD relationships;
- zero semantics;
- migration formulas;
- out-of-default-bound migration guidance;
- retained derived directional outputs.

Frozen historical versioned documentation was not modified.

## Validation

Final exact candidate:

- Category-C tests: 97 passed
- native binding uncertainty: 19 passed
- native MCMC: 86 passed
- Category-A/shared binding regression: 171 passed
- complete kinetic suite: 733 passed
- resampling: 50 passed
- full suite: 2,085 passed
- website build: passed
- `uv run ty check`: passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `git diff --check`: passed
- repository graph refresh: passed

Independent audit and closure concluded:

- scientific authority: PASS
- numerical robustness: PASS
- migration safety: PASS
- compatibility handling: PASS
- MCMC boundary execution: PASS
- deterministic uncertainty/reporting: PASS
- Pass-1 regression: PASS
- documentation: PASS
- readability: PASS
- `PASS — 0 closure findings`
- `READY TO COMMIT THE AUDITED DIFF`

## Scope exclusions

This PR does not scientifically change:

- the ten Pass-1 Category-A association models;
- generic `pop_2st` / `pop_3st`;
- Eyring models;
- generic 3/4/5/6-state topology;
- modifiers;
- statistics;
- experiment implementations.

## Breaking-change note

Existing `3st_binding_cs` parameter files using independent:

- `KAB`;
- `KBA`

must migrate to:

- `KEQ_AB`;
- `KEX_AB`.

Existing `3st_binding_if` parameter files using independent:

- `KBC`;
- `KCB`

must migrate to:

- `KEQ_BC`;
- `KEX_BC`.

The models themselves retain their names.