### PR TITLE
fix: unify Eyring thermodynamic authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- Eyring models now use one log-domain transition-state authority without the
+  former `1e16 s^-1` rate saturation. Positive rates outside binary64
+  representability fail explicitly, while representable subnormal rates remain
+  valid. Equilibrium populations now come directly from thermodynamic state
+  coordinates for all two-, three-, and four-state Eyring models, preserving
+  detailed balance, cycle closure, and population invariance under uniform
+  kinetic slowdown. Mathematically positive state populations below binary64
+  representability now fail explicitly instead of becoming structural zero.
+  Invalid Celsius temperatures at or below absolute zero and non-finite
+  temperatures are rejected, exact 0 °C retains its condition identity, and
+  derived directional rates and normalized populations receive deterministic
+  propagated uncertainty when the fit covariance is qualified.
+  These are correctness fixes; public Eyring model and H/S parameter names,
+  units, defaults, scopes, and TOML syntax are unchanged.
 - `3st_binding_cs` and `3st_binding_if` now use equilibrium parameters and mass
   balances as the sole population authority, independently of tagged kinetic
   scales. This is a breaking independent-parameter change: conformational

--- a/src/chemex/configuration/conditions.py
+++ b/src/chemex/configuration/conditions.py
@@ -14,6 +14,7 @@ from pydantic import (
 from pydantic_core.core_schema import ValidationInfo
 
 from chemex.configuration.utils import key_to_lower, to_lower
+from chemex.models.kinetic._eyring import temperature_to_kelvin
 from chemex.models.model import ModelSpec
 
 T = TypeVar("T")
@@ -52,7 +53,9 @@ class Conditions(BaseModel, frozen=True):
     def rounded(self) -> Self:
         """Return a new instance with rounded h_larmor_frq and temperature."""
         h_larmor_frq = round(self.h_larmor_frq, 1) if self.h_larmor_frq else None
-        temperature = round(self.temperature, 1) if self.temperature else None
+        temperature = (
+            round(self.temperature, 1) if self.temperature is not None else None
+        )
         return self.model_copy(
             update={"h_larmor_frq": h_larmor_frq, "temperature": temperature},
         )
@@ -151,9 +154,11 @@ class ConditionsWithValidations(Conditions, frozen=True):
             msg = 'To use the "hd" model, d2o must be provided'
             raise ValueError(msg)
 
-        if "eyring" in model_name and self.temperature is None:
-            msg = 'To use the "eyring" model, "temperature" must be provided'
-            raise ValueError(msg)
+        if "eyring" in model_name:
+            if self.temperature is None:
+                msg = 'To use the "eyring" model, "temperature" must be provided'
+                raise ValueError(msg)
+            temperature_to_kelvin(self.temperature)
 
         # Binding models require both concentrations to be present.
         are_not_both_set = self.p_total is None or self.l_total is None

--- a/src/chemex/configuration/types.py
+++ b/src/chemex/configuration/types.py
@@ -10,9 +10,6 @@ from typing import Annotated
 
 from pydantic import AfterValidator, Field
 
-# Constants
-MAX_TEMPERATURE = 500.0  # Maximum physically reasonable temperature in Kelvin
-
 
 # Validators for common patterns
 def validate_positive(v: float) -> float:
@@ -35,14 +32,6 @@ def validate_probability(v: float) -> float:
     """Validate that a value is a valid probability [0, 1]."""
     if not 0.0 <= v <= 1.0:
         msg = f"Must be between 0 and 1, got {v}"
-        raise ValueError(msg)
-    return v
-
-
-def validate_temperature(v: float) -> float:
-    """Validate that a temperature is physically reasonable."""
-    if not 0.0 < v < MAX_TEMPERATURE:
-        msg = f"Temperature must be between 0 and {MAX_TEMPERATURE} K, got {v}"
         raise ValueError(msg)
     return v
 
@@ -109,17 +98,6 @@ PositiveFrequency = Annotated[
 ]
 """Positive frequency in Hz (> 0)."""
 
-Temperature = Annotated[
-    float,
-    Field(
-        gt=0.0,
-        lt=MAX_TEMPERATURE,
-        description=f"Temperature in Kelvin (0-{MAX_TEMPERATURE} K)",
-    ),
-    AfterValidator(validate_temperature),
-]
-f"""Temperature in Kelvin, physically reasonable range (0-{MAX_TEMPERATURE} K)."""
-
 RelaxationTime = Annotated[
     float,
     Field(
@@ -180,6 +158,5 @@ Population = Annotated[
 OptionalPulseWidth = PulseWidth | None
 OptionalFrequency = Frequency | None
 OptionalPositiveFrequency = PositiveFrequency | None
-OptionalTemperature = Temperature | None
 OptionalDelay = Delay | None
 OptionalB1Field = B1Field | None

--- a/src/chemex/models/kinetic/_eyring.py
+++ b/src/chemex/models/kinetic/_eyring.py
@@ -1,0 +1,386 @@
+"""Shared scientific authority for temperature-dependent Eyring models."""
+
+from __future__ import annotations
+
+import math
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+from scipy import constants
+
+MIN_POSITIVE_FLOAT = math.nextafter(0.0, 1.0)
+_LOG_MIN_POSITIVE_FLOAT = math.log(MIN_POSITIVE_FLOAT)
+_LOG_MAX_FLOAT = math.log(sys.float_info.max)
+_LOG_EYRING_FREQUENCY_FACTOR = math.log(constants.k / constants.h)
+
+
+@dataclass(frozen=True, slots=True)
+class ThermodynamicCoordinate:
+    """Enthalpy and entropy coordinates relative to reference state A."""
+
+    enthalpy: float
+    entropy: float
+
+
+def _validate_coordinate(
+    coordinate: ThermodynamicCoordinate,
+    *,
+    description: str,
+) -> None:
+    if not math.isfinite(coordinate.enthalpy) or not math.isfinite(coordinate.entropy):
+        msg = f"{description} thermodynamic coordinates must be finite"
+        raise ValueError(msg)
+
+
+def _validate_kelvin(kelvin: float) -> float:
+    if not math.isfinite(kelvin) or kelvin <= 0.0:
+        msg = "Eyring absolute temperature must be finite and strictly positive"
+        raise ValueError(msg)
+    return kelvin
+
+
+def temperature_to_kelvin(temperature: float) -> float:
+    """Validate a public Celsius temperature and return absolute temperature."""
+    kelvin = float(temperature) + constants.zero_Celsius
+    if not math.isfinite(kelvin) or kelvin <= 0.0:
+        msg = (
+            "Eyring temperature must be finite and above absolute zero "
+            f"(-273.15 degrees Celsius), got {temperature!r}"
+        )
+        raise ValueError(msg)
+    return kelvin
+
+
+def state_log_boltzmann_weight(
+    state: ThermodynamicCoordinate,
+    kelvin: float,
+) -> float:
+    """Return ``log(w_i)`` for one state's coordinate relative to state A."""
+    _validate_coordinate(state, description="State")
+    absolute_temperature = _validate_kelvin(kelvin)
+    log_weight = state.entropy / constants.R - state.enthalpy / (
+        constants.R * absolute_temperature
+    )
+    if not math.isfinite(log_weight):
+        msg = "Eyring state log Boltzmann weight is outside the finite binary64 domain"
+        raise ValueError(msg)
+    return log_weight
+
+
+def directional_log_rate(
+    initial_state: ThermodynamicCoordinate,
+    transition_state: ThermodynamicCoordinate,
+    kelvin: float,
+) -> float:
+    """Return the Eyring log rate from one state through a shared transition state."""
+    _validate_coordinate(initial_state, description="Initial-state")
+    _validate_coordinate(transition_state, description="Transition-state")
+    absolute_temperature = _validate_kelvin(kelvin)
+    activation_enthalpy = transition_state.enthalpy - initial_state.enthalpy
+    activation_entropy = transition_state.entropy - initial_state.entropy
+    return (
+        _LOG_EYRING_FREQUENCY_FACTOR
+        + math.log(absolute_temperature)
+        + activation_entropy / constants.R
+        - activation_enthalpy / (constants.R * absolute_temperature)
+    )
+
+
+def _positive_float_from_log(log_value: float, *, quantity: str) -> float:
+    """Convert one positive Eyring quantity from log space or fail closed."""
+    if math.isnan(log_value):
+        msg = f"Eyring log {quantity} must not be NaN"
+        raise ValueError(msg)
+    if log_value > _LOG_MAX_FLOAT:
+        msg = f"Eyring {quantity} exceeds maximum finite binary64 value"
+        raise ValueError(msg)
+    if log_value < _LOG_MIN_POSITIVE_FLOAT:
+        msg = f"Positive Eyring {quantity} is below binary64 representability"
+        raise ValueError(msg)
+
+    value = math.exp(log_value)
+    if value == 0.0:
+        msg = f"Positive Eyring {quantity} is below binary64 representability"
+        raise ValueError(msg)
+    if not math.isfinite(value):
+        msg = f"Eyring {quantity} exceeds maximum finite binary64 value"
+        raise ValueError(msg)
+    return value
+
+
+def rate_from_log(log_rate: float) -> float:
+    """Convert a positive mathematical rate to binary64 or fail closed."""
+    return _positive_float_from_log(log_rate, quantity="rate")
+
+
+def calculate_directional_rate(
+    initial_state: ThermodynamicCoordinate,
+    transition_state: ThermodynamicCoordinate,
+    temperature: float,
+) -> float:
+    """Calculate one directional Eyring rate from public Celsius temperature."""
+    kelvin = temperature_to_kelvin(temperature)
+    return rate_from_log(directional_log_rate(initial_state, transition_state, kelvin))
+
+
+def calculate_rate_from_coordinates(
+    initial_enthalpy: float,
+    initial_entropy: float,
+    transition_enthalpy: float,
+    transition_entropy: float,
+    temperature: float,
+) -> float:
+    """Scalar constraint-expression adapter for one directional Eyring rate."""
+    return calculate_directional_rate(
+        ThermodynamicCoordinate(initial_enthalpy, initial_entropy),
+        ThermodynamicCoordinate(transition_enthalpy, transition_entropy),
+        temperature,
+    )
+
+
+def calculate_rate_component(
+    initial_enthalpy: float,
+    initial_entropy: float,
+    transition_enthalpy: float,
+    transition_entropy: float,
+    temperature: float,
+) -> dict[str, float]:
+    """Constraint-expression mapping adapter for one directional Eyring rate."""
+    return {
+        "rate": calculate_rate_from_coordinates(
+            initial_enthalpy,
+            initial_entropy,
+            transition_enthalpy,
+            transition_entropy,
+            temperature,
+        )
+    }
+
+
+def rate_partial_initial_enthalpy(
+    initial_enthalpy: float,
+    initial_entropy: float,
+    transition_enthalpy: float,
+    transition_entropy: float,
+    temperature: float,
+) -> float:
+    rate = calculate_rate_from_coordinates(
+        initial_enthalpy,
+        initial_entropy,
+        transition_enthalpy,
+        transition_entropy,
+        temperature,
+    )
+    kelvin = temperature_to_kelvin(temperature)
+    return rate / (constants.R * kelvin)
+
+
+def rate_partial_initial_entropy(
+    initial_enthalpy: float,
+    initial_entropy: float,
+    transition_enthalpy: float,
+    transition_entropy: float,
+    temperature: float,
+) -> float:
+    rate = calculate_rate_from_coordinates(
+        initial_enthalpy,
+        initial_entropy,
+        transition_enthalpy,
+        transition_entropy,
+        temperature,
+    )
+    return -rate / constants.R
+
+
+def rate_partial_transition_enthalpy(
+    initial_enthalpy: float,
+    initial_entropy: float,
+    transition_enthalpy: float,
+    transition_entropy: float,
+    temperature: float,
+) -> float:
+    return -rate_partial_initial_enthalpy(
+        initial_enthalpy,
+        initial_entropy,
+        transition_enthalpy,
+        transition_entropy,
+        temperature,
+    )
+
+
+def rate_partial_transition_entropy(
+    initial_enthalpy: float,
+    initial_entropy: float,
+    transition_enthalpy: float,
+    transition_entropy: float,
+    temperature: float,
+) -> float:
+    return -rate_partial_initial_entropy(
+        initial_enthalpy,
+        initial_entropy,
+        transition_enthalpy,
+        transition_entropy,
+        temperature,
+    )
+
+
+def rate_partial_temperature(
+    initial_enthalpy: float,
+    initial_entropy: float,
+    transition_enthalpy: float,
+    transition_entropy: float,
+    temperature: float,
+) -> float:
+    rate = calculate_rate_from_coordinates(
+        initial_enthalpy,
+        initial_entropy,
+        transition_enthalpy,
+        transition_entropy,
+        temperature,
+    )
+    kelvin = temperature_to_kelvin(temperature)
+    activation_enthalpy = transition_enthalpy - initial_enthalpy
+    return rate * (1.0 / kelvin + activation_enthalpy / (constants.R * kelvin * kelvin))
+
+
+EYRING_RATE_PARTIALS = (
+    rate_partial_initial_enthalpy,
+    rate_partial_initial_entropy,
+    rate_partial_transition_enthalpy,
+    rate_partial_transition_entropy,
+    rate_partial_temperature,
+)
+
+
+def thermodynamic_populations(
+    states: Mapping[str, ThermodynamicCoordinate],
+    temperature: float,
+) -> dict[str, float]:
+    """Normalize equilibrium populations from thermodynamic state coordinates."""
+    if not states:
+        msg = "Eyring population calculation requires at least one state"
+        raise ValueError(msg)
+    kelvin = temperature_to_kelvin(temperature)
+    log_weights = {
+        name: state_log_boltzmann_weight(coordinate, kelvin)
+        for name, coordinate in states.items()
+    }
+    reference = max(log_weights.values())
+    relative_log_weights = {
+        name: log_weight - reference for name, log_weight in log_weights.items()
+    }
+    log_scaled_total = math.log(
+        math.fsum(math.exp(value) for value in relative_log_weights.values())
+    )
+    # Classify normalized log probabilities before exponentiation so a finite
+    # thermodynamic state cannot silently disappear as structural zero.
+    return {
+        name: _positive_float_from_log(
+            relative_log_weight - log_scaled_total,
+            quantity="population",
+        )
+        for name, relative_log_weight in relative_log_weights.items()
+    }
+
+
+def _population_partial(
+    state_count: int,
+    population_index: int,
+    argument_index: int,
+) -> Callable[..., float]:
+    """Build one exact softmax partial for a flattened Eyring state call."""
+
+    def partial(*arguments: float) -> float:
+        expected_arity = 2 * (state_count - 1) + 1
+        if len(arguments) != expected_arity:
+            msg = (
+                "Eyring population derivative received "
+                f"{len(arguments)} arguments instead of {expected_arity}"
+            )
+            raise ValueError(msg)
+        temperature = arguments[-1]
+        kelvin = temperature_to_kelvin(temperature)
+        states = (
+            ThermodynamicCoordinate(0.0, 0.0),
+            *(
+                ThermodynamicCoordinate(arguments[index], arguments[index + 1])
+                for index in range(0, expected_arity - 1, 2)
+            ),
+        )
+        populations = tuple(
+            thermodynamic_populations(
+                {str(index): state for index, state in enumerate(states)},
+                temperature,
+            ).values()
+        )
+        population = populations[population_index]
+
+        if argument_index == expected_arity - 1:
+            mean_enthalpy = math.fsum(
+                probability * state.enthalpy
+                for probability, state in zip(populations, states, strict=True)
+            )
+            centered_enthalpy = states[population_index].enthalpy - mean_enthalpy
+            if centered_enthalpy == 0.0:
+                return 0.0
+            direct = population * centered_enthalpy / (constants.R * kelvin * kelvin)
+            if direct != 0.0:
+                return direct
+            magnitude = _positive_float_from_log(
+                math.log(population)
+                + math.log(abs(centered_enthalpy))
+                - math.log(constants.R)
+                - 2.0 * math.log(kelvin),
+                quantity="population derivative",
+            )
+            return math.copysign(magnitude, centered_enthalpy)
+
+        coordinate_index = argument_index // 2 + 1
+        coordinate_population = populations[coordinate_index]
+        selected = population_index == coordinate_index
+        signed_coupling = (
+            coordinate_population - float(selected)
+            if argument_index % 2 == 0
+            else float(selected) - coordinate_population
+        )
+        denominator = constants.R * kelvin if argument_index % 2 == 0 else constants.R
+        direct = population * signed_coupling / denominator
+        if direct != 0.0:
+            return direct
+        coupling = (
+            math.fsum(
+                probability
+                for index, probability in enumerate(populations)
+                if index != coordinate_index
+            )
+            if selected
+            else coordinate_population
+        )
+        magnitude = _positive_float_from_log(
+            math.log(population) + math.log(coupling) - math.log(denominator),
+            quantity="population derivative",
+        )
+        if argument_index % 2 == 0:
+            return -magnitude if selected else magnitude
+        return magnitude if selected else -magnitude
+
+    return partial
+
+
+def thermodynamic_population_partials(
+    components: Sequence[str],
+) -> dict[str, tuple[Callable[..., float], ...]]:
+    """Return exact coupled derivatives for named normalized populations."""
+    names = tuple(components)
+    if len(names) < 2 or len(set(names)) != len(names):
+        msg = "Eyring populations require at least two distinct component names"
+        raise ValueError(msg)
+    arity = 2 * (len(names) - 1) + 1
+    return {
+        name: tuple(
+            _population_partial(len(names), population_index, argument_index)
+            for argument_index in range(arity)
+        )
+        for population_index, name in enumerate(names)
+    }

--- a/src/chemex/models/kinetic/settings_2st_eyring.py
+++ b/src/chemex/models/kinetic/settings_2st_eyring.py
@@ -2,22 +2,31 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import numpy as np
-from scipy import constants
-
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_2st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._eyring import (
+    EYRING_RATE_PARTIALS,
+    ThermodynamicCoordinate,
+    calculate_directional_rate,
+    calculate_rate_component,
+    temperature_to_kelvin,
+    thermodynamic_population_partials,
+    thermodynamic_populations,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.userfunctions import (
+    AnalyticFunctionLinearization,
+    function_linearization_registry,
+    user_function_registry,
+)
 
 NAME = "2st_eyring"
 
 PL = ("p_total", "l_total")
 TPL = ("temperature", "p_total", "l_total")
 
-# Physical constants
-MAX_RATE_CONSTANT = 1e16  # Maximum rate constant (s⁻¹) for numerical stability
+REFERENCE_STATE = ThermodynamicCoordinate(enthalpy=0.0, entropy=0.0)
 
 
 @lru_cache(maxsize=100)
@@ -28,16 +37,28 @@ def calculate_kij_2st_eyring(
     ds_ab: float,
     temperature: float,
 ) -> dict[str, float]:
-    kelvin = temperature + constants.zero_Celsius
-    kbt_h = constants.k * kelvin / constants.h
-    rt = constants.R * kelvin
-    dh_a = ds_a = 0.0
-    kab = kbt_h * np.exp(-(dh_ab - dh_a - kelvin * (ds_ab - ds_a)) / rt)
-    kba = kbt_h * np.exp(-(dh_ab - dh_b - kelvin * (ds_ab - ds_b)) / rt)
-    # Clip values for numerical stability
-    kab = np.clip(kab, 0.0, MAX_RATE_CONSTANT)
-    kba = np.clip(kba, 0.0, MAX_RATE_CONSTANT)
-    return {"kab": kab, "kba": kba}
+    state_b = ThermodynamicCoordinate(enthalpy=dh_b, entropy=ds_b)
+    transition_ab = ThermodynamicCoordinate(enthalpy=dh_ab, entropy=ds_ab)
+    return {
+        "kab": calculate_directional_rate(REFERENCE_STATE, transition_ab, temperature),
+        "kba": calculate_directional_rate(state_b, transition_ab, temperature),
+    }
+
+
+@lru_cache(maxsize=100)
+def calculate_populations_2st_eyring(
+    dh_b: float,
+    ds_b: float,
+    temperature: float,
+) -> dict[str, float]:
+    populations = thermodynamic_populations(
+        {
+            "a": REFERENCE_STATE,
+            "b": ThermodynamicCoordinate(enthalpy=dh_b, entropy=ds_b),
+        },
+        temperature,
+    )
+    return {f"p{state}": population for state, population in populations.items()}
 
 
 def make_settings_2st_eyring(conditions: Conditions) -> dict[str, ParamLocalSetting]:
@@ -45,6 +66,7 @@ def make_settings_2st_eyring(conditions: Conditions) -> dict[str, ParamLocalSett
     if celsius is None:
         msg = "The 'temperature' is None"
         raise ValueError(msg)
+    temperature_to_kelvin(celsius)
     return {
         "dh_b": ParamLocalSetting(
             name_setting=NameSetting("dh_b", "", PL),
@@ -77,29 +99,57 @@ def make_settings_2st_eyring(conditions: Conditions) -> dict[str, ParamLocalSett
         "kab": ParamLocalSetting(
             name_setting=NameSetting("kab", "", TPL),
             min=0.0,
-            expr=f"kij_2st_eyring({{dh_b}},{{ds_b}},{{dh_ab}},{{ds_ab}},{celsius})['kab']",
+            expr=f"eyring_rate(0.0,0.0,{{dh_ab}},{{ds_ab}},{celsius})['rate']",
         ),
         "kba": ParamLocalSetting(
             name_setting=NameSetting("kba", "", TPL),
             min=0.0,
-            expr=f"kij_2st_eyring({{dh_b}},{{ds_b}},{{dh_ab}},{{ds_ab}},{celsius})['kba']",
+            expr=(
+                f"eyring_rate({{dh_b}},{{ds_b}},{{dh_ab}},{{ds_ab}},{celsius})['rate']"
+            ),
         ),
         "pa": ParamLocalSetting(
             name_setting=NameSetting("pa", "", TPL),
             min=0.0,
             max=1.0,
-            expr="pop_2st({kab},{kba})['pa']",
+            expr=f"pop_2st_eyring({{dh_b}},{{ds_b}},{celsius})['pa']",
         ),
         "pb": ParamLocalSetting(
             name_setting=NameSetting("pb", "", TPL),
             min=0.0,
             max=1.0,
-            expr="pop_2st({kab},{kba})['pb']",
+            expr=f"pop_2st_eyring({{dh_b}},{{ds_b}},{celsius})['pb']",
         ),
     }
 
 
 def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_2st_eyring)
-    user_functions = {"kij_2st_eyring": calculate_kij_2st_eyring, "pop_2st": pop_2st}
+    user_functions = {
+        "eyring_rate": calculate_rate_component,
+        "kij_2st_eyring": calculate_kij_2st_eyring,
+        "pop_2st": pop_2st,
+        "pop_2st_eyring": calculate_populations_2st_eyring,
+    }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    population_partials = thermodynamic_population_partials(("pa", "pb"))
+    function_linearization_registry.register(
+        NAME,
+        (
+            AnalyticFunctionLinearization(
+                "eyring_rate",
+                "rate",
+                "eyring-directional-rate-partials-v1",
+                EYRING_RATE_PARTIALS,
+            ),
+            *(
+                AnalyticFunctionLinearization(
+                    "pop_2st_eyring",
+                    component,
+                    "eyring-thermodynamic-population-partials-v1",
+                    population_partials[component],
+                )
+                for component in ("pa", "pb")
+            ),
+        ),
+    )

--- a/src/chemex/models/kinetic/settings_3st_eyring.py
+++ b/src/chemex/models/kinetic/settings_3st_eyring.py
@@ -4,14 +4,25 @@ from collections.abc import Callable
 from functools import lru_cache
 from typing import Literal
 
-import numpy as np
-from scipy import constants
-
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_3st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._eyring import (
+    EYRING_RATE_PARTIALS,
+    ThermodynamicCoordinate,
+    calculate_directional_rate,
+    calculate_rate_component,
+    temperature_to_kelvin,
+    thermodynamic_population_partials,
+    thermodynamic_populations,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
+from chemex.parameters.userfunctions import (
+    AnalyticFunctionLinearization,
+    FunctionLinearization,
+    function_linearization_registry,
+    user_function_registry,
+)
 
 NAME = "3st_eyring"
 LINEAR_NAME = "3st_eyring_linear"
@@ -20,11 +31,10 @@ FORK_NAME = "3st_eyring_fork"
 PL = ("p_total", "l_total")
 TPL = ("temperature", "p_total", "l_total")
 
-MAX_RATE_CONSTANT = 1e16
-
 Edge = Literal["ab", "ac", "bc"]
 LINEAR_EDGES: tuple[Edge, ...] = ("ab", "bc")
 FORK_EDGES: tuple[Edge, ...] = ("ab", "ac")
+REFERENCE_STATE = ThermodynamicCoordinate(enthalpy=0.0, entropy=0.0)
 
 
 def _calculate_kij_3st_eyring(
@@ -32,27 +42,21 @@ def _calculate_kij_3st_eyring(
     ds_b: float,
     dh_c: float,
     ds_c: float,
-    transition_terms: tuple[tuple[Edge, float, float], ...],
+    transition_states: dict[Edge, ThermodynamicCoordinate],
     temperature: float,
 ) -> dict[str, float]:
-    kelvin = temperature + constants.zero_Celsius
-    kbt_h = constants.k * kelvin / constants.h
-    rt = constants.R * kelvin
-    state_terms = {
-        "a": (0.0, 0.0),
-        "b": (dh_b, ds_b),
-        "c": (dh_c, ds_c),
+    states = {
+        "a": REFERENCE_STATE,
+        "b": ThermodynamicCoordinate(dh_b, ds_b),
+        "c": ThermodynamicCoordinate(dh_c, ds_c),
     }
     rates: dict[str, float] = {}
-    for edge, dh_transition, ds_transition in transition_terms:
+    for edge, transition_state in transition_states.items():
         for initial, final in (edge, edge[::-1]):
-            dh_initial, ds_initial = state_terms[initial]
-            activation_free_energy = (
-                dh_transition - dh_initial - kelvin * (ds_transition - ds_initial)
-            )
-            rate = kbt_h * np.exp(-activation_free_energy / rt)
-            rates[f"k{initial}{final}"] = float(
-                np.clip(rate, 0.0, MAX_RATE_CONSTANT),
+            rates[f"k{initial}{final}"] = calculate_directional_rate(
+                states[initial],
+                transition_state,
+                temperature,
             )
     return rates
 
@@ -70,12 +74,15 @@ def calculate_kij_3st_eyring_linear(
     temperature: float,
 ) -> dict[str, float]:
     return _calculate_kij_3st_eyring(
-        dh_b,
-        ds_b,
-        dh_c,
-        ds_c,
-        (("ab", dh_ab, ds_ab), ("bc", dh_bc, ds_bc)),
-        temperature,
+        dh_b=dh_b,
+        ds_b=ds_b,
+        dh_c=dh_c,
+        ds_c=ds_c,
+        transition_states={
+            "ab": ThermodynamicCoordinate(dh_ab, ds_ab),
+            "bc": ThermodynamicCoordinate(dh_bc, ds_bc),
+        },
+        temperature=temperature,
     )
 
 
@@ -96,13 +103,35 @@ def calculate_kij_3st_eyring_fork(
     temperature: float,
 ) -> dict[str, float]:
     return _calculate_kij_3st_eyring(
-        dh_b,
-        ds_b,
-        dh_c,
-        ds_c,
-        (("ab", dh_ab, ds_ab), ("ac", dh_ac, ds_ac)),
+        dh_b=dh_b,
+        ds_b=ds_b,
+        dh_c=dh_c,
+        ds_c=ds_c,
+        transition_states={
+            "ab": ThermodynamicCoordinate(dh_ab, ds_ab),
+            "ac": ThermodynamicCoordinate(dh_ac, ds_ac),
+        },
+        temperature=temperature,
+    )
+
+
+@lru_cache(maxsize=100)
+def calculate_populations_3st_eyring(
+    dh_b: float,
+    ds_b: float,
+    dh_c: float,
+    ds_c: float,
+    temperature: float,
+) -> dict[str, float]:
+    populations = thermodynamic_populations(
+        {
+            "a": REFERENCE_STATE,
+            "b": ThermodynamicCoordinate(dh_b, ds_b),
+            "c": ThermodynamicCoordinate(dh_c, ds_c),
+        },
         temperature,
     )
+    return {f"p{state}": population for state, population in populations.items()}
 
 
 def _thermodynamic_settings(edges: tuple[Edge, ...]) -> dict[str, ParamLocalSetting]:
@@ -153,34 +182,30 @@ def _thermodynamic_settings(edges: tuple[Edge, ...]) -> dict[str, ParamLocalSett
 
 def _rate_settings(
     edges: tuple[Edge, ...],
-    function_name: str,
     temperature: float,
 ) -> dict[str, ParamLocalSetting]:
-    arguments = ["{dh_b}", "{ds_b}", "{dh_c}", "{ds_c}"]
+    state_arguments = {
+        "a": ("0.0", "0.0"),
+        "b": ("{dh_b}", "{ds_b}"),
+        "c": ("{dh_c}", "{ds_c}"),
+    }
+    settings: dict[str, ParamLocalSetting] = {}
     for edge in edges:
-        arguments.extend((f"{{dh_{edge}}}", f"{{ds_{edge}}}"))
-    arguments.append(str(temperature))
-    call = f"{function_name}({','.join(arguments)})"
-    return {
-        f"k{initial}{final}": ParamLocalSetting(
-            name_setting=NameSetting(f"k{initial}{final}", "", TPL),
-            min=0.0,
-            expr=f"{call}['k{initial}{final}']",
-        )
-        for edge in edges
-        for initial, final in (edge, edge[::-1])
-    }
+        for initial, final in (edge, edge[::-1]):
+            state_enthalpy, state_entropy = state_arguments[initial]
+            settings[f"k{initial}{final}"] = ParamLocalSetting(
+                name_setting=NameSetting(f"k{initial}{final}", "", TPL),
+                min=0.0,
+                expr=(
+                    f"eyring_rate({state_enthalpy},{state_entropy},"
+                    f"{{dh_{edge}}},{{ds_{edge}}},{temperature})['rate']"
+                ),
+            )
+    return settings
 
 
-def _population_settings(edges: tuple[Edge, ...]) -> dict[str, ParamLocalSetting]:
-    active_rates = {
-        f"k{initial}{final}" for edge in edges for initial, final in (edge, edge[::-1])
-    }
-    arguments = [
-        f"{{{rate}}}" if rate in active_rates else "0.0"
-        for rate in ("kab", "kba", "kac", "kca", "kbc", "kcb")
-    ]
-    call = f"pop_3st({','.join(arguments)})"
+def _population_settings(temperature: float) -> dict[str, ParamLocalSetting]:
+    call = f"pop_3st_eyring({{dh_b}},{{ds_b}},{{dh_c}},{{ds_c}},{temperature})"
     return {
         f"p{state}": ParamLocalSetting(
             name_setting=NameSetting(f"p{state}", "", TPL),
@@ -195,23 +220,23 @@ def _population_settings(edges: tuple[Edge, ...]) -> dict[str, ParamLocalSetting
 def _make_settings_3st_eyring(
     conditions: Conditions,
     edges: tuple[Edge, ...],
-    function_name: str,
 ) -> dict[str, ParamLocalSetting]:
     celsius = conditions.temperature
     if celsius is None:
         msg = "The 'temperature' is None"
         raise ValueError(msg)
+    temperature_to_kelvin(celsius)
     return {
         **_thermodynamic_settings(edges),
-        **_rate_settings(edges, function_name, celsius),
-        **_population_settings(edges),
+        **_rate_settings(edges, celsius),
+        **_population_settings(celsius),
     }
 
 
 def make_settings_3st_eyring_linear(
     conditions: Conditions,
 ) -> dict[str, ParamLocalSetting]:
-    return _make_settings_3st_eyring(conditions, LINEAR_EDGES, "kij_3st_eyring")
+    return _make_settings_3st_eyring(conditions, LINEAR_EDGES)
 
 
 # Compatibility name: 3st_eyring retains the historical linear topology.
@@ -224,7 +249,6 @@ def make_settings_3st_eyring_fork(
     return _make_settings_3st_eyring(
         conditions,
         FORK_EDGES,
-        "kij_3st_eyring_fork",
     )
 
 
@@ -232,7 +256,34 @@ def _user_functions(
     rate_function: Callable[..., dict[str, float]],
     function_name: str,
 ) -> dict[str, object]:
-    return {function_name: rate_function, "pop_3st": pop_3st}
+    return {
+        "eyring_rate": calculate_rate_component,
+        function_name: rate_function,
+        "pop_3st": pop_3st,
+        "pop_3st_eyring": calculate_populations_3st_eyring,
+    }
+
+
+def _linearizations() -> tuple[FunctionLinearization, ...]:
+    components = ("pa", "pb", "pc")
+    population_partials = thermodynamic_population_partials(components)
+    return (
+        AnalyticFunctionLinearization(
+            "eyring_rate",
+            "rate",
+            "eyring-directional-rate-partials-v1",
+            EYRING_RATE_PARTIALS,
+        ),
+        *(
+            AnalyticFunctionLinearization(
+                "pop_3st_eyring",
+                component,
+                "eyring-thermodynamic-population-partials-v1",
+                population_partials[component],
+            )
+            for component in components
+        ),
+    )
 
 
 def register() -> None:
@@ -247,6 +298,8 @@ def register() -> None:
     )
     user_function_registry.register(name=NAME, user_functions=linear_functions)
     user_function_registry.register(name=LINEAR_NAME, user_functions=linear_functions)
+    function_linearization_registry.register(NAME, _linearizations())
+    function_linearization_registry.register(LINEAR_NAME, _linearizations())
     user_function_registry.register(
         name=FORK_NAME,
         user_functions=_user_functions(
@@ -254,3 +307,4 @@ def register() -> None:
             "kij_3st_eyring_fork",
         ),
     )
+    function_linearization_registry.register(FORK_NAME, _linearizations())

--- a/src/chemex/models/kinetic/settings_4st_eyring.py
+++ b/src/chemex/models/kinetic/settings_4st_eyring.py
@@ -8,25 +8,33 @@ thermodynamic parameters.
 from __future__ import annotations
 
 from functools import lru_cache
-from itertools import permutations
-
-import numpy as np
-from scipy import constants
 
 from chemex.configuration.conditions import Conditions
 from chemex.models.constraints import pop_4st
 from chemex.models.factory import model_factory
+from chemex.models.kinetic._eyring import (
+    EYRING_RATE_PARTIALS,
+    ThermodynamicCoordinate,
+    calculate_directional_rate,
+    calculate_rate_component,
+    temperature_to_kelvin,
+    thermodynamic_population_partials,
+    thermodynamic_populations,
+)
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
-from chemex.parameters.userfunctions import user_function_registry
-from chemex.typing import Array
+from chemex.parameters.userfunctions import (
+    AnalyticFunctionLinearization,
+    function_linearization_registry,
+    user_function_registry,
+)
 
 NAME = "4st_eyring"
 
 PL = ("p_total", "l_total")
 TPL = ("temperature", "p_total", "l_total")
 
-# Physical constants
-MAX_RATE_CONSTANT = 1e16  # Maximum rate constant (s⁻¹) for numerical stability
+REFERENCE_STATE = ThermodynamicCoordinate(enthalpy=0.0, entropy=0.0)
+EDGES = ("ab", "ac", "ad", "bc", "bd", "cd")
 
 
 @lru_cache(maxsize=100)
@@ -80,17 +88,6 @@ def calculate_kij_4st_eyring(
         Dictionary containing rate constants (s⁻¹) for all state transitions.
         Keys are formatted as 'kij' where i and j are states ('a', 'b', 'c', 'd').
 
-    Notes
-    -----
-    The rate constants are calculated using Eyring equation:
-    k_ij = (k_B*T/h) * exp(-ΔG‡_ij / RT)
-
-    Where ΔG‡_ij is the activation free energy for transition from state i to j:
-    ΔG‡_ij = ΔH‡_ij - T*ΔS‡_ij
-
-    Rate constants are clipped to [0, 1e16] s⁻¹ for numerical stability.
-
-
     Examples
     --------
     >>> rates = calculate_kij_4st_eyring(
@@ -102,80 +99,88 @@ def calculate_kij_4st_eyring(
     >>> print(f"k_ab = {rates['kab']:.2e} s⁻¹")
 
     """
-    kelvin = temperature + constants.zero_Celsius
-    kbt_h = constants.k * kelvin / constants.h
-    rt = constants.R * kelvin
+    states = {
+        "a": REFERENCE_STATE,
+        "b": ThermodynamicCoordinate(dh_b, ds_b),
+        "c": ThermodynamicCoordinate(dh_c, ds_c),
+        "d": ThermodynamicCoordinate(dh_d, ds_d),
+    }
+    transition_states = {
+        "ab": ThermodynamicCoordinate(dh_ab, ds_ab),
+        "ac": ThermodynamicCoordinate(dh_ac, ds_ac),
+        "ad": ThermodynamicCoordinate(dh_ad, ds_ad),
+        "bc": ThermodynamicCoordinate(dh_bc, ds_bc),
+        "bd": ThermodynamicCoordinate(dh_bd, ds_bd),
+        "cd": ThermodynamicCoordinate(dh_cd, ds_cd),
+    }
+    rates: dict[str, float] = {}
+    for edge, transition_state in transition_states.items():
+        for initial, final in (edge, edge[::-1]):
+            rates[f"k{initial}{final}"] = calculate_directional_rate(
+                states[initial],
+                transition_state,
+                temperature,
+            )
+    return rates
 
-    # Reference state A has zero enthalpy and entropy
-    dh_a = ds_a = 0.0
 
-    # Calculate activation free energies for all transitions
-    ddg_ij = np.array(
-        (
-            dh_ab - dh_a - kelvin * (ds_ab - ds_a),
-            dh_ac - dh_a - kelvin * (ds_ac - ds_a),
-            dh_ad - dh_a - kelvin * (ds_ad - ds_a),
-            dh_ab - dh_b - kelvin * (ds_ab - ds_b),
-            dh_bc - dh_b - kelvin * (ds_bc - ds_b),
-            dh_bd - dh_b - kelvin * (ds_bd - ds_b),
-            dh_ac - dh_c - kelvin * (ds_ac - ds_c),
-            dh_bc - dh_c - kelvin * (ds_bc - ds_c),
-            dh_cd - dh_c - kelvin * (ds_cd - ds_c),
-            dh_ad - dh_d - kelvin * (ds_ad - ds_d),
-            dh_bd - dh_d - kelvin * (ds_bd - ds_d),
-            dh_cd - dh_d - kelvin * (ds_cd - ds_d),
-        ),
+@lru_cache(maxsize=100)
+def calculate_populations_4st_eyring(
+    dh_b: float,
+    ds_b: float,
+    dh_c: float,
+    ds_c: float,
+    dh_d: float,
+    ds_d: float,
+    temperature: float,
+) -> dict[str, float]:
+    populations = thermodynamic_populations(
+        {
+            "a": REFERENCE_STATE,
+            "b": ThermodynamicCoordinate(dh_b, ds_b),
+            "c": ThermodynamicCoordinate(dh_c, ds_c),
+            "d": ThermodynamicCoordinate(dh_d, ds_d),
+        },
+        temperature,
     )
-
-    # Apply Eyring equation
-    kij_values: Array = kbt_h * np.exp(-ddg_ij / rt)
-
-    # Clip values for numerical stability
-    kij_values = np.clip(kij_values, 0.0, MAX_RATE_CONSTANT)
-
-    # Generate rate constant names in same order as permutations
-    kij_names = (f"k{i}{j}" for i, j in permutations("abcd", 2))
-
-    return dict(zip(kij_names, kij_values, strict=True))
+    return {f"p{state}": population for state, population in populations.items()}
 
 
 def create_kij_4st_eyring_settings(temperature: float) -> dict[str, ParamLocalSetting]:
-    return {
-        f"k{i}{j}": ParamLocalSetting(
-            name_setting=NameSetting(f"k{i}{j}", "", TPL),
-            min=0.0,
-            expr=(
-                f"kij_4st_eyring("
-                f"{{dh_b}}, {{ds_b}}, "
-                f"{{dh_c}}, {{ds_c}}, "
-                f"{{dh_d}}, {{ds_d}},"
-                f"{{dh_ab}}, {{ds_ab}}, "
-                f"{{dh_ac}}, {{ds_ac}}, "
-                f"{{dh_ad}}, {{ds_ad}}, "
-                f"{{dh_bc}}, {{ds_bc}}, "
-                f"{{dh_bd}}, {{ds_bd}}, "
-                f"{{dh_cd}}, {{ds_cd}},"
-                f" {temperature}"
-                f")['k{i}{j}']"
-            ),
-        )
-        for i, j in permutations("abcd", 2)
+    state_arguments = {
+        "a": ("0.0", "0.0"),
+        "b": ("{dh_b}", "{ds_b}"),
+        "c": ("{dh_c}", "{ds_c}"),
+        "d": ("{dh_d}", "{ds_d}"),
     }
+    settings: dict[str, ParamLocalSetting] = {}
+    for edge in EDGES:
+        for initial, final in (edge, edge[::-1]):
+            state_enthalpy, state_entropy = state_arguments[initial]
+            settings[f"k{initial}{final}"] = ParamLocalSetting(
+                name_setting=NameSetting(f"k{initial}{final}", "", TPL),
+                min=0.0,
+                expr=(
+                    f"eyring_rate({state_enthalpy},{state_entropy},"
+                    f"{{dh_{edge}}},{{ds_{edge}}},{temperature})['rate']"
+                ),
+            )
+    return settings
 
 
-def create_pop_4st_eyring_settings() -> dict[str, ParamLocalSetting]:
+def create_pop_4st_eyring_settings(
+    temperature: float,
+) -> dict[str, ParamLocalSetting]:
+    call = (
+        "pop_4st_eyring("
+        f"{{dh_b}},{{ds_b}},{{dh_c}},{{ds_c}},{{dh_d}},{{ds_d}},{temperature})"
+    )
     return {
         f"p{state}": ParamLocalSetting(
             name_setting=NameSetting(f"p{state}", "", TPL),
             min=0.0,
             max=1.0,
-            expr=f"pop_4st("
-            f"{{kab}},{{kba}},"
-            f"{{kac}},{{kca}},"
-            f"{{kad}},{{kda}},"
-            f"{{kbc}},{{kcb}},"
-            f"{{kbd}},{{kdb}},"
-            f"{{kcd}},{{kdc}})['p{state}']",
+            expr=f"{call}['p{state}']",
         )
         for state in "abcd"
     }
@@ -204,6 +209,7 @@ def make_settings_4st_eyring(conditions: Conditions) -> dict[str, ParamLocalSett
     if celsius is None:
         msg = "The 'temperature' is None"
         raise ValueError(msg)
+    temperature_to_kelvin(celsius)
     return {
         "dh_b": ParamLocalSetting(
             name_setting=NameSetting("dh_b", "", PL),
@@ -332,14 +338,38 @@ def make_settings_4st_eyring(conditions: Conditions) -> dict[str, ParamLocalSett
             vary=False,
         ),
         **create_kij_4st_eyring_settings(celsius),
-        **create_pop_4st_eyring_settings(),
+        **create_pop_4st_eyring_settings(celsius),
     }
 
 
 def register() -> None:
     model_factory.register(name=NAME, setting_maker=make_settings_4st_eyring)
     user_functions = {
+        "eyring_rate": calculate_rate_component,
         "kij_4st_eyring": calculate_kij_4st_eyring,
         "pop_4st": pop_4st,
+        "pop_4st_eyring": calculate_populations_4st_eyring,
     }
     user_function_registry.register(name=NAME, user_functions=user_functions)
+    components = ("pa", "pb", "pc", "pd")
+    population_partials = thermodynamic_population_partials(components)
+    function_linearization_registry.register(
+        NAME,
+        (
+            AnalyticFunctionLinearization(
+                "eyring_rate",
+                "rate",
+                "eyring-directional-rate-partials-v1",
+                EYRING_RATE_PARTIALS,
+            ),
+            *(
+                AnalyticFunctionLinearization(
+                    "pop_4st_eyring",
+                    component,
+                    "eyring-thermodynamic-population-partials-v1",
+                    population_partials[component],
+                )
+                for component in components
+            ),
+        ),
+    )

--- a/src/chemex/optimize/deterministic_uncertainty.py
+++ b/src/chemex/optimize/deterministic_uncertainty.py
@@ -22,6 +22,7 @@ from chemex.optimize.direct_trf import (
 from chemex.optimize.grouped_direct_trf import FitPartitionProof
 from chemex.optimize.uncertainty import (
     CompiledConstraintLinearizationCapabilities,
+    FunctionAnalyticPartialCapability,
     FunctionFiniteDifferenceCapability,
     MissingFunctionLinearizationCapability,
     OperationTerminal,
@@ -42,7 +43,11 @@ from chemex.parameters.parameterization import (
     ParameterRole,
     ReportableParameterSet,
 )
-from chemex.parameters.userfunctions import function_linearization_registry
+from chemex.parameters.userfunctions import (
+    AnalyticFunctionLinearization,
+    NumericalFunctionLinearization,
+    function_linearization_registry,
+)
 
 
 class InterpretationCompleteness(StrEnum):
@@ -74,21 +79,34 @@ class ProfiledGridBasis:
 type DeterministicUncertaintyBasis = ContinuousTrfBasis | ProfiledGridBasis
 
 
+def _compile_model_function_capability(
+    capability: NumericalFunctionLinearization | AnalyticFunctionLinearization,
+) -> FunctionFiniteDifferenceCapability | FunctionAnalyticPartialCapability:
+    if isinstance(capability, AnalyticFunctionLinearization):
+        return FunctionAnalyticPartialCapability(
+            function_id=capability.function_id,
+            component=capability.component,
+            implementation_identity=capability.implementation_identity,
+            partials=capability.partials,
+        )
+    return FunctionFiniteDifferenceCapability(
+        function_id=capability.function_id,
+        component=capability.component,
+        argument_scales=capability.argument_scales,
+        output_scale=capability.output_scale,
+        argument_domains=capability.argument_domains,
+        relative_steps=True,
+        normalized_population_components=capability.normalized_population_components,
+    )
+
+
 def compile_model_constraint_linearization_capabilities(
     parameterization: ActiveParameterization,
     output_scope: tuple[str, ...],
 ) -> CompiledConstraintLinearizationCapabilities:
     """Compile only the model-owned scientific-function derivative policies."""
     capabilities = tuple(
-        FunctionFiniteDifferenceCapability(
-            function_id=item.function_id,
-            component=item.component,
-            argument_scales=item.argument_scales,
-            output_scale=item.output_scale,
-            argument_domains=item.argument_domains,
-            relative_steps=True,
-            normalized_population_components=item.normalized_population_components,
-        )
+        _compile_model_function_capability(item)
         for item in function_linearization_registry.get(
             parameterization.binder.model_name
         )

--- a/src/chemex/parameters/userfunctions.py
+++ b/src/chemex/parameters/userfunctions.py
@@ -27,6 +27,21 @@ class NumericalFunctionLinearization:
     normalized_population_components: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True, slots=True)
+class AnalyticFunctionLinearization:
+    """Model-owned analytic derivatives for one scientific function component."""
+
+    function_id: str
+    component: str | None
+    implementation_identity: str
+    partials: tuple[Callable[..., float], ...]
+
+
+type FunctionLinearization = (
+    NumericalFunctionLinearization | AnalyticFunctionLinearization
+)
+
+
 def population_linearizations(
     argument_scales: tuple[float, ...],
     argument_domains: tuple[FunctionArgumentDomain, ...],
@@ -74,16 +89,24 @@ user_function_registry = Registry()
 class LinearizationRegistry:
     """Registry for explicitly approved model-owned function derivatives."""
 
-    _items: ClassVar[dict[str, tuple[NumericalFunctionLinearization, ...]]] = {}
+    _items: ClassVar[
+        dict[
+            str,
+            tuple[FunctionLinearization, ...],
+        ]
+    ] = {}
 
     def register(
         self,
         name: str,
-        capabilities: tuple[NumericalFunctionLinearization, ...],
+        capabilities: tuple[FunctionLinearization, ...],
     ) -> None:
         self._items[name] = capabilities
 
-    def get(self, name: str) -> tuple[NumericalFunctionLinearization, ...]:
+    def get(
+        self,
+        name: str,
+    ) -> tuple[FunctionLinearization, ...]:
         return self._items.get(name, ())
 
 

--- a/tests/configuration/test_conditions.py
+++ b/tests/configuration/test_conditions.py
@@ -1,8 +1,9 @@
 import pytest
 from pydantic import ValidationError
 
-from chemex.configuration.conditions import ConditionsWithValidations
+from chemex.configuration.conditions import Conditions, ConditionsWithValidations
 from chemex.models.model import ModelSpec
+from chemex.parameters.name import ParamName
 
 
 def test_hd_model_requires_d2o() -> None:
@@ -24,3 +25,32 @@ def test_eyring_model_requires_temperature() -> None:
             {},
             context={"model": ModelSpec(name="2st_eyring")},
         )
+
+
+@pytest.mark.parametrize(
+    "temperature",
+    (-273.15, -273.15000000000003, float("nan"), float("inf"), float("-inf")),
+)
+def test_eyring_model_rejects_temperature_outside_physical_domain(
+    temperature: float,
+) -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Eyring temperature must be finite and above absolute zero",
+    ):
+        ConditionsWithValidations.model_validate(
+            {"temperature": temperature},
+            context={"model": ModelSpec(name="2st_eyring")},
+        )
+
+
+def test_exact_zero_celsius_remains_part_of_condition_identity() -> None:
+    zero = Conditions(temperature=0.0).rounded()
+    absent = Conditions().rounded()
+
+    assert zero.temperature == 0.0
+    assert zero != absent
+    assert ParamName("kab", conditions=zero).id_ == "__KAB__0_0C"
+    assert (
+        ParamName("kab", conditions=zero).id_ != ParamName("kab", conditions=absent).id_
+    )

--- a/tests/models/kinetic/README.md
+++ b/tests/models/kinetic/README.md
@@ -1,131 +1,14 @@
-# Tests for ChemEx 4-State Eyring Model
+# Eyring kinetic-model tests
 
-This directory contains comprehensive tests for the `4st_eyring` kinetic model implementation.
-
-## Test Structure
-
-- `test_settings_4st_eyring.py`: Comprehensive unit tests for the core functionality
-- `test_4st_eyring_integration.py`: Integration tests for model registration and framework integration
+This directory qualifies the shared Eyring scientific authority and all five
+public Eyring model names. The focused tests cover the independent
+high-precision numerical oracle, binary64 representability boundaries,
+thermodynamic populations, detailed balance and four-state cycle closure,
+topology integration, condition identity, deterministic uncertainty, MCMC, and
+resampling.
 
 ## Running Tests
 
-### Prerequisites
-
-Install pytest if not already available:
 ```bash
-pip install pytest pytest-cov
+uv run pytest -q tests/models/kinetic -k eyring
 ```
-
-### Run All Tests
-
-```bash
-# From the repository root
-python -m pytest tests/models/kinetic/ -v
-
-# Run with coverage
-python -m pytest tests/models/kinetic/ --cov=src/chemex/models/kinetic/settings_4st_eyring --cov-report=html
-```
-
-### Run Specific Test Classes
-
-```bash
-# Unit tests only
-python -m pytest tests/models/kinetic/test_settings_4st_eyring.py::TestCalculateKij4stEyring -v
-
-# Integration tests only
-python -m pytest tests/models/kinetic/test_4st_eyring_integration.py -v
-```
-
-## Test Coverage
-
-The test suite covers:
-
-### Core Function Tests (`TestCalculateKij4stEyring`)
-- Basic functionality and return value validation
-- Temperature range validation and boundary conditions
-- Temperature dependence (Arrhenius behavior)
-- Correct implementation of Eyring equation
-- Detailed balance consistency for forward/reverse reactions
-- Entropy effects on equilibrium ratios
-- Numerical stability with extreme parameters
-- Function caching behavior
-- Parameter type handling (int, float, numpy types)
-
-### Settings Creation Tests (`TestMakeSettings4stEyring`)
-- Parameter creation and default values
-- Temperature validation error handling
-- Expression generation with temperature embedding
-- Parameter bounds and variation flags
-
-### Physical Realism Tests (`TestPhysicalRealism`)
-- Arrhenius plot linearity across temperature range
-- Detailed balance for all state pairs
-- Correlation coefficient validation for temperature dependence
-
-### Integration Tests (`TestEyring4stIntegration`)
-- Model factory registration
-- Multi-temperature consistency
-- Parameter bounds and defaults validation
-- Rate constant and population generation
-- Framework integration testing
-
-## Test Data
-
-Tests use realistic thermodynamic parameters:
-- State energies: 8-25 kJ/mol above ground state
-- Activation energies: 50-120 kJ/mol (typical for protein folding)
-- Temperature range: -100°C to +200°C for validation
-- Entropy values: Typically set to 0 for simplicity
-
-## Expected Behavior
-
-### Passing Tests
-All tests should pass without errors when:
-- The Eyring equation is correctly implemented
-- Temperature validation works properly
-- Detailed balance is maintained
-- Physical constants are used correctly
-- Parameter generation is complete
-
-### Common Failure Modes
-Tests may fail if:
-- Scipy constants are not available
-- Temperature conversion is incorrect
-- Activation free energy calculation has errors
-- Rate constant expressions are malformed
-- Model registration fails
-
-## Performance Considerations
-
-- Tests include caching validation to ensure performance
-- Large parameter sweeps are avoided for speed
-- Numerical precision is tested to 1e-10 relative tolerance
-- Integration tests verify model factory efficiency
-
-## Adding New Tests
-
-When adding tests:
-1. Follow pytest conventions with `test_` prefixes
-2. Use descriptive test method names
-3. Include docstrings explaining test purpose
-4. Use realistic parameter values
-5. Test both normal and edge cases
-6. Validate physical meaning of results
-
-## Troubleshooting
-
-### Import Errors
-If tests fail with import errors:
-```bash
-# Ensure the package is in PYTHONPATH
-export PYTHONPATH="${PYTHONPATH}:/path/to/ChemEx/src"
-```
-
-### Missing Dependencies
-Install required packages:
-```bash
-pip install scipy numpy pytest
-```
-
-### Numerical Precision Issues
-Adjust tolerance in assertions if needed, but investigate first to ensure correctness.

--- a/tests/models/kinetic/test_3st_eyring_integration.py
+++ b/tests/models/kinetic/test_3st_eyring_integration.py
@@ -86,24 +86,18 @@ def test_compatibility_name_and_explicit_linear_name_have_same_model_behavior() 
         assert left.expr == right.expr
 
 
-@pytest.mark.parametrize(
-    ("model_name", "arguments"),
-    [
-        ("3st_eyring_linear", "{kab},{kba},0.0,0.0,{kbc},{kcb}"),
-        ("3st_eyring_fork", "{kab},{kba},{kac},{kca},0.0,0.0"),
-    ],
-)
-def test_population_constraints_encode_the_absent_edge_as_exact_zero(
+@pytest.mark.parametrize("model_name", ("3st_eyring_linear", "3st_eyring_fork"))
+def test_population_constraints_depend_only_on_state_coordinates(
     model_name: str,
-    arguments: str,
 ) -> None:
     register()
     settings = model_factory.create(model_name, Conditions(temperature=25.0))
 
     for population in ("pa", "pb", "pc"):
         expression = settings[population].expr
-        assert "pop_3st" in expression
-        assert arguments in expression
+        assert "pop_3st_eyring" in expression
+        assert "{dh_b},{ds_b},{dh_c},{ds_c},25.0" in expression
+        assert all(rate not in expression for rate in ("{kab}", "{kba}", "{kbc}"))
 
 
 def test_parameter_file_bounds_override_eyring_defaults() -> None:

--- a/tests/models/kinetic/test_4st_eyring_integration.py
+++ b/tests/models/kinetic/test_4st_eyring_integration.py
@@ -108,8 +108,7 @@ class TestEyring4stIntegration:
 
                     # Check that the expression is properly formatted
                     expr = settings[rate_key].expr
-                    assert "kij_4st_eyring" in expr
-                    assert f"['k{i}{j}']" in expr
+                    assert "eyring_rate" in expr
                     assert "30.0" in expr  # Temperature should be embedded
 
     def test_population_generation(self):
@@ -122,9 +121,9 @@ class TestEyring4stIntegration:
             pop_key = f"p{state}"
             assert pop_key in settings
 
-            # Check that the expression uses the pop_4st function
+            # Populations come from the Eyring thermodynamic state authority.
             expr = settings[pop_key].expr
-            assert "pop_4st(" in expr
+            assert "pop_4st_eyring(" in expr
             assert f"['p{state}']" in expr
 
     def test_consistency_with_2st_eyring(self):
@@ -140,10 +139,10 @@ class TestEyring4stIntegration:
         assert "pa" in settings
         assert "pb" in settings
 
-        # Check that the rate expressions contain the relevant thermodynamic parameters
+        # A -> B uses the shared AB transition state; B -> A also uses state B.
         kab_expr = settings["kab"].expr
-        assert "dh_b" in kab_expr or "DH_B" in kab_expr
         assert "dh_ab" in kab_expr or "DH_AB" in kab_expr
+        assert "dh_b" in settings["kba"].expr
 
 
 if __name__ == "__main__":

--- a/tests/models/kinetic/test_eyring_authority.py
+++ b/tests/models/kinetic/test_eyring_authority.py
@@ -1,0 +1,337 @@
+"""Independent numerical tests for the shared Eyring scientific authority."""
+
+from __future__ import annotations
+
+import math
+import sys
+from decimal import Decimal, localcontext
+
+import pytest
+from scipy import constants
+
+from chemex.models.kinetic._eyring import (
+    ThermodynamicCoordinate,
+    calculate_directional_rate,
+    directional_log_rate,
+    rate_from_log,
+    temperature_to_kelvin,
+    thermodynamic_population_partials,
+    thermodynamic_populations,
+)
+
+ZERO = ThermodynamicCoordinate(enthalpy=0.0, entropy=0.0)
+
+
+def _decimal_eyring_rate(
+    kelvin: str,
+    activation_enthalpy: str,
+    activation_entropy: str = "0",
+) -> Decimal:
+    """Evaluate the Eyring equation independently with exact SI literals."""
+    with localcontext() as context:
+        context.prec = 100
+        temperature = Decimal(kelvin)
+        gas_constant = Decimal("8.31446261815324")
+        frequency_factor = Decimal("1.380649e-23") / Decimal("6.62607015e-34")
+        exponent = Decimal(activation_entropy) / gas_constant - Decimal(
+            activation_enthalpy
+        ) / (gas_constant * temperature)
+        return frequency_factor * temperature * exponent.exp()
+
+
+def _decimal_two_state_population(
+    kelvin: Decimal,
+    state_enthalpy: float,
+    state_entropy: float = 0.0,
+) -> Decimal:
+    """Return P(B) from an independent exact-SI Boltzmann calculation."""
+    with localcontext() as context:
+        context.prec = 100
+        gas_constant = Decimal("8.31446261815324")
+        log_weight = Decimal(str(state_entropy)) / gas_constant - Decimal(
+            str(state_enthalpy)
+        ) / (gas_constant * kelvin)
+        weight = log_weight.exp()
+        return weight / (Decimal(1) + weight)
+
+
+def _enthalpy_for_population(target: Decimal, kelvin: Decimal) -> float:
+    """Choose a binary64 H coordinate whose Decimal population is near target."""
+    with localcontext() as context:
+        context.prec = 100
+        gas_constant = Decimal("8.31446261815324")
+        log_weight = (target / (Decimal(1) - target)).ln()
+        return float(-gas_constant * kelvin * log_weight)
+
+
+@pytest.mark.parametrize(
+    ("celsius", "kelvin"),
+    ((25.0, 298.15), (50.0, 323.15), (0.0, 273.15)),
+)
+def test_public_celsius_temperature_is_converted_to_kelvin(
+    celsius: float,
+    kelvin: float,
+) -> None:
+    assert temperature_to_kelvin(celsius) == kelvin
+
+
+def test_ordinary_rates_match_high_precision_oracle_at_two_temperatures() -> None:
+    transition_state = ThermodynamicCoordinate(enthalpy=65_000.0, entropy=0.0)
+
+    rate_298 = calculate_directional_rate(ZERO, transition_state, 25.0)
+    rate_323 = calculate_directional_rate(ZERO, transition_state, 50.0)
+
+    assert rate_298 == pytest.approx(float(_decimal_eyring_rate("298.15", "65000")))
+    assert rate_323 == pytest.approx(float(_decimal_eyring_rate("323.15", "65000")))
+    assert rate_298 == pytest.approx(25.45392415, rel=5.0e-10)
+    assert rate_323 == pytest.approx(209.74952472, rel=5.0e-10)
+
+
+def test_log_k_over_temperature_is_linear_in_inverse_temperature() -> None:
+    transition_state = ThermodynamicCoordinate(enthalpy=65_000.0, entropy=12.0)
+    temperatures = (280.0, 298.15, 323.15, 360.0)
+    ordinates = tuple(
+        directional_log_rate(ZERO, transition_state, kelvin) - math.log(kelvin)
+        for kelvin in temperatures
+    )
+    slopes = tuple(
+        (right_y - left_y) / (1.0 / right_t - 1.0 / left_t)
+        for left_t, right_t, left_y, right_y in zip(
+            temperatures[:-1],
+            temperatures[1:],
+            ordinates[:-1],
+            ordinates[1:],
+            strict=True,
+        )
+    )
+
+    assert max(slopes) - min(slopes) <= 2.0e-9 * abs(slopes[0])
+    assert slopes[0] == pytest.approx(-65_000.0 / constants.R, rel=2.0e-15)
+
+
+def test_low_positive_kelvin_is_valid_without_an_arbitrary_upper_limit() -> None:
+    lowest_public_celsius = math.nextafter(-constants.zero_Celsius, math.inf)
+    low_rate = calculate_directional_rate(ZERO, ZERO, lowest_public_celsius)
+
+    assert temperature_to_kelvin(lowest_public_celsius) > 0.0
+    assert 0.0 < low_rate < 1.0
+    assert temperature_to_kelvin(1.0e300) == 1.0e300
+
+
+def test_high_finite_temperature_rate_remains_available_when_representable() -> None:
+    celsius = 1.0e100
+    transition_state = ThermodynamicCoordinate(enthalpy=0.0, entropy=-2_000.0)
+
+    rate = calculate_directional_rate(ZERO, transition_state, celsius)
+    expected = _decimal_eyring_rate("1e100", "0", "-2000")
+
+    assert math.isfinite(rate)
+    assert rate == pytest.approx(float(expected), rel=3.0e-14)
+
+
+def test_direct_factorization_underflow_does_not_erase_representable_rate() -> None:
+    kelvin = Decimal("32")
+    with localcontext() as context:
+        context.prec = 100
+        barrier = Decimal("750") * Decimal("8.31446261815324") * kelvin
+        expected = _decimal_eyring_rate("32", str(barrier))
+
+    rate = calculate_directional_rate(
+        ZERO,
+        ThermodynamicCoordinate(enthalpy=float(barrier), entropy=0.0),
+        -241.15,
+    )
+
+    assert expected > Decimal.from_float(math.nextafter(0.0, 1.0))
+    assert expected < Decimal.from_float(sys.float_info.min)
+    assert rate > 0.0
+    expected_float = float(expected)
+    # Four ulps accommodates small cross-libm log/exp differences while remaining
+    # billions of ulps away from structural zero for this fixture.
+    assert abs(rate - expected_float) <= 4 * math.ulp(expected_float)
+
+
+def test_binary64_rate_classification_includes_minimum_subnormal() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+    log_minimum = math.log(minimum)
+
+    assert Decimal.from_float(log_minimum).exp() >= Decimal.from_float(minimum)
+    assert rate_from_log(log_minimum) == minimum
+
+
+def test_binary64_rate_classification_rejects_positive_underflow() -> None:
+    minimum = math.nextafter(0.0, 1.0)
+    log_below = math.nextafter(math.log(minimum), -math.inf)
+
+    assert Decimal.from_float(log_below).exp() < Decimal.from_float(minimum)
+    with pytest.raises(ValueError, match="below binary64 representability"):
+        rate_from_log(log_below)
+
+
+def test_binary64_rate_classification_includes_near_maximum() -> None:
+    log_maximum = math.log(sys.float_info.max)
+    expected = math.exp(log_maximum)
+
+    assert Decimal.from_float(log_maximum).exp() <= Decimal.from_float(
+        sys.float_info.max
+    )
+    assert rate_from_log(log_maximum) == expected
+    assert math.isfinite(expected)
+
+
+def test_binary64_rate_classification_rejects_overflow() -> None:
+    log_above = math.nextafter(math.log(sys.float_info.max), math.inf)
+
+    assert Decimal.from_float(log_above).exp() > Decimal.from_float(sys.float_info.max)
+    with pytest.raises(ValueError, match="exceeds maximum finite binary64"):
+        rate_from_log(log_above)
+
+
+def test_state_populations_match_high_precision_boltzmann_oracle() -> None:
+    states = {
+        "a": ZERO,
+        "b": ThermodynamicCoordinate(enthalpy=8_000.0, entropy=10.0),
+        "c": ThermodynamicCoordinate(enthalpy=12_000.0, entropy=-5.0),
+        "d": ThermodynamicCoordinate(enthalpy=15_000.0, entropy=15.0),
+    }
+    populations = thermodynamic_populations(states, 25.0)
+    with localcontext() as context:
+        context.prec = 100
+        temperature = Decimal("298.15")
+        gas_constant = Decimal("8.31446261815324")
+        weights = {
+            state: (
+                Decimal(str(coordinate.entropy)) / gas_constant
+                - Decimal(str(coordinate.enthalpy)) / (gas_constant * temperature)
+            ).exp()
+            for state, coordinate in states.items()
+        }
+        total = sum(weights.values())
+        expected = {state: float(weight / total) for state, weight in weights.items()}
+
+    assert populations == pytest.approx(expected, rel=3.0e-15)
+    assert math.fsum(populations.values()) == pytest.approx(1.0, rel=0.0, abs=2e-16)
+
+
+def test_representable_subnormal_population_remains_positive() -> None:
+    kelvin = Decimal("0.01")
+    minimum = Decimal.from_float(math.nextafter(0.0, 1.0))
+    enthalpy = _enthalpy_for_population(Decimal(8) * minimum, kelvin)
+    expected = _decimal_two_state_population(kelvin, enthalpy)
+
+    populations = thermodynamic_populations(
+        {"a": ZERO, "b": ThermodynamicCoordinate(enthalpy, 0.0)},
+        float(kelvin) - constants.zero_Celsius,
+    )
+
+    assert minimum < expected < Decimal.from_float(sys.float_info.min)
+    assert 0.0 < populations["b"] < sys.float_info.min
+    assert abs(populations["b"] - float(expected)) <= 4 * math.ulp(float(expected))
+
+
+def test_minimum_positive_population_boundary_is_representable() -> None:
+    kelvin = Decimal("0.01")
+    minimum_float = math.nextafter(0.0, 1.0)
+    minimum = Decimal.from_float(minimum_float)
+    enthalpy = _enthalpy_for_population(Decimal("1.1") * minimum, kelvin)
+    expected = _decimal_two_state_population(kelvin, enthalpy)
+
+    populations = thermodynamic_populations(
+        {"a": ZERO, "b": ThermodynamicCoordinate(enthalpy, 0.0)},
+        float(kelvin) - constants.zero_Celsius,
+    )
+
+    assert minimum <= expected < Decimal("1.5") * minimum
+    assert populations["b"] == minimum_float
+
+
+def test_positive_population_just_below_binary64_fails_closed() -> None:
+    kelvin = Decimal("0.01")
+    minimum = Decimal.from_float(math.nextafter(0.0, 1.0))
+    enthalpy = _enthalpy_for_population(Decimal("0.9") * minimum, kelvin)
+    expected = _decimal_two_state_population(kelvin, enthalpy)
+
+    assert Decimal(0) < expected < minimum
+    with pytest.raises(ValueError, match="population.*below binary64 representability"):
+        thermodynamic_populations(
+            {"a": ZERO, "b": ThermodynamicCoordinate(enthalpy, 0.0)},
+            float(kelvin) - constants.zero_Celsius,
+        )
+
+
+def test_audited_positive_population_underflow_reproducer_fails_closed() -> None:
+    kelvin = Decimal("0.01")
+    enthalpy = 61.959375430421595
+    expected = _decimal_two_state_population(kelvin, enthalpy)
+
+    assert Decimal(0) < expected < Decimal.from_float(math.nextafter(0.0, 1.0))
+    assert Decimal("2.3107e-324") < expected < Decimal("2.3108e-324")
+    with pytest.raises(ValueError, match="population.*below binary64 representability"):
+        thermodynamic_populations(
+            {"a": ZERO, "b": ThermodynamicCoordinate(enthalpy, 0.0)},
+            float(kelvin) - constants.zero_Celsius,
+        )
+
+
+def test_tiny_representable_population_has_nonzero_normalized_partial() -> None:
+    kelvin = Decimal("0.01")
+    minimum = Decimal.from_float(math.nextafter(0.0, 1.0))
+    enthalpy = _enthalpy_for_population(Decimal(8) * minimum, kelvin)
+    expected_population = _decimal_two_state_population(kelvin, enthalpy)
+    with localcontext() as context:
+        context.prec = 100
+        expected_partial = (
+            -expected_population
+            * (Decimal(1) - expected_population)
+            / (Decimal("8.31446261815324") * kelvin)
+        )
+    partials = thermodynamic_population_partials(("pa", "pb"))
+
+    derivative_a = partials["pa"][0](enthalpy, 0.0, -273.14)
+    derivative_b = partials["pb"][0](enthalpy, 0.0, -273.14)
+
+    assert derivative_b < 0.0
+    assert derivative_b != -0.0
+    assert abs(derivative_b - float(expected_partial)) <= 4 * math.ulp(
+        float(expected_partial)
+    )
+    assert math.fsum((derivative_a, derivative_b)) == 0.0
+
+
+def test_unrepresentable_population_fails_before_exposing_false_zero_partial() -> None:
+    enthalpy = 61.959375430421595
+    partial = thermodynamic_population_partials(("pa", "pb"))["pb"][0]
+
+    with pytest.raises(ValueError, match="population.*below binary64 representability"):
+        partial(enthalpy, 0.0, -273.14)
+
+
+def test_population_partial_underflow_does_not_invalidate_population() -> None:
+    kelvin = Decimal("298.15")
+    minimum = Decimal.from_float(math.nextafter(0.0, 1.0))
+    enthalpy = _enthalpy_for_population(Decimal(1000) * minimum, kelvin)
+    populations = thermodynamic_populations(
+        {"a": ZERO, "b": ThermodynamicCoordinate(enthalpy, 0.0)},
+        25.0,
+    )
+    partial = thermodynamic_population_partials(("pa", "pb"))["pb"][0]
+
+    assert populations["b"] > 0.0
+    with pytest.raises(
+        ValueError,
+        match="population derivative.*below binary64 representability",
+    ):
+        partial(enthalpy, 0.0, 25.0)
+
+
+def test_population_partials_preserve_normalized_softmax_coupling() -> None:
+    arguments = (8_000.0, 10.0, 12_000.0, -5.0, 25.0)
+    partials = thermodynamic_population_partials(("pa", "pb", "pc"))
+    jacobian = tuple(
+        tuple(partial(*arguments) for partial in partials[component])
+        for component in ("pa", "pb", "pc")
+    )
+
+    for column in zip(*jacobian, strict=True):
+        # Each derivative is O(1e-2); this is below two binary64 ulps of their sum.
+        assert math.fsum(column) == pytest.approx(0.0, abs=4.0e-18)

--- a/tests/models/kinetic/test_eyring_model_authority.py
+++ b/tests/models/kinetic/test_eyring_model_authority.py
@@ -1,0 +1,617 @@
+"""Cross-model thermodynamic invariants for the public Eyring models."""
+
+from __future__ import annotations
+
+import math
+import sys
+from collections.abc import Callable
+from decimal import Decimal, localcontext
+from types import SimpleNamespace
+
+import pytest
+from scipy import constants
+
+from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Method
+from chemex.configuration.parameters import DefaultSetting
+from chemex.models.factory import model_factory
+from chemex.models.kinetic._eyring import calculate_rate_from_coordinates
+from chemex.models.kinetic.settings_2st_eyring import (
+    calculate_kij_2st_eyring,
+    calculate_populations_2st_eyring,
+    make_settings_2st_eyring,
+)
+from chemex.models.kinetic.settings_2st_eyring import (
+    register as register_2st_eyring,
+)
+from chemex.models.kinetic.settings_3st_eyring import (
+    calculate_kij_3st_eyring_fork,
+    calculate_kij_3st_eyring_linear,
+    calculate_populations_3st_eyring,
+    make_settings_3st_eyring_fork,
+    make_settings_3st_eyring_linear,
+)
+from chemex.models.kinetic.settings_4st_eyring import (
+    calculate_kij_4st_eyring,
+    calculate_populations_4st_eyring,
+    make_settings_4st_eyring,
+)
+from chemex.nmr.basis import Basis
+from chemex.optimize.deterministic_uncertainty import (
+    compile_model_constraint_linearization_capabilities,
+)
+from chemex.optimize.uncertainty import (
+    FunctionAnalyticPartialCapability,
+)
+from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import ConstraintDomainError
+from chemex.parameters.spin_system import SpinSystem
+from chemex.parameters.userfunctions import (
+    AnalyticFunctionLinearization,
+    function_linearization_registry,
+    user_function_registry,
+)
+from chemex.runtime import AnalysisSession
+
+RateCalculator = Callable[..., dict[str, float]]
+
+
+def _decimal_directional_rate(
+    celsius: str,
+    initial: tuple[str, str],
+    transition_state: tuple[str, str],
+) -> float:
+    """Evaluate one directional rate independently from exact SI literals."""
+    with localcontext() as context:
+        context.prec = 100
+        gas_constant = Decimal("8.31446261815324")
+        frequency_factor = Decimal("1.380649e-23") / Decimal("6.62607015e-34")
+        kelvin = Decimal(celsius) + Decimal("273.15")
+        activation_enthalpy = Decimal(transition_state[0]) - Decimal(initial[0])
+        activation_entropy = Decimal(transition_state[1]) - Decimal(initial[1])
+        exponent = activation_entropy / gas_constant - activation_enthalpy / (
+            gas_constant * kelvin
+        )
+        return float(frequency_factor * kelvin * exponent.exp())
+
+
+def _prepare_eyring_model(
+    model_name: str,
+    *,
+    temperature: float = 25.0,
+    defaults: dict[str, float] | None = None,
+) -> tuple[AnalysisSession, dict[str, str]]:
+    conditions = Conditions(
+        h_larmor_frq=600.0,
+        temperature=temperature,
+        p_total=1.0e-3,
+        l_total=2.0e-3,
+    )
+    session = AnalysisSession.create()
+    session.set_model(model_name)
+    basis = Basis(type="iz", spin_system="nh", model=session.model.spec)
+    spin_system = SpinSystem.from_name("G23N-HN")
+    settings = model_factory.create(model_name, conditions)
+    local_ids = {
+        name: setting.name_setting.get_param_name(spin_system, conditions).id_
+        for name, setting in settings.items()
+    }
+    config = SimpleNamespace(
+        conditions=conditions,
+        to_be_fitted=SimpleNamespace(rates=[], model_free=[]),
+    )
+    session.parameter_factory.create_parameters(
+        config,  # ty: ignore[invalid-argument-type]
+        basis=basis,
+        spin_system=spin_system,
+    )
+    session.parameters.set_defaults(
+        [
+            (ParamName.from_section(name), DefaultSetting(value))
+            for name, value in (defaults or {}).items()
+        ]
+    )
+    assert session.parameter_factory.try_seal_definitions(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    return session, local_ids
+
+
+def _assert_log_detailed_balance(
+    rates: dict[str, float],
+    states: dict[str, tuple[float, float]],
+    edges: tuple[str, ...],
+    celsius: float,
+) -> None:
+    kelvin = celsius + constants.zero_Celsius
+    for edge in edges:
+        initial, final = edge
+        dh_i, ds_i = states[initial]
+        dh_j, ds_j = states[final]
+        actual = math.log(rates[f"k{edge}"]) - math.log(rates[f"k{edge[::-1]}"])
+        expected = -((dh_j - dh_i) - kelvin * (ds_j - ds_i)) / (constants.R * kelvin)
+        assert actual == pytest.approx(expected, rel=2.0e-14, abs=2.0e-14)
+
+
+@pytest.mark.parametrize("celsius", (-241.15, 25.0, 50.0, 1.0e6))
+def test_two_state_log_detailed_balance_across_temperature(celsius: float) -> None:
+    rates = calculate_kij_2st_eyring(8_000.0, 10.0, 65_000.0, 20.0, celsius)
+
+    _assert_log_detailed_balance(
+        rates,
+        {"a": (0.0, 0.0), "b": (8_000.0, 10.0)},
+        ("ab",),
+        celsius,
+    )
+
+
+def test_subnormal_representable_edge_preserves_log_detailed_balance() -> None:
+    kelvin = 32.0
+    state_enthalpy = 10.0 * constants.R * kelvin
+    transition_enthalpy = 750.0 * constants.R * kelvin
+    rates = calculate_kij_2st_eyring(
+        state_enthalpy,
+        0.0,
+        transition_enthalpy,
+        0.0,
+        kelvin - constants.zero_Celsius,
+    )
+
+    assert 0.0 < rates["kab"] < sys.float_info.min
+    actual = math.log(rates["kab"]) - math.log(rates["kba"])
+    # Subnormal quantization limits the log ratio here; 2e-10 is below one
+    # relative spacing of the smaller returned rate.
+    assert actual == pytest.approx(-10.0, rel=0.0, abs=2.0e-10)
+
+
+@pytest.mark.parametrize(
+    ("calculator", "transition_terms", "edges"),
+    (
+        (
+            calculate_kij_3st_eyring_linear,
+            (65_000.0, 20.0, 70_000.0, 5.0),
+            ("ab", "bc"),
+        ),
+        (calculate_kij_3st_eyring_fork, (65_000.0, 20.0, 72_000.0, 15.0), ("ab", "ac")),
+    ),
+)
+def test_three_state_topologies_obey_log_detailed_balance(
+    calculator: RateCalculator,
+    transition_terms: tuple[float, ...],
+    edges: tuple[str, ...],
+) -> None:
+    rates = calculator(8_000.0, 10.0, 12_000.0, -5.0, *transition_terms, 25.0)
+
+    _assert_log_detailed_balance(
+        rates,
+        {"a": (0.0, 0.0), "b": (8_000.0, 10.0), "c": (12_000.0, -5.0)},
+        edges,
+        25.0,
+    )
+
+
+def _four_state_parameters(transition_shift: float = 0.0) -> dict[str, float]:
+    return {
+        "dh_b": 8_000.0,
+        "ds_b": 10.0,
+        "dh_c": 12_000.0,
+        "ds_c": -5.0,
+        "dh_d": 15_000.0,
+        "ds_d": 15.0,
+        "dh_ab": 75_000.0 + transition_shift,
+        "ds_ab": 50.0,
+        "dh_ac": 80_000.0 + transition_shift,
+        "ds_ac": 30.0,
+        "dh_ad": 85_000.0 + transition_shift,
+        "ds_ad": 70.0,
+        "dh_bc": 70_000.0 + transition_shift,
+        "ds_bc": 20.0,
+        "dh_bd": 77_000.0 + transition_shift,
+        "ds_bd": 40.0,
+        "dh_cd": 72_000.0 + transition_shift,
+        "ds_cd": 25.0,
+        "temperature": 25.0,
+    }
+
+
+def test_four_state_rates_obey_pairwise_balance_and_cycle_closure() -> None:
+    parameters = _four_state_parameters()
+    rates = calculate_kij_4st_eyring(**parameters)
+    states = {
+        "a": (0.0, 0.0),
+        "b": (parameters["dh_b"], parameters["ds_b"]),
+        "c": (parameters["dh_c"], parameters["ds_c"]),
+        "d": (parameters["dh_d"], parameters["ds_d"]),
+    }
+
+    _assert_log_detailed_balance(
+        rates,
+        states,
+        ("ab", "ac", "ad", "bc", "bd", "cd"),
+        parameters["temperature"],
+    )
+    cycle_affinity = math.fsum(
+        (
+            math.log(rates["kab"]) - math.log(rates["kba"]),
+            math.log(rates["kbc"]) - math.log(rates["kcb"]),
+            math.log(rates["kca"]) - math.log(rates["kac"]),
+        )
+    )
+    assert cycle_affinity == pytest.approx(0.0, abs=3.0e-14)
+
+
+def test_legacy_four_state_positional_wrapper_maps_all_six_barriers() -> None:
+    """Protect the long retained callable surface against positional edge swaps."""
+    temperature = "25.0"
+    states = {
+        "a": ("0", "0"),
+        "b": ("6100", "4"),
+        "c": ("11200", "-8"),
+        "d": ("-3200", "13"),
+    }
+    transition_states = {
+        "ab": ("-25000", "-10"),
+        "ac": ("42000", "3"),
+        "ad": ("48000", "-7"),
+        "bc": ("55000", "19"),
+        "bd": ("60000", "-13"),
+        "cd": ("67000", "27"),
+    }
+
+    # Deliberately positional: this is compatibility coverage for the historical
+    # 19-argument order, not a test of the cleaner keyword-facing declaration.
+    rates = calculate_kij_4st_eyring(
+        6100.0,
+        4.0,
+        11200.0,
+        -8.0,
+        -3200.0,
+        13.0,
+        -25000.0,
+        -10.0,
+        42000.0,
+        3.0,
+        48000.0,
+        -7.0,
+        55000.0,
+        19.0,
+        60000.0,
+        -13.0,
+        67000.0,
+        27.0,
+        25.0,
+    )
+
+    for edge, transition_state in transition_states.items():
+        for initial, final in (edge, edge[::-1]):
+            expected = _decimal_directional_rate(
+                temperature,
+                states[initial],
+                transition_state,
+            )
+            actual = rates[f"k{initial}{final}"]
+            # Thirty-two ulps covers the independent Decimal-to-libm evaluation
+            # path while remaining far smaller than any deliberate edge swap.
+            assert abs(actual - expected) <= 32 * math.ulp(expected), edge
+
+    assert rates["kab"] > 1.0e16
+    assert rates["kab"] != 1.0e16
+    assert rates["kba"] == pytest.approx(
+        _decimal_directional_rate(temperature, states["b"], transition_states["ab"]),
+        rel=3.0e-15,
+    )
+
+
+def test_rate_is_not_saturated_at_former_limit() -> None:
+    rates = calculate_kij_2st_eyring(0.0, 0.0, -50_000.0, 0.0, 25.0)
+
+    assert rates["kab"] > 1.0e16
+    assert rates["kba"] > 1.0e16
+    assert rates["kab"] == rates["kba"]
+
+
+def test_two_state_population_ratio_comes_directly_from_state_coordinates() -> None:
+    populations = calculate_populations_2st_eyring(8_000.0, 10.0, 25.0)
+    kelvin = 298.15
+    expected_ratio = math.exp(-(8_000.0 - kelvin * 10.0) / (constants.R * kelvin))
+
+    assert populations["pb"] / populations["pa"] == pytest.approx(
+        expected_ratio, rel=2.0e-15
+    )
+
+
+def test_population_boundary_distinguishes_balance_from_unrepresentability() -> None:
+    celsius = -273.14
+    representable_enthalpy = 61.72329710480702
+    rates = calculate_kij_2st_eyring(
+        representable_enthalpy,
+        0.0,
+        representable_enthalpy,
+        0.0,
+        celsius,
+    )
+    populations = calculate_populations_2st_eyring(
+        representable_enthalpy,
+        0.0,
+        celsius,
+    )
+
+    assert populations["pb"] > 0.0
+    assert math.log(rates["kab"]) - math.log(rates["kba"]) == pytest.approx(
+        math.log(populations["pb"]) - math.log(populations["pa"]),
+        abs=6.0e-10,
+    )
+
+    unrepresentable_enthalpy = 61.959375430421595
+    still_representable_rates = calculate_kij_2st_eyring(
+        unrepresentable_enthalpy,
+        0.0,
+        unrepresentable_enthalpy,
+        0.0,
+        celsius,
+    )
+    assert all(rate > 0.0 for rate in still_representable_rates.values())
+    with pytest.raises(ValueError, match="population.*below binary64 representability"):
+        calculate_populations_2st_eyring(
+            unrepresentable_enthalpy,
+            0.0,
+            celsius,
+        )
+
+
+def test_three_state_population_is_independent_of_topology() -> None:
+    expected = calculate_populations_3st_eyring(
+        8_000.0,
+        10.0,
+        12_000.0,
+        -5.0,
+        25.0,
+    )
+    linear = make_settings_3st_eyring_linear(Conditions(temperature=25.0))
+    fork = make_settings_3st_eyring_fork(Conditions(temperature=25.0))
+
+    assert expected.keys() == {"pa", "pb", "pc"}
+    assert all("pop_3st_eyring" in linear[name].expr for name in expected)
+    assert all(linear[name].expr == fork[name].expr for name in expected)
+    assert all("pop_3st(" not in linear[name].expr for name in expected)
+
+
+def test_four_state_populations_are_invariant_to_uniform_kinetic_slowdown() -> None:
+    ordinary_parameters = _four_state_parameters()
+    slow_parameters = _four_state_parameters(transition_shift=100_000.0)
+    ordinary_rates = calculate_kij_4st_eyring(**ordinary_parameters)
+    slow_rates = calculate_kij_4st_eyring(**slow_parameters)
+    populations = calculate_populations_4st_eyring(
+        ordinary_parameters["dh_b"],
+        ordinary_parameters["ds_b"],
+        ordinary_parameters["dh_c"],
+        ordinary_parameters["ds_c"],
+        ordinary_parameters["dh_d"],
+        ordinary_parameters["ds_d"],
+        ordinary_parameters["temperature"],
+    )
+    slow_populations = calculate_populations_4st_eyring(
+        slow_parameters["dh_b"],
+        slow_parameters["ds_b"],
+        slow_parameters["dh_c"],
+        slow_parameters["ds_c"],
+        slow_parameters["dh_d"],
+        slow_parameters["ds_d"],
+        slow_parameters["temperature"],
+    )
+
+    assert slow_populations == populations
+    rate_scales = {
+        name: slow_rates[name] / ordinary_rate
+        for name, ordinary_rate in ordinary_rates.items()
+    }
+    assert max(rate_scales.values()) < 1.0e-15
+    assert max(rate_scales.values()) == pytest.approx(
+        min(rate_scales.values()), rel=8.0e-14
+    )
+    settings = make_settings_4st_eyring(Conditions(temperature=25.0))
+    assert all("pop_4st_eyring" in settings[name].expr for name in populations)
+    assert all("pop_4st(" not in settings[name].expr for name in populations)
+
+
+def test_settings_expose_each_directional_barrier_without_tuple_ordering() -> None:
+    settings = make_settings_4st_eyring(Conditions(temperature=25.0))
+
+    assert settings["kab"].expr == ("eyring_rate(0.0,0.0,{dh_ab},{ds_ab},25.0)['rate']")
+    assert settings["kba"].expr == (
+        "eyring_rate({dh_b},{ds_b},{dh_ab},{ds_ab},25.0)['rate']"
+    )
+    assert settings["kbc"].expr == (
+        "eyring_rate({dh_b},{ds_b},{dh_bc},{ds_bc},25.0)['rate']"
+    )
+    assert settings["kcb"].expr == (
+        "eyring_rate({dh_c},{ds_c},{dh_bc},{ds_bc},25.0)['rate']"
+    )
+
+
+def test_two_state_settings_use_thermodynamic_population_authority() -> None:
+    settings = make_settings_2st_eyring(Conditions(temperature=25.0))
+
+    assert settings["pa"].expr == "pop_2st_eyring({dh_b},{ds_b},25.0)['pa']"
+    assert settings["pb"].expr == "pop_2st_eyring({dh_b},{ds_b},25.0)['pb']"
+
+
+def test_directional_rate_registers_exact_thermodynamic_partials() -> None:
+    register_2st_eyring()
+    capability = next(
+        item
+        for item in function_linearization_registry.get("2st_eyring")
+        if isinstance(item, AnalyticFunctionLinearization)
+    )
+    arguments = (8_000.0, 10.0, 65_000.0, 20.0, 25.0)
+    rate = calculate_rate_from_coordinates(*arguments)
+    kelvin = 298.15
+    expected = (
+        rate / (constants.R * kelvin),
+        -rate / constants.R,
+        -rate / (constants.R * kelvin),
+        rate / constants.R,
+    )
+
+    assert (capability.function_id, capability.component) == ("eyring_rate", "rate")
+    assert tuple(partial(*arguments) for partial in capability.partials[:4]) == (
+        pytest.approx(expected, rel=2.0e-15)
+    )
+
+
+def test_eyring_parameter_scoping_preserves_current_contract() -> None:
+    settings = make_settings_2st_eyring(Conditions(temperature=25.0))
+    spin_g = SpinSystem.from_name("G23N-HN")
+    spin_a = SpinSystem.from_name("A24N-HN")
+    base = Conditions(
+        temperature=0.0,
+        h_larmor_frq=600.0,
+        p_total=1.0e-3,
+        l_total=2.0e-3,
+    )
+    changed_temperature_and_field = Conditions(
+        temperature=25.0,
+        h_larmor_frq=800.0,
+        p_total=1.0e-3,
+        l_total=2.0e-3,
+    )
+    changed_concentration = Conditions(
+        temperature=0.0,
+        h_larmor_frq=600.0,
+        p_total=2.0e-3,
+        l_total=2.0e-3,
+    )
+
+    dh_base = settings["dh_b"].name_setting.get_param_name(spin_g, base)
+    dh_other = settings["dh_b"].name_setting.get_param_name(
+        spin_a, changed_temperature_and_field
+    )
+    kab_base = settings["kab"].name_setting.get_param_name(spin_g, base)
+    kab_temperature = settings["kab"].name_setting.get_param_name(
+        spin_a, changed_temperature_and_field
+    )
+    kab_concentration = settings["kab"].name_setting.get_param_name(
+        spin_g, changed_concentration
+    )
+
+    assert dh_base.id_ == dh_other.id_
+    assert kab_base.id_ != kab_temperature.id_
+    assert dh_base.id_ == "__DH_B__1_000E_03M_2_000E_03M"
+    assert kab_base.id_ == "__KAB__0_0C_1_000E_03M_2_000E_03M"
+    assert "600_0MHZ" not in kab_base.id_
+    assert "G23" not in kab_base.id_
+    assert kab_base.id_ != kab_concentration.id_
+    assert (
+        calculate_kij_2st_eyring(8_000.0, 10.0, 65_000.0, 20.0, 0.0)["kab"]
+        != calculate_kij_2st_eyring(8_000.0, 10.0, 65_000.0, 20.0, 25.0)["kab"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "legacy_function"),
+    (
+        ("2st_eyring", "kij_2st_eyring"),
+        ("2st_eyring", "pop_2st"),
+        ("3st_eyring", "kij_3st_eyring"),
+        ("3st_eyring", "pop_3st"),
+        ("3st_eyring_linear", "kij_3st_eyring"),
+        ("3st_eyring_fork", "kij_3st_eyring_fork"),
+        ("4st_eyring", "kij_4st_eyring"),
+        ("4st_eyring", "pop_4st"),
+    ),
+)
+def test_legacy_eyring_calculator_bindings_remain_available(
+    model_name: str,
+    legacy_function: str,
+) -> None:
+    session = AnalysisSession.create()
+    session.set_model(model_name)
+
+    assert legacy_function in user_function_registry.get(model_name)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "population_names"),
+    (
+        ("2st_eyring", ("pa", "pb")),
+        ("3st_eyring", ("pa", "pb", "pc")),
+        ("3st_eyring_linear", ("pa", "pb", "pc")),
+        ("3st_eyring_fork", ("pa", "pb", "pc")),
+        ("4st_eyring", ("pa", "pb", "pc", "pd")),
+    ),
+)
+def test_all_eyring_models_compile_rate_and_population_uncertainty_capabilities(
+    model_name: str,
+    population_names: tuple[str, ...],
+) -> None:
+    session, local_ids = _prepare_eyring_model(model_name)
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    output_ids = (local_ids["kab"], *(local_ids[name] for name in population_names))
+    parameterization = session.compile_parameterization(Method(), set(output_ids))
+
+    compiled = compile_model_constraint_linearization_capabilities(
+        parameterization,
+        output_ids,
+    )
+
+    assert any(
+        isinstance(capability, FunctionAnalyticPartialCapability)
+        and (capability.function_id, capability.component) == ("eyring_rate", "rate")
+        for capability in compiled.capabilities
+    )
+    population_capabilities = tuple(
+        capability
+        for capability in compiled.capabilities
+        if isinstance(capability, FunctionAnalyticPartialCapability)
+        and capability.component in population_names
+    )
+    assert {capability.component for capability in population_capabilities} == set(
+        population_names
+    )
+    assert all(
+        capability.implementation_identity
+        == "eyring-thermodynamic-population-partials-v1"
+        for capability in population_capabilities
+    )
+
+
+@pytest.mark.parametrize(
+    ("barrier", "message"),
+    (
+        (200_000.0, "below binary64 representability"),
+        (-200_000.0, "exceeds maximum finite binary64"),
+    ),
+)
+def test_unrepresentable_eyring_rate_is_a_typed_constraint_domain_failure(
+    barrier: float,
+    message: str,
+) -> None:
+    session, _ = _prepare_eyring_model(
+        "2st_eyring",
+        temperature=-273.149999,
+        defaults={"dh_ab": barrier},
+    )
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert message in str(error.__cause__)
+
+
+def test_unrepresentable_population_is_typed_constraint_domain_failure() -> None:
+    enthalpy = 61.959375430421595
+    session, _ = _prepare_eyring_model(
+        "2st_eyring",
+        temperature=-273.14,
+        defaults={"dh_b": enthalpy, "dh_ab": enthalpy},
+    )
+
+    assert not session.try_build_analysis_values()
+    error = session.parameter_factory.native_construction_error
+    assert isinstance(error, ConstraintDomainError)
+    assert isinstance(error.__cause__, ValueError)
+    assert "population" in str(error.__cause__)
+    assert "below binary64 representability" in str(error.__cause__)

--- a/tests/models/kinetic/test_eyring_workflows.py
+++ b/tests/models/kinetic/test_eyring_workflows.py
@@ -1,0 +1,773 @@
+"""Workflow qualification for Eyring uncertainty, MCMC, and resampling."""
+
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+from dataclasses import dataclass
+from decimal import Decimal, localcontext
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from pydantic import BaseModel
+
+from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Method
+from chemex.configuration.parameters import DefaultSetting
+from chemex.containers.data import Data
+from chemex.containers.profile import Profile, PulseSequence
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationResult,
+)
+from chemex.models.factory import model_factory
+from chemex.nmr.basis import Basis
+from chemex.nmr.spectrometer import Spectrometer
+from chemex.optimize.deterministic_uncertainty import (
+    AcceptedDeterministicFitFacts,
+    ContinuousTrfBasis,
+    DeterministicUncertainty,
+    derive_deterministic_uncertainty,
+)
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    DirectTrfInvocation,
+    OptimizationProblem,
+    canonical_chi_square,
+    execute_direct_trf,
+)
+from chemex.optimize.grouped_direct_trf import FitDecomposition
+from chemex.optimize.native_mcmc import (
+    McmcOperationTerminal,
+    McmcPlan,
+    execute_mcmc_evidence,
+    resolve_product_mcmc_policy,
+)
+from chemex.optimize.native_resampling import (
+    OperationTerminal,
+    OptimizationStrategy,
+    ResamplingDatasetManifest,
+    ResamplingPlan,
+    ResamplingScheme,
+    execute_resampling_evidence,
+)
+from chemex.optimize.uncertainty import ParameterUnit, UncertaintyUnavailableKind
+from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import (
+    ActiveParameterization,
+    SealedParameterModel,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.printers.data import Printer
+from chemex.printers.parameters import write_parameters
+from chemex.runtime import AnalysisSession
+
+
+class _EyringKernelSettings(BaseModel):
+    kind: str = "eyring-workflow-qualification"
+
+
+class _EyringSpectrometer:
+    def __init__(self, spin_system: SpinSystem) -> None:
+        self.spin_system = spin_system
+        self.values = {"kab": 0.0, "pb": 0.0}
+
+    def update(self, values: dict[str, float]) -> None:
+        self.values = dict(values)
+
+    def new_native_workspace(self) -> _EyringSpectrometer:
+        return deepcopy(self)
+
+    def native_kernel_descriptor(self) -> dict[str, str]:
+        return {"kind": "eyring-workflow-spectrometer"}
+
+
+class _EyringPulseSequence:
+    settings = _EyringKernelSettings()
+
+    def calculate(self, spectrometer: _EyringSpectrometer, data: Data) -> np.ndarray:
+        metadata = np.asarray(data.metadata, dtype=np.float64)
+        return spectrometer.values["kab"] + spectrometer.values["pb"] * metadata
+
+    def is_reference(self, metadata: np.ndarray) -> np.ndarray:
+        return np.zeros(metadata.shape, dtype=np.bool_)
+
+
+def _decimal_eyring_rate(
+    temperature: float,
+    initial_enthalpy: float,
+    initial_entropy: float,
+    transition_enthalpy: float,
+    transition_entropy: float,
+) -> float:
+    """Evaluate a directional rate independently from exact SI literals."""
+    with localcontext() as context:
+        context.prec = 100
+        gas_constant = Decimal("8.31446261815324")
+        frequency_factor = Decimal("1.380649e-23") / Decimal("6.62607015e-34")
+        kelvin = Decimal(str(temperature)) + Decimal("273.15")
+        activation_enthalpy = Decimal(str(transition_enthalpy)) - Decimal(
+            str(initial_enthalpy)
+        )
+        activation_entropy = Decimal(str(transition_entropy)) - Decimal(
+            str(initial_entropy)
+        )
+        exponent = activation_entropy / gas_constant - activation_enthalpy / (
+            gas_constant * kelvin
+        )
+        return float(frequency_factor * kelvin * exponent.exp())
+
+
+def _decimal_two_state_population(
+    temperature: float,
+    state_enthalpy: float,
+    state_entropy: float,
+) -> float:
+    """Evaluate P(B) independently from exact SI Boltzmann weights."""
+    with localcontext() as context:
+        context.prec = 100
+        gas_constant = Decimal("8.31446261815324")
+        kelvin = Decimal(str(temperature)) + Decimal("273.15")
+        log_weight = Decimal(str(state_entropy)) / gas_constant - Decimal(
+            str(state_enthalpy)
+        ) / (gas_constant * kelvin)
+        weight = log_weight.exp()
+        return float(weight / (Decimal(1) + weight))
+
+
+@dataclass(frozen=True, slots=True)
+class _EyringWorkflow:
+    session: AnalysisSession
+    local_ids: dict[str, str]
+    parameter_model: SealedParameterModel
+    parameterization: ActiveParameterization
+    engine: EvaluationEngine
+    problem: OptimizationProblem
+    accepted: AcceptedFitResult
+    profile: Profile
+
+
+@dataclass(frozen=True, slots=True)
+class _MultiTemperatureEyringWorkflow:
+    session: AnalysisSession
+    temperatures: tuple[float, ...]
+    local_ids: dict[float, dict[str, str]]
+    parameter_model: SealedParameterModel
+    parameterization: ActiveParameterization
+    engine: EvaluationEngine
+    problem: OptimizationProblem
+    accepted: AcceptedFitResult
+    profiles: tuple[Profile, ...]
+
+
+def _build_eyring_workflow(
+    *,
+    temperature: float = 25.0,
+    true_dh_b: float = 8_000.0,
+    true_ds_b: float = 10.0,
+    true_dh_ab: float = 65_000.0,
+    true_ds_ab: float = 20.0,
+    fitted_names: tuple[str, ...] = ("DH_AB", "DH_B"),
+    execute_fit: bool = True,
+    error: float = 0.02,
+) -> _EyringWorkflow:
+    conditions = Conditions(
+        h_larmor_frq=600.0,
+        temperature=temperature,
+        p_total=1.0e-3,
+        l_total=2.0e-3,
+    )
+    session = AnalysisSession.create()
+    session.set_model("2st_eyring")
+    basis = Basis(type="iz", spin_system="nh", model=session.model.spec)
+    spin_system = SpinSystem.from_name("G23N-HN")
+    settings = model_factory.create("2st_eyring", conditions)
+    local_ids = {
+        name: setting.name_setting.get_param_name(spin_system, conditions).id_
+        for name, setting in settings.items()
+    }
+    config = SimpleNamespace(
+        conditions=conditions,
+        to_be_fitted=SimpleNamespace(rates=[], model_free=[]),
+    )
+    session.parameter_factory.create_parameters(
+        config,  # ty: ignore[invalid-argument-type]
+        basis=basis,
+        spin_system=spin_system,
+    )
+    initial_values = {
+        "dh_b": true_dh_b if not execute_fit else true_dh_b - 500.0,
+        "ds_b": true_ds_b,
+        "dh_ab": true_dh_ab if not execute_fit else true_dh_ab - 500.0,
+        "ds_ab": true_ds_ab,
+    }
+    session.parameters.set_defaults(
+        [
+            (ParamName.from_section(name), DefaultSetting(value))
+            for name, value in initial_values.items()
+        ]
+    )
+    assert session.parameter_factory.try_seal_definitions(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+
+    metadata = np.asarray((0.0, 40.0, 90.0, 150.0, 220.0, 300.0))
+    true_rate = _decimal_eyring_rate(
+        temperature,
+        0.0,
+        0.0,
+        true_dh_ab,
+        true_ds_ab,
+    )
+    true_population = _decimal_two_state_population(
+        temperature,
+        true_dh_b,
+        true_ds_b,
+    )
+    noise = np.asarray((0.010, -0.015, 0.006, 0.018, -0.011, 0.004))
+    observed = true_rate + true_population * metadata
+    if execute_fit:
+        observed = observed + noise
+    data = Data(
+        exp=np.asarray(observed, dtype=np.float64),
+        err=np.full(metadata.shape, error, dtype=np.float64),
+        metadata=metadata,
+    )
+    profile = Profile(
+        data,
+        cast("Spectrometer", _EyringSpectrometer(spin_system)),
+        cast("PulseSequence", _EyringPulseSequence()),
+        {"kab": local_ids["kab"], "pb": local_ids["pb"]},
+        cast("Printer", None),
+        is_scaled=False,
+    )
+    experiments = cast("Any", (SimpleNamespace(profiles=(profile,)),))
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    configuration = session.parameter_factory.sealed_configuration
+    assert parameter_model is not None
+    assert configuration is not None
+    requested_ids = {local_ids[name] for name in ("kab", "kba", "pa", "pb")}
+    required_ids = profile.param_ids | requested_ids
+    independent_names = {"DH_B", "DS_B", "DH_AB", "DS_AB"}
+    parameterization = session.compile_parameterization(
+        Method(
+            fit=list(fitted_names),
+            fix=sorted(independent_names.difference(fitted_names)),
+        ),
+        required_ids,
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    if execute_fit:
+        outcome = execute_direct_trf(
+            problem,
+            DirectTrfInvocation.for_problem(problem, objective_request_budget=100),
+            parameterization,
+            engine,
+        )
+        accepted = outcome.accepted_result
+        assert accepted is not None
+    else:
+        lifecycle = problem.lifecycle_frame(problem.start, parameterization)
+        frame = EvaluationFrame.from_lifecycle_frame(parameterization, lifecycle)
+        evaluation = engine.new_evaluator().evaluate(frame)
+        assert isinstance(evaluation, EvaluationResult)
+        accepted = AcceptedFitResult.for_qualification(
+            occurrence_identity="eyring-workflow-accepted-occurrence",
+            problem_identity=problem.identity,
+            invocation_identity="eyring-workflow-invocation",
+            execution_identity="eyring-workflow-execution",
+            materialization_identity="eyring-workflow-materialization",
+            parameterization_identity=parameterization.identity,
+            evaluator_parameterization_identity=parameterization.evaluator_identity,
+            source_occurrence_identity=problem.source_snapshot.occurrence_identity,
+            source_revision=problem.source_snapshot.revision,
+            controlled_ids=problem.controlled_ids,
+            vector=problem.start,
+            chi_square=canonical_chi_square(evaluation.residuals),
+            evaluation_result=evaluation,
+            commit_scope=problem.commit_scope,
+            commit_items=evaluation.resolved_values.ordered_items(),
+            origin_context_identity="eyring-workflow-qualification",
+        )
+    return _EyringWorkflow(
+        session,
+        local_ids,
+        parameter_model,
+        parameterization,
+        engine,
+        problem,
+        accepted,
+        profile,
+    )
+
+
+def _build_multitemperature_eyring_workflow() -> _MultiTemperatureEyringWorkflow:
+    temperatures = (-20.0, 25.0, 70.0)
+    true_coordinates = {
+        "dh_b": 8_000.0,
+        "ds_b": 10.0,
+        "dh_ab": 65_000.0,
+        "ds_ab": 20.0,
+    }
+    session = AnalysisSession.create()
+    session.set_model("2st_eyring")
+    basis = Basis(type="iz", spin_system="nh", model=session.model.spec)
+    spin_system = SpinSystem.from_name("G23N-HN")
+    local_ids: dict[float, dict[str, str]] = {}
+
+    for temperature in temperatures:
+        conditions = Conditions(
+            h_larmor_frq=600.0,
+            temperature=temperature,
+            p_total=1.0e-3,
+            l_total=2.0e-3,
+        )
+        settings = model_factory.create("2st_eyring", conditions)
+        local_ids[temperature] = {
+            name: setting.name_setting.get_param_name(spin_system, conditions).id_
+            for name, setting in settings.items()
+        }
+        config = SimpleNamespace(
+            conditions=conditions,
+            to_be_fitted=SimpleNamespace(rates=[], model_free=[]),
+        )
+        session.parameter_factory.create_parameters(
+            config,  # ty: ignore[invalid-argument-type]
+            basis=basis,
+            spin_system=spin_system,
+        )
+
+    initial_values = {
+        "dh_b": true_coordinates["dh_b"] - 300.0,
+        "ds_b": true_coordinates["ds_b"] - 1.0,
+        "dh_ab": true_coordinates["dh_ab"] - 300.0,
+        "ds_ab": true_coordinates["ds_ab"] - 1.0,
+    }
+    session.parameters.set_defaults(
+        [
+            (ParamName.from_section(name), DefaultSetting(value))
+            for name, value in initial_values.items()
+        ]
+    )
+    assert session.parameter_factory.try_seal_definitions(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+
+    metadata = np.asarray((0.0, 40.0, 90.0, 150.0, 220.0, 300.0))
+    noise = np.asarray((0.010, -0.015, 0.006, 0.018, -0.011, 0.004))
+    profiles: list[Profile] = []
+    for temperature in temperatures:
+        rate = _decimal_eyring_rate(
+            temperature,
+            0.0,
+            0.0,
+            true_coordinates["dh_ab"],
+            true_coordinates["ds_ab"],
+        )
+        population = _decimal_two_state_population(
+            temperature,
+            true_coordinates["dh_b"],
+            true_coordinates["ds_b"],
+        )
+        data = Data(
+            exp=np.asarray(rate + population * metadata + noise, dtype=np.float64),
+            err=np.full(metadata.shape, 0.02, dtype=np.float64),
+            metadata=metadata,
+        )
+        profile = Profile(
+            data,
+            cast("Spectrometer", _EyringSpectrometer(spin_system)),
+            cast("PulseSequence", _EyringPulseSequence()),
+            {
+                "kab": local_ids[temperature]["kab"],
+                "pb": local_ids[temperature]["pb"],
+            },
+            cast("Printer", None),
+            is_scaled=False,
+        )
+        profiles.append(profile)
+
+    profile_tuple = tuple(profiles)
+    experiments = cast("Any", (SimpleNamespace(profiles=profile_tuple),))
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    configuration = session.parameter_factory.sealed_configuration
+    assert parameter_model is not None
+    assert configuration is not None
+    requested_ids = {
+        local_ids[temperature][name]
+        for temperature in temperatures
+        for name in ("kab", "kba", "pa", "pb")
+    }
+    required_ids = requested_ids | {
+        param_id for profile in profile_tuple for param_id in profile.param_ids
+    }
+    parameterization = session.compile_parameterization(
+        Method(fit=["DH_B", "DS_B", "DH_AB", "DS_AB"]),
+        required_ids,
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    outcome = execute_direct_trf(
+        problem,
+        DirectTrfInvocation.for_problem(problem, objective_request_budget=300),
+        parameterization,
+        engine,
+    )
+    accepted = outcome.accepted_result
+    assert accepted is not None
+    return _MultiTemperatureEyringWorkflow(
+        session,
+        temperatures,
+        local_ids,
+        parameter_model,
+        parameterization,
+        engine,
+        problem,
+        accepted,
+        profile_tuple,
+    )
+
+
+def _derive_uncertainty(
+    workflow: _EyringWorkflow | _MultiTemperatureEyringWorkflow,
+) -> DeterministicUncertainty:
+    decomposition = FitDecomposition.from_root(
+        workflow.problem,
+        workflow.parameterization,
+        workflow.engine,
+    )
+    return derive_deterministic_uncertainty(
+        AcceptedDeterministicFitFacts(
+            workflow.accepted,
+            workflow.problem,
+            workflow.parameterization,
+            workflow.engine,
+            ContinuousTrfBasis(decomposition.partition_proof),
+            "eyring-workflow-uncertainty",
+        )
+    )
+
+
+def test_real_fit_reports_directional_rate_and_population_uncertainty(
+    tmp_path: Path,
+) -> None:
+    workflow = _build_eyring_workflow()
+    uncertainty = _derive_uncertainty(workflow)
+    output_names = ("kab", "kba", "pa", "pb")
+
+    assert all(
+        (conclusion := uncertainty.parameter(workflow.local_ids[name])) is not None
+        and conclusion.reportable
+        and conclusion.standard_error is not None
+        and math.isfinite(conclusion.standard_error)
+        for name in output_names
+    )
+    resolved = dict(workflow.accepted.commit_items)
+    write_parameters(
+        tmp_path,
+        parameter_model=workflow.parameter_model,
+        parameter_values=resolved,
+        parameterization=workflow.parameterization,
+        fitted_ids=workflow.problem.controlled_ids,
+        deterministic_uncertainty=uncertainty,
+    )
+    constrained = (tmp_path / "Parameters" / "constrained.toml").read_text()
+    for name in ("KAB", "KBA", "PA", "PB"):
+        assert any(name in line and "# ±" in line for line in constrained.splitlines())
+
+
+def test_one_temperature_is_rank_deficient_but_multiple_temperatures_add_rank() -> None:
+    gas_constant = 8.31446261815324
+
+    def row(kelvin: float) -> tuple[float, float]:
+        return (-1.0 / (gas_constant * kelvin), 1.0 / gas_constant)
+
+    one_temperature = np.asarray((row(298.15), row(298.15)))
+    multiple_temperatures = np.asarray(
+        tuple(row(value) for value in (298.15, 303.15, 308.15))
+    )
+
+    assert np.linalg.matrix_rank(one_temperature) == 1
+    assert np.linalg.matrix_rank(multiple_temperatures) == 2
+    covariance = np.linalg.inv(multiple_temperatures.T @ multiple_temperatures)
+    correlation = covariance[0, 1] / math.sqrt(covariance[0, 0] * covariance[1, 1])
+    assert correlation > 0.999
+
+
+def test_multitemperature_fit_qualifies_shared_h_s_and_derived_output(
+    tmp_path: Path,
+) -> None:
+    workflow = _build_multitemperature_eyring_workflow()
+    uncertainty = _derive_uncertainty(workflow)
+    first_ids = workflow.local_ids[workflow.temperatures[0]]
+
+    for name in ("dh_b", "ds_b", "dh_ab", "ds_ab"):
+        assert {
+            workflow.local_ids[temperature][name]
+            for temperature in workflow.temperatures
+        } == {first_ids[name]}
+    for name in ("kab", "kba", "pa", "pb"):
+        assert len(
+            {
+                workflow.local_ids[temperature][name]
+                for temperature in workflow.temperatures
+            }
+        ) == len(workflow.temperatures)
+
+    root = uncertainty.root_evidence
+    assert root is not None
+    assert root.rank_diagnostic is not None
+    assert root.rank_diagnostic.rank == len(workflow.problem.controlled_ids) == 4
+    assert root.covariance is not None
+    assert math.isfinite(root.covariance.jacobian_condition)
+    assert root.covariance.usable
+    assert root.correlations is not None
+    dh_index = root.correlations.output_ids.index(first_ids["dh_ab"])
+    ds_index = root.correlations.output_ids.index(first_ids["ds_ab"])
+    correlation = root.correlations.entries[dh_index][ds_index].value
+    assert correlation is not None
+    assert 0.98 < abs(correlation) < 1.0
+
+    for name in ("dh_b", "ds_b", "dh_ab", "ds_ab"):
+        conclusion = uncertainty.parameter(first_ids[name])
+        assert conclusion is not None
+        assert conclusion.reportable
+        assert conclusion.standard_error is not None
+        assert math.isfinite(conclusion.standard_error)
+    for temperature in workflow.temperatures:
+        for name in ("kab", "kba", "pa", "pb"):
+            conclusion = uncertainty.parameter(workflow.local_ids[temperature][name])
+            assert conclusion is not None
+            assert conclusion.reportable
+            assert conclusion.standard_error is not None
+            assert math.isfinite(conclusion.standard_error)
+
+    resolved = dict(workflow.accepted.commit_items)
+    for temperature in workflow.temperatures:
+        expected_rate = _decimal_eyring_rate(
+            temperature,
+            0.0,
+            0.0,
+            resolved[first_ids["dh_ab"]],
+            resolved[first_ids["ds_ab"]],
+        )
+        actual_rate = resolved[workflow.local_ids[temperature]["kab"]]
+        assert actual_rate == pytest.approx(expected_rate, rel=3.0e-14)
+
+    write_parameters(
+        tmp_path,
+        parameter_model=workflow.parameter_model,
+        parameter_values=resolved,
+        parameterization=workflow.parameterization,
+        fitted_ids=workflow.problem.controlled_ids,
+        deterministic_uncertainty=uncertainty,
+    )
+    fitted = (tmp_path / "Parameters" / "fitted.toml").read_text()
+    constrained = (tmp_path / "Parameters" / "constrained.toml").read_text()
+    assert all(
+        any(name in line and "# ±" in line for line in fitted.splitlines())
+        for name in ("DH_B", "DS_B", "DH_AB", "DS_AB")
+    )
+    for temperature in workflow.temperatures:
+        qualifier = f"{temperature:.1f}C"
+        assert qualifier in constrained
+    assert all(
+        any(name in line and "# ±" in line for line in constrained.splitlines())
+        for name in ("KAB", "KBA", "PA", "PB")
+    )
+
+
+def test_one_temperature_h_s_fit_reports_rank_deficient_uncertainty() -> None:
+    workflow = _build_eyring_workflow(fitted_names=("DH_AB", "DS_AB"))
+    uncertainty = _derive_uncertainty(workflow)
+
+    assert all(
+        (conclusion := uncertainty.parameter(param_id)) is not None
+        and not conclusion.reportable
+        and conclusion.unavailable_kind is UncertaintyUnavailableKind.RANK_DEFICIENT
+        for param_id in workflow.problem.controlled_ids
+    )
+
+
+def test_mcmc_retries_an_unavailable_eyring_activation_proposal() -> None:
+    workflow = _build_eyring_workflow(
+        temperature=-273.14,
+        true_dh_b=0.0,
+        true_ds_b=0.0,
+        true_dh_ab=0.0,
+        true_ds_ab=0.0,
+        fitted_names=("DH_AB",),
+        execute_fit=False,
+        error=1.0e300,
+    )
+    plan = McmcPlan.for_accepted(
+        workflow.accepted,
+        source_problem=workflow.problem,
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        policy=resolve_product_mcmc_policy(
+            dimension=1,
+            walkers=8,
+            steps=2,
+            root_seed=770,
+        ),
+        coordinate_units=(
+            (workflow.problem.controlled_ids[0], ParameterUnit.ENERGY_PER_MOLE),
+        ),
+    )
+    evaluator = workflow.engine.new_evaluator()
+    initial_evaluations = tuple(
+        evaluator.evaluate(
+            EvaluationFrame.from_lifecycle_frame(
+                workflow.parameterization,
+                workflow.problem.lifecycle_frame(vector, workflow.parameterization),
+            )
+        )
+        for vector in plan.initial_ensemble
+    )
+    assert any(
+        isinstance(evaluation, EvaluationFailure)
+        and evaluation.stage == "resolution"
+        and evaluation.category == "domain_error"
+        and "function_id='eyring_rate'" in evaluation.message
+        for evaluation in initial_evaluations
+    )
+
+    operation = execute_mcmc_evidence(workflow.accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    initial_state = operation.evidence.states[0]
+    assert initial_state.positions != plan.initial_ensemble
+    assert all(math.isfinite(value) for value in initial_state.log_densities)
+
+
+def test_mcmc_retries_an_unrepresentable_eyring_population_proposal() -> None:
+    workflow = _build_eyring_workflow(
+        temperature=-273.14,
+        true_dh_b=61.72329710480702,
+        true_ds_b=0.0,
+        true_dh_ab=61.72329710480702,
+        true_ds_ab=0.0,
+        fitted_names=("DH_B",),
+        execute_fit=False,
+        error=1.0e300,
+    )
+    plan = McmcPlan.for_accepted(
+        workflow.accepted,
+        source_problem=workflow.problem,
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        policy=resolve_product_mcmc_policy(
+            dimension=1,
+            walkers=8,
+            steps=2,
+            root_seed=771,
+        ),
+        coordinate_units=(
+            (workflow.problem.controlled_ids[0], ParameterUnit.ENERGY_PER_MOLE),
+        ),
+    )
+    evaluator = workflow.engine.new_evaluator()
+    initial_evaluations = tuple(
+        evaluator.evaluate(
+            EvaluationFrame.from_lifecycle_frame(
+                workflow.parameterization,
+                workflow.problem.lifecycle_frame(vector, workflow.parameterization),
+            )
+        )
+        for vector in plan.initial_ensemble
+    )
+    assert any(
+        isinstance(evaluation, EvaluationFailure)
+        and evaluation.stage == "resolution"
+        and evaluation.category == "domain_error"
+        and "function_id='pop_2st_eyring'" in evaluation.message
+        for evaluation in initial_evaluations
+    )
+
+    operation = execute_mcmc_evidence(workflow.accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    assert all(
+        math.isfinite(value) for value in operation.evidence.states[0].log_densities
+    )
+
+
+def test_monte_carlo_recomputes_eyring_rates_from_resampled_coordinates() -> None:
+    workflow = _build_eyring_workflow()
+    accepted = workflow.accepted
+    size = workflow.engine.plan.observation_count
+    dataset = ResamplingDatasetManifest(
+        workflow.engine.plan,
+        tuple(
+            float(value) for value in accepted.evaluation_result.normalized_calculations
+        ),
+        tuple(False for _ in range(size)),
+        tuple("G23" for _ in range(size)),
+        tuple(f"eyring-observation-{index}" for index in range(size)),
+    )
+    plan = ResamplingPlan.for_accepted(
+        accepted,
+        dataset=dataset,
+        source_problem=workflow.problem,
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        scheme=ResamplingScheme.MONTE_CARLO,
+        replicate_count=3,
+        replicate_structural_identities=tuple(
+            f"eyring-monte-carlo-{index}" for index in range(3)
+        ),
+        replicate_component_identities=tuple(
+            (f"eyring-direct-trf-{index}",) for index in range(3)
+        ),
+        root_seed=770,
+        output_scope=workflow.problem.commit_scope,
+        output_units=("native",) * len(workflow.problem.commit_scope),
+        minimum_successful_count=3,
+        strategy=OptimizationStrategy.DIRECT_TRF,
+        strategy_settings=(("objective_request_budget", "100"),),
+    )
+
+    operation = execute_resampling_evidence(accepted, plan)
+
+    assert operation.terminal is OperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 3
+    for outcome in operation.evidence.outcomes:
+        assert outcome.success is not None
+        resolved = dict(outcome.success.resolved_items)
+        expected_rate = _decimal_eyring_rate(
+            25.0,
+            0.0,
+            0.0,
+            resolved[workflow.local_ids["dh_ab"]],
+            resolved[workflow.local_ids["ds_ab"]],
+        )
+        assert resolved[workflow.local_ids["kab"]] == pytest.approx(
+            expected_rate,
+            rel=3.0e-14,
+        )

--- a/tests/models/kinetic/test_settings_2st_eyring.py
+++ b/tests/models/kinetic/test_settings_2st_eyring.py
@@ -6,7 +6,6 @@ from scipy import constants
 
 from chemex.configuration.conditions import Conditions
 from chemex.models.kinetic.settings_2st_eyring import (
-    MAX_RATE_CONSTANT,
     calculate_kij_2st_eyring,
     make_settings_2st_eyring,
 )
@@ -38,9 +37,6 @@ class TestCalculateKij2stEyring:
         for key, value in rates.items():
             assert value > 0, f"Rate {key} should be positive, got {value}"
             assert np.isfinite(value), f"Rate {key} should be finite, got {value}"
-            assert value <= MAX_RATE_CONSTANT, (
-                f"Rate {key} exceeds maximum, got {value}"
-            )
 
     def test_temperature_dependence(self, default_params):
         """Test that rate constants change appropriately with temperature."""
@@ -73,7 +69,6 @@ class TestCalculateKij2stEyring:
 
         ddg_ab = dh_ab - dh_a - T * (ds_ab - ds_a)
         expected_kab = kbt_h * np.exp(-ddg_ab / RT)
-        expected_kab = np.clip(expected_kab, 0.0, MAX_RATE_CONSTANT)
 
         assert np.isclose(rates["kab"], expected_kab, rtol=1e-10), (
             f"Calculated kab {rates['kab']:.2e} doesn't match expected {expected_kab:.2e}"
@@ -137,9 +132,6 @@ class TestCalculateKij2stEyring:
         for key, value in rates_low.items():
             assert value > 0, f"Rate {key} should be positive"
             assert np.isfinite(value), f"Rate {key} should be finite"
-            assert value <= MAX_RATE_CONSTANT, (
-                f"Rate {key} should be clipped at maximum"
-            )
 
     def test_caching(self, default_params):
         """Test that function caching works correctly."""
@@ -266,11 +258,12 @@ class TestPhysicalRealism:
                 f"at {temperatures[i - 1]}°C"
             )
 
-        # Check Arrhenius plot linearity (ln(k) vs 1/T)
-        ln_rates = [np.log(r) for r in rates_kab]
-        inv_temps = [
-            1 / constants.convert_temperature(t, "C", "K") for t in temperatures
+        # Eyring linearity is ln(k/T) versus 1/T.
+        kelvin = [constants.convert_temperature(t, "C", "K") for t in temperatures]
+        ln_rates = [
+            np.log(rate / temp) for rate, temp in zip(rates_kab, kelvin, strict=True)
         ]
+        inv_temps = [1 / temp for temp in kelvin]
 
         # Simple linear regression
         n = len(ln_rates)

--- a/tests/models/kinetic/test_settings_3st_eyring.py
+++ b/tests/models/kinetic/test_settings_3st_eyring.py
@@ -10,7 +10,6 @@ from scipy import constants
 
 from chemex.configuration.conditions import Conditions
 from chemex.models.kinetic.settings_3st_eyring import (
-    MAX_RATE_CONSTANT,
     calculate_kij_3st_eyring_fork,
     calculate_kij_3st_eyring_linear,
     make_settings_3st_eyring_fork,
@@ -49,7 +48,7 @@ def test_calculators_return_only_active_finite_rates(
     rates = calculator(*arguments)
 
     assert rates.keys() == expected_rates
-    assert all(0.0 < rate <= MAX_RATE_CONSTANT for rate in rates.values())
+    assert all(rate > 0.0 for rate in rates.values())
     assert all(np.isfinite(rate) for rate in rates.values())
 
 
@@ -114,10 +113,13 @@ def test_temperature_dependence_is_preserved(
     "calculator",
     [calculate_kij_3st_eyring_linear, calculate_kij_3st_eyring_fork],
 )
-def test_rate_clipping_policy_is_preserved(calculator: RateCalculator) -> None:
+def test_rates_are_not_saturated_at_the_former_limit(
+    calculator: RateCalculator,
+) -> None:
     rates = calculator(0.0, 0.0, 0.0, 0.0, -2.0e5, 0.0, -2.0e5, 0.0, 25.0)
 
-    assert set(rates.values()) == {MAX_RATE_CONSTANT}
+    assert all(rate > 1.0e16 for rate in rates.values())
+    assert len(set(rates.values())) == 1
 
 
 def test_calculators_cache_repeated_inputs() -> None:

--- a/tests/models/kinetic/test_settings_4st_eyring.py
+++ b/tests/models/kinetic/test_settings_4st_eyring.py
@@ -6,7 +6,6 @@ from scipy import constants
 
 from chemex.configuration.conditions import Conditions
 from chemex.models.kinetic.settings_4st_eyring import (
-    MAX_RATE_CONSTANT,
     calculate_kij_4st_eyring,
     make_settings_4st_eyring,
 )
@@ -53,9 +52,6 @@ class TestCalculateKij4stEyring:
         for key, value in rates.items():
             assert value > 0, f"Rate {key} should be positive, got {value}"
             assert np.isfinite(value), f"Rate {key} should be finite, got {value}"
-            assert value <= MAX_RATE_CONSTANT, (
-                f"Rate {key} exceeds maximum, got {value}"
-            )
 
     def test_temperature_dependence(self, default_params):
         """Test that rate constants change appropriately with temperature."""
@@ -312,11 +308,12 @@ class TestPhysicalRealism:
                 f"Rate at {temperatures[i]}°C should be higher than at {temperatures[i - 1]}°C"
             )
 
-        # Check Arrhenius plot linearity (ln(k) vs 1/T should be approximately linear)
-        ln_rates = [np.log(r) for r in rates_kab]
-        inv_temps = [
-            1 / constants.convert_temperature(t, "C", "K") for t in temperatures
+        # Eyring linearity is ln(k/T) versus 1/T.
+        kelvin = [constants.convert_temperature(t, "C", "K") for t in temperatures]
+        ln_rates = [
+            np.log(rate / temp) for rate, temp in zip(rates_kab, kelvin, strict=True)
         ]
+        inv_temps = [1 / temp for temp in kelvin]
 
         # Simple linear regression
         n = len(ln_rates)

--- a/website/docs/user_guide/fitting/kinetic_models.md
+++ b/website/docs/user_guide/fitting/kinetic_models.md
@@ -156,28 +156,60 @@ using Eyring transition state theory. These models are particularly useful for
 studying exchange processes where thermodynamic parameters govern the
 temperature dependence of exchange rates.
 
-### Theoretical Background
+### Thermodynamic convention and temperature
 
-The Eyring equation relates the rate constant to the activation free energy:
+ChemEx input temperatures are in degrees Celsius. Eyring calculations convert
+them to Kelvin internally with `T = temperature + 273.15`. The public domain is
+every finite temperature strictly above -273.15 °C; absolute zero, lower
+temperatures, NaN, and infinities are rejected. There is no artificial upper
+temperature limit.
 
-```
-k_ij = (k_B * T / h) * exp(-ΔG‡_ij / RT)
-```
+State A is the thermodynamic reference, so `H_A = S_A = 0`. Every `DH_I` and
+`DS_I` parameter is the coordinate of state I relative to A. Likewise,
+`DH_IJ` and `DS_IJ` are the shared IJ transition-state coordinates relative to
+A, not separate forward activation parameters. Enthalpies use J mol⁻¹ and
+entropies use J mol⁻¹ K⁻¹.
 
-where:
-
-- `k_ij` is the rate constant for transition from state i to j (s⁻¹)
-- `k_B` is Boltzmann's constant (1.380649×10⁻²³ J/K)
-- `T` is temperature in Kelvin
-- `h` is Planck's constant (6.62607015×10⁻³⁴ J·s)
-- `ΔG‡_ij` is the activation free energy (J/mol)
-- `R` is the gas constant (8.314462618 J/mol/K)
-
-The activation free energy is calculated from enthalpic and entropic contributions:
+For the directional transition i → j, ChemEx therefore uses
 
 ```
-ΔG‡_ij = ΔH‡_ij - T * ΔS‡_ij
+Delta H double dagger (i -> j) = H_TS_ij - H_i
+Delta S double dagger (i -> j) = S_TS_ij - S_i
+
+log(k_ij) = log(k_B / h) + log(T)
+            + (S_TS_ij - S_i) / R
+            - (H_TS_ij - H_i) / (R * T)
 ```
+
+Here `T` is in Kelvin, `k_ij` is in s⁻¹, and the transmission coefficient is
+one. A shared transition state makes the forward/reverse pair obey
+
+```
+log(k_ij / k_ji) = -((H_j - H_i) - T * (S_j - S_i)) / (R * T)
+```
+
+The equilibrium populations are calculated directly from state coordinates,
+not from rate magnitudes:
+
+```
+log(w_i) = S_i / R - H_i / (R * T)
+p_i = w_i / sum(w)
+```
+
+The topology still selects the kinetic edges. This population authority ensures
+detailed balance for every present edge and thermodynamic cycle consistency in
+`4st_eyring`, even when all transition states are shifted to make kinetics much
+slower.
+
+Rates are evaluated in the log domain and are not clipped or saturated. If a
+mathematically positive rate lies below the minimum positive binary64 value or
+above the maximum finite binary64 value, parameter evaluation fails explicitly
+instead of producing zero, infinity, or a capped rate.
+
+Finite Eyring state coordinates likewise imply strictly positive populations.
+If a normalized state population lies below the minimum positive binary64 value,
+ChemEx rejects the evaluation instead of converting that state to structural
+zero.
 
 ### 2st_eyring Model Parameters
 
@@ -188,10 +220,10 @@ The `2st_eyring` model uses the following thermodynamic parameters:
 - `DH_B`: Enthalpy difference (J/mol) for state B relative to A
 - `DS_B`: Entropy difference (J/mol/K) for state B relative to A
 
-**Transition Barriers:**
+**Transition-state coordinates (relative to state A):**
 
-- `DH_AB`: Activation enthalpy (J/mol) for A → B transition
-- `DS_AB`: Activation entropy (J/mol/K) for A → B transition
+- `DH_AB`: Enthalpy coordinate (J/mol) of the shared AB transition state
+- `DS_AB`: Entropy coordinate (J/mol/K) of the shared AB transition state
 
 The model automatically calculates both forward (k_AB) and reverse (k_BA) rate constants from these parameters.
 
@@ -209,18 +241,18 @@ Both topologies use the following state parameters:
 - `DH_B`, `DH_C`: Enthalpy differences (J/mol) for states B, C
 - `DS_B`, `DS_C`: Entropy differences (J/mol/K) for states B, C
 
-**Linear Transition Barriers (`3st_eyring`, `3st_eyring_linear`):**
+**Linear transition-state coordinates (`3st_eyring`, `3st_eyring_linear`):**
 
-- `DH_AB`, `DH_BC`: Activation enthalpies (J/mol) for the AB and BC transitions
-- `DS_AB`, `DS_BC`: Activation entropies (J/mol/K) for the AB and BC transitions
+- `DH_AB`, `DH_BC`: Enthalpy coordinates (J/mol) of the AB and BC transition states
+- `DS_AB`, `DS_BC`: Entropy coordinates (J/mol/K) of the AB and BC transition states
 
 The linear models calculate k_AB, k_BA, k_BC, and k_CB. There is no direct A ↔ C
 pathway.
 
-**Fork Transition Barriers (`3st_eyring_fork`):**
+**Fork transition-state coordinates (`3st_eyring_fork`):**
 
-- `DH_AB`, `DH_AC`: Activation enthalpies (J/mol) for the AB and AC transitions
-- `DS_AB`, `DS_AC`: Activation entropies (J/mol/K) for the AB and AC transitions
+- `DH_AB`, `DH_AC`: Enthalpy coordinates (J/mol) of the AB and AC transition states
+- `DS_AB`, `DS_AC`: Entropy coordinates (J/mol/K) of the AB and AC transition states
 
 The fork model calculates k_AB, k_BA, k_AC, and k_CA. There is no direct B ↔ C
 pathway.
@@ -237,20 +269,40 @@ The `4st_eyring` model implements a full 4-state system:
 - `DH_B`, `DH_C`, `DH_D`: Enthalpy differences (J/mol) for states B, C, D
 - `DS_B`, `DS_C`, `DS_D`: Entropy differences (J/mol/K) for states B, C, D
 
-**Transition Barriers:**
+**Transition-state coordinates (relative to state A):**
 
-- `DH_AB`, `DH_AC`, `DH_AD`: Activation enthalpies (J/mol) for transitions from A
-- `DH_BC`, `DH_BD`, `DH_CD`: Activation enthalpies (J/mol) for transitions between B, C, D
-- `DS_AB`, `DS_AC`, `DS_AD`: Activation entropies (J/mol/K) for transitions from A
-- `DS_BC`, `DS_BD`, `DS_CD`: Activation entropies (J/mol/K) for transitions between B, C, D
+- `DH_AB`, `DH_AC`, `DH_AD`: Enthalpy coordinates (J/mol) of the AB, AC, and AD transition states
+- `DH_BC`, `DH_BD`, `DH_CD`: Enthalpy coordinates (J/mol) of the BC, BD, and CD transition states
+- `DS_AB`, `DS_AC`, `DS_AD`: Entropy coordinates (J/mol/K) of the AB, AC, and AD transition states
+- `DS_BC`, `DS_BD`, `DS_CD`: Entropy coordinates (J/mol/K) of the BC, BD, and CD transition states
 
 The model automatically calculates all 12 rate constants (k_AB, k_BA, k_AC, k_CA, k_AD, k_DA, k_BC, k_CB, k_BD, k_DB, k_CD, k_DC).
-
-:::note
-State A serves as the reference state with ΔH_A = ΔS_A = 0 for all Eyring models. Rate constants are automatically clipped to [0, 1×10¹⁶ s⁻¹] for numerical stability.
-:::
 
 All Eyring state and transition enthalpy parameters have default bounds of
 [-2×10⁵, 2×10⁵] J/mol. The corresponding entropy parameters have default
 bounds of [-5×10², 5×10²] J/mol/K. Explicit bounds in parameter files override
 these defaults.
+
+### Identifiability, uncertainty, and parameter scope
+
+At one temperature, varying both H and S for the same state or transition state
+is non-identifiable: the data determine the corresponding free-energy
+combination, not H and S separately. Different H/S pairs can therefore give the
+same rate or population, and deterministic uncertainty can correctly be
+unavailable because the covariance is rank deficient. Measurements at multiple
+temperatures can restore mathematical rank, but H/S correlation remains strong
+over a narrow temperature interval. Use a meaningful temperature span when H
+and S are both fitted.
+
+When the covariance is qualified, ChemEx propagates deterministic uncertainty
+to derived directional rates and to the coupled, normalized populations. Eyring
+models use the generic MCMC and resampling workflows; each proposal or replicate
+recalculates rates and populations through the same thermodynamic authority.
+
+The current ChemEx scoping contract shares Eyring H/S parameters across
+temperature, magnetic field, and spin system, but splits them when `p_total` or
+`l_total` changes. This concentration scoping is a compatibility contract, not
+a universal thermodynamic requirement. Derived rates and populations are scoped
+by temperature, `p_total`, and `l_total`; changing magnetic field alone does not
+create another chemical kinetic rate. Public parameter names, units, defaults,
+and TOML syntax are unchanged.


### PR DESCRIPTION
## Summary

This unifies the scientific and numerical authority for ChemEx’s temperature-dependent Eyring kinetic models:

- `2st_eyring`
- `3st_eyring`
- `3st_eyring_linear`
- `3st_eyring_fork`
- `4st_eyring`

The public H/S parameterization and model names are unchanged.

The implementation now uses one shared Eyring authority for:

- Celsius-to-Kelvin validation;
- directional rate calculation;
- binary64 representability;
- thermodynamic state populations;
- analytic rate and population derivatives.

## Scientific convention

State A remains the thermodynamic reference:

`H_A = 0`

`S_A = 0`

State coordinates are defined relative to A.

For transition:

`i → j`

through shared transition state `ij`:

`ΔH‡ = H_TS,ij - H_i`

`ΔS‡ = S_TS,ij - S_i`

and:

`ln k_ij(T) = ln(k_B/h) + ln(T) + ΔS‡/R - ΔH‡/(RT)`.

Public temperatures remain in °C and are converted internally to K.

H is in J mol⁻¹.

S is in J mol⁻¹ K⁻¹.

The transmission coefficient remains κ = 1.

## Temperature domain

Eyring temperature must now be:

- finite;
- strictly above absolute zero.

The following are rejected before scientific evaluation:

- `-273.15 °C`;
- temperatures below absolute zero;
- NaN;
- ±infinity.

No arbitrary high-temperature ceiling is imposed.

Exactly `0 °C` is now preserved correctly as a real condition rather than being confused with an absent temperature.

## Log-domain rate evaluation

The previous implementations evaluated the Eyring exponential directly and capped rates at:

`1e16 s⁻¹`.

That cap could alter directional rate ratios and therefore change:

- equilibrium constants;
- detailed balance;
- populations;
- thermodynamic cycle closure.

The cap has been removed.

Rates are now evaluated from `log(k)` and classified against the positive finite binary64 domain.

A mathematically positive rate:

- is returned if representable;
- fails closed if below minimum positive binary64;
- fails closed if above maximum finite binary64.

Positive rates are never converted into structural zero and finite rates are never saturated.

This also fixes cases where direct factorization underflowed an intermediate exponential even though the final rate was representable.

## Thermodynamic population authority

Eyring populations no longer depend on directional-rate magnitudes or generic stationary-population solvers.

For each state:

`ln w_i = S_i/R - H_i/(RT)`

and populations are obtained from stable normalized state weights.

Therefore equilibrium composition is determined directly by the thermodynamic state coordinates.

This applies to:

- two-state;
- both three-state topologies;
- four-state Eyring models.

The generic `pop_2st`, `pop_3st`, and `pop_4st` implementations are unchanged.

## Positive population representability

Finite Eyring state coordinates imply mathematically positive state populations.

ChemEx now distinguishes:

- representable positive populations;
- mathematically positive populations below binary64 support.

A population below supported positive binary64 representation fails closed rather than becoming structural `0.0`.

No epsilon floor or population renormalization is introduced.

The same policy prevents false-zero population derivatives.

## Detailed balance

For every reversible edge:

`p_i k_ij = p_j k_ji`

within binary64 precision.

The forward/reverse rate ratio follows the state free-energy difference rather than independent numerical clipping.

Tests cover:

- ordinary equilibria;
- strongly biased equilibria;
- low/high temperature;
- slow rates;
- representable subnormal rates.

## Four-state thermodynamics

The previous `4st_eyring` population calculation depended on the generic stationary solver.

For very slow positive networks, generic topology tolerances could treat active edges as absent and produce populations that changed when every transition was uniformly slowed.

`4st_eyring` now derives populations directly from its state thermodynamic coordinates.

Uniformly shifting all transition-state heights changes kinetics but leaves equilibrium populations unchanged.

The generic `pop_4st` helper itself is intentionally unchanged.

## Cycle consistency

The complete four-state Eyring model is thermodynamically consistent because all equilibrium ratios derive from state free energies.

Cycle closure is explicitly tested in log space.

The former per-rate saturation could introduce an artificial nonzero cycle affinity; removing clipping restores the intended equilibrium cycle relation.

## Public compatibility

Preserved:

- all Eyring public model names;
- `3st_eyring` as the historical linear alias;
- H/S parameter names;
- H/S units;
- default values;
- bounds;
- vary/fix defaults;
- parameter scopes;
- CLI/TOML syntax;
- derived rate/population names and IDs;
- existing calculator signatures.

The long four-state calculator signature remains available as a compatibility wrapper.

Internally it delegates to explicit named state and transition-state mappings, avoiding fragile positional edge ordering in the scientific implementation.

No parameter-file migration is required.

## Ordinary compatibility

For ordinary finite, previously unclipped regimes, candidate-versus-base differences are limited to binary64 evaluation order.

Maximum observed differences were approximately:

- directional rates: `< 5e-15` relative;
- populations: `< 2e-15` scale.

Intentional behavior changes are limited to:

- removal of rate saturation;
- unrepresentable rate failures;
- unrepresentable positive-population failures;
- invalid temperature rejection;
- four-state slow-network population correction;
- exact `0 °C` identity;
- added propagated uncertainty.

## Derived uncertainty

Eyring rate and population functions now register analytic model-owned partial derivatives through the existing deterministic uncertainty infrastructure.

Directional-rate derivatives follow the exact Eyring expressions.

Population derivatives use normalized softmax coupling, preserving:

`Σ_i dp_i = 0`.

Generated output can now include propagated uncertainties for derived:

- rates;
- populations;

when covariance is qualified.

The existing fail-closed uncertainty semantics remain unchanged.

## Identifiability

The public H/S fitting defaults are preserved for compatibility.

The documentation now makes the identifiability limitation explicit:

At one temperature, H and S enter only through their free-energy combination and are not independently identifiable.

Multiple temperatures restore formal rank, although H/S estimates remain strongly correlated unless the temperature span is sufficiently informative.

Production tests cover both:

- one-temperature rank deficiency;
- multi-temperature rank recovery with finite covariance and propagated uncertainty.

## MCMC and resampling

No Eyring-specific MCMC or resampling implementation was added.

Invalid or unrepresentable Eyring proposals use the existing generic finite-density MCMC contract.

Monte Carlo/bootstrap recompute Eyring quantities through the same shared scientific authority.

Independent Decimal oracles verify resampled directional rates.

## Scoping

The existing Eyring parameter scoping contract is preserved.

State/transition-state H/S parameters remain shared across:

- temperature;
- magnetic field;
- spin system;

under the current scope, but split when total concentration qualifiers differ.

Derived rates and populations remain temperature- and concentration-qualified.

Changing concentration-scoping policy is explicitly outside this PR.

## Readability

Readability was treated as a release criterion.

The final flow is:

public Celsius
→ validated Kelvin

state + transition-state coordinates
→ activation H/S
→ log directional rate
→ positive binary64 classification
→ rate

and:

state coordinates
→ normalized log weights
→ positive binary64 classification
→ populations

The physical equation, constants, temperature conversion, and representability policy are centralized.

Topology-specific settings modules remain thin and declarative.

The four-state internal topology uses explicit named edge mappings.

No generic graph DSL or broad numerical framework was introduced.

Independent audit concluded:

`READABILITY PASS`.

## Documentation

Current Eyring documentation now covers:

- Celsius input and Kelvin evaluation;
- valid temperature domain;
- H/S units;
- state and TS coordinate convention;
- exact Eyring equation;
- no rate clipping;
- rate and population representability;
- equilibrium population authority;
- detailed balance and four-state cycle consistency;
- identifiability;
- uncertainty propagation;
- current scoping semantics.

Frozen historical versioned documentation was not modified.

## Validation

Final exact candidate:

- focused Eyring, Python 3.13: 134 passed
- focused Eyring, Python 3.14: 134 passed
- Linux Python 3.13 authority/boundary suite: 21 passed
- conditions/binding uncertainty regression: 27 passed
- complete kinetic suite: 795 passed
- full suite: 2,153 passed
- website build: passed
- `uv run ty check`: passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `git diff --check`: passed
- graph refresh: passed

Independent audit and closure concluded:

- Eyring scientific authority: PASS
- units/constants: PASS
- temperature/domain: PASS
- rate representability: PASS
- population authority: PASS
- population representability: PASS
- detailed balance: PASS
- four-state cycle consistency: PASS
- deterministic uncertainty: PASS
- MCMC/resampling: PASS
- compatibility: PASS
- test portability: PASS
- documentation: PASS
- readability: PASS
- `PASS — 0 closure findings`
- `READY TO COMMIT THE AUDITED DIFF`

## Scope exclusions

This PR intentionally does not change:

- association/binding equilibrium authority;
- generic `pop_2st`;
- generic `pop_3st`;
- generic `pop_4st`;
- generic topology architecture;
- `.mf`, `.rs`, `.tc` modifier semantics;
- generic MCMC behavior;
- generic resampling behavior;
- concentration-scoping policy;
- Eyring public H/S parameterization;
- reference-temperature / `k_ref` parameterization.