### PR TITLE
fix: unify generic N-state topology and domain authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,23 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
 - Added explicit `3st_eyring_linear` (A ↔ B ↔ C) and `3st_eyring_fork`
   (B ↔ A ↔ C) temperature-dependent kinetic models. The existing
   `3st_eyring` name remains a compatibility name for the linear topology.
+- Added generic `4st_linear`, `4st_fork`, `5st_linear`, `5st_fork`,
+  `6st_linear`, and `6st_fork` kinetic models. Generic `_linear` models are
+  A-B-C-… chains, generic `_fork` models are A-centered stars, and unsuffixed
+  generic models are complete graphs. The historical `3st_triangle` name
+  remains an exact compatibility name for complete `3st`.
 
 ### Changed
+- **Breaking generic N-state default:** bare `4st`, `5st`, and `6st` now fit
+  every complete-graph `KEX` from the normal `200 s^-1` default. In particular,
+  `KEX_AD` and `KEX_BD` no longer inherit historical zero/fixed defaults. To
+  reproduce the previous sparse behavior, set both values to `0.0` in the
+  parameter file and explicitly apply
+  `ROLES = [{ FIX = ["KEX_AD", "KEX_BD"] }]` in the version 2 Method Step.
+  Existing `run_info/restart.toml` files retain explicit zero values and bounds
+  but not old fit/fix roles, so the explicit Method action is also required when
+  continuing those fits. Omitted historical defaults carry no reliable version
+  signal and receive the new complete-model policy.
 - ChemEx now presents known failures and user interruptions once at the CLI
   boundary, reports verified diagnostic paths when available, and exits with
   status 130 for Ctrl-C. Unexpected internal exceptions remain concise and
@@ -32,6 +47,18 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.MM.MICRO)
   signature; the obsolete `DH_AC` and `DS_AC` arguments have been removed.
 
 ### Fixed
+- Generic three- through six-state models now enforce one closed population
+  simplex before scientific evaluation and derive every structural directional
+  pair from one validated `KEX = k_forward + k_reverse` authority. This prevents
+  constrained negative populations or exchange scales from reaching NMR
+  matrices, removes the former `1e-100` denominator floor, preserves exact-zero
+  populations and exact-zero `KEX`, rejects a positive-`KEX` pair whose two
+  endpoint populations are zero, and fails when a mathematically positive
+  direction cannot be represented in binary64. Direct TRF and resampling now
+  use boundary-capable simplex coordinates; invalid MCMC proposals follow the
+  existing zero-density contract. Qualified deterministic uncertainty is
+  propagated analytically to `PA` and directional rates, with the established
+  boundary warning on simplex faces.
 - Eyring models now use one log-domain transition-state authority without the
   former `1e16 s^-1` rate saturation. Positive rates outside binary64
   representability fail explicitly, while representable subnormal rates remain

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,6 +25,30 @@ One named stage in a Method Plan that defines profile selection, parameter
 roles and constraints, search, and requested statistics for that stage.
 _Avoid_: Method section, Method
 
+**Generic N-state Model**:
+A population-authoritative kinetic model whose public name declares a complete,
+linear, or A-centered-fork structural exchange topology over three through six
+states.
+_Avoid_: Generic graph, N-state DSL
+
+**Structural Exchange Edge**:
+An unordered state pair present in a kinetic model's declared topology. It owns
+one public `KEX_ij` and the derived directional pair `Kij`/`Kji`; setting its
+`KEX_ij` to zero switches the edge off dynamically without making it absent.
+_Avoid_: Enabled edge, nonzero edge
+
+**Population Simplex**:
+The closed scientific domain in which every state population is nonnegative and
+the complete population vector sums to one. Generic N-state models expose the
+non-A populations and derive `PA` as the validated complement.
+_Avoid_: Population normalization, softmax coordinates
+
+**Feasible Coordinates**:
+Private solver coordinates compiled from model-owned scientific domains. They
+keep public parameter names and continuation values unchanged while ensuring a
+local optimizer proposes only representable domain states.
+_Avoid_: Public reparameterization, clipping
+
 **Evidence**:
 The validated source observations or samples of a statistical analysis together
 with their scientific state.

--- a/docs/adr/0006-make-generic-nstate-domain-authoritative.md
+++ b/docs/adr/0006-make-generic-nstate-domain-authoritative.md
@@ -1,0 +1,74 @@
+---
+status: accepted
+---
+
+# Make generic N-state topology and domain authoritative
+
+ChemEx will define each Generic N-state Model from one explicit topology record:
+its public model name, ordered states, and Structural Exchange Edges. Unsuffixed
+`Nst` names are complete graphs, `Nst_linear` names are consecutive chains, and
+`Nst_fork` names are A-centered stars. `3st_triangle` remains an exact
+compatibility name for complete `3st`. Structural absence is declared directly;
+it is not represented by generating a complete graph and deleting or fixing an
+edge.
+
+The model owns two scientific functions. The population-complement function
+validates the closed Population Simplex and derives `PA` from the independent
+non-A populations. The pair-rate function validates a structural `KEX` and its
+two endpoint populations, then derives both directional rates together. It
+preserves `KEX = k_forward + k_reverse`, detailed balance, exact-zero endpoints,
+and exact-zero `KEX` without a denominator floor. A positive `KEX` at two zero
+endpoints, a negative input, or a mathematically positive but unrepresentable
+directional rate is a scientific-domain failure.
+
+Direct TRF compiles the model-owned Population Simplex into boundary-capable
+Feasible Coordinates. Fixed populations and user bounds reduce the remaining
+mass available to fitted populations; public continuation and output remain in
+`PB`, `PC`, and higher-state coordinates. Deterministic resampling reuses Direct
+TRF. MCMC remains in public coordinates and maps model-domain rejection through
+its existing invalid-density contract. Deterministic Uncertainty uses registered
+analytic function derivatives and retains its existing one-sided-boundary
+warning policy for simplex faces.
+
+Every complete-model Structural Exchange Edge is estimation-capable with the
+same default. Consequently, bare `4st`, `5st`, and `6st` deliberately change
+`KEX_AD` and `KEX_BD` from the historical zero/fixed behavior to `200 s^-1` and
+fitted. An explicit parameter value of zero still disables either edge. To
+reproduce the old role as well as the old value, a Method Step must explicitly
+fix both parameters. Generated restart files preserve values and bounds but not
+historical roles, and omitted parameter defaults have no reliable age signal;
+ChemEx will not infer either intent.
+
+## Considered options
+
+- Recursive construction from smaller model dictionaries was rejected because
+  topology depended on merge history and obscured the special AD/BD defaults.
+- A generic graph DSL was rejected because three small edge constructors and an
+  explicit public table expose the scientific contract more clearly.
+- Complete-graph generation followed by edge deletion or dormant zero/fixed
+  edges was rejected because structural absence and dynamic `KEX = 0` have
+  different public meanings.
+- A softmax population parameterization, clipping, renormalization, penalties,
+  and epsilon floors were rejected because they remove exact boundaries or
+  change supplied scientific values.
+- A generic MCMC or optimizer rewrite was rejected because the existing
+  model-owned feasible-coordinate and invalid-density seams already provide the
+  required authority.
+- Restart-age heuristics and hidden compatibility defaults were rejected because
+  old artifacts do not preserve enough role provenance to infer user intent.
+
+## Consequences
+
+Scientists can verify all generic topologies by inspection, and all inputs,
+constraints, restart values, deterministic trials, MCMC proposals, and
+resampling fits cross the same model-owned Population Simplex and pair-rate
+authority before reaching an NMR exchange matrix. Complete models can still
+represent disconnected static mixtures by fixing selected structural `KEX`
+values to zero; irreducibility is not required.
+
+The public population and exchange names, condition scopes, valid ordinary
+three-state behavior, directional orientation, NMR basis, and output coordinate
+conventions remain unchanged. New 4/5/6-state linear and fork names are added.
+The active AD/BD defaults for bare 4/5/6-state models, strict domain failures,
+and newly qualified propagated directional-rate uncertainty are intentional
+behavior changes.

--- a/src/chemex/models/kinetic/settings_nst.py
+++ b/src/chemex/models/kinetic/settings_nst.py
@@ -1,270 +1,361 @@
+"""Generic N-state topology, population, and pairwise exchange authority."""
+
 from __future__ import annotations
 
-from itertools import permutations
+import math
+from dataclasses import dataclass
+from itertools import combinations, pairwise
 
 from chemex.configuration.conditions import Conditions
 from chemex.models.factory import model_factory
 from chemex.parameters.setting import NameSetting, ParamLocalSetting
+from chemex.parameters.userfunctions import (
+    AnalyticFunctionLinearization,
+    FunctionLinearization,
+    function_linearization_registry,
+    user_function_registry,
+)
 
 TPL = ("temperature", "p_total", "l_total")
+type Edge = tuple[str, str]
 
 
-def kex_p_to_k(states: str) -> str:
-    kex = f"{{kex_{min(states)}{max(states)}}}"
-    p1 = f"{{p{states[0]}}}"
-    p2 = f"{{p{states[1]}}}"
-    return f"{kex} * {p2} / max({p1} + {p2}, 1e-100)"
+def complete_edges(states: str) -> tuple[Edge, ...]:
+    """Return every unordered pair in a complete N-state topology."""
+    return tuple(combinations(states, 2))
 
 
-def create_kij_settings(states: str = "abc") -> dict[str, ParamLocalSetting]:
-    if len(states) <= 1:
-        msg = "'state_nb' should be larger than 2"
-        raise ValueError(msg)
-    return {
-        f"k{i}{j}": ParamLocalSetting(
-            name_setting=NameSetting(f"k{i}{j}", "", TPL),
-            expr=kex_p_to_k(f"{i}{j}"),
+def linear_edges(states: str) -> tuple[Edge, ...]:
+    """Return consecutive pairs in the A-B-C-... path topology."""
+    return tuple(pairwise(states))
+
+
+def fork_edges(states: str) -> tuple[Edge, ...]:
+    """Return the A-centered star topology."""
+    return tuple((states[0], state) for state in states[1:])
+
+
+@dataclass(frozen=True, slots=True)
+class Topology:
+    """One public generic N-state model and its structural exchange edges."""
+
+    model_name: str
+    states: str
+    edges: tuple[Edge, ...]
+
+
+# Unsuffixed models are complete. Named variants declare structural absence
+# directly; they are not complete graphs with edges deleted afterwards.
+TOPOLOGIES = (
+    Topology("3st", "abc", complete_edges("abc")),
+    Topology("3st_triangle", "abc", complete_edges("abc")),
+    Topology("3st_linear", "abc", linear_edges("abc")),
+    Topology("3st_fork", "abc", fork_edges("abc")),
+    Topology("4st", "abcd", complete_edges("abcd")),
+    Topology("4st_linear", "abcd", linear_edges("abcd")),
+    Topology("4st_fork", "abcd", fork_edges("abcd")),
+    Topology("5st", "abcde", complete_edges("abcde")),
+    Topology("5st_linear", "abcde", linear_edges("abcde")),
+    Topology("5st_fork", "abcde", fork_edges("abcde")),
+    Topology("6st", "abcdef", complete_edges("abcdef")),
+    Topology("6st_linear", "abcdef", linear_edges("abcdef")),
+    Topology("6st_fork", "abcdef", fork_edges("abcdef")),
+)
+_TOPOLOGY_BY_NAME = {topology.model_name: topology for topology in TOPOLOGIES}
+
+
+def calculate_population_complement(
+    *independent_populations: float,
+) -> dict[str, float]:
+    """Validate the closed population simplex and return its state-A complement."""
+    if not independent_populations:
+        raise ValueError("at least one independent population is required")
+    if any(not math.isfinite(value) for value in independent_populations):
+        raise ValueError("independent populations must be finite")
+    if any(value < 0.0 for value in independent_populations):
+        raise ValueError("independent populations must be nonnegative")
+    total = math.fsum(independent_populations)
+    if total > 1.0:
+        raise ValueError("independent population sum must not exceed one")
+    pa = 1.0 - total
+    if pa < 0.0:
+        raise ValueError("derived state-A population must be nonnegative")
+    return {"pa": pa}
+
+
+def _validate_pair_inputs(kex: float, p_i: float, p_j: float) -> None:
+    if not math.isfinite(kex):
+        raise ValueError("KEX must be finite")
+    if kex < 0.0:
+        raise ValueError("KEX must be nonnegative")
+    if not math.isfinite(p_i) or not math.isfinite(p_j):
+        raise ValueError("endpoint populations must be finite")
+    if p_i < 0.0 or p_j < 0.0:
+        raise ValueError("endpoint populations must be nonnegative")
+
+
+def _scaled_positive_product_ratio(
+    multiplier: float,
+    numerator: float,
+    denominator: float,
+) -> float:
+    """Evaluate ``multiplier * numerator / denominator`` with one final scaling.
+
+    Splitting each positive input into a binary mantissa and exponent prevents a
+    subnormal population ratio from rounding before the exchange scale is
+    applied. ``ldexp`` then performs the only potentially subnormal rounding.
+    """
+    multiplier_fraction, multiplier_exponent = math.frexp(multiplier)
+    numerator_fraction, numerator_exponent = math.frexp(numerator)
+    denominator_fraction, denominator_exponent = math.frexp(denominator)
+    fraction = multiplier_fraction * numerator_fraction / denominator_fraction
+    exponent = multiplier_exponent + numerator_exponent - denominator_exponent
+    return math.ldexp(fraction, exponent)
+
+
+def calculate_pair_rates(kex: float, p_i: float, p_j: float) -> dict[str, float]:
+    """Split total pairwise exchange into detailed-balance directions.
+
+    ``forward`` is i -> j and is therefore proportional to ``p_j``.
+    ``reverse`` is j -> i and is proportional to ``p_i``.
+    """
+    _validate_pair_inputs(kex, p_i, p_j)
+    if kex == 0.0:
+        return {"forward": 0.0, "reverse": 0.0}
+    if p_i == 0.0 and p_j == 0.0:
+        raise ValueError(
+            "directional exchange is undefined when both endpoint populations are zero"
         )
-        for i, j in permutations(states, 2)
+    if p_i == 0.0:
+        return {"forward": kex, "reverse": 0.0}
+    if p_j == 0.0:
+        return {"forward": 0.0, "reverse": kex}
+
+    smaller, larger = sorted((p_i, p_j))
+    denominator = math.fsum((smaller, larger))
+    smaller_rate = _scaled_positive_product_ratio(kex, smaller, denominator)
+    if smaller_rate == 0.0:
+        raise ValueError(
+            "a mathematically positive directional rate cannot be represented "
+            "as positive binary64"
+        )
+    larger_rate = kex - smaller_rate
+    if larger_rate <= 0.0:
+        raise ValueError("directional exchange could not be represented in binary64")
+    if p_j <= p_i:
+        forward, reverse = smaller_rate, larger_rate
+    else:
+        forward, reverse = larger_rate, smaller_rate
+    return {"forward": forward, "reverse": reverse}
+
+
+def _population_partial(*independent_populations: float) -> float:
+    calculate_population_complement(*independent_populations)
+    return -1.0
+
+
+def _pair_derivative_denominator(kex: float, p_i: float, p_j: float) -> float:
+    _validate_pair_inputs(kex, p_i, p_j)
+    denominator = math.fsum((p_i, p_j))
+    if denominator == 0.0:
+        raise ValueError("directional-rate derivatives are undefined at a zero pair")
+    return denominator
+
+
+def _forward_d_kex(kex: float, p_i: float, p_j: float) -> float:
+    denominator = _pair_derivative_denominator(kex, p_i, p_j)
+    return p_j / denominator
+
+
+def _forward_d_pi(kex: float, p_i: float, p_j: float) -> float:
+    denominator = _pair_derivative_denominator(kex, p_i, p_j)
+    return -kex * p_j / (denominator * denominator)
+
+
+def _forward_d_pj(kex: float, p_i: float, p_j: float) -> float:
+    denominator = _pair_derivative_denominator(kex, p_i, p_j)
+    return kex * p_i / (denominator * denominator)
+
+
+def _reverse_d_kex(kex: float, p_i: float, p_j: float) -> float:
+    denominator = _pair_derivative_denominator(kex, p_i, p_j)
+    return p_i / denominator
+
+
+def _reverse_d_pi(kex: float, p_i: float, p_j: float) -> float:
+    denominator = _pair_derivative_denominator(kex, p_i, p_j)
+    return kex * p_j / (denominator * denominator)
+
+
+def _reverse_d_pj(kex: float, p_i: float, p_j: float) -> float:
+    denominator = _pair_derivative_denominator(kex, p_i, p_j)
+    return -kex * p_i / (denominator * denominator)
+
+
+def _population_settings(states: str) -> dict[str, ParamLocalSetting]:
+    return {
+        f"p{state}": ParamLocalSetting(
+            name_setting=NameSetting(f"p{state}", "", TPL),
+            value=0.02,
+            min=0.0,
+            max=1.0,
+            vary=True,
+        )
+        for state in states[1:]
     }
+
+
+def _population_complement_setting(states: str) -> ParamLocalSetting:
+    arguments = ", ".join(f"{{p{state}}}" for state in states[1:])
+    minimum, maximum = (-math.inf, math.inf) if len(states) == 3 else (0.0, 1.0)
+    return ParamLocalSetting(
+        name_setting=NameSetting("pa", "", TPL),
+        min=minimum,
+        max=maximum,
+        expr=f"population_complement({arguments})['pa']",
+    )
+
+
+def _kex_settings(edges: tuple[Edge, ...]) -> dict[str, ParamLocalSetting]:
+    return {
+        f"kex_{left}{right}": ParamLocalSetting(
+            name_setting=NameSetting(f"kex_{left}{right}", "", TPL),
+            value=200.0,
+            min=0.0,
+            max=1.0e6,
+            vary=True,
+        )
+        for left, right in edges
+    }
+
+
+def _directional_rate_settings(
+    edges: tuple[Edge, ...],
+) -> dict[str, ParamLocalSetting]:
+    settings: dict[str, ParamLocalSetting] = {}
+    for left, right in edges:
+        arguments = f"{{kex_{left}{right}}}, {{p{left}}}, {{p{right}}}"
+        settings[f"k{left}{right}"] = ParamLocalSetting(
+            name_setting=NameSetting(f"k{left}{right}", "", TPL),
+            expr=f"pair_rates({arguments})['forward']",
+        )
+        settings[f"k{right}{left}"] = ParamLocalSetting(
+            name_setting=NameSetting(f"k{right}{left}", "", TPL),
+            expr=f"pair_rates({arguments})['reverse']",
+        )
+    return settings
+
+
+def _make_settings(topology: Topology) -> dict[str, ParamLocalSetting]:
+    """Build populations, structural KEX values, and directional rate pairs."""
+    return {
+        **_population_settings(topology.states),
+        **_kex_settings(topology.edges),
+        "pa": _population_complement_setting(topology.states),
+        **_directional_rate_settings(topology.edges),
+    }
+
+
+def _settings_for(model_name: str) -> dict[str, ParamLocalSetting]:
+    return _make_settings(_TOPOLOGY_BY_NAME[model_name])
+
+
+def make_settings_3st(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("3st")
 
 
 def make_settings_3st_linear(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
-    kij_settings = create_kij_settings("abc")
-    del kij_settings["kac"]
-    del kij_settings["kca"]
-    return {
-        "pb": ParamLocalSetting(
-            name_setting=NameSetting("pb", "", TPL),
-            value=0.02,
-            min=0.0,
-            max=1.0,
-            vary=True,
-        ),
-        "pc": ParamLocalSetting(
-            name_setting=NameSetting("pc", "", TPL),
-            value=0.02,
-            min=0.0,
-            max=1.0,
-            vary=True,
-        ),
-        "kex_ab": ParamLocalSetting(
-            name_setting=NameSetting("kex_ab", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "kex_bc": ParamLocalSetting(
-            name_setting=NameSetting("kex_bc", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "pa": ParamLocalSetting(
-            name_setting=NameSetting("pa", "", TPL),
-            expr="1.0 - {pb} - {pc}",
-        ),
-        **kij_settings,
-    }
+    return _settings_for("3st_linear")
 
 
 def make_settings_3st_fork(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
-    kij_settings = create_kij_settings("abc")
-    del kij_settings["kbc"]
-    del kij_settings["kcb"]
-    return {
-        "pb": ParamLocalSetting(
-            name_setting=NameSetting("pb", "", TPL),
-            value=0.02,
-            min=0.0,
-            max=1.0,
-            vary=True,
-        ),
-        "pc": ParamLocalSetting(
-            name_setting=NameSetting("pc", "", TPL),
-            value=0.02,
-            min=0.0,
-            max=1.0,
-            vary=True,
-        ),
-        "kex_ab": ParamLocalSetting(
-            name_setting=NameSetting("kex_ab", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "kex_ac": ParamLocalSetting(
-            name_setting=NameSetting("kex_ac", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "pa": ParamLocalSetting(
-            name_setting=NameSetting("pa", "", TPL),
-            expr="1.0 - {pb} - {pc}",
-        ),
-        **kij_settings,
-    }
+    return _settings_for("3st_fork")
 
 
-def make_settings_3st(conditions: Conditions) -> dict[str, ParamLocalSetting]:
-    return {
-        **make_settings_3st_fork(conditions),
-        **make_settings_3st_linear(conditions),
-    }
+def make_settings_4st(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("4st")
 
 
-def make_settings_4st(conditions: Conditions) -> dict[str, ParamLocalSetting]:
-    return {
-        **make_settings_3st(conditions),
-        "pd": ParamLocalSetting(
-            name_setting=NameSetting("pd", "", TPL),
-            value=0.02,
-            min=0.0,
-            max=1.0,
-            vary=True,
-        ),
-        "kex_ad": ParamLocalSetting(
-            name_setting=NameSetting("kex_ad", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=0.0,
-        ),
-        "kex_bd": ParamLocalSetting(
-            name_setting=NameSetting("kex_bd", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=0.0,
-        ),
-        "kex_cd": ParamLocalSetting(
-            name_setting=NameSetting("kex_cd", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "pa": ParamLocalSetting(
-            name_setting=NameSetting("pa", "", TPL),
-            min=0.0,
-            max=1.0,
-            expr="1.0 - {pb} - {pc} - {pd}",
-        ),
-        **create_kij_settings("abcd"),
-    }
+def make_settings_4st_linear(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("4st_linear")
 
 
-def make_settings_5st(conditions: Conditions) -> dict[str, ParamLocalSetting]:
-    return {
-        **make_settings_4st(conditions),
-        "pe": ParamLocalSetting(
-            name_setting=NameSetting("pe", "", TPL),
-            value=0.02,
-            min=0.0,
-            max=1.0,
-            vary=True,
-        ),
-        "kex_ae": ParamLocalSetting(
-            name_setting=NameSetting("kex_ae", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "kex_be": ParamLocalSetting(
-            name_setting=NameSetting("kex_be", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "kex_ce": ParamLocalSetting(
-            name_setting=NameSetting("kex_ce", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "kex_de": ParamLocalSetting(
-            name_setting=NameSetting("kex_de", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "pa": ParamLocalSetting(
-            name_setting=NameSetting("pa", "", TPL),
-            min=0.0,
-            max=1.0,
-            expr="1.0 - {pb} - {pc} - {pd} - {pe}",
-        ),
-        **create_kij_settings("abcde"),
-    }
+def make_settings_4st_fork(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("4st_fork")
 
 
-def make_settings_6st(conditions: Conditions) -> dict[str, ParamLocalSetting]:
-    return {
-        **make_settings_5st(conditions),
-        "pf": ParamLocalSetting(
-            name_setting=NameSetting("pf", "", TPL),
-            value=0.02,
-            min=0.0,
-            max=1.0,
-            vary=True,
+def make_settings_5st(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("5st")
+
+
+def make_settings_5st_linear(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("5st_linear")
+
+
+def make_settings_5st_fork(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("5st_fork")
+
+
+def make_settings_6st(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("6st")
+
+
+def make_settings_6st_linear(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("6st_linear")
+
+
+def make_settings_6st_fork(_conditions: Conditions) -> dict[str, ParamLocalSetting]:
+    return _settings_for("6st_fork")
+
+
+def _linearizations(state_count: int) -> tuple[FunctionLinearization, ...]:
+    return (
+        AnalyticFunctionLinearization(
+            "population_complement",
+            "pa",
+            "generic-nstate-population-complement-partials-v1",
+            (_population_partial,) * (state_count - 1),
         ),
-        "kex_af": ParamLocalSetting(
-            name_setting=NameSetting("kex_af", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
+        AnalyticFunctionLinearization(
+            "pair_rates",
+            "forward",
+            "generic-nstate-pair-rate-partials-v1",
+            (_forward_d_kex, _forward_d_pi, _forward_d_pj),
         ),
-        "kex_bf": ParamLocalSetting(
-            name_setting=NameSetting("kex_bf", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
+        AnalyticFunctionLinearization(
+            "pair_rates",
+            "reverse",
+            "generic-nstate-pair-rate-partials-v1",
+            (_reverse_d_kex, _reverse_d_pi, _reverse_d_pj),
         ),
-        "kex_cf": ParamLocalSetting(
-            name_setting=NameSetting("kex_cf", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "kex_df": ParamLocalSetting(
-            name_setting=NameSetting("kex_df", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "kex_ef": ParamLocalSetting(
-            name_setting=NameSetting("kex_ef", "", TPL),
-            min=0.0,
-            max=1.0e6,
-            value=200.0,
-            vary=True,
-        ),
-        "pa": ParamLocalSetting(
-            name_setting=NameSetting("pa", "", TPL),
-            min=0.0,
-            max=1.0,
-            expr="1.0 - {pb} - {pc} - {pd} - {pe} - {pf}",
-        ),
-        **create_kij_settings("abcdef"),
-    }
+    )
 
 
 def register() -> None:
-    model_factory.register(name="3st", setting_maker=make_settings_3st)
-    model_factory.register(name="3st_triangle", setting_maker=make_settings_3st)
-    model_factory.register(name="3st_linear", setting_maker=make_settings_3st_linear)
-    model_factory.register(name="3st_fork", setting_maker=make_settings_3st_fork)
-    model_factory.register(name="4st", setting_maker=make_settings_4st)
-    model_factory.register(name="5st", setting_maker=make_settings_5st)
-    model_factory.register(name="6st", setting_maker=make_settings_6st)
+    user_functions = {
+        "population_complement": calculate_population_complement,
+        "pair_rates": calculate_pair_rates,
+    }
+    makers = {
+        "3st": make_settings_3st,
+        "3st_triangle": make_settings_3st,
+        "3st_linear": make_settings_3st_linear,
+        "3st_fork": make_settings_3st_fork,
+        "4st": make_settings_4st,
+        "4st_linear": make_settings_4st_linear,
+        "4st_fork": make_settings_4st_fork,
+        "5st": make_settings_5st,
+        "5st_linear": make_settings_5st_linear,
+        "5st_fork": make_settings_5st_fork,
+        "6st": make_settings_6st,
+        "6st_linear": make_settings_6st_linear,
+        "6st_fork": make_settings_6st_fork,
+    }
+    for topology in TOPOLOGIES:
+        model_name = topology.model_name
+        model_factory.register(name=model_name, setting_maker=makers[model_name])
+        user_function_registry.register(model_name, user_functions)
+        function_linearization_registry.register(
+            model_name,
+            _linearizations(len(topology.states)),
+        )

--- a/src/chemex/optimize/de_direct_trf.py
+++ b/src/chemex/optimize/de_direct_trf.py
@@ -593,12 +593,12 @@ class DeSearchInvocation:
 
         search_problem = derive_search_problem()
         feasible = search_problem.feasible_coordinates
-        if feasible is not None and not feasible.supports_box_only_algorithms:
+        if feasible is not None and feasible.uses_private_relaxation_coordinates:
             raise DirectTrfConstructionError(
                 "DE search over relaxation-feasibility coordinates is not yet "
                 "qualified; use Direct TRF for this method section"
             )
-        if feasible is not None:
+        if feasible is not None and feasible.supports_box_only_algorithms:
             feasible_lower, feasible_upper = feasible.solver_bounds
             child_indices = {
                 param_id: index

--- a/src/chemex/optimize/native_mcmc.py
+++ b/src/chemex/optimize/native_mcmc.py
@@ -1014,7 +1014,7 @@ class McmcPlan:
                 "Native MCMC qualification currently supports box-bounded problems"
             )
         feasible = problem.feasible_coordinates
-        if feasible is not None and not feasible.supports_box_only_algorithms:
+        if feasible is not None and feasible.uses_private_relaxation_coordinates:
             raise McmcConstructionError(
                 "Native MCMC has not qualified the Jacobian measure for private "
                 "relaxation-feasibility coordinates"

--- a/src/chemex/optimize/uncertainty.py
+++ b/src/chemex/optimize/uncertainty.py
@@ -112,6 +112,38 @@ def _simple_bound_warning_ids(
     return frozenset(warned)
 
 
+def _population_simplex_warning_ids(
+    problem: OptimizationProblem,
+    resolved_values: Mapping[str, float],
+    controlled_ids: Sequence[str],
+    covariance: Sequence[Sequence[float]],
+) -> frozenset[str]:
+    """Attribute a complement-face warning to its varying populations."""
+    chart = problem.feasible_coordinates
+    if chart is None or not chart.population_simplexes:
+        return frozenset()
+    local_indices = {param_id: index for index, param_id in enumerate(controlled_ids)}
+    warned: set[str] = set()
+    for simplex in chart.population_simplexes:
+        varying = tuple(
+            param_id for param_id in simplex.population_ids if param_id in local_indices
+        )
+        if not varying:
+            continue
+        slack = resolved_values[simplex.complement_id]
+        indices = tuple(local_indices[param_id] for param_id in varying)
+        variance = math.fsum(
+            float(covariance[row][column]) for row in indices for column in indices
+        )
+        if slack < 0.0 or (
+            variance > 0.0
+            and math.isfinite(variance)
+            and slack / math.sqrt(variance) <= _BOUNDARY_THRESHOLD
+        ):
+            warned.update(varying)
+    return frozenset(warned)
+
+
 class UncertaintyConstructionError(ValueError):
     """Raised only for malformed policy or artifact construction."""
 
@@ -1879,20 +1911,27 @@ class CovarianceEvidence:
 
     @property
     def simple_bound_warning_ids(self) -> frozenset[str]:
-        """Controlled coordinates within the threshold of their own box bounds."""
+        """Controlled coordinates near a box bound or simplex complement face."""
         standard_errors = {
             param_id: math.sqrt(self.covariance[index][index])
             if self.covariance[index][index] > 0.0
             else None
             for index, param_id in enumerate(self.controlled_ids)
         }
-        return _simple_bound_warning_ids(
+        box = _simple_bound_warning_ids(
             self.controlled_ids,
             self.accepted_vector,
             self.source_problem.lower_bounds,
             self.source_problem.upper_bounds,
             standard_errors,
         )
+        simplex = _population_simplex_warning_ids(
+            self.source_problem,
+            self.accepted_anchor.evaluation_result.resolved_values,
+            self.controlled_ids,
+            self.covariance,
+        )
+        return box | simplex
 
 
 @dataclass(frozen=True, slots=True)
@@ -2977,6 +3016,38 @@ class RootAnchoredBlockCovariance:
         return UncertaintyUnavailableKind.COVARIANCE_NUMERICAL_FAILURE
 
 
+def _root_anchored_simple_bound_warning_ids(
+    source_bundle: UncertaintyEvidence,
+    completed_blocks: Sequence[RootAnchoredBlockCovariance],
+) -> frozenset[str]:
+    """Return box- and simplex-face warnings from completed covariance blocks."""
+    standard_errors = {
+        entry.param_id: entry.value
+        for block in completed_blocks
+        for entry in block.marginal_errors
+    }
+    box = _simple_bound_warning_ids(
+        source_bundle.source_problem.controlled_ids,
+        source_bundle.accepted_anchor.vector,
+        source_bundle.source_problem.lower_bounds,
+        source_bundle.source_problem.upper_bounds,
+        standard_errors,
+    )
+    simplex = frozenset().union(
+        *(
+            _population_simplex_warning_ids(
+                source_bundle.source_problem,
+                source_bundle.accepted_anchor.evaluation_result.resolved_values,
+                block.controlled_ids,
+                block.covariance,
+            )
+            for block in completed_blocks
+            if block.covariance is not None
+        )
+    )
+    return box | simplex
+
+
 @dataclass(frozen=True, slots=True)
 class RootAnchoredBlockCovarianceEvidence:
     """Failure-isolated covariance blocks anchored to one accepted root result."""
@@ -3095,19 +3166,10 @@ class RootAnchoredBlockCovarianceEvidence:
 
     @property
     def simple_bound_warning_ids(self) -> frozenset[str]:
-        """Recovered controlled coordinates near their own root box bounds."""
-        source = self.source_bundle
-        standard_errors = {
-            entry.param_id: entry.value
-            for block in self.blocks
-            for entry in block.marginal_errors
-        }
-        return _simple_bound_warning_ids(
-            source.source_problem.controlled_ids,
-            source.accepted_anchor.vector,
-            source.source_problem.lower_bounds,
-            source.source_problem.upper_bounds,
-            standard_errors,
+        """Recovered controlled coordinates near a root domain boundary."""
+        return _root_anchored_simple_bound_warning_ids(
+            self.source_bundle,
+            self.blocks,
         )
 
 
@@ -3206,18 +3268,9 @@ class RootAnchoredBlockCovarianceOperation:
 
     @property
     def simple_bound_warning_ids(self) -> frozenset[str]:
-        source = self.source_bundle
-        standard_errors = {
-            entry.param_id: entry.value
-            for block in self.completed_blocks
-            for entry in block.marginal_errors
-        }
-        return _simple_bound_warning_ids(
-            source.source_problem.controlled_ids,
-            source.accepted_anchor.vector,
-            source.source_problem.lower_bounds,
-            source.source_problem.upper_bounds,
-            standard_errors,
+        return _root_anchored_simple_bound_warning_ids(
+            self.source_bundle,
+            self.completed_blocks,
         )
 
     def to_record(self) -> dict[str, object]:
@@ -4806,6 +4859,98 @@ def _profiled_normalization_regular(
     return True
 
 
+def _population_simplex_boundary_claims(
+    accepted: AcceptedFitResult,
+    problem: OptimizationProblem,
+    covariance: tuple[tuple[float, ...], ...],
+    controlled_indices: tuple[int, ...],
+    residual_variance_scale: float,
+) -> tuple[bool, ClaimState, tuple[str, ...]]:
+    """Qualify complement faces represented by model-owned simplex charts."""
+    chart = problem.feasible_coordinates
+    if chart is None:
+        return True, ClaimState.SATISFIED, ()
+    local_by_id = {
+        problem.controlled_ids[root_index]: local_index
+        for local_index, root_index in enumerate(controlled_indices)
+    }
+    strict_interior = True
+    separation = ClaimState.SATISFIED
+    details: list[str] = []
+    resolved = accepted.evaluation_result.resolved_values
+    for simplex in chart.population_simplexes:
+        varying = tuple(
+            param_id for param_id in simplex.population_ids if param_id in local_by_id
+        )
+        if not varying:
+            continue
+        slack = resolved[simplex.complement_id]
+        label = f"simplex[{simplex.complement_id}]"
+        if slack < 0.0:
+            return False, ClaimState.VIOLATED, (f"{label}: negative slack",)
+        strict_interior = strict_interior and slack != 0.0
+        local_indices = tuple(local_by_id[item] for item in varying)
+        variance = math.fsum(
+            covariance[row][column] for row in local_indices for column in local_indices
+        )
+        if residual_variance_scale == 0.0 or variance == 0.0:
+            separation = ClaimState.INDETERMINATE
+            details.append(f"{label}: zero scaled variance")
+            continue
+        if variance < 0.0 or not math.isfinite(variance):
+            separation = ClaimState.INDETERMINATE
+            details.append(f"{label}: invalid directional variance")
+            continue
+        zeta = float(slack / math.sqrt(variance))
+        details.append(f"{label} zeta={zeta.hex()}")
+        if not math.isfinite(zeta):
+            separation = ClaimState.INDETERMINATE
+        elif zeta <= _BOUNDARY_THRESHOLD:
+            separation = ClaimState.VIOLATED
+    return strict_interior, separation, tuple(details)
+
+
+def _least_qualified_claim_state(left: ClaimState, right: ClaimState) -> ClaimState:
+    if ClaimState.VIOLATED in (left, right):
+        return ClaimState.VIOLATED
+    if ClaimState.INDETERMINATE in (left, right):
+        return ClaimState.INDETERMINATE
+    return ClaimState.SATISFIED
+
+
+def _coordinate_box_boundary_claims(
+    value: float,
+    lower: float,
+    upper: float,
+    variance: float,
+    residual_variance_scale: float,
+    root_index: int,
+) -> tuple[bool, ClaimState, tuple[str, ...]]:
+    if not lower <= value <= upper:
+        return False, ClaimState.VIOLATED, (f"box[{root_index}]: outside bounds",)
+    strict_interior = value not in (lower, upper)
+    separation = ClaimState.SATISFIED
+    details: list[str] = []
+    for label, slack in (("lower", value - lower), ("upper", upper - value)):
+        if math.isinf(slack):
+            continue
+        if residual_variance_scale == 0.0 or variance == 0.0:
+            separation = ClaimState.INDETERMINATE
+            details.append(f"{label}[{root_index}]: zero scaled variance")
+            continue
+        if variance < 0.0 or not math.isfinite(variance):
+            separation = ClaimState.INDETERMINATE
+            details.append(f"{label}[{root_index}]: invalid directional variance")
+            continue
+        zeta = float(slack / math.sqrt(variance))
+        details.append(f"{label}[{root_index}] zeta={zeta.hex()}")
+        if not math.isfinite(zeta):
+            separation = ClaimState.INDETERMINATE
+        elif zeta <= _BOUNDARY_THRESHOLD:
+            separation = ClaimState.VIOLATED
+    return strict_interior, separation, tuple(details)
+
+
 def _box_boundary_claims(
     accepted: AcceptedFitResult,
     problem: OptimizationProblem,
@@ -4822,37 +4967,34 @@ def _box_boundary_claims(
     separation = ClaimState.SATISFIED
     details: list[str] = []
     for local_index, root_index in enumerate(indices):
-        value = accepted.vector[root_index]
-        lower = problem.lower_bounds[root_index]
-        upper = problem.upper_bounds[root_index]
-        if not lower <= value <= upper:
-            return (
-                ClaimAssessment("INTERIOR_POINT", ClaimState.VIOLATED),
-                ClaimAssessment("BOUNDARY_SEPARATION", ClaimState.VIOLATED),
+        coordinate_interior, coordinate_separation, coordinate_details = (
+            _coordinate_box_boundary_claims(
+                accepted.vector[root_index],
+                problem.lower_bounds[root_index],
+                problem.upper_bounds[root_index],
+                covariance[local_index][local_index],
+                residual_variance_scale,
+                root_index,
             )
-        if value in (lower, upper):
-            strict_interior = False
-        for label, slack in (
-            ("lower", value - lower),
-            ("upper", upper - value),
-        ):
-            if math.isinf(slack):
-                continue
-            variance = covariance[local_index][local_index]
-            if residual_variance_scale == 0.0 or variance == 0.0:
-                separation = ClaimState.INDETERMINATE
-                details.append(f"{label}[{root_index}]: zero scaled variance")
-                continue
-            if variance < 0.0 or not math.isfinite(variance):
-                separation = ClaimState.INDETERMINATE
-                details.append(f"{label}[{root_index}]: invalid directional variance")
-                continue
-            zeta = float(slack / math.sqrt(variance))
-            details.append(f"{label}[{root_index}] zeta={zeta.hex()}")
-            if not math.isfinite(zeta):
-                separation = ClaimState.INDETERMINATE
-            elif zeta <= _BOUNDARY_THRESHOLD:
-                separation = ClaimState.VIOLATED
+        )
+        strict_interior = strict_interior and coordinate_interior
+        separation = _least_qualified_claim_state(
+            separation,
+            coordinate_separation,
+        )
+        details.extend(coordinate_details)
+    simplex_interior, simplex_separation, simplex_details = (
+        _population_simplex_boundary_claims(
+            accepted,
+            problem,
+            covariance,
+            indices,
+            residual_variance_scale,
+        )
+    )
+    strict_interior = strict_interior and simplex_interior
+    separation = _least_qualified_claim_state(separation, simplex_separation)
+    details.extend(simplex_details)
     return (
         ClaimAssessment(
             "INTERIOR_POINT",

--- a/src/chemex/parameters/feasible_coordinates.py
+++ b/src/chemex/parameters/feasible_coordinates.py
@@ -1,4 +1,4 @@
-"""Exact private solver coordinates for model-owned relaxation feasibility."""
+"""Exact private solver coordinates for model-owned scientific feasibility."""
 
 from __future__ import annotations
 
@@ -170,6 +170,112 @@ class RateFloor:
     cross_id: str
 
 
+@dataclass(frozen=True, slots=True)
+class PopulationSimplex:
+    """One model-owned population complement and its independent coordinates."""
+
+    complement_id: str
+    population_ids: tuple[str, ...]
+
+
+def _population_interval(
+    param_id: str,
+    remaining_ids: Sequence[str],
+    used_values: Sequence[float],
+    lower_by_id: Mapping[str, float],
+    upper_by_id: Mapping[str, float],
+) -> tuple[float, float]:
+    lower = max(0.0, lower_by_id[param_id])
+    future_minimum = math.fsum(
+        max(0.0, lower_by_id[remaining_id]) for remaining_id in remaining_ids
+    )
+    available = 1.0 - math.fsum(used_values)
+    upper = min(1.0, upper_by_id[param_id], available - future_minimum)
+    if lower > upper:
+        raise ScientificFeasibilityError(
+            f"Population {param_id!r} has no feasible simplex interval"
+        )
+    return lower, upper
+
+
+def _decode_population_simplexes(
+    simplexes: Sequence[PopulationSimplex],
+    base_values: Mapping[str, float],
+    public: dict[str, float],
+    lower_by_id: Mapping[str, float],
+    upper_by_id: Mapping[str, float],
+) -> None:
+    controlled = set(public)
+    for simplex in simplexes:
+        transformed_ids = tuple(
+            param_id for param_id in simplex.population_ids if param_id in controlled
+        )
+        used_values = [
+            base_values[param_id]
+            for param_id in simplex.population_ids
+            if param_id not in controlled
+        ]
+        for index, param_id in enumerate(transformed_ids):
+            lower, upper = _population_interval(
+                param_id,
+                transformed_ids[index + 1 :],
+                used_values,
+                lower_by_id,
+                upper_by_id,
+            )
+            coordinate = public[param_id]
+            if not 0.0 <= coordinate <= 1.0:
+                raise ScientificFeasibilityError(
+                    f"Private population coordinate for {param_id!r} is outside [0, 1]"
+                )
+            value = (
+                lower
+                if coordinate == 0.0
+                else upper
+                if coordinate == 1.0
+                else lower + coordinate * (upper - lower)
+            )
+            public[param_id] = value
+            used_values.append(value)
+
+
+def _encode_population_simplexes(
+    simplexes: Sequence[PopulationSimplex],
+    public_start: Mapping[str, float],
+    controlled_ids: Sequence[str],
+    lower_by_id: Mapping[str, float],
+    upper_by_id: Mapping[str, float],
+) -> dict[str, float]:
+    controlled = set(controlled_ids)
+    solver_values: dict[str, float] = {}
+    for simplex in simplexes:
+        transformed_ids = tuple(
+            param_id for param_id in simplex.population_ids if param_id in controlled
+        )
+        used_values = [
+            public_start[param_id]
+            for param_id in simplex.population_ids
+            if param_id not in controlled
+        ]
+        for index, param_id in enumerate(transformed_ids):
+            lower, upper = _population_interval(
+                param_id,
+                transformed_ids[index + 1 :],
+                used_values,
+                lower_by_id,
+                upper_by_id,
+            )
+            value = public_start[param_id]
+            if not lower <= value <= upper:
+                raise ScientificFeasibilityError(
+                    f"Initial population {param_id!r} is outside its simplex interval"
+                )
+            width = upper - lower
+            solver_values[param_id] = 0.0 if width == 0.0 else (value - lower) / width
+            used_values.append(value)
+    return solver_values
+
+
 def _rate_floor(specification: RateFloor, values: Mapping[str, float]) -> float:
     cross = values[specification.cross_id]
     if specification.kind is RateFloorKind.REPEATED_DIAGONAL:
@@ -204,16 +310,43 @@ def _floor_within_finite_ceiling(
 
 
 @dataclass(frozen=True, slots=True)
-class _FeasibilityProjectionProvenance:
-    """Private immutable closure proof compiled with one feasibility chart."""
+class _RelaxationDomainProvenance:
+    """One relaxation block bound to its controlled dependency closure."""
 
-    controlled_domain_groups: tuple[frozenset[str], ...]
+    block: RelaxationPsdBlock
+    controlled_dependencies: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class _PopulationDomainProvenance:
+    """One population simplex bound to its controlled dependency closure."""
+
+    simplex: PopulationSimplex
+    controlled_dependencies: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class _FeasibilityProjectionProvenance:
+    """Named domain associations and the chart's immutable closure proof."""
+
+    relaxation_domains: tuple[_RelaxationDomainProvenance, ...]
+    population_domains: tuple[_PopulationDomainProvenance, ...]
     has_root_projection_authority: bool
+
+    @property
+    def domain_records(
+        self,
+    ) -> tuple[_RelaxationDomainProvenance | _PopulationDomainProvenance, ...]:
+        return self.relaxation_domains + self.population_domains
+
+    @property
+    def controlled_domain_groups(self) -> tuple[frozenset[str], ...]:
+        return tuple(item.controlled_dependencies for item in self.domain_records)
 
 
 @dataclass(frozen=True, slots=True)
 class FeasibleCoordinates:
-    """Role-aware exact chart over the represented relaxation PSD domains."""
+    """Role-aware exact chart over represented model-owned domains."""
 
     parameterization: ActiveParameterization = field(repr=False, compare=False)
     base_frame: IndependentValueFrame = field(repr=False, compare=False)
@@ -225,6 +358,7 @@ class FeasibleCoordinates:
     static_rate_floors: tuple[tuple[str, float], ...]
     cross_rate_ids: tuple[str, ...]
     blocks: tuple[RelaxationPsdBlock, ...]
+    population_simplexes: tuple[PopulationSimplex, ...]
     _projection_provenance: _FeasibilityProjectionProvenance | None = field(
         default=None,
         init=False,
@@ -263,6 +397,16 @@ class FeasibleCoordinates:
 
     @property
     def has_coordinate_transform(self) -> bool:
+        return bool(
+            self.rate_excess_ids
+            or self.rate_floors
+            or self.cross_rate_ids
+            or self.population_simplexes
+        )
+
+    @property
+    def uses_private_relaxation_coordinates(self) -> bool:
+        """Whether this chart changes public relaxation coordinates privately."""
         return bool(self.rate_excess_ids or self.rate_floors or self.cross_rate_ids)
 
     @property
@@ -271,6 +415,7 @@ class FeasibleCoordinates:
             not self.rate_excess_ids
             and not self.rate_floors
             and not self.cross_rate_ids
+            and not self.population_simplexes
             and self.solver_lower_bounds == self.public_lower_bounds
             and self.solver_upper_bounds == self.public_upper_bounds
         )
@@ -295,7 +440,7 @@ class FeasibleCoordinates:
     @property
     def domain_parameter_groups(self) -> tuple[frozenset[str], ...]:
         """Return parameter-ID hyperedges that must remain in one fit component."""
-        return tuple(
+        relaxation_groups = tuple(
             frozenset(
                 (
                     *block.diagonal_ids,
@@ -304,6 +449,10 @@ class FeasibleCoordinates:
             )
             for block in self.blocks
         )
+        population_groups = tuple(
+            frozenset(simplex.population_ids) for simplex in self.population_simplexes
+        )
+        return relaxation_groups + population_groups
 
     def frame_with_updates(self, updates: Mapping[str, float]) -> IndependentValueFrame:
         """Return a compatible source frame with independent public updates."""
@@ -335,6 +484,11 @@ class FeasibleCoordinates:
     ) -> FeasibleCoordinates | None:
         """Project an exact root chart onto one closed fit component."""
         self.require_root_projection_authority()
+        provenance = self._projection_provenance
+        if provenance is None:
+            raise FeasibleCoordinateConstructionError(
+                "Component feasibility projection lacks compiler provenance"
+            )
         selected = set(controlled_ids)
         root_indices = {
             param_id: index for index, param_id in enumerate(self.controlled_ids)
@@ -346,10 +500,10 @@ class FeasibleCoordinates:
             )
             != controlled_ids
             or len(selected) != len(controlled_ids)
-            or len(self.controlled_domain_groups) != len(self.blocks)
             or any(
-                dependencies & selected and not dependencies <= selected
-                for dependencies in self.controlled_domain_groups
+                item.controlled_dependencies & selected
+                and not item.controlled_dependencies <= selected
+                for item in provenance.domain_records
             )
         ):
             raise FeasibleCoordinateConstructionError(
@@ -367,37 +521,60 @@ class FeasibleCoordinates:
             raise FeasibleCoordinateConstructionError(
                 "Component feasibility projection changed root public bounds"
             )
+        projected_relaxation_domains = tuple(
+            _RelaxationDomainProvenance(
+                block=item.block,
+                controlled_dependencies=item.controlled_dependencies & selected,
+            )
+            for item in provenance.relaxation_domains
+        )
+        projected_population_domains = tuple(
+            _PopulationDomainProvenance(
+                simplex=item.simplex,
+                controlled_dependencies=item.controlled_dependencies & selected,
+            )
+            for item in provenance.population_domains
+            if item.controlled_dependencies & selected
+        )
+        projected_population_simplexes = tuple(
+            item.simplex for item in projected_population_domains
+        )
         projected = _seal_projection_provenance(
             type(self)(
-                self.parameterization,
-                frame,
-                controlled_ids,
-                lower_bounds,
-                upper_bounds,
-                tuple(item for item in self.rate_excess_ids if item[0] in selected),
-                tuple(item for item in self.rate_floors if item.rate_id in selected),
-                tuple(item for item in self.static_rate_floors if item[0] in selected),
-                tuple(
+                parameterization=self.parameterization,
+                base_frame=frame,
+                controlled_ids=controlled_ids,
+                public_lower_bounds=lower_bounds,
+                public_upper_bounds=upper_bounds,
+                rate_excess_ids=tuple(
+                    item for item in self.rate_excess_ids if item[0] in selected
+                ),
+                rate_floors=tuple(
+                    item for item in self.rate_floors if item.rate_id in selected
+                ),
+                static_rate_floors=tuple(
+                    item for item in self.static_rate_floors if item[0] in selected
+                ),
+                cross_rate_ids=tuple(
                     param_id for param_id in self.cross_rate_ids if param_id in selected
                 ),
-                self.blocks,
-                tuple(
+                blocks=self.blocks,
+                population_simplexes=projected_population_simplexes,
+                solver_start=tuple(
                     self.solver_start[root_indices[param_id]]
                     for param_id in controlled_ids
                 ),
-                tuple(
+                solver_lower_bounds=tuple(
                     self.solver_lower_bounds[root_indices[param_id]]
                     for param_id in controlled_ids
                 ),
-                tuple(
+                solver_upper_bounds=tuple(
                     self.solver_upper_bounds[root_indices[param_id]]
                     for param_id in controlled_ids
                 ),
             ),
-            tuple(
-                dependencies & selected
-                for dependencies in self.controlled_domain_groups
-            ),
+            projected_relaxation_domains,
+            projected_population_domains,
             has_root_projection_authority=False,
         )
         return None if projected.is_noop else projected
@@ -417,21 +594,37 @@ class FeasibleCoordinates:
         floor_rate_ids = {item.rate_id for item in self.rate_floors}
         static_rate_floors = dict(self.static_rate_floors)
         cross_rates = set(self.cross_rate_ids)
-        raw_updates = {
-            param_id: value
-            for param_id, value in public.items()
-            if param_id not in rate_excess
-            and param_id not in floor_rate_ids
-            and param_id not in cross_rates
+        population_ids = {
+            param_id
+            for simplex in self.population_simplexes
+            for param_id in simplex.population_ids
         }
-        frame = self.base_frame.with_updates(raw_updates)
-        resolved = self.parameterization.resolve(frame)
         lower_by_id = dict(
             zip(self.controlled_ids, self.public_lower_bounds, strict=True)
         )
         upper_by_id = dict(
             zip(self.controlled_ids, self.public_upper_bounds, strict=True)
         )
+        _decode_population_simplexes(
+            self.population_simplexes,
+            dict(self.base_frame.ordered_items()),
+            public,
+            lower_by_id,
+            upper_by_id,
+        )
+        raw_updates = {
+            param_id: value
+            for param_id, value in public.items()
+            if param_id not in rate_excess
+            and param_id not in floor_rate_ids
+            and param_id not in cross_rates
+            and param_id not in population_ids
+        }
+        raw_updates.update(
+            {param_id: public[param_id] for param_id in population_ids & set(public)}
+        )
+        frame = self.base_frame.with_updates(raw_updates)
+        resolved = self.parameterization.resolve(frame)
         excess_by_rate = {
             rate_id: tuple(
                 diagonal_id
@@ -862,14 +1055,21 @@ def _controlled_dependencies(
 
 def _seal_projection_provenance(
     chart: FeasibleCoordinates,
-    controlled_domain_groups: tuple[frozenset[str], ...],
+    relaxation_domains: tuple[_RelaxationDomainProvenance, ...],
+    population_domains: tuple[_PopulationDomainProvenance, ...],
     *,
     has_root_projection_authority: bool,
 ) -> FeasibleCoordinates:
     """Seal compiler-owned closure proof and complete scientific chart identity."""
     controlled = frozenset(chart.controlled_ids)
-    if len(controlled_domain_groups) != len(chart.blocks) or any(
-        not dependencies <= controlled for dependencies in controlled_domain_groups
+    domain_records = relaxation_domains + population_domains
+    if (
+        tuple(item.block for item in relaxation_domains) != chart.blocks
+        or tuple(item.simplex for item in population_domains)
+        != chart.population_simplexes
+        or any(
+            not item.controlled_dependencies <= controlled for item in domain_records
+        )
     ):
         raise FeasibleCoordinateConstructionError(
             "Feasibility dependency provenance differs from its root chart"
@@ -878,8 +1078,9 @@ def _seal_projection_provenance(
         chart,
         "_projection_provenance",
         _FeasibilityProjectionProvenance(
-            controlled_domain_groups,
-            has_root_projection_authority,
+            relaxation_domains=relaxation_domains,
+            population_domains=population_domains,
+            has_root_projection_authority=has_root_projection_authority,
         ),
     )
     object.__setattr__(
@@ -907,8 +1108,24 @@ def _seal_projection_provenance(
                 chart.cross_rate_ids,
                 relaxation_blocks_identity(chart.blocks),
                 tuple(
-                    tuple(sorted(dependencies))
-                    for dependencies in controlled_domain_groups
+                    (simplex.complement_id, simplex.population_ids)
+                    for simplex in chart.population_simplexes
+                ),
+                tuple(
+                    (
+                        "relaxation",
+                        item.block.domain_id,
+                        tuple(sorted(item.controlled_dependencies)),
+                    )
+                    for item in relaxation_domains
+                ),
+                tuple(
+                    (
+                        "population",
+                        item.simplex.complement_id,
+                        tuple(sorted(item.controlled_dependencies)),
+                    )
+                    for item in population_domains
                 ),
                 chart.solver_start,
                 chart.solver_lower_bounds,
@@ -919,12 +1136,16 @@ def _seal_projection_provenance(
     return chart
 
 
-def _controlled_domain_groups(
+def _controlled_domain_provenance(
     parameterization: ActiveParameterization,
     blocks: Sequence[RelaxationPsdBlock],
+    population_simplexes: Sequence[PopulationSimplex],
     controlled_ids: Sequence[str],
-) -> tuple[frozenset[str], ...]:
-    """Resolve every PSD domain to immutable root-controlled dependencies."""
+) -> tuple[
+    tuple[_RelaxationDomainProvenance, ...],
+    tuple[_PopulationDomainProvenance, ...],
+]:
+    """Bind every represented domain to its root-controlled dependencies."""
     controlled = frozenset(controlled_ids)
     constraints = {
         item.target_id: item for item in parameterization.program.constraints
@@ -947,17 +1168,32 @@ def _controlled_domain_groups(
         cache[param_id] = result
         return result
 
-    return tuple(
-        frozenset(
-            dependency
-            for param_id in (
-                *block.diagonal_ids,
-                *(item[2] for item in block.off_diagonal_ids),
-            )
-            for dependency in resolve(param_id)
+    relaxation_domains = tuple(
+        _RelaxationDomainProvenance(
+            block=block,
+            controlled_dependencies=frozenset(
+                dependency
+                for param_id in (
+                    *block.diagonal_ids,
+                    *(item[2] for item in block.off_diagonal_ids),
+                )
+                for dependency in resolve(param_id)
+            ),
         )
         for block in blocks
     )
+    population_domains = tuple(
+        _PopulationDomainProvenance(
+            simplex=simplex,
+            controlled_dependencies=frozenset(
+                dependency
+                for param_id in simplex.population_ids
+                for dependency in resolve(param_id)
+            ),
+        )
+        for simplex in population_simplexes
+    )
+    return relaxation_domains, population_domains
 
 
 def _is_intrinsic_rate_derivation(
@@ -1221,6 +1457,43 @@ def _bounded_dynamic_floor_controller_bounds(
     return bounds
 
 
+def _active_population_simplexes(
+    parameterization: ActiveParameterization,
+    frame: IndependentValueFrame,
+    controlled_ids: Sequence[str],
+) -> tuple[PopulationSimplex, ...]:
+    """Find generic N-state simplexes declared by model-owned complements."""
+    independent = {param_id for param_id, _value in frame.ordered_items()}
+    controlled = set(controlled_ids)
+    simplexes: list[PopulationSimplex] = []
+    for constraint in parameterization.program.constraints:
+        expression = constraint.expression
+        if (
+            not isinstance(expression, FunctionExpression)
+            or expression.function_id != "population_complement"
+            or expression.component != "pa"
+            or not all(
+                isinstance(argument, ReferenceExpression)
+                for argument in expression.arguments
+            )
+        ):
+            continue
+        population_ids = tuple(
+            argument.param_id
+            for argument in expression.arguments
+            if isinstance(argument, ReferenceExpression)
+        )
+        if (
+            len(population_ids) < 2
+            or len(set(population_ids)) != len(population_ids)
+            or not set(population_ids) <= independent
+            or not set(population_ids) & controlled
+        ):
+            continue
+        simplexes.append(PopulationSimplex(constraint.target_id, population_ids))
+    return tuple(simplexes)
+
+
 def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
     parameterization: ActiveParameterization,
     frame: IndependentValueFrame,
@@ -1228,7 +1501,7 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
     lower_bounds: tuple[float, ...],
     upper_bounds: tuple[float, ...],
 ) -> FeasibleCoordinates | None:
-    """Compile an exact supported chart for the active relaxation domains."""
+    """Compile exact supported coordinates for active model-owned domains."""
     blocks = active_relaxation_blocks(parameterization)
     chart_blocks = tuple(
         block
@@ -1236,6 +1509,11 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
         if not _is_intrinsic_relaxation_block(parameterization, block)
     )
     controlled = set(controlled_ids)
+    population_simplexes = _active_population_simplexes(
+        parameterization,
+        frame,
+        controlled_ids,
+    )
     rate_excess_ids = _derived_diagonal_transforms(
         parameterization,
         controlled,
@@ -1416,6 +1694,13 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
     solver_upper: list[float] = []
     lower_by_id = dict(zip(controlled_ids, lower_bounds, strict=True))
     upper_by_id = dict(zip(controlled_ids, upper_bounds, strict=True))
+    population_solver_values = _encode_population_simplexes(
+        population_simplexes,
+        public_start,
+        controlled_ids,
+        lower_by_id,
+        upper_by_id,
+    )
     transformed_ids = frozenset(
         {
             *(item[0] for item in rate_excess_ids),
@@ -1434,7 +1719,11 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
         transformed_ids,
     )
     for param_id in controlled_ids:
-        if rate_map[param_id]:
+        if param_id in population_solver_values:
+            solver_start.append(population_solver_values[param_id])
+            solver_lower.append(0.0)
+            solver_upper.append(1.0)
+        elif rate_map[param_id]:
             floor = max(
                 lower_by_id[param_id],
                 static_rate_floors.get(param_id, -math.inf),
@@ -1530,23 +1819,31 @@ def compile_feasible_coordinates(  # noqa: C901 - complete role-aware chart
                 )
             )
             solver_upper.append(min(upper_by_id[param_id], controller_upper))
+    relaxation_provenance, population_provenance = _controlled_domain_provenance(
+        parameterization,
+        blocks,
+        population_simplexes,
+        controlled_ids,
+    )
     chart = _seal_projection_provenance(
         FeasibleCoordinates(
-            parameterization,
-            frame,
-            controlled_ids,
-            lower_bounds,
-            upper_bounds,
-            rate_excess_ids,
-            tuple(rate_floors),
-            tuple(sorted(static_rate_floors.items())),
-            cross_ids,
-            blocks,
-            tuple(solver_start),
-            tuple(solver_lower),
-            tuple(solver_upper),
+            parameterization=parameterization,
+            base_frame=frame,
+            controlled_ids=controlled_ids,
+            public_lower_bounds=lower_bounds,
+            public_upper_bounds=upper_bounds,
+            rate_excess_ids=rate_excess_ids,
+            rate_floors=tuple(rate_floors),
+            static_rate_floors=tuple(sorted(static_rate_floors.items())),
+            cross_rate_ids=cross_ids,
+            blocks=blocks,
+            population_simplexes=population_simplexes,
+            solver_start=tuple(solver_start),
+            solver_lower_bounds=tuple(solver_lower),
+            solver_upper_bounds=tuple(solver_upper),
         ),
-        _controlled_domain_groups(parameterization, blocks, controlled_ids),
+        relaxation_provenance,
+        population_provenance,
         has_root_projection_authority=True,
     )
     return None if chart.is_noop else chart

--- a/tests/models/kinetic/test_nstate_domain.py
+++ b/tests/models/kinetic/test_nstate_domain.py
@@ -1,0 +1,248 @@
+"""Fast scientific-domain tests for the generic N-state model authority."""
+
+from __future__ import annotations
+
+import math
+import struct
+from decimal import Decimal, localcontext
+
+import pytest
+
+from chemex.models.kinetic.settings_nst import (
+    calculate_pair_rates,
+    calculate_population_complement,
+    register,
+)
+from chemex.parameters.userfunctions import (
+    AnalyticFunctionLinearization,
+    function_linearization_registry,
+)
+
+
+def _positive_ulp_distance(left: float, right: float) -> int:
+    """Return the binary64 ULP distance between finite nonnegative values."""
+    assert math.isfinite(left) and left >= 0.0
+    assert math.isfinite(right) and right >= 0.0
+    left_bits = struct.unpack(">Q", struct.pack(">d", left))[0]
+    right_bits = struct.unpack(">Q", struct.pack(">d", right))[0]
+    return abs(left_bits - right_bits)
+
+
+def test_population_complement_accepts_closed_simplex_boundaries() -> None:
+    assert calculate_population_complement(0.0, 0.0)["pa"] == 1.0
+    assert calculate_population_complement(0.4, 0.6)["pa"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "populations",
+    (
+        (-0.1, 0.2),
+        (0.7, 0.7),
+        (math.inf, 0.0),
+        (math.nan, 0.0),
+    ),
+)
+def test_population_complement_rejects_values_outside_simplex(
+    populations: tuple[float, ...],
+) -> None:
+    with pytest.raises(ValueError, match="population"):
+        calculate_population_complement(*populations)
+
+
+def test_pair_rates_match_independent_ordinary_oracle() -> None:
+    rates = calculate_pair_rates(360.0, 0.2, 0.6)
+
+    assert rates == pytest.approx({"forward": 270.0, "reverse": 90.0})
+    assert rates["forward"] + rates["reverse"] == 360.0
+    assert 0.2 * rates["forward"] == pytest.approx(0.6 * rates["reverse"])
+
+
+@pytest.mark.parametrize(
+    ("p_i", "p_j", "expected"),
+    (
+        (0.0, 0.4, {"forward": 125.0, "reverse": 0.0}),
+        (0.4, 0.0, {"forward": 0.0, "reverse": 125.0}),
+    ),
+)
+def test_pair_rates_preserve_exact_zero_endpoint_semantics(
+    p_i: float,
+    p_j: float,
+    expected: dict[str, float],
+) -> None:
+    assert calculate_pair_rates(125.0, p_i, p_j) == expected
+
+
+def test_pair_rates_allow_zero_kex_with_two_zero_endpoints() -> None:
+    assert calculate_pair_rates(0.0, 0.0, 0.0) == {
+        "forward": 0.0,
+        "reverse": 0.0,
+    }
+
+
+def test_pair_rates_reject_positive_kex_with_two_zero_endpoints() -> None:
+    with pytest.raises(ValueError, match="both endpoint populations are zero"):
+        calculate_pair_rates(1.0, 0.0, 0.0)
+
+
+@pytest.mark.parametrize(
+    ("kex", "p_i", "p_j"),
+    (
+        (-1.0, 0.2, 0.3),
+        (math.inf, 0.2, 0.3),
+        (1.0, -0.2, 0.3),
+        (1.0, math.nan, 0.3),
+    ),
+)
+def test_pair_rates_reject_invalid_inputs(kex: float, p_i: float, p_j: float) -> None:
+    with pytest.raises(ValueError):
+        calculate_pair_rates(kex, p_i, p_j)
+
+
+@pytest.mark.parametrize(
+    ("p_i", "p_j", "kex", "expected_forward"),
+    (
+        (1.0e-120, 2.0e-120, 300.0, 200.0),
+        (1.0e-200, 3.0e-200, 400.0, 300.0),
+        (math.ulp(0.0), 1.0, 1.0e6, 1.0e6),
+    ),
+)
+def test_pair_rates_have_no_population_denominator_floor(
+    p_i: float,
+    p_j: float,
+    kex: float,
+    expected_forward: float,
+) -> None:
+    rates = calculate_pair_rates(kex, p_i, p_j)
+
+    assert rates["forward"] == pytest.approx(expected_forward, rel=1.0e-15)
+    assert rates["forward"] + rates["reverse"] == kex
+    assert p_i * rates["forward"] == pytest.approx(
+        p_j * rates["reverse"],
+        rel=2.0e-15,
+        abs=math.ulp(0.0),
+    )
+
+
+def test_minimum_subnormal_pair_rate_matches_high_precision_oracle() -> None:
+    p_i = 0.7
+    p_j = math.ulp(0.0)
+    kex = 1.0e6
+
+    with localcontext() as context:
+        context.prec = 200
+        expected_forward = float(
+            Decimal.from_float(kex)
+            * Decimal.from_float(p_j)
+            / (Decimal.from_float(p_i) + Decimal.from_float(p_j))
+        )
+        expected_flux = float(
+            Decimal.from_float(p_i)
+            * Decimal.from_float(kex)
+            * Decimal.from_float(p_j)
+            / (Decimal.from_float(p_i) + Decimal.from_float(p_j))
+        )
+
+    rates = calculate_pair_rates(kex, p_i, p_j)
+    forward_flux = p_i * rates["forward"]
+    reverse_flux = p_j * rates["reverse"]
+
+    assert rates["forward"] > 0.0
+    assert _positive_ulp_distance(rates["forward"], expected_forward) <= 1
+    assert _positive_ulp_distance(forward_flux, expected_flux) <= 1
+    assert _positive_ulp_distance(reverse_flux, expected_flux) <= 1
+    assert _positive_ulp_distance(forward_flux, reverse_flux) <= 1
+    assert rates["forward"] + rates["reverse"] == kex
+
+
+def test_highly_biased_normal_pair_rate_matches_high_precision_oracle() -> None:
+    p_i = 0.7
+    p_j = 1.0e-200
+    kex = 1.0e6
+    with localcontext() as context:
+        context.prec = 200
+        expected_forward = float(
+            Decimal.from_float(kex)
+            * Decimal.from_float(p_j)
+            / (Decimal.from_float(p_i) + Decimal.from_float(p_j))
+        )
+
+    rates = calculate_pair_rates(kex, p_i, p_j)
+
+    assert _positive_ulp_distance(rates["forward"], expected_forward) <= 1
+    assert rates["forward"] + rates["reverse"] == kex
+    assert p_i * rates["forward"] == pytest.approx(
+        p_j * rates["reverse"],
+        rel=2.0e-15,
+    )
+
+
+def test_pair_rates_reject_unrepresentable_positive_direction() -> None:
+    with pytest.raises(ValueError, match="cannot be represented"):
+        calculate_pair_rates(0.5, math.ulp(0.0), 1.0)
+
+
+def test_registered_pair_rate_partials_match_independent_oracle() -> None:
+    register()
+    capabilities = {
+        (item.function_id, item.component): item
+        for item in function_linearization_registry.get("4st")
+        if isinstance(item, AnalyticFunctionLinearization)
+    }
+    forward = capabilities[("pair_rates", "forward")]
+    reverse = capabilities[("pair_rates", "reverse")]
+    arguments = (360.0, 0.2, 0.6)
+
+    assert tuple(partial(*arguments) for partial in forward.partials) == pytest.approx(
+        (0.75, -337.5, 112.5)
+    )
+    assert tuple(partial(*arguments) for partial in reverse.partials) == pytest.approx(
+        (0.25, 337.5, -112.5)
+    )
+
+
+def test_pair_rate_partials_are_finite_at_one_zero_endpoint() -> None:
+    register()
+    capabilities = {
+        (item.function_id, item.component): item
+        for item in function_linearization_registry.get("4st")
+        if isinstance(item, AnalyticFunctionLinearization)
+    }
+
+    forward = capabilities[("pair_rates", "forward")]
+    reverse = capabilities[("pair_rates", "reverse")]
+    arguments = (125.0, 0.0, 0.4)
+    assert tuple(partial(*arguments) for partial in forward.partials) == pytest.approx(
+        (1.0, -312.5, 0.0)
+    )
+    assert tuple(partial(*arguments) for partial in reverse.partials) == pytest.approx(
+        (0.0, 312.5, 0.0)
+    )
+
+
+def test_pair_rate_partials_fail_closed_at_a_zero_pair() -> None:
+    register()
+    capabilities = {
+        (item.function_id, item.component): item
+        for item in function_linearization_registry.get("4st")
+        if isinstance(item, AnalyticFunctionLinearization)
+    }
+
+    for component in ("forward", "reverse"):
+        for partial in capabilities[("pair_rates", component)].partials:
+            with pytest.raises(ValueError, match="undefined at a zero pair"):
+                partial(0.0, 0.0, 0.0)
+
+
+def test_registered_population_complement_partials_preserve_coupled_pa() -> None:
+    register()
+    capability = next(
+        item
+        for item in function_linearization_registry.get("6st")
+        if isinstance(item, AnalyticFunctionLinearization)
+        and (item.function_id, item.component) == ("population_complement", "pa")
+    )
+
+    assert (
+        tuple(partial(0.1, 0.2, 0.3, 0.1, 0.1) for partial in capability.partials)
+        == (-1.0,) * 5
+    )

--- a/tests/models/kinetic/test_nstate_integration.py
+++ b/tests/models/kinetic/test_nstate_integration.py
@@ -1,0 +1,459 @@
+"""Small production-stack tests for generic N-state model authority."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from chemex.configuration.methods import Method, Selection
+from chemex.configuration.parameters import (
+    DefaultListType,
+    DefaultSetting,
+    read_defaults,
+)
+from chemex.experiments.builder import Experiments, build_experiments
+from chemex.parameters.feasible_coordinates import compile_feasible_coordinates
+from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import (
+    ConstraintDomainError,
+    NoParameterMatchError,
+    ParameterRole,
+)
+from chemex.parameters.spin_system import SpinSystem
+from chemex.printers.parameters import classify_parameters
+from chemex.run_info import serialize_parameter_file
+from chemex.runtime import AnalysisSession
+
+ROOT = Path(__file__).parents[3]
+EXPERIMENT = ROOT / "examples/Experiments/RELAXATION_HZNZ/Experiments/800mhz.toml"
+PROFILE = SpinSystem.from_name("G2N-HN")
+
+
+def _build_session(
+    model_name: str,
+    defaults: DefaultListType | None = None,
+) -> tuple[AnalysisSession, Experiments]:
+    session = AnalysisSession.create()
+    session.set_model(model_name)
+    experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[PROFILE], exclude=None),
+        session=session,
+    )
+    session.parameters.set_defaults([] if defaults is None else defaults)
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    return session, experiments
+
+
+def _names_by_id(session: AnalysisSession) -> Mapping[str, str]:
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    return {
+        definition.param_id: definition.name
+        for definition in parameter_model.definitions
+    }
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_kex"),
+    (
+        ("4st", {"KEX_AB", "KEX_AC", "KEX_AD", "KEX_BC", "KEX_BD", "KEX_CD"}),
+        ("4st_linear", {"KEX_AB", "KEX_BC", "KEX_CD"}),
+        ("4st_fork", {"KEX_AB", "KEX_AC", "KEX_AD"}),
+    ),
+)
+def test_named_topologies_reach_the_sealed_parameter_model(
+    model_name: str,
+    expected_kex: set[str],
+) -> None:
+    session, experiments = _build_session(model_name)
+    names = set(_names_by_id(session).values())
+
+    assert {name for name in names if name.startswith("KEX_")} == expected_kex
+    resolved = session.resolve_current_values(experiments.param_ids)
+    for name in expected_kex:
+        edge = name.removeprefix("KEX_")
+        left, right = edge.lower()
+        p_left = resolved[f"__P{left.upper()}"]
+        p_right = resolved[f"__P{right.upper()}"]
+        kex = resolved[f"__{name}"]
+        forward = resolved[f"__K{edge}"]
+        reverse = resolved[f"__K{edge[::-1]}"]
+        expected_forward = kex * p_right / (p_left + p_right)
+        expected_reverse = kex * p_left / (p_left + p_right)
+
+        assert forward == pytest.approx(expected_forward)
+        assert reverse == pytest.approx(expected_reverse)
+        assert forward + reverse == pytest.approx(kex)
+        assert p_left * forward == pytest.approx(p_right * reverse)
+
+
+def test_invalid_simplex_fails_during_resolution_before_profile_calculation() -> None:
+    session, experiments = _build_session("4st")
+    snapshot = session.analysis_values.snapshot()
+    session.analysis_values.commit(
+        {"__PB": 0.7, "__PC": 0.7},
+        expected=snapshot,
+        scope=("__PB", "__PC"),
+    )
+
+    with pytest.raises(ConstraintDomainError) as error:
+        session.resolve_current_values(experiments.param_ids)
+
+    assert error.value.context["function_id"] == "population_complement"
+
+
+def test_negative_constrained_kex_fails_before_negative_directional_rates() -> None:
+    session, experiments = _build_session("4st")
+    parameterization = session.compile_parameterization(
+        Method(constraints=["[KEX_AB] = -1.0"]),
+        experiments.param_ids,
+    )
+
+    with pytest.raises(ConstraintDomainError) as error:
+        parameterization.resolve(
+            parameterization.frame_from_snapshot(session.analysis_values.snapshot())
+        )
+
+    assert error.value.context["function_id"] == "pair_rates"
+
+
+def test_absent_edge_method_selector_uses_normal_no_match_diagnostic() -> None:
+    session, experiments = _build_session("4st_linear")
+
+    with pytest.raises(NoParameterMatchError):
+        session.compile_parameterization(Method(fit=["KEX_AD"]), experiments.param_ids)
+
+
+def test_resolved_rates_reach_exchange_matrices_with_conservative_orientation() -> None:
+    session, experiments = _build_session("4st")
+    snapshot = session.analysis_values.snapshot()
+    session.analysis_values.commit(
+        {"__PB": 0.2, "__PC": 0.3, "__PD": 0.1, "__KEX_AB": 360.0},
+        expected=snapshot,
+        scope=("__PB", "__PC", "__PD", "__KEX_AB"),
+    )
+    resolved = session.resolve_current_values(experiments.param_ids)
+    profile = next(iter(experiments)).profiles[0]
+
+    profile.calculate_from_values(resolved)
+
+    basis = profile.spectrometer.basis
+    exchange = sum(
+        resolved[param_id] * basis.matrices[name.lower()]
+        for param_id, name in _names_by_id(session).items()
+        if name.startswith("K") and not name.startswith("KEX_")
+    )
+    block_size = len(basis)
+    assert resolved["__KAB"] == pytest.approx(120.0)
+    assert resolved["__KBA"] == pytest.approx(240.0)
+    assert exchange[block_size, 0] == pytest.approx(120.0)
+    assert exchange[0, block_size] == pytest.approx(240.0)
+    np.testing.assert_allclose(exchange.sum(axis=0), 0.0, atol=1.0e-13)
+
+
+def test_complete_model_cycles_are_consistent_with_population_authority() -> None:
+    session, experiments = _build_session("4st")
+    snapshot = session.analysis_values.snapshot()
+    session.analysis_values.commit(
+        {"__PB": 0.2, "__PC": 0.3, "__PD": 0.1},
+        expected=snapshot,
+        scope=("__PB", "__PC", "__PD"),
+    )
+    values = session.resolve_current_values(experiments.param_ids)
+
+    triangle = (
+        values["__KAB"]
+        / values["__KBA"]
+        * values["__KBC"]
+        / values["__KCB"]
+        * values["__KCA"]
+        / values["__KAC"]
+    )
+    four_state_cycle = (
+        values["__KAB"]
+        / values["__KBA"]
+        * values["__KBD"]
+        / values["__KDB"]
+        * values["__KDC"]
+        / values["__KCD"]
+        * values["__KCA"]
+        / values["__KAC"]
+    )
+    assert triangle == pytest.approx(1.0)
+    assert four_state_cycle == pytest.approx(1.0)
+
+
+def test_disconnected_five_state_mixture_preserves_populations_and_is_finite() -> None:
+    session, experiments = _build_session("5st_linear")
+    snapshot = session.analysis_values.snapshot()
+    session.analysis_values.commit(
+        {
+            "__PB": 0.2,
+            "__PC": 0.1,
+            "__PD": 0.25,
+            "__PE": 0.25,
+            "__KEX_BC": 0.0,
+        },
+        expected=snapshot,
+        scope=("__PB", "__PC", "__PD", "__PE", "__KEX_BC"),
+    )
+    resolved = session.resolve_current_values(experiments.param_ids)
+    profile = next(iter(experiments)).profiles[0]
+    calculation = profile.calculate_from_values(resolved)
+
+    assert resolved["__KBC"] == resolved["__KCB"] == 0.0
+    assert math.fsum(resolved[f"__P{state}"] for state in "ABCDE") == pytest.approx(1.0)
+    assert resolved["__PA"] + resolved["__PB"] == pytest.approx(0.4)
+    assert math.fsum(resolved[f"__P{state}"] for state in "CDE") == pytest.approx(0.6)
+    assert np.all(np.isfinite(calculation))
+
+    basis = profile.spectrometer.basis
+    exchange = sum(
+        resolved[param_id] * basis.matrices[name.lower()]
+        for param_id, name in _names_by_id(session).items()
+        if name.startswith("K") and not name.startswith("KEX_")
+    )
+    np.testing.assert_allclose(exchange.sum(axis=0), 0.0, atol=1.0e-13)
+
+    profile.update_spectrometer_from_values(resolved)
+    start = profile.spectrometer.get_start_magnetization(("iz",))
+    initialized = {
+        state: float(
+            (profile.spectrometer.basis.vectors[f"iz_{state}"].T @ start).item()
+        )
+        for state in "abcde"
+    }
+    assert initialized == pytest.approx(
+        {state: resolved[f"__P{state.upper()}"] for state in "abcde"}
+    )
+
+
+def test_simplex_feasible_coordinates_respect_fixed_populations_and_boundaries() -> (
+    None
+):
+    session, experiments = _build_session("4st")
+    snapshot = session.analysis_values.snapshot()
+    committed = session.analysis_values.commit(
+        {"__PB": 0.2, "__PC": 0.1, "__PD": 0.3},
+        expected=snapshot,
+        scope=("__PB", "__PC", "__PD"),
+    )
+    parameterization = session.compile_parameterization(
+        Method(fix=["PB", "PC", "PD"], fit=["PC"]),
+        experiments.param_ids,
+    )
+    frame = parameterization.frame_from_snapshot(committed)
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    controlled_ids = tuple(
+        param_id
+        for param_id in parameterization.independent_ids
+        if parameterization.role(param_id) is ParameterRole.FIT
+    )
+    lower = tuple(
+        parameter_model.configuration[param_id].lower_bound
+        for param_id in controlled_ids
+    )
+    upper = tuple(
+        parameter_model.configuration[param_id].upper_bound
+        for param_id in controlled_ids
+    )
+
+    chart = compile_feasible_coordinates(
+        parameterization,
+        frame,
+        controlled_ids,
+        lower,
+        upper,
+    )
+
+    assert chart is not None
+    assert chart.has_coordinate_transform
+    assert not chart.uses_private_relaxation_coordinates
+    pc_index = controlled_ids.index("__PC")
+    lower_vector = list(chart.solver_start)
+    upper_vector = list(chart.solver_start)
+    lower_vector[pc_index] = 0.0
+    upper_vector[pc_index] = 1.0
+    lower_point = chart.decode(lower_vector)
+    upper_point = chart.decode(upper_vector)
+    lower_values = parameterization.resolve(lower_point.frame)
+    upper_values = parameterization.resolve(upper_point.frame)
+    assert (lower_values["__PB"], lower_values["__PC"], lower_values["__PD"]) == (
+        0.2,
+        0.0,
+        0.3,
+    )
+    assert lower_values["__PA"] == 0.5
+    assert (upper_values["__PB"], upper_values["__PC"], upper_values["__PD"]) == (
+        0.2,
+        0.5,
+        0.3,
+    )
+    assert upper_values["__PA"] == 0.0
+
+
+def test_simplex_coordinates_respect_joint_fit_bounds_and_held_mass() -> None:
+    session, experiments = _build_session(
+        "4st",
+        [
+            (ParamName.from_section("PB"), DefaultSetting(0.2, 0.1, 0.3)),
+            (ParamName.from_section("PC"), DefaultSetting(0.3, 0.2, 0.4)),
+            (ParamName.from_section("PD"), DefaultSetting(0.25)),
+        ],
+    )
+    parameterization = session.compile_parameterization(
+        Method(fix=["PB", "PC", "PD"], fit=["PB", "PC"]),
+        experiments.param_ids,
+    )
+    frame = parameterization.frame_from_snapshot(session.analysis_values.snapshot())
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    controlled_ids = tuple(
+        param_id
+        for param_id in parameterization.independent_ids
+        if parameterization.role(param_id) is ParameterRole.FIT
+    )
+    bounds = parameter_model.configuration
+    chart = compile_feasible_coordinates(
+        parameterization,
+        frame,
+        controlled_ids,
+        tuple(bounds[param_id].lower_bound for param_id in controlled_ids),
+        tuple(bounds[param_id].upper_bound for param_id in controlled_ids),
+    )
+
+    assert chart is not None
+    lower_vector = list(chart.solver_start)
+    upper_vector = list(chart.solver_start)
+    for name in ("__PB", "__PC"):
+        index = controlled_ids.index(name)
+        lower_vector[index] = 0.0
+        upper_vector[index] = 1.0
+    lower = parameterization.resolve(chart.decode(lower_vector).frame)
+    upper = parameterization.resolve(chart.decode(upper_vector).frame)
+
+    assert (
+        lower["__PB"],
+        lower["__PC"],
+        lower["__PD"],
+        lower["__PA"],
+    ) == pytest.approx((0.1, 0.2, 0.25, 0.45))
+    assert (
+        upper["__PB"],
+        upper["__PC"],
+        upper["__PD"],
+        upper["__PA"],
+    ) == pytest.approx((0.3, 0.4, 0.25, 0.05))
+
+
+@pytest.mark.parametrize("model_name", ("4st", "4st_linear", "4st_fork"))
+def test_restart_and_output_expose_only_structural_public_coordinates(
+    model_name: str,
+) -> None:
+    session, experiments = _build_session(model_name)
+    parameter_model = session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    parameterization = session.compile_parameterization(Method(), experiments.param_ids)
+    snapshot = session.analysis_values.snapshot()
+    resolved = parameterization.resolve(parameterization.frame_from_snapshot(snapshot))
+    restart = serialize_parameter_file(parameter_model, snapshot, state_kind="restart")
+    classified = classify_parameters(
+        parameter_model,
+        resolved,
+        parameterization,
+        tuple(
+            param_id
+            for param_id in parameterization.independent_ids
+            if parameterization.role(param_id) is ParameterRole.FIT
+        ),
+    )
+    restart_keys = {
+        line.split("=", 1)[0].strip().strip('"')
+        for line in restart.splitlines()
+        if "=" in line
+    }
+    constrained_ids = {
+        parameter.param_id
+        for parameter in (
+            *classified.constrained.global_.values(),
+            *classified.constrained.local.values(),
+        )
+    }
+    names = _names_by_id(session)
+
+    assert {"PB", "PC", "PD"} <= restart_keys
+    assert {name for name in restart_keys if name.startswith("KEX_")} == {
+        name for name in names.values() if name.startswith("KEX_")
+    }
+    assert "PA" not in restart_keys
+    assert not {
+        name
+        for name in restart_keys
+        if name.startswith("K") and not name.startswith("KEX_")
+    }
+    assert names.keys() >= constrained_ids
+    assert {names[param_id] for param_id in constrained_ids} >= {"PA"}
+    kinetic_constrained_names = {
+        names[param_id]
+        for param_id in constrained_ids
+        if names[param_id] == "PA" or names[param_id].startswith("K")
+    }
+    assert all(
+        name == "PA" or (name.startswith("K") and not name.startswith("KEX_"))
+        for name in kinetic_constrained_names
+    )
+
+
+def test_legacy_restart_preserves_zero_values_but_not_historical_fixed_roles(
+    tmp_path: Path,
+) -> None:
+    session, experiments = _build_session("4st")
+    snapshot = session.analysis_values.snapshot()
+    zeroed = session.analysis_values.commit(
+        {"__KEX_AD": 0.0, "__KEX_BD": 0.0},
+        expected=snapshot,
+        scope=("__KEX_AD", "__KEX_BD"),
+    )
+    restart_path = tmp_path / "restart.toml"
+    restart_path.write_text(
+        serialize_parameter_file(
+            session.parameter_factory.sealed_parameter_model,
+            zeroed,
+            state_kind="restart",
+        )
+    )
+
+    continued = AnalysisSession.create()
+    continued.set_model("4st")
+    continued_experiments = build_experiments(
+        [EXPERIMENT],
+        Selection(include=[PROFILE], exclude=None),
+        session=continued,
+    )
+    continued.parameters.set_defaults(read_defaults([restart_path]))
+    assert continued.try_build_analysis_values()
+    ordinary = continued.compile_parameterization(
+        Method(),
+        continued_experiments.param_ids,
+    )
+    migrated = continued.compile_parameterization(
+        Method(fix=["KEX_AD", "KEX_BD"]),
+        continued_experiments.param_ids,
+    )
+    values = ordinary.resolve(
+        ordinary.frame_from_snapshot(continued.analysis_values.snapshot())
+    )
+
+    assert values["__KEX_AD"] == values["__KEX_BD"] == 0.0
+    assert ordinary.role("__KEX_AD") is ParameterRole.FIT
+    assert ordinary.role("__KEX_BD") is ParameterRole.FIT
+    assert migrated.role("__KEX_AD") is ParameterRole.FIX
+    assert migrated.role("__KEX_BD") is ParameterRole.FIX

--- a/tests/models/kinetic/test_nstate_topologies.py
+++ b/tests/models/kinetic/test_nstate_topologies.py
@@ -1,0 +1,286 @@
+"""Public topology and settings signatures for generic N-state models."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+
+import pytest
+
+from chemex.configuration.conditions import Conditions
+from chemex.models.factory import model_factory
+from chemex.models.kinetic.settings_nst import (
+    complete_edges,
+    fork_edges,
+    linear_edges,
+    register,
+)
+from chemex.parameters.setting import ParamLocalSetting
+
+type Edge = tuple[str, str]
+
+EXPECTED_COMPLETE: dict[str, tuple[Edge, ...]] = {
+    "abc": (("a", "b"), ("a", "c"), ("b", "c")),
+    "abcd": (
+        ("a", "b"),
+        ("a", "c"),
+        ("a", "d"),
+        ("b", "c"),
+        ("b", "d"),
+        ("c", "d"),
+    ),
+    "abcde": (
+        ("a", "b"),
+        ("a", "c"),
+        ("a", "d"),
+        ("a", "e"),
+        ("b", "c"),
+        ("b", "d"),
+        ("b", "e"),
+        ("c", "d"),
+        ("c", "e"),
+        ("d", "e"),
+    ),
+    "abcdef": (
+        ("a", "b"),
+        ("a", "c"),
+        ("a", "d"),
+        ("a", "e"),
+        ("a", "f"),
+        ("b", "c"),
+        ("b", "d"),
+        ("b", "e"),
+        ("b", "f"),
+        ("c", "d"),
+        ("c", "e"),
+        ("c", "f"),
+        ("d", "e"),
+        ("d", "f"),
+        ("e", "f"),
+    ),
+}
+
+EXPECTED_LINEAR: dict[str, tuple[Edge, ...]] = {
+    "abc": (("a", "b"), ("b", "c")),
+    "abcd": (("a", "b"), ("b", "c"), ("c", "d")),
+    "abcde": (("a", "b"), ("b", "c"), ("c", "d"), ("d", "e")),
+    "abcdef": (
+        ("a", "b"),
+        ("b", "c"),
+        ("c", "d"),
+        ("d", "e"),
+        ("e", "f"),
+    ),
+}
+
+EXPECTED_FORK: dict[str, tuple[Edge, ...]] = {
+    "abc": (("a", "b"), ("a", "c")),
+    "abcd": (("a", "b"), ("a", "c"), ("a", "d")),
+    "abcde": (("a", "b"), ("a", "c"), ("a", "d"), ("a", "e")),
+    "abcdef": (
+        ("a", "b"),
+        ("a", "c"),
+        ("a", "d"),
+        ("a", "e"),
+        ("a", "f"),
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("builder", "expected"),
+    (
+        (complete_edges, EXPECTED_COMPLETE),
+        (linear_edges, EXPECTED_LINEAR),
+        (fork_edges, EXPECTED_FORK),
+    ),
+)
+def test_topology_edge_builders_are_explicit(
+    builder: Callable[[str], tuple[Edge, ...]],
+    expected: dict[str, tuple[Edge, ...]],
+) -> None:
+    for states, edges in expected.items():
+        assert builder(states) == edges
+
+
+MODEL_TO_EDGES = {
+    **{f"{len(states)}st": edges for states, edges in EXPECTED_COMPLETE.items()},
+    "3st_triangle": EXPECTED_COMPLETE["abc"],
+    **{f"{len(states)}st_linear": edges for states, edges in EXPECTED_LINEAR.items()},
+    **{f"{len(states)}st_fork": edges for states, edges in EXPECTED_FORK.items()},
+}
+
+
+def _setting_signature(setting: ParamLocalSetting) -> tuple[object, ...]:
+    name = setting.name_setting
+    return (
+        name.name,
+        name.spin_system_part,
+        name.conditions_part,
+        name.allow_residue_specific,
+        setting.value,
+        setting.min,
+        setting.max,
+        setting.vary,
+        setting.supports_estimation,
+        setting.report_only,
+        setting.expr,
+    )
+
+
+@pytest.mark.parametrize(("model_name", "edges"), MODEL_TO_EDGES.items())
+def test_public_model_settings_match_declared_topology(
+    model_name: str,
+    edges: tuple[Edge, ...],
+) -> None:
+    register()
+    settings = model_factory.create(model_name, Conditions())
+    state_count = int(model_name[0])
+    states = "abcdef"[:state_count]
+    population_names = {f"p{state}" for state in states[1:]}
+    kex_names = {f"kex_{left}{right}" for left, right in edges}
+    rate_names = {
+        f"k{source}{target}"
+        for left, right in edges
+        for source, target in ((left, right), (right, left))
+    }
+
+    assert population_names <= settings.keys()
+    assert {name for name in settings if name.startswith("kex_")} == kex_names
+    assert {
+        name
+        for name in settings
+        if name.startswith("k") and not name.startswith("kex_")
+    } == rate_names
+    assert set(settings) == population_names | {"pa"} | kex_names | rate_names
+
+    for name in population_names:
+        setting = settings[name]
+        assert (setting.value, setting.min, setting.max, setting.vary) == (
+            0.02,
+            0.0,
+            1.0,
+            True,
+        )
+        assert setting.name_setting.conditions_part == (
+            "temperature",
+            "p_total",
+            "l_total",
+        )
+    for name in kex_names:
+        setting = settings[name]
+        assert (setting.value, setting.min, setting.max, setting.vary) == (
+            200.0,
+            0.0,
+            1.0e6,
+            True,
+        )
+        assert setting.name_setting.conditions_part == (
+            "temperature",
+            "p_total",
+            "l_total",
+        )
+    assert "population_complement" in settings["pa"].expr
+    assert (settings["pa"].min, settings["pa"].max) == (
+        (-math.inf, math.inf) if state_count == 3 else (0.0, 1.0)
+    )
+    assert all("pair_rates" in settings[name].expr for name in rate_names)
+
+
+def test_three_state_triangle_is_an_exact_signature_alias() -> None:
+    register()
+    canonical = model_factory.create("3st", Conditions())
+    compatibility = model_factory.create("3st_triangle", Conditions())
+
+    assert tuple(canonical) == tuple(compatibility)
+    assert {
+        name: _setting_signature(setting) for name, setting in canonical.items()
+    } == {name: _setting_signature(setting) for name, setting in compatibility.items()}
+
+
+@pytest.mark.parametrize(
+    ("model_name", "edges"),
+    (
+        ("3st", EXPECTED_COMPLETE["abc"]),
+        ("3st_triangle", EXPECTED_COMPLETE["abc"]),
+        ("3st_linear", EXPECTED_LINEAR["abc"]),
+        ("3st_fork", EXPECTED_FORK["abc"]),
+    ),
+)
+def test_three_state_settings_preserve_frozen_base_metadata(
+    model_name: str,
+    edges: tuple[Edge, ...],
+) -> None:
+    """Freeze the public metadata shipped at the audited base commit."""
+    register()
+    settings = model_factory.create(model_name, Conditions())
+
+    for name in ("pb", "pc"):
+        setting = settings[name]
+        assert _setting_signature(setting)[:-1] == (
+            name,
+            "",
+            ("temperature", "p_total", "l_total"),
+            True,
+            0.02,
+            0.0,
+            1.0,
+            True,
+            False,
+            False,
+        )
+    pa = settings["pa"]
+    assert _setting_signature(pa)[:-1] == (
+        "pa",
+        "",
+        ("temperature", "p_total", "l_total"),
+        True,
+        None,
+        -math.inf,
+        math.inf,
+        False,
+        False,
+        False,
+    )
+    assert pa.dependencies == {"pb", "pc"}
+
+    for left, right in edges:
+        kex = settings[f"kex_{left}{right}"]
+        assert _setting_signature(kex)[:-1] == (
+            f"kex_{left}{right}",
+            "",
+            ("temperature", "p_total", "l_total"),
+            True,
+            200.0,
+            0.0,
+            1.0e6,
+            True,
+            False,
+            False,
+        )
+        for source, target in ((left, right), (right, left)):
+            rate = settings[f"k{source}{target}"]
+            assert _setting_signature(rate)[:-1] == (
+                f"k{source}{target}",
+                "",
+                ("temperature", "p_total", "l_total"),
+                True,
+                None,
+                -math.inf,
+                math.inf,
+                False,
+                False,
+                False,
+            )
+            assert rate.dependencies == {
+                f"kex_{left}{right}",
+                f"p{left}",
+                f"p{right}",
+            }
+
+
+def test_all_audited_public_model_names_are_registered() -> None:
+    register()
+
+    assert MODEL_TO_EDGES.keys() <= model_factory.set
+    assert not {"4st_complete", "5st_complete", "6st_complete"} & model_factory.set

--- a/tests/models/kinetic/test_nstate_workflows.py
+++ b/tests/models/kinetic/test_nstate_workflows.py
@@ -1,0 +1,843 @@
+"""Focused Direct-TRF, MCMC, resampling, and uncertainty N-state workflows."""
+
+from __future__ import annotations
+
+import math
+import tomllib
+from argparse import Namespace
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from pydantic import BaseModel
+
+from chemex.configuration.conditions import Conditions
+from chemex.configuration.methods import Method
+from chemex.configuration.parameters import (
+    DefaultListType,
+    DefaultSetting,
+    read_defaults,
+)
+from chemex.containers.data import Data
+from chemex.containers.profile import Profile, PulseSequence
+from chemex.evaluation.native import (
+    EvaluationEngine,
+    EvaluationFailure,
+    EvaluationFrame,
+    EvaluationResult,
+)
+from chemex.models.factory import model_factory
+from chemex.nmr.basis import Basis
+from chemex.nmr.spectrometer import Spectrometer
+from chemex.optimize import de_direct_trf as de_module
+from chemex.optimize import native_mcmc as native_mcmc_module
+from chemex.optimize import uncertainty as uncertainty_module
+from chemex.optimize.de_direct_trf import (
+    DeSearchInvocation,
+    DeSearchTerminal,
+    execute_de_search,
+)
+from chemex.optimize.deterministic_uncertainty import (
+    AcceptedDeterministicFitFacts,
+    ContinuousTrfBasis,
+    DeterministicUncertainty,
+    derive_deterministic_uncertainty,
+)
+from chemex.optimize.direct_trf import (
+    AcceptedFitResult,
+    DirectTrfInvocation,
+    OptimizationProblem,
+    canonical_chi_square,
+    execute_direct_trf,
+)
+from chemex.optimize.grouped_direct_trf import FitDecomposition
+from chemex.optimize.native_mcmc import (
+    McmcOperationTerminal,
+    McmcPlan,
+    execute_mcmc_evidence,
+    resolve_product_mcmc_policy,
+)
+from chemex.optimize.native_resampling import (
+    OperationTerminal,
+    OptimizationStrategy,
+    ResamplingDatasetManifest,
+    ResamplingPlan,
+    ResamplingScheme,
+    execute_resampling_evidence,
+)
+from chemex.optimize.uncertainty import ParameterUnit
+from chemex.parameters.name import ParamName
+from chemex.parameters.parameterization import ActiveParameterization, ParameterRole
+from chemex.parameters.spin_system import SpinSystem
+from chemex.run_info import write_run_info
+from chemex.runtime import AnalysisSession
+
+
+class _NStateKernelSettings(BaseModel):
+    kind: str = "nstate-workflow-qualification"
+
+
+class _NStateSpectrometer:
+    def __init__(self, spin_system: SpinSystem) -> None:
+        self.spin_system = spin_system
+        self.values = {
+            "pb": 0.0,
+            "pc": 0.0,
+            "pd": 0.0,
+            "pe": 0.0,
+            "pf": 0.0,
+        }
+
+    def update(self, values: dict[str, float]) -> None:
+        self.values = dict(values)
+
+    def new_native_workspace(self) -> _NStateSpectrometer:
+        return deepcopy(self)
+
+    def native_kernel_descriptor(self) -> dict[str, str]:
+        return {"kind": "nstate-workflow-spectrometer"}
+
+
+class _NStatePulseSequence:
+    settings = _NStateKernelSettings()
+
+    def calculate(
+        self,
+        spectrometer: _NStateSpectrometer,
+        data: Data,
+    ) -> np.ndarray:
+        metadata = np.asarray(data.metadata, dtype=np.float64)
+        return sum(
+            spectrometer.values[name] * metadata**power
+            for power, name in enumerate(("pb", "pc", "pd", "pe", "pf"), 1)
+            if name in spectrometer.values
+        )
+
+    def is_reference(self, metadata: np.ndarray) -> np.ndarray:
+        return np.zeros(metadata.shape, dtype=np.bool_)
+
+
+@dataclass(frozen=True, slots=True)
+class _NStateWorkflow:
+    session: AnalysisSession
+    local_ids: dict[str, str]
+    component_local_ids: tuple[dict[str, str], ...]
+    parameterization: ActiveParameterization
+    engine: EvaluationEngine
+    problem: OptimizationProblem
+
+
+def _fit_workflow(workflow: _NStateWorkflow) -> AcceptedFitResult:
+    outcome = execute_direct_trf(
+        workflow.problem,
+        DirectTrfInvocation.for_problem(
+            workflow.problem,
+            objective_request_budget=100,
+        ),
+        workflow.parameterization,
+        workflow.engine,
+    )
+    accepted = outcome.accepted_result
+    assert accepted is not None
+    return accepted
+
+
+def _qualified_accepted_at(
+    workflow: _NStateWorkflow,
+    template: AcceptedFitResult,
+    vector: tuple[float, ...],
+) -> AcceptedFitResult:
+    """Materialize an exact valid vector for isolated production qualification."""
+    lifecycle = workflow.problem.lifecycle_frame(vector, workflow.parameterization)
+    evaluated = workflow.engine.new_evaluator().evaluate(
+        EvaluationFrame.from_lifecycle_frame(workflow.parameterization, lifecycle)
+    )
+    assert isinstance(evaluated, EvaluationResult)
+    return AcceptedFitResult.for_qualification(
+        occurrence_identity=f"nstate-exact-{template.occurrence_identity}",
+        problem_identity=workflow.problem.identity,
+        invocation_identity=template.invocation_identity,
+        execution_identity=template.execution_identity,
+        materialization_identity=f"exact-{template.materialization_identity}",
+        parameterization_identity=template.parameterization_identity,
+        evaluator_parameterization_identity=(
+            template.evaluator_parameterization_identity
+        ),
+        source_occurrence_identity=template.source_occurrence_identity,
+        source_revision=template.source_revision,
+        controlled_ids=template.controlled_ids,
+        vector=vector,
+        chi_square=canonical_chi_square(evaluated.residuals),
+        evaluation_result=evaluated,
+        commit_scope=template.commit_scope,
+        commit_items=tuple(
+            (param_id, evaluated.resolved_values[param_id])
+            for param_id in template.commit_scope
+        ),
+        origin_context_identity=template.origin_context_identity,
+    )
+
+
+def _build_workflow(
+    *,
+    start: dict[str, float],
+    target: dict[str, float],
+    fitted_name: str | tuple[str, ...],
+    include_rates: bool = False,
+    temperatures: tuple[float, ...] = (25.0,),
+    model_name: str = "4st_fork",
+    defaults: DefaultListType | None = None,
+) -> _NStateWorkflow:
+    session = AnalysisSession.create()
+    session.set_model(model_name)
+    basis = Basis(type="iz", spin_system="nh", model=session.model.spec)
+    spin_system = SpinSystem.from_name("G23N-HN")
+    population_names = tuple(f"p{state}" for state in session.model.states[1:])
+    component_local_ids: list[dict[str, str]] = []
+    for temperature in temperatures:
+        conditions = Conditions(
+            h_larmor_frq=600.0,
+            temperature=temperature,
+            p_total=1.0e-3,
+            l_total=2.0e-3,
+        )
+        settings = model_factory.create(model_name, conditions)
+        component_local_ids.append(
+            {
+                name: setting.name_setting.get_param_name(spin_system, conditions).id_
+                for name, setting in settings.items()
+            }
+        )
+        config = SimpleNamespace(
+            conditions=conditions,
+            to_be_fitted=SimpleNamespace(rates=[], model_free=[]),
+        )
+        session.parameter_factory.create_parameters(
+            config,  # ty: ignore[invalid-argument-type]
+            basis=basis,
+            spin_system=spin_system,
+        )
+    session.parameters.set_defaults(
+        [
+            (ParamName.from_section(name), DefaultSetting(value))
+            for name, value in start.items()
+        ]
+        if defaults is None
+        else defaults
+    )
+    assert session.parameter_factory.try_seal_definitions(), repr(
+        session.parameter_factory.native_construction_error
+    )
+    assert session.try_build_analysis_values(), repr(
+        session.parameter_factory.native_construction_error
+    )
+
+    metadata = np.asarray((0.25, 0.5, 0.8, 1.1, 1.5, 2.0))
+    observed = sum(
+        target[name] * metadata**power for power, name in enumerate(population_names, 1)
+    )
+    data = Data(
+        exp=np.asarray(observed, dtype=np.float64),
+        err=np.full(metadata.shape, 1.0e-4),
+        metadata=metadata,
+    )
+    profiles = tuple(
+        Profile(
+            deepcopy(data),
+            cast("Spectrometer", _NStateSpectrometer(spin_system)),
+            cast("PulseSequence", _NStatePulseSequence()),
+            {name: local_ids[name] for name in population_names},
+            cast("Any", None),
+            is_scaled=False,
+        )
+        for local_ids in component_local_ids
+    )
+    experiments = cast("Any", (SimpleNamespace(profiles=profiles),))
+    required_ids = set().union(*(profile.param_ids for profile in profiles))
+    required_ids.update(local_ids["pa"] for local_ids in component_local_ids)
+    if include_rates:
+        for local_ids in component_local_ids:
+            required_ids.update((local_ids["kab"], local_ids["kba"]))
+    fitted_names = (fitted_name,) if isinstance(fitted_name, str) else fitted_name
+    held_names = sorted({name.upper() for name in population_names} - set(fitted_names))
+    if include_rates:
+        held_names.append("KEX_AB")
+    parameterization = session.compile_parameterization(
+        Method(fit=list(fitted_names), fix=held_names),
+        required_ids,
+    )
+    engine = EvaluationEngine.from_experiments(experiments, parameterization)
+    configuration = session.parameter_factory.sealed_configuration
+    assert configuration is not None
+    problem = OptimizationProblem.from_native(
+        engine.plan,
+        parameterization,
+        configuration,
+        session.analysis_values.snapshot(),
+    )
+    return _NStateWorkflow(
+        session,
+        component_local_ids[0],
+        tuple(component_local_ids),
+        parameterization,
+        engine,
+        problem,
+    )
+
+
+def _derive_uncertainty(
+    workflow: _NStateWorkflow,
+    accepted: AcceptedFitResult,
+) -> DeterministicUncertainty:
+    decomposition = FitDecomposition.from_root(
+        workflow.problem,
+        workflow.parameterization,
+        workflow.engine,
+    )
+    return derive_deterministic_uncertainty(
+        AcceptedDeterministicFitFacts(
+            accepted,
+            workflow.problem,
+            workflow.parameterization,
+            workflow.engine,
+            ContinuousTrfBasis(decomposition.partition_proof),
+            "nstate-workflow-uncertainty",
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("fitted_name", "start", "target", "boundary_name"),
+    (
+        (
+            "PB",
+            {"pb": 0.1, "pc": 0.25, "pd": 0.35},
+            {"pb": 0.0, "pc": 0.25, "pd": 0.35},
+            "pb",
+        ),
+        (
+            "PD",
+            {"pb": 0.2, "pc": 0.3, "pd": 0.4},
+            {"pb": 0.2, "pc": 0.3, "pd": 0.5},
+            "pa",
+        ),
+        (
+            "PD",
+            {"pb": 0.2, "pc": 0.3, "pd": 0.1},
+            {"pb": 0.2, "pc": 0.3, "pd": 0.0},
+            "pd",
+        ),
+    ),
+)
+def test_direct_trf_reaches_closed_simplex_boundaries(
+    fitted_name: str,
+    start: dict[str, float],
+    target: dict[str, float],
+    boundary_name: str,
+) -> None:
+    workflow = _build_workflow(start=start, target=target, fitted_name=fitted_name)
+
+    accepted = _fit_workflow(workflow)
+    resolved = accepted.evaluation_result.resolved_values
+    assert resolved[workflow.local_ids[boundary_name]] == pytest.approx(
+        0.0,
+        abs=1.0e-7,
+    )
+    assert all(
+        resolved[workflow.local_ids[name]] >= 0.0 for name in ("pa", "pb", "pc", "pd")
+    )
+    assert sum(
+        resolved[workflow.local_ids[name]] for name in ("pa", "pb", "pc", "pd")
+    ) == pytest.approx(1.0)
+
+
+def test_selected_coordinate_de_uses_public_nstate_simplex_values() -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.2, "pc": 0.3, "pd": 0.2},
+        target={"pb": 0.2, "pc": 0.3, "pd": 0.45},
+        fitted_name="PD",
+    )
+    selected_id = workflow.problem.controlled_ids[0]
+    invocation = DeSearchInvocation.for_product_problem(
+        workflow.problem,
+        search_coordinates=((selected_id, 0.0, 1.0, "linear"),),
+        root_seed=773,
+    )
+    chart = invocation.search_problem.feasible_coordinates
+    assert chart is not None
+    assert chart.population_simplexes
+    assert not chart.uses_private_relaxation_coordinates
+    assert invocation.search_problem.controlled_ids == (selected_id,)
+    assert tuple(item.param_id for item in invocation.search_coordinates) == (
+        selected_id,
+    )
+
+    def valid_and_exterior_backend(live, _invocation, _solver_start):
+        valid = np.asarray((0.45,), dtype=np.float64)
+        exterior = np.asarray((0.8,), dtype=np.float64)
+        valid_objective = live.objective(valid)
+        assert math.isfinite(valid_objective)
+        assert live.objective(exterior) == math.inf
+        return SimpleNamespace(
+            success=True,
+            message="Optimization terminated successfully.",
+            nit=1,
+            nfev=2,
+            x=valid,
+            fun=valid_objective,
+            population=np.tile(valid, (invocation.population.size, 1)),
+            population_energies=np.full(
+                invocation.population.size,
+                valid_objective,
+            ),
+        )
+
+    with patch.object(
+        de_module,
+        "_invoke_de_backend",
+        side_effect=valid_and_exterior_backend,
+    ):
+        outcome = execute_de_search(
+            workflow.problem,
+            invocation,
+            workflow.parameterization,
+            workflow.engine,
+        )
+
+    assert outcome.terminal is DeSearchTerminal.POPULATION_CONVERGED
+    assert outcome.valid_candidate_count == 1
+    assert outcome.rejected_trial_count == 1
+    assert outcome.best_candidate is not None
+    assert outcome.best_candidate.selected_vector == (0.45,)
+
+
+def test_mcmc_accepts_exact_nstate_simplex_boundary_and_retries_exterior() -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.2, "pc": 0.3, "pd": 0.4},
+        target={"pb": 0.2, "pc": 0.3, "pd": 0.5},
+        fitted_name="PD",
+    )
+    template = _fit_workflow(workflow)
+    accepted = _qualified_accepted_at(workflow, template, (0.5,))
+    assert accepted.evaluation_result.resolved_values[workflow.local_ids["pa"]] == 0.0
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=workflow.problem,
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        policy=resolve_product_mcmc_policy(
+            dimension=1,
+            walkers=8,
+            steps=1,
+            root_seed=774,
+        ),
+        coordinate_units=(
+            (workflow.problem.controlled_ids[0], ParameterUnit.FRACTION),
+        ),
+    )
+    kernel = native_mcmc_module._LogDensityKernel(
+        native_mcmc_module._McmcWorkerContext.from_plan(plan)
+    )
+
+    assert math.isfinite(kernel.evaluate(np.asarray((0.5,))).value)
+    assert kernel.evaluate(np.asarray((0.5001,))).value == -math.inf
+
+    operation = execute_mcmc_evidence(accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    initial = operation.evidence.states[0]
+    assert all(math.isfinite(value) for value in initial.log_densities)
+    attempts = native_mcmc_module._initialization_attempts_for_positions(
+        plan,
+        initial.positions,
+    )
+    assert attempts is not None
+    assert any(attempt > 0 for attempt in attempts)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "populations", "root_seed"),
+    (
+        (
+            "5st_fork",
+            {"pb": 0.1, "pc": 0.2, "pd": 0.3, "pe": 0.4},
+            775,
+        ),
+        (
+            "6st_fork",
+            {"pb": 0.1, "pc": 0.15, "pd": 0.2, "pe": 0.25, "pf": 0.3},
+            776,
+        ),
+    ),
+)
+def test_higher_state_mcmc_initializer_retries_to_valid_simplex_walkers(
+    model_name: str,
+    populations: dict[str, float],
+    root_seed: int,
+) -> None:
+    fitted_names = tuple(name.upper() for name in populations)
+    workflow = _build_workflow(
+        start=populations,
+        target=populations,
+        fitted_name=fitted_names,
+        model_name=model_name,
+    )
+    template = _fit_workflow(workflow)
+    accepted = _qualified_accepted_at(
+        workflow,
+        template,
+        tuple(populations[name] for name in populations),
+    )
+    dimension = len(accepted.vector)
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=workflow.problem,
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        policy=resolve_product_mcmc_policy(
+            dimension=dimension,
+            walkers=2 * dimension + 2,
+            steps=1,
+            root_seed=root_seed,
+        ),
+        coordinate_units=tuple(
+            (param_id, ParameterUnit.FRACTION)
+            for param_id in workflow.problem.controlled_ids
+        ),
+    )
+
+    operation = execute_mcmc_evidence(accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    initial = operation.evidence.states[0]
+    attempts = native_mcmc_module._initialization_attempts_for_positions(
+        plan,
+        initial.positions,
+    )
+    assert attempts is not None
+    assert any(attempt > 0 for attempt in attempts)
+    for vector in initial.positions:
+        resolved = workflow.parameterization.resolve(
+            workflow.problem.lifecycle_frame(vector, workflow.parameterization)
+        )
+        values = tuple(
+            resolved[workflow.local_ids[name]] for name in ("pa", *populations)
+        )
+        assert all(value >= 0.0 for value in values)
+        assert math.fsum(values) == pytest.approx(1.0)
+
+
+def test_mcmc_retries_public_population_proposals_outside_the_simplex() -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.2, "pc": 0.3, "pd": 0.4},
+        target={"pb": 0.2, "pc": 0.3, "pd": 0.5},
+        fitted_name="PD",
+    )
+    accepted = _fit_workflow(workflow)
+    plan = McmcPlan.for_accepted(
+        accepted,
+        source_problem=workflow.problem,
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        policy=resolve_product_mcmc_policy(
+            dimension=1,
+            walkers=8,
+            steps=2,
+            root_seed=771,
+        ),
+        coordinate_units=(
+            (workflow.problem.controlled_ids[0], ParameterUnit.FRACTION),
+        ),
+    )
+    evaluator = workflow.engine.new_evaluator()
+    initial_evaluations = tuple(
+        evaluator.evaluate(
+            EvaluationFrame.from_lifecycle_frame(
+                workflow.parameterization,
+                workflow.problem.lifecycle_frame(vector, workflow.parameterization),
+            )
+        )
+        for vector in plan.initial_ensemble
+    )
+
+    assert any(
+        isinstance(evaluation, EvaluationFailure)
+        and evaluation.stage == "resolution"
+        and evaluation.category == "domain_error"
+        and "function_id='population_complement'" in evaluation.message
+        for evaluation in initial_evaluations
+    )
+
+    operation = execute_mcmc_evidence(accepted, plan)
+
+    assert operation.terminal is McmcOperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    assert all(
+        math.isfinite(value) for value in operation.evidence.states[0].log_densities
+    )
+
+
+def test_monte_carlo_reuses_direct_trf_simplex_coordinates() -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.15, "pc": 0.25, "pd": 0.35},
+        target={"pb": 0.1, "pc": 0.25, "pd": 0.35},
+        fitted_name="PB",
+    )
+    accepted = _fit_workflow(workflow)
+    size = workflow.engine.plan.observation_count
+    dataset = ResamplingDatasetManifest(
+        workflow.engine.plan,
+        tuple(
+            float(value) for value in accepted.evaluation_result.normalized_calculations
+        ),
+        tuple(False for _ in range(size)),
+        tuple("G23" for _ in range(size)),
+        tuple(f"nstate-observation-{index}" for index in range(size)),
+    )
+    plan = ResamplingPlan.for_accepted(
+        accepted,
+        dataset=dataset,
+        source_problem=workflow.problem,
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        scheme=ResamplingScheme.MONTE_CARLO,
+        replicate_count=2,
+        replicate_structural_identities=("nstate-mc-0", "nstate-mc-1"),
+        replicate_component_identities=(("nstate-trf-0",), ("nstate-trf-1",)),
+        root_seed=772,
+        output_scope=workflow.problem.commit_scope,
+        output_units=("native",) * len(workflow.problem.commit_scope),
+        minimum_successful_count=2,
+        strategy=OptimizationStrategy.DIRECT_TRF,
+        strategy_settings=(("objective_request_budget", "100"),),
+    )
+
+    operation = execute_resampling_evidence(accepted, plan)
+
+    assert operation.terminal is OperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    assert operation.evidence.successful_count == 2
+    for outcome in operation.evidence.outcomes:
+        assert outcome.success is not None
+        resolved = dict(outcome.success.resolved_items)
+        populations = tuple(
+            resolved[workflow.local_ids[name]] for name in ("pa", "pb", "pc", "pd")
+        )
+        assert all(value >= 0.0 for value in populations)
+        assert sum(populations) == pytest.approx(1.0)
+
+
+def test_bootstrap_near_simplex_face_never_commits_negative_pa() -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.2, "pc": 0.3, "pd": 0.45},
+        target={"pb": 0.2, "pc": 0.3, "pd": 0.499},
+        fitted_name="PD",
+    )
+    accepted = _fit_workflow(workflow)
+    size = workflow.engine.plan.observation_count
+    dataset = ResamplingDatasetManifest(
+        workflow.engine.plan,
+        tuple(
+            float(value) for value in accepted.evaluation_result.normalized_calculations
+        ),
+        tuple(False for _ in range(size)),
+        tuple("G23" for _ in range(size)),
+        tuple(f"nstate-bootstrap-{index}" for index in range(size)),
+    )
+    plan = ResamplingPlan.for_accepted(
+        accepted,
+        dataset=dataset,
+        source_problem=workflow.problem,
+        parameterization=workflow.parameterization,
+        source_engine=workflow.engine,
+        scheme=ResamplingScheme.BOOTSTRAP,
+        replicate_count=2,
+        replicate_structural_identities=("nstate-bs-0", "nstate-bs-1"),
+        replicate_component_identities=(("nstate-bs-trf-0",), ("nstate-bs-trf-1",)),
+        root_seed=777,
+        output_scope=workflow.problem.commit_scope,
+        output_units=("native",) * len(workflow.problem.commit_scope),
+        minimum_successful_count=1,
+        strategy=OptimizationStrategy.DIRECT_TRF,
+        strategy_settings=(("objective_request_budget", "100"),),
+    )
+    before = workflow.session.analysis_values.snapshot()
+
+    operation = execute_resampling_evidence(accepted, plan)
+
+    assert operation.terminal is OperationTerminal.COMPLETED
+    assert operation.evidence is not None
+    assert workflow.session.analysis_values.snapshot() == before
+    for outcome in operation.evidence.outcomes:
+        if outcome.success is None:
+            assert outcome.failure is not None
+            continue
+        resolved = dict(outcome.success.resolved_items)
+        populations = tuple(
+            resolved[workflow.local_ids[name]] for name in ("pa", "pb", "pc", "pd")
+        )
+        assert all(value >= 0.0 for value in populations)
+        assert math.fsum(populations) == pytest.approx(1.0)
+
+
+def test_post_fit_restart_round_trip_preserves_public_nstate_values_and_roles(
+    tmp_path: Path,
+) -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.2, "pc": 0.25, "pd": 0.3},
+        target={"pb": 0.13, "pc": 0.25, "pd": 0.3},
+        fitted_name="PB",
+        include_rates=True,
+    )
+    starting = workflow.session.analysis_values.snapshot()
+    parameter_model = workflow.session.parameter_factory.sealed_parameter_model
+    assert parameter_model is not None
+    args = Namespace(
+        experiments=[],
+        parameters=[],
+        method=None,
+        output=tmp_path / "Output",
+        model="4st_fork",
+        include=None,
+        exclude=None,
+        workers=1,
+        native_threads="auto",
+    )
+    with patch("chemex.run_info._git_metadata", return_value=None):
+        run_info = write_run_info(
+            args,
+            parameter_model=parameter_model,
+            starting_values=starting,
+            input_files=(),
+            argv=("chemex", "fit"),
+            working_directory=tmp_path,
+        )
+    accepted = _fit_workflow(workflow)
+    committed = workflow.session.analysis_values.commit(
+        dict(accepted.commit_items),
+        expected=starting,
+        scope=accepted.commit_scope,
+    )
+
+    run_info.publish_restart(committed)
+
+    restart_path = tmp_path / "Output" / "run_info" / "restart.toml"
+    restart = tomllib.loads(restart_path.read_text(encoding="utf-8"))
+    restart_names = {name.split(",", 1)[0] for name in restart["GLOBAL"]}
+    assert {"PB", "PC", "PD", "KEX_AB", "KEX_AC", "KEX_AD"} <= restart_names
+    assert "PA" not in restart_names
+    assert not {
+        name
+        for name in restart_names
+        if name.startswith("K") and not name.startswith("KEX_")
+    }
+
+    continued = _build_workflow(
+        start={"pb": 0.2, "pc": 0.25, "pd": 0.3},
+        target={"pb": 0.13, "pc": 0.25, "pd": 0.3},
+        fitted_name="PB",
+        model_name="4st_fork",
+        defaults=read_defaults([restart_path]),
+    )
+    continued_model = continued.session.parameter_factory.sealed_parameter_model
+    assert continued_model is not None
+    all_ids = {definition.param_id for definition in continued_model.definitions}
+    ordinary = continued.session.compile_parameterization(Method(), all_ids)
+    resolved = ordinary.resolve(
+        ordinary.frame_from_snapshot(continued.session.analysis_values.snapshot())
+    )
+    for name in ("pb", "pc", "pd", "kex_ab", "kex_ac", "kex_ad"):
+        param_id = continued.local_ids[name]
+        assert resolved[param_id] == committed[workflow.local_ids[name]]
+    for name in ("kex_ab", "kex_ac", "kex_ad"):
+        assert ordinary.role(continued.local_ids[name]) is ParameterRole.FIT
+    for name in ("pa", "kab", "kba", "kac", "kca", "kad", "kda"):
+        assert ordinary.role(continued.local_ids[name]) is ParameterRole.DERIVED
+
+
+def test_directional_rates_and_pa_receive_coupled_deterministic_uncertainty() -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.15, "pc": 0.25, "pd": 0.35},
+        target={"pb": 0.1, "pc": 0.25, "pd": 0.35},
+        fitted_name="PB",
+        include_rates=True,
+    )
+    accepted = _fit_workflow(workflow)
+    uncertainty = _derive_uncertainty(workflow, accepted)
+    standard_errors = {
+        name: uncertainty.parameter(workflow.local_ids[name]).standard_error
+        for name in ("pb", "pa", "kab", "kba")
+    }
+
+    assert all(value is not None for value in standard_errors.values())
+    pb_error = standard_errors["pb"]
+    assert pb_error is not None
+    assert standard_errors["pa"] == pytest.approx(pb_error)
+    assert standard_errors["kab"] == pytest.approx(500.0 * pb_error)
+    assert standard_errors["kba"] == pytest.approx(500.0 * pb_error)
+
+
+def test_pa_zero_qualifies_symmetric_deterministic_uncertainty_as_boundary() -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.2, "pc": 0.3, "pd": 0.4},
+        target={"pb": 0.2, "pc": 0.3, "pd": 0.5},
+        fitted_name="PD",
+        include_rates=True,
+    )
+    accepted = _fit_workflow(workflow)
+    uncertainty = _derive_uncertainty(workflow, accepted)
+    conclusion = uncertainty.parameter(workflow.local_ids["pd"])
+
+    assert conclusion is not None
+    assert conclusion.standard_error is not None
+    assert conclusion.unavailable_kind is None
+    assert conclusion.boundary_warning
+
+
+@pytest.mark.parametrize("interrupt_second_block", (False, True))
+def test_block_recovery_retains_pa_face_warning(
+    interrupt_second_block: bool,
+) -> None:
+    workflow = _build_workflow(
+        start={"pb": 0.2, "pc": 0.3, "pd": 0.4},
+        target={"pb": 0.2, "pc": 0.3, "pd": 0.5},
+        fitted_name="PD",
+        temperatures=(25.0, 30.0),
+    )
+    accepted = _fit_workflow(workflow)
+    original_svd = uncertainty_module.svd
+    call_count = 0
+
+    def rank_deficient_root_then_maybe_interrupt(*args: Any, **kwargs: Any):
+        nonlocal call_count
+        call_count += 1
+        if interrupt_second_block and call_count == 3:
+            raise KeyboardInterrupt
+        left, singular, right = original_svd(*args, **kwargs)
+        if call_count == 1:
+            singular = np.array(singular, copy=True)
+            singular[-1] = 0.0
+        return left, singular, right
+
+    with patch(
+        "chemex.optimize.uncertainty.svd",
+        side_effect=rank_deficient_root_then_maybe_interrupt,
+    ):
+        uncertainty = _derive_uncertainty(workflow, accepted)
+
+    operation = uncertainty.block_operation
+    assert operation is not None
+    expected_completed = 1 if interrupt_second_block else 2
+    assert len(operation.completed_blocks) == expected_completed
+    warned = operation.simple_bound_warning_ids
+    if operation.complete_evidence is not None:
+        assert operation.complete_evidence.simple_bound_warning_ids == warned
+    for local_ids in workflow.component_local_ids[:expected_completed]:
+        assert local_ids["pd"] in warned

--- a/tests/test_native_de_direct_trf.py
+++ b/tests/test_native_de_direct_trf.py
@@ -228,6 +228,28 @@ def test_mixed_domain_de_uses_the_derived_child_psd_bound() -> None:
     )
 
 
+def test_de_rejects_private_relaxation_coordinates_without_measure() -> None:
+    _session, _experiments, _parameterization, _engine, problem = (
+        _qualification_problem(
+            Method(
+                fit=["ETAZ_A", "R1A_A"],
+                fix=["R1_A", "PB", "KEX_AB"],
+            )
+        )
+    )
+    selected_id = next(item for item in problem.controlled_ids if "__ETAZ_A" in item)
+
+    with pytest.raises(
+        DirectTrfConstructionError,
+        match="relaxation-feasibility coordinates",
+    ):
+        DeSearchInvocation.for_product_problem(
+            problem,
+            search_coordinates=((selected_id, -1.0, 1.0, "linear"),),
+            root_seed=597,
+        )
+
+
 def _successful_backend_result(
     invocation: DeSearchInvocation,
     solver_vector: np.ndarray,

--- a/tests/test_native_mcmc.py
+++ b/tests/test_native_mcmc.py
@@ -1166,6 +1166,7 @@ def test_mcmc_rejects_private_relaxation_coordinates_without_measure() -> None:
         feasible_coordinates=SimpleNamespace(
             is_noop=False,
             identity="private-relaxation-chart",
+            uses_private_relaxation_coordinates=True,
             supports_box_only_algorithms=False,
             solver_bounds=(problem.lower_bounds, problem.upper_bounds),
         ),

--- a/tests/test_relaxation_feasibility.py
+++ b/tests/test_relaxation_feasibility.py
@@ -1008,6 +1008,7 @@ def test_component_projection_rejects_a_non_closed_root_feasibility_domain() -> 
     )
 
     assert root is not None
+    assert root.uses_private_relaxation_coordinates
     with pytest.raises(TypeError):
         dataclasses.replace(
             root,

--- a/website/docs/user_guide/fitting/kinetic_models.md
+++ b/website/docs/user_guide/fitting/kinetic_models.md
@@ -9,8 +9,19 @@ The kinetic model (specified with the `-d` or `--model` option) defines the type
 | Model Name          | Description                                                                     |
 | ------------------- | ------------------------------------------------------------------------------- |
 | `2st`               | 2-state exchange model (default)                                                |
-| `3st`               | 3-state exchange model                                                          |
-| `4st`               | 4-state exchange model                                                          |
+| `3st`               | Complete 3-state exchange model                                                  |
+| `3st_triangle`      | Historical explicit compatibility name for `3st`                                |
+| `3st_linear`        | Linear A ↔ B ↔ C exchange model                                                  |
+| `3st_fork`          | A-centered B ↔ A ↔ C exchange model                                              |
+| `4st`               | Complete 4-state exchange model                                                  |
+| `4st_linear`        | Linear 4-state exchange model                                                    |
+| `4st_fork`          | A-centered 4-state exchange model                                                |
+| `5st`               | Complete 5-state exchange model                                                  |
+| `5st_linear`        | Linear 5-state exchange model                                                    |
+| `5st_fork`          | A-centered 5-state exchange model                                                |
+| `6st`               | Complete 6-state exchange model                                                  |
+| `6st_linear`        | Linear 6-state exchange model                                                    |
+| `6st_fork`          | A-centered 6-state exchange model                                                |
 | `2st_hd`            | 2-state exchange model for H/D solvent exchange studies                         |
 | `2st_eyring`        | 2-state exchange model for temperature-dependent studies                        |
 | `3st_eyring`        | Compatibility name for the linear 3-state Eyring model                          |
@@ -37,6 +48,108 @@ For any kinetic model, you can add the `.rs` suffix to make the kinetic paramete
 :::note
 For any kinetic model, you can add the `.mf` suffix to create a model that fits model-free parameters directly (e.g., `TAUC_A`, `S2_A`), rather than individual relaxation parameters (e.g., `R1_A`, `R2_A`). For an example, see `CEST_15N_TR/` under `Examples/Experiments/`.
 :::
+
+## Generic N-state models
+
+The generic family supports three through six states. Its public model name is
+the topology contract:
+
+| Model | Topology |
+| --- | --- |
+| `3st`, `4st`, `5st`, `6st` | Complete graph: every unordered state pair exchanges |
+| `3st_linear`, `4st_linear`, `5st_linear`, `6st_linear` | Chain A ↔ B ↔ C ↔ D ↔ E ↔ F, truncated at the selected state count |
+| `3st_fork`, `4st_fork`, `5st_fork`, `6st_fork` | A-centered star: A exchanges directly with every other state |
+| `3st_triangle` | Exact historical compatibility name for the canonical complete `3st` model |
+
+`PB`, `PC`, and any higher non-A populations are independent fractions; `PA`
+is derived so that all populations sum to one. ChemEx enforces the complete
+closed simplex: every population must be finite and nonnegative and their sum
+must be exactly representable as no greater than one. Exact zero populations
+and `PA = 0` are valid. Values are not clipped, renormalized, or replaced by a
+small positive floor.
+
+For every structural edge `i` ↔ `j`, `KEX_ij` is the total exchange scale in
+s⁻¹:
+
+$$
+KEX_{ij} = K_{ij} + K_{ji}.
+$$
+
+ChemEx derives the directional rates from the prescribed populations:
+
+$$
+K_{ij} = KEX_{ij}\frac{P_j}{P_i + P_j}, \qquad
+K_{ji} = KEX_{ij}\frac{P_i}{P_i + P_j}.
+$$
+
+The first state in a directional name is its source, so `KAB` means A → B.
+`KEX_ij = 0` produces exact zero in both directions and dynamically switches
+off an existing structural edge. If exactly one endpoint population is zero,
+the outgoing rate from that endpoint equals `KEX_ij` and the reciprocal rate is
+zero. If both endpoint populations are zero, `KEX_ij = 0` remains valid, but a
+positive `KEX_ij` is rejected because its directional split is undefined.
+Positive rates too small to be represented as positive binary64 values are
+also rejected instead of being changed into structural zero.
+
+An absent edge in a `_linear` or `_fork` model is different from an edge fixed
+to zero in a complete model: the absent edge has no `KEX` or directional-rate
+parameters and cannot be selected by a Method Step. In a complete model,
+setting selected structural `KEX` values to zero can create disconnected
+kinetic components. Positive prescribed populations may remain in multiple
+components; ChemEx treats them as static mixture weights for non-interconverting
+subensembles and does not require an irreducible generator or a unique global
+stationary distribution.
+
+Direct TRF and its Monte Carlo/bootstrap reruns use closed, bounded simplex
+coordinates internally while continuation and output retain public `PB`, `PC`,
+and higher-state coordinates. MCMC remains in those public coordinates and
+rejects proposals outside the simplex through its normal zero-density path.
+Qualified interior deterministic covariance is propagated analytically to
+`PA` and the directional rates. At a population boundary, symmetric errors are
+reported only with ChemEx's boundary warning; the positive-`KEX` zero/zero split
+has no valid central rate or derivative.
+
+### Breaking default change for complete 4/5/6-state models
+
+Bare `4st`, `5st`, and `6st` are now genuinely complete by default. Every
+structural `KEX`, including `KEX_AD` and `KEX_BD`, starts at `200 s⁻¹`, is
+bounded to `[0, 1e6] s⁻¹`, and is fitted by default. Earlier releases inherited
+historical `KEX_AD = KEX_BD = 0` fixed defaults. This is an intentional breaking
+change.
+
+To reproduce the old sparse behavior for any of `4st`, `5st`, or `6st`, use a
+normal parameter file:
+
+```toml title="legacy-complete-parameters.toml"
+[GLOBAL]
+KEX_AD = 0.0
+KEX_BD = 0.0
+```
+
+and explicitly preserve the roles in a version 2 Method Plan:
+
+```toml title="legacy-complete-method.toml"
+FORMAT_VERSION = 2
+
+[FIT]
+ROLES = [{ FIX = ["KEX_AD", "KEX_BD"] }]
+```
+
+Select the required state count normally:
+
+```text
+chemex fit ... -d 4st -p legacy-complete-parameters.toml -m legacy-complete-method.toml
+chemex fit ... -d 5st -p legacy-complete-parameters.toml -m legacy-complete-method.toml
+chemex fit ... -d 6st -p legacy-complete-parameters.toml -m legacy-complete-method.toml
+```
+
+Old generated `run_info/restart.toml` files preserve the numerical zero values
+and their bounds, but do not preserve the historical fitted/fixed roles. When
+such a restart is loaded under the new complete model, `KEX_AD` and `KEX_BD`
+therefore become ordinary fitted coordinates unless the Method Step above fixes
+them. Plain historical parameter files that omitted the two values carry no
+reliable version or intent signal; ChemEx applies the new complete defaults
+rather than guessing their age.
 
 ## Three-State Association Models
 


### PR DESCRIPTION

## Summary

Make generic multi-state kinetic models scientifically authoritative and topology-consistent.

Public topology contract:

- bare `Nst` = complete graph;
- `Nst_linear` = chain/path;
- `Nst_fork` = A-centered star;
- `3st_triangle` remains an exact compatibility alias of `3st`.

Adds:

- `4st_linear`
- `4st_fork`
- `5st_linear`
- `5st_fork`
- `6st_linear`
- `6st_fork`

## Population authority

- PB/PC/... remain public independent populations.
- PA remains their complement.
- The complete simplex is now enforced.
- Exact zero populations and PA=0 remain valid.
- Invalid negative populations or sum >1 fail before NMR evaluation.
- No clipping or renormalization.

## Pairwise exchange authority

For every structural edge:

`KEX_ij = k_ij + k_ji`

with populations determining the directional split and detailed balance.

The implementation:

- removes the historical `1e-100` denominator floor;
- handles exact-zero endpoints explicitly;
- rejects positive-KEX zero/zero endpoint ambiguity;
- rejects negative/nonfinite KEX;
- preserves representable subnormal rates with exponent-aware binary64 evaluation;
- fails closed when a mathematically positive directional rate is not representable.

## Topology rationalization

Bare 4st/5st/6st models are now genuinely complete graphs.

Historical `KEX_AD` and `KEX_BD` zero/fixed defaults are removed.

They now use the same normal complete-model baseline as all other edges:

- 200 s^-1;
- [0, 1e6];
- varying/estimable.

This is an intentional breaking default change.

## Migration

To reproduce historical bare 4st/5st/6st behavior:

Parameter file:
```toml
[GLOBAL]
KEX_AD = 0.0
KEX_BD = 0.0
```

Method:
```toml
FORMAT_VERSION = 2

[FIT]
ROLES = [{ FIX = ["KEX_AD", "KEX_BD"] }]
```

Legacy restart files preserve numerical zero values but not historical FIT/FIX role authority, so the Method must explicitly fix AD/BD when reproducing the old behavior.

No heuristic migration based on file age or omission was introduced.

## Optimization

Direct TRF now uses a boundary-capable simplex feasible-coordinate chart while retaining public PB/PC/... continuation coordinates.

Exact zero and PA=0 remain reachable.

DE and MCMC continue to operate in public coordinates; only private relaxation-coordinate geometries remain prohibited.

Resampling reuses the same Direct-TRF feasibility authority.

## Uncertainty

- PA covariance remains correctly coupled.
- Generic directional rates now have analytic uncertainty propagation.
- Simplex-face warnings propagate through complete and partial block covariance recovery.
- Boundary cases remain qualified rather than silently presented as ordinary symmetric interiors.

## Compatibility

Preserved:

- existing public parameter names;
- scopes;
- 3st/3st_triangle behavior and metadata;
- 3st_linear;
- 3st_fork;
- ordinary explicit higher-state calculations;
- restart/output public coordinates;
- NMR basis orientation;
- Eyring;
- binding/association;
- modifiers;
- scaling/weighting.

Intentional changes are limited to:

- invalid scientific-domain rejection;
- numerical correction at extreme populations;
- new topology names;
- complete 4/5/6 defaults;
- directional-rate uncertainty.

## Architecture/readability

- topology is explicitly declared;
- no recursive dictionary inheritance/deletion;
- one population-domain authority;
- one pairwise-rate authority;
- typed feasible-coordinate provenance;
- single DE/MCMC private-relaxation capability contract;
- single root-anchored box-plus-simplex warning aggregation authority;
- no graph DSL or model-specific optimizer branches.

Independent audit result:

`PASS — 0 closure findings`

`READABILITY PASS`

`READY TO COMMIT THE AUDITED DIFF`

## Validation

Final production candidate before remediation:

- full suite Python 3.14.5: `2215 passed`
- complete kinetic suite: `857 passed`
- focused Python 3.13 N-state suite: `62 passed`
- website production build: passed
- ty: passed
- Ruff check/format: passed
- diff check: passed
- graph refresh: passed

Focused validation after audit remediation:

- four N-state files: `76 passed`
- DE regression: `15 passed`
- MCMC regression: `86 passed`
- relaxation feasibility: `43 passed`
- binding uncertainty: `19 passed`
- Eyring workflows: `7 passed`
- focused block/boundary uncertainty regressions: passed
- final C1/C2 focused closure: `8 passed`
- ty: passed
- Ruff check/format: passed
- `git diff --check`: passed

The full suite was intentionally not repeated after narrow remediation; GitHub CI provides the final Python 3.13/3.14 integration matrix.
